### PR TITLE
Client and Server expects account in ace_auth to be lowercase only.

### DIFF
--- a/Source/ACE/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE/Command/Handlers/AccountCommands.cs
@@ -15,12 +15,13 @@ namespace ACE.Command
             var result = DatabaseManager.Authentication.SelectPreparedStatement(AuthenticationPreparedStatement.AccountMaxIndex);
             Debug.Assert(result != null);
 
-            uint accountId = result.Read<uint>(0, "MAX(`id`)") + 1;
+            uint accountId  = result.Read<uint>(0, "MAX(`id`)") + 1;
+            string account  = parameters[0].ToLower();
             string salt     = SHA2.Hash(SHA2Type.SHA256, Path.GetRandomFileName());
             string password = SHA2.Hash(SHA2Type.SHA256, parameters[1]);
             string digest   = SHA2.Hash(SHA2Type.SHA256, password + salt);
 
-            DatabaseManager.Authentication.ExecutePreparedStatement(AuthenticationPreparedStatement.AccountInsert, accountId, parameters[0], digest, salt);
+            DatabaseManager.Authentication.ExecutePreparedStatement(AuthenticationPreparedStatement.AccountInsert, accountId, account, digest, salt);
         }
     }
 }


### PR DESCRIPTION
This is my first pull request, please let me know if I'm doing this incorrectly.

Simple change I made to the accountcreate command to correct and prevent the issue I experienced when setting up ACE.

The client always sends accounts as lowercase regardless of what the user types in the command line. The server itself resolves the difference and connects as well. The issue surfaces when attempting to create a character. That packet is sent, but no response is ever recv'd.