### PR TITLE
Implemented "/friends remove -all", "/friends old" and Appear Offline.

### DIFF
--- a/Source/ACE.Database/CharacterDatabase.cs
+++ b/Source/ACE.Database/CharacterDatabase.cs
@@ -33,6 +33,7 @@ namespace ACE.Database
             CharacterFriendsSelect,
             CharacterFriendInsert,
             CharacterFriendDelete,
+            CharacterFriendsRemoveAll,
 
             CharacterPropertiesBoolSelect,
             CharacterPropertiesIntSelect,
@@ -62,6 +63,7 @@ namespace ACE.Database
             AddPreparedStatement(CharacterPreparedStatement.CharacterListSelect, "SELECT `guid`, `name`, `deleteTime` FROM `character` WHERE `accountId` = ? AND `deleted` = 0 ORDER BY `name` ASC;", MySqlDbType.UInt32);
             AddPreparedStatement(CharacterPreparedStatement.CharacterFriendInsert, "INSERT INTO `character_friends` (`id`, `friendId`) VALUES (?, ?);", MySqlDbType.UInt32, MySqlDbType.UInt32);
             AddPreparedStatement(CharacterPreparedStatement.CharacterFriendDelete, "DELETE FROM  `character_friends` WHERE `id` = ? AND `friendId` = ?;", MySqlDbType.UInt32, MySqlDbType.UInt32);
+            AddPreparedStatement(CharacterPreparedStatement.CharacterFriendsRemoveAll, "DELETE FROM  `character_friends` WHERE `id` = ?;", MySqlDbType.UInt32);
             AddPreparedStatement(CharacterPreparedStatement.CharacterSelectByName, "SELECT `guid`, `accountId`, `name`, `templateOption`, `startArea` FROM `character` WHERE `deleted` = 0 AND `deleteTime` = 0 AND `name` = ?;", MySqlDbType.VarString);
 
             // world entry
@@ -365,6 +367,11 @@ namespace ACE.Database
         public async Task AddFriend(uint characterId, uint friendCharacterId)
         {
             await ExecutePreparedStatementAsync(CharacterPreparedStatement.CharacterFriendInsert, characterId, friendCharacterId);
+        }
+
+        public async Task RemoveAllFriends(uint characterId)
+        {
+            await ExecutePreparedStatementAsync(CharacterPreparedStatement.CharacterFriendsRemoveAll, characterId);
         }
     }
 }

--- a/Source/ACE.Database/ICharacterDatabase.cs
+++ b/Source/ACE.Database/ICharacterDatabase.cs
@@ -26,6 +26,7 @@ namespace ACE.Database
 
         Task DeleteFriend(uint characterId, uint friendCharacterId);
         Task AddFriend(uint characterId, uint friendCharacterId);
+        Task RemoveAllFriends(uint characterId);
         
         /// <summary>
         /// loads object properties into the provided db object

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -197,6 +197,11 @@ namespace ACE.Entity
                 friends.Remove(friend);
         }
 
+        public void RemoveAllFriends()
+        {
+            friends.Clear();
+        }
+
         /// <summary>
         /// This should be moved back to the ACE project when time permits.
         /// </summary>

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -96,11 +96,14 @@
     <Compile Include="Network\Enum\CharacterGenerationVerificationResponse.cs" />
     <Compile Include="Network\Enum\RemoveFriendResult.cs" />
     <Compile Include="Network\Enum\SessionState.cs" />
+    <Compile Include="Network\Enum\SingleCharacterOption.cs" />
     <Compile Include="Network\Enum\Sound.cs" />
     <Compile Include="Network\Enum\UpdatePositionFlag.cs" />
     <Compile Include="Network\Enum\Vital.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAddFriend.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAdvocateTeleport.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionRemoveAllFriends.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionSetSingleCharacterOption.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAutonomousPosition.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionEmote.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionHouseQuery.cs" />
@@ -142,6 +145,7 @@
     <Compile Include="Network\GameEvent\GameEventFraglessPacket.cs" />
     <Compile Include="Network\Handlers\AuthenticationHandler.cs" />
     <Compile Include="Network\Handlers\CharacterHandler.cs" />
