### PR TITLE
Add option to send different host address than external host address during world handoff

### DIFF
--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -4,6 +4,8 @@
         "Welcome": "Welcome to this ACE server!\nFor more information visit http://www.acemulator.org.",
         "Network": {
             "Host": "127.0.0.1",
+            "InternalHost": "127.0.0.1",
+            "SendInternalHostOnLocalNetwork":  false,
             "LoginPort": 9000,
             "WorldPort": 9008
         }

--- a/Source/ACE/Managers/ConfigManager.cs
+++ b/Source/ACE/Managers/ConfigManager.cs
@@ -9,6 +9,8 @@ namespace ACE.Managers
         public string Host { get; set; }
         public uint LoginPort { get; set; }
         public uint WorldPort { get; set; }
+        public string InternalHost { get; set; }
+        public bool SendInternalHostOnLocalNetwork { get; set; }
     }
 
     public struct ConfigServer
@@ -44,6 +46,7 @@ namespace ACE.Managers
     {
         public static Config Config { get; private set; }
         public static byte[] Host { get; } = new byte[4];
+        public static byte[] InternalHost { get; } = new byte[4];
 
         public static void Initialise()
         {
@@ -55,6 +58,9 @@ namespace ACE.Managers
                 string[] hostSplit = Config.Server.Network.Host.Split('.');
                 for (uint i = 0; i < 4; i++)
                     Host[i] = Convert.ToByte(hostSplit[i]);
+                hostSplit = Config.Server.Network.InternalHost.Split('.');
+                for (uint i = 0; i < 4; i++)
+                    InternalHost[i] = Convert.ToByte(hostSplit[i]);
             }
             catch (Exception exception)
             {

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -53,9 +53,7 @@ namespace ACE.Network
             referralPacket.Payload.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
 
             string[] ConnectingIPAddress = session.EndPoint.Address.ToString().Split('.');
-
-            Debug.WriteLine(ConnectingIPAddress.ToString());
-            
+          
             if (ConnectingIPAddress[0] == "10" || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168"))
             {
                 var host = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName());
@@ -63,9 +61,7 @@ namespace ACE.Network
                 {
                     if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                     {
-                        //Debug.WriteLine(ip.ToString());
                         byte[] WorldInternalIP = new byte[4];
-                        //Convert.ToByte
                         string[] hostSplit = ip.ToString().Split('.');
                         for (uint i = 0; i < 4; i++)
                             WorldInternalIP[i] = Convert.ToByte(hostSplit[i]);

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -53,21 +53,12 @@ namespace ACE.Network
             referralPacket.Payload.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
 
             string[] ConnectingIPAddress = session.EndPoint.Address.ToString().Split('.');
-          
-            if (ConnectingIPAddress[0] == "10" || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168"))
+            if (ConfigManager.Config.Server.Network.SendInternalHostOnLocalNetwork && 
+                (ConnectingIPAddress[0] == "10" 
+                || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) 
+                || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168")))
             {
-                var host = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName());
-                foreach (var ip in host.AddressList)
-                {
-                    if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
-                    {
-                        byte[] WorldInternalIP = new byte[4];
-                        string[] hostSplit = ip.ToString().Split('.');
-                        for (uint i = 0; i < 4; i++)
-                            WorldInternalIP[i] = Convert.ToByte(hostSplit[i]);
-                        referralPacket.Payload.Write(WorldInternalIP);
-                    }
-                }
+                referralPacket.Payload.Write(ConfigManager.InternalHost);
             }
             else
             {

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -51,7 +51,33 @@ namespace ACE.Network
             referralPacket.Payload.Write(session.WorldConnectionKey);
             referralPacket.Payload.Write((ushort)2);
             referralPacket.Payload.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
-            referralPacket.Payload.Write(ConfigManager.Host);
+
+            string[] ConnectingIPAddress = session.EndPoint.Address.ToString().Split('.');
+
+            Debug.WriteLine(ConnectingIPAddress.ToString());
+            
+            if (ConnectingIPAddress[0] == "10" || (ConnectingIPAddress[0] == "172" && System.Convert.ToInt16(ConnectingIPAddress[1]) >= 16 && System.Convert.ToInt16(ConnectingIPAddress[1]) <= 31) || (ConnectingIPAddress[0] == "192" && ConnectingIPAddress[1] == "168"))
+            {
+                var host = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName());
+                foreach (var ip in host.AddressList)
+                {
+                    if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                    {
+                        //Debug.WriteLine(ip.ToString());
+                        byte[] WorldInternalIP = new byte[4];
+                        //Convert.ToByte
+                        string[] hostSplit = ip.ToString().Split('.');
+                        for (uint i = 0; i < 4; i++)
+                            WorldInternalIP[i] = Convert.ToByte(hostSplit[i]);
+                        referralPacket.Payload.Write(WorldInternalIP);
+                    }
+                }
+            }
+            else
+            {
+                referralPacket.Payload.Write(ConfigManager.Host);
+            }
+
             referralPacket.Payload.Write(0ul);
             referralPacket.Payload.Write((ushort)0x18);
             referralPacket.Payload.Write((ushort)0);


### PR DESCRIPTION
The purpose of this code is to allow a server operator to configure their external IP for clients connecting from the internet as well as allowing clients connecting on the intranet to use the local network IP address of the server instead.

The options are configurable via config.json and set to false by default.