### PR TITLE
Changed ParseCommand to support the use of quotes

### DIFF
--- a/Source/ACE/Command/CommandManager.cs
+++ b/Source/ACE/Command/CommandManager.cs
@@ -71,6 +71,32 @@ namespace ACE.Command
             parameters = new string[commandSplit.Length - 1];
 
             Array.Copy(commandSplit, 1, parameters, 0, commandSplit.Length - 1);
+
+            if (commandLine.Contains("\""))
+            {
+                var listParameters = new List<string>();
+
+                for (int start = 0; start < parameters.Length; start++)
+                    if (!parameters[start].StartsWith("\""))
+                        listParameters.Add(parameters[start]);
+                    else
+                    {
+                        listParameters.Add(parameters[start].Replace("\"",""));
+                        for (int end = start + 1; end < parameters.Length; end++)
+                        {
+                            if (!parameters[end].EndsWith("\""))
+                                listParameters[start] = listParameters[start] + " " + parameters[end];
+                            else
+                            {
+                                listParameters[start] = listParameters[start] + " " + parameters[end].Replace("\"", "");
+                                start = end;
+                                break;
+                            }
+                        }
+                    }
+                Array.Resize(ref parameters, listParameters.Count);
+                parameters = listParameters.ToArray();
+            }
         }
 
         public static CommandHandlerResponse GetCommandHandler(Session session, string command, string[] parameters, out CommandHandlerInfo commandInfo)


### PR DESCRIPTION
This change allows any command to work with quotes to better delimit some parameters.

An example of this would be for commands that require the use of a character name which has spaces in it such as Maia the Lawyer. 

The change results in the following command working as expected:

set-characteraccess "maia the laywer" admin

Another example this change would fix would be the eventual problem with teleto which it gets wired-up.
Without the change, the command reads like teleto maia the laywer and would try to teleport to the character named maia instead of the full name. teleto "maia the lawyer" then corrects this issue and finds the right player.