+    <Compile Include="Network\Handlers\FriendsOldHandler.cs" />
     <Compile Include="Network\Managers\PacketManager.cs" />
     <Compile Include="Network\Extensions.cs" />
     <Compile Include="Network\Managers\NetworkManager.cs" />

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -373,8 +373,7 @@ namespace ACE.Entity
 
                 foreach (var friendSession in inverseFriends)
                 {
-                    if (friendSession.Player.IsOnline)
-                        new GameEventFriendsListUpdate(friendSession, GameEventFriendsListUpdate.FriendsUpdateTypeFlag.FriendStatusChanged, playerFriend, true, IsOnline).Send();
+                    new GameEventFriendsListUpdate(friendSession, GameEventFriendsListUpdate.FriendsUpdateTypeFlag.FriendStatusChanged, playerFriend, true, IsOnline).Send();
                 }
             }
         }
@@ -429,6 +428,21 @@ namespace ACE.Entity
             new GameEventFriendsListUpdate(Session, GameEventFriendsListUpdate.FriendsUpdateTypeFlag.FriendRemoved, friendToRemove).Send();
 
             return RemoveFriendResult.Success;
+        }
+
+        public async void RemoveAllFriends()
+        {
+            // Remove all from DB
+            await DatabaseManager.Character.RemoveAllFriends(Guid.Low);
+
+            // Remove from character object
+            character.RemoveAllFriends();
+        }
+
+        public void ChangeOnlineStatus(bool isOnline)
+        {
+            IsOnline = isOnline;
+            SendFriendStatusUpdates();
         }
 
         private void SendSelf()

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -94,7 +94,7 @@ namespace ACE.Managers
             sessionLock.EnterReadLock();
             try
             {
-                return sessionStore.SingleOrDefault(s => s.Player.Guid.Low == characterGuid.Low);
+                return sessionStore.SingleOrDefault(s => s.Player?.Guid.Low == characterGuid.Low);
             }
             finally
             {
@@ -107,7 +107,7 @@ namespace ACE.Managers
             sessionLock.EnterReadLock();
             try
             {
-                return sessionStore.Where(s => s.Player.Friends.FirstOrDefault(f => f.Id.Low == characterGuid.Low) != null).ToList();
+                return sessionStore.Where(s => s.Player?.Friends.FirstOrDefault(f => f.Id.Low == characterGuid.Low) != null).ToList();
             }
             finally
             {

--- a/Source/ACE/Network/Enum/SingleCharacterOption.cs
+++ b/Source/ACE/Network/Enum/SingleCharacterOption.cs
@@ -1,0 +1,7 @@
+﻿namespace ACE.Network.Enum
+{
+    public enum SingleCharacterOption
+    {
+        AppearOffline   = 0x0027
+    }
+}

--- a/Source/ACE/Network/Fragments/FragmentOpcode.cs
+++ b/Source/ACE/Network/Fragments/FragmentOpcode.cs
@@ -1,33 +1,33 @@
 ﻿
 namespace ACE.Network.Fragments
 {
-    // order by opcode name
     public enum FragmentOpcode
     {
-        None                           = 0x0000,
-        CharacterCreate                = 0xF656,
-        CharacterCreateResponse        = 0xF643,
-        CharacterDelete                = 0xF655,
-        CharacterEnterWorld            = 0xF657,
-        CharacterEnterWorldRequest     = 0xF7C8,
-        CharacterEnterWorldServerReady = 0xF7DF,
-        CharacterError                 = 0xF659,
-        CharacterList                  = 0xF658,
-        CharacterRestore               = 0xF7D9,
-        CharacterRestoreResponse       = 0xF643,
-        GameAction                     = 0xF7B1,
-        GameEvent                      = 0xF7B0,
-        ObjectCreate                   = 0xF745,
-        ObjectDelete                   = 0xF747,
-        PatchStatus                    = 0xF7EA,
-        PlayerCreate                   = 0xF746,
-        PlayerTeleport                 = 0xF751,
-        ServerName                     = 0xF7E1,
-        SetState                       = 0xF74B,
-        TextboxString                  = 0xF7E0,
-        UpdatePosition                 = 0xF748,
-
-        // to be named...
-        Unknown75E5                    = 0xF7E5
+        None                            = 0x0000,
+        CharacterCreateResponse         = 0xF643,
+        CharacterRestoreResponse        = 0xF643,
+        CharacterDelete                 = 0xF655,
+        CharacterCreate                 = 0xF656,
+        CharacterEnterWorld             = 0xF657,
+        CharacterList                   = 0xF658,
+        CharacterError                  = 0xF659,
+        ObjectCreate                    = 0xF745,
+        PlayerCreate                    = 0xF746,
+        ObjectDelete                    = 0xF747,
+        UpdatePosition                  = 0xF748,
+        SetState                        = 0xF74B,
+        PlayerTeleport                  = 0xF751,
+        GameEvent                       = 0xF7B0,
+        GameAction                      = 0xF7B1,
+        CharacterEnterWorldRequest      = 0xF7C8,
+        FriendsOld                      = 0xF7CD,
+        CharacterRestore                = 0xF7D9,
+        CharacterEnterWorldServerReady  = 0xF7DF,
+        TextboxString                   = 0xF7E0,
+        ServerName                      = 0xF7E1,
+        Unknown75E5                     = 0xF7E5,  // to be named...
+        PatchStatus                     = 0xF7EA
+        
+        
     }
 }

--- a/Source/ACE/Network/GameAction/Actions/GameActionRemoveAllFriends.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionRemoveAllFriends.cs
@@ -1,0 +1,13 @@
+﻿namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.RemoveAllFriends)]
+    public class GameActionRemoveAllFriends : GameActionPacket
+    {
+        public GameActionRemoveAllFriends(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        public override void Handle()
+        {
+            session.Player.RemoveAllFriends();
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/Actions/GameActionSetSingleCharacterOption.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionSetSingleCharacterOption.cs
@@ -1,0 +1,29 @@
+﻿using ACE.Network.Enum;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.SetSingleCharacterOption)]
+    public class GameActionSetSingleCharacterOption : GameActionPacket
+    {
+        private SingleCharacterOption option;
+        private uint optionValue;
+
+        public GameActionSetSingleCharacterOption(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        public override void Read()
+        {
+            option = (SingleCharacterOption)fragment.Payload.ReadUInt32();
+            optionValue = fragment.Payload.ReadUInt32();
+        }
+
+        public override void Handle()
+        {
+            switch(option)
+            {
+                case SingleCharacterOption.AppearOffline:
+                    session.Player.ChangeOnlineStatus(optionValue == 1 ? false : true);
+                    break;
+            }            
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/GameActionOpcode.cs
+++ b/Source/ACE/Network/GameAction/GameActionOpcode.cs
@@ -3,20 +3,22 @@ namespace ACE.Network.GameAction
 {
     public enum GameActionOpcode
     {
-        Talk                = 0x0015,
-        RemoveFriend        = 0x0017,
-        AddFriend           = 0x0018,
-        UpdateRequest       = 0x001F,
-        TitleSet            = 0x002C,
-        RaiseVital          = 0x0044,
-        RaiseAbility        = 0x0045,
-        RaiseSkill          = 0x0046,
-        LoginComplete       = 0x00A1,
-        AdvocateTeleport    = 0x00D6,
-        Emote               = 0x01E1,
-        PingRequest         = 0x01E9,
-        HouseQuery          = 0x021E,
-        MoveToState         = 0xF61C,
-        AutonomousPosition  = 0xF753
+        SetSingleCharacterOption    = 0x0005,
+        Talk                        = 0x0015,
+        RemoveFriend                = 0x0017,
+        AddFriend                   = 0x0018,
+        UpdateRequest               = 0x001F,
+        RemoveAllFriends            = 0x0025,
+        TitleSet                    = 0x002C,
+        RaiseVital                  = 0x0044,
+        RaiseAbility                = 0x0045,
+        RaiseSkill                  = 0x0046,
+        LoginComplete               = 0x00A1,
+        AdvocateTeleport            = 0x00D6,
+        Emote                       = 0x01E1,
+        PingRequest                 = 0x01E9,
+        HouseQuery                  = 0x021E,
+        MoveToState                 = 0xF61C,
+        AutonomousPosition          = 0xF753
     }
 }

--- a/Source/ACE/Network/Handlers/FriendsOldHandler.cs
+++ b/Source/ACE/Network/Handlers/FriendsOldHandler.cs
@@ -1,0 +1,14 @@
+﻿using ACE.Network.Enum;
+using ACE.Network.Fragments;
+
+namespace ACE.Network.Handlers
+{
+    public static class FriendsOldHandler
+    {
+        [Fragment(FragmentOpcode.FriendsOld, SessionState.WorldConnected)]
+        public static void FriendsOld(ClientPacketFragment fragment, Session session)
+        {
+            ChatPacket.SendSystemMessage(session, "That command is not used in the emulator.");            
+        }
+    }
+}


### PR DESCRIPTION
/friends old just sends a chat packet saying that the command isn't used in the emu.

I also had to fix a bug in two WorldManager methods that I added in an earlier PR.  There was a scenario where the Session.Player was null and it was causing the LINQ query to throw an exception.

Appear Offline is actually part of a GameAction that is used for setting many different options.  The Handle method for it now just has a switch in it (there are ~52 options) for now but we may want to go to something else in the future as we add new features.

Resolves #72 