### PR TITLE
Option to Enable Automatic Account Creation

### DIFF
--- a/Source/ACE/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE/Command/Handlers/AccountCommands.cs
@@ -21,5 +21,19 @@ namespace ACE.Command
 
             DatabaseManager.Authentication.CreateAccount(acc);
         }
+
+        // enable-autoaccountcreate
+        [CommandHandler("enable-autoaccountcreate", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 0)]
+        public static void HandleEnableAutoAccountCreate(Session session, params string[] parameters)
+        {
+            //TODO: setup bool flipper code
+
+            var config = Managers.ConfigManager.Config.Server.EnableAutoAccountCreate;
+            if (config != true)
+            {
+                //TODO: change state of Managers.ConfigManager.Config.Server.EnableAutoAccountCreate from false to true
+            }
+            System.Console.WriteLine("Enabled Automatic Account Creation for this server");
+        }
     }
 }

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -2,6 +2,7 @@
     "Server": {
         "WorldName": "ACEmulator",
         "Welcome": "Welcome to this ACE server!\nFor more information visit http://www.acemulator.org.",
+        "EnableAutoAccountCreate":  false,
         "Network": {
             "Host": "127.0.0.1",
             "LoginPort": 9000,

--- a/Source/ACE/Managers/ConfigManager.cs
+++ b/Source/ACE/Managers/ConfigManager.cs
@@ -16,6 +16,7 @@ namespace ACE.Managers
         public string WorldName { get; set; }
         public string Welcome { get; set; }
         public ConfigServerNetwork Network { get; set; }
+        public bool EnableAutoAccountCreate { get; set; }
     }
 
     public struct ConfigMySqlDatabase

--- a/Source/ACE/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE/Network/Handlers/AuthenticationHandler.cs
@@ -20,8 +20,26 @@ namespace ACE.Network
             packet.Payload.ReadUInt32();
             string glsTicket  = packet.Payload.ReadString32L();
 
-            var result = await DatabaseManager.Authentication.GetAccountByName(account);
-            AccountSelectCallback(result, session);
+            try
+            {
+                var result = await DatabaseManager.Authentication.GetAccountByName(account);
+                AccountSelectCallback(result, session);
+            }
+            catch (System.IndexOutOfRangeException ex)
+            {
+                if (ConfigManager.Config.Server.EnableAutoAccountCreate)
+                {
+                    string password = System.Convert.ToString(glsTicket);
+                    // TODO: convert password to normal string
+                    Command.AccountCommands.HandleAccountCreate(session, account, password);
+                    var result = await DatabaseManager.Authentication.GetAccountByName(account);
+                    AccountSelectCallback(result, session);
+                }
+                else
+                {
+                    AccountSelectCallback(null, session);
+                }
+            }
         }
 
         private static void AccountSelectCallback(Account account, Session session)


### PR DESCRIPTION
Added a configurable variable to Config.json.example for allowing the server to create an account for the client when one does not already exist on the server.