### PR TITLE
Fix for server crash when account does not exist for connecting client

### DIFF
--- a/Source/ACE/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE/Network/Handlers/AuthenticationHandler.cs
@@ -20,8 +20,15 @@ namespace ACE.Network
             packet.Payload.ReadUInt32();
             string glsTicket  = packet.Payload.ReadString32L();
 
-            var result = await DatabaseManager.Authentication.GetAccountByName(account);
-            AccountSelectCallback(result, session);
+            try
+            {
+                var result = await DatabaseManager.Authentication.GetAccountByName(account);
+                AccountSelectCallback(result, session);
+            }
+            catch (System.IndexOutOfRangeException ex)
+            {
+                AccountSelectCallback(null, session);
+            }
         }
 
         private static void AccountSelectCallback(Account account, Session session)


### PR DESCRIPTION
Please use this PR if rejecting PR #34. this contains the fix to the server crash when an account is not created and a client tried to connect to the server using the invalid account.

this fix is already in PR #34 so if that one is accepted, reject this one.