### PR TITLE
Fix for NAT issues on internal connections to WorldServer

### DIFF
--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -53,9 +53,7 @@ namespace ACE.Network
             referralPacket.Payload.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
 
             string[] ConnectingIPAddress = session.EndPoint.Address.ToString().Split('.');
-
-            Debug.WriteLine(ConnectingIPAddress.ToString());
-            
+          
             if (ConnectingIPAddress[0] == "10" || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168"))
             {
                 var host = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName());
@@ -63,9 +61,7 @@ namespace ACE.Network
                 {
                     if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                     {
-                        //Debug.WriteLine(ip.ToString());
                         byte[] WorldInternalIP = new byte[4];
-                        //Convert.ToByte
                         string[] hostSplit = ip.ToString().Split('.');
                         for (uint i = 0; i < 4; i++)
                             WorldInternalIP[i] = Convert.ToByte(hostSplit[i]);

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -51,7 +51,33 @@ namespace ACE.Network
             referralPacket.Payload.Write(session.WorldConnectionKey);
             referralPacket.Payload.Write((ushort)2);
             referralPacket.Payload.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
-            referralPacket.Payload.Write(ConfigManager.Host);
+
+            string[] ConnectingIPAddress = session.EndPoint.Address.ToString().Split('.');
+
+            Debug.WriteLine(ConnectingIPAddress.ToString());
+            
+            if (ConnectingIPAddress[0] == "10" || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168"))
+            {
+                var host = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName());
+                foreach (var ip in host.AddressList)
+                {
+                    if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                    {
+                        //Debug.WriteLine(ip.ToString());
+                        byte[] WorldInternalIP = new byte[4];
+                        //Convert.ToByte
+                        string[] hostSplit = ip.ToString().Split('.');
+                        for (uint i = 0; i < 4; i++)
+                            WorldInternalIP[i] = Convert.ToByte(hostSplit[i]);
+                        referralPacket.Payload.Write(WorldInternalIP);
+                    }
+                }
+            }
+            else
+            {
+                referralPacket.Payload.Write(ConfigManager.Host);
+            }
+
             referralPacket.Payload.Write(0ul);
             referralPacket.Payload.Write((ushort)0x18);
             referralPacket.Payload.Write((ushort)0);


### PR DESCRIPTION
This fix is meant help alleviate a NAT issue some people will see when configuring server IP to external address. 

Due to problematic NAT routing, connecting to external IP while on internal network leads to black screen on hand-off to world server. Others may not even be able to connect to server using external IP address.

This fix should allow for external IP connection for those outside of network, and internal IP connection for those inside the network.