### PR TITLE
Support easy permissions in ACEmulator

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -12,11 +12,18 @@ namespace ACE.Common
         public uint WorldPort { get; set; }
     }
 
+    public struct ConfigAccountDefaults
+    {
+        public bool OverrideCharacterPermissions { get; set; }
+        public uint DefaultAccessLevel { get; set; }
+    }
+
     public struct ConfigServer
     {
         public string WorldName { get; set; }
         public string Welcome { get; set; }
         public ConfigServerNetwork Network { get; set; }
+        public ConfigAccountDefaults Accounts { get; set; }
     }
 
     public struct ConfigMySqlDatabase

--- a/Source/ACE/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE/Command/Handlers/AccountCommands.cs
@@ -15,16 +15,21 @@ namespace ACE.Command.Handlers
         [CommandHandler("accountcreate", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 2)]
         public static void HandleAccountCreate(Session session, params string[] parameters)
         {
-            uint accountId          = DatabaseManager.Authentication.GetMaxId() + 1;
-            string account          = parameters[0].ToLower();
-            string salt             = SHA2.Hash(SHA2Type.SHA256, Path.GetRandomFileName());
-            string password         = SHA2.Hash(SHA2Type.SHA256, parameters[1]);
-            AccessLevel accessLevel = AccessLevel.Player;
+            uint accountId                  = DatabaseManager.Authentication.GetMaxId() + 1;
+            string account                  = parameters[0].ToLower();
+            string salt                     = SHA2.Hash(SHA2Type.SHA256, Path.GetRandomFileName());
+            string password                 = SHA2.Hash(SHA2Type.SHA256, parameters[1]);
+            AccessLevel accessLevel         = AccessLevel.Player;
+            AccessLevel defaultAccessLevel  = (AccessLevel)Common.ConfigManager.Config.Server.Accounts.DefaultAccessLevel;
 
+            if (!Enum.IsDefined(typeof(AccessLevel), defaultAccessLevel))
+                defaultAccessLevel = AccessLevel.Player;
+
+            accessLevel = defaultAccessLevel;
             if (parameters.Length > 2)
                 if (Enum.TryParse(parameters[2], true, out accessLevel))
                     if (!Enum.IsDefined(typeof(AccessLevel), accessLevel))
-                        accessLevel = AccessLevel.Player;
+                        accessLevel = defaultAccessLevel;
 
             string articleAorAN = "a";
             if (accessLevel == AccessLevel.Advocate || accessLevel == AccessLevel.Admin || accessLevel == AccessLevel.Envoy)

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -6,6 +6,14 @@
             "Host": "127.0.0.1",
             "LoginPort": 9000,
             "WorldPort": 9008
+        },
+        "Accounts": {
+            "OverrideCharacterPermissions": true,
+            // false = Emulator mimics how permissions worked on real servers | true = Use Account AccessLevel to apply to all characters of an account
+            // If the above option is set to false, each character needs permissions set using set-characteraccess command
+            "DefaultAccessLevel": 0
+            // 0 = Player | 1 = Advocate | 2 = Sentinel | 3 = Envoy | 4 = Developer | 5 = Admin
+            // New accounts are created with the above AccessLevel unless explicitly changed using accountcreate command
         }
     },
     "MySql": {

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -195,6 +195,22 @@ namespace ACE.Entity
         public async void Load()
         {
             character = await DatabaseManager.Character.LoadCharacter(Guid.Low);
+
+            if (Common.ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions)
+            {
+                if (Session.AccessLevel == AccessLevel.Admin)
+                    character.IsAdmin = true;
+                if (Session.AccessLevel == AccessLevel.Developer)
+                    character.IsArch = true;
+                if (Session.AccessLevel == AccessLevel.Envoy)
+                    character.IsEnvoy = true;
+                //TODO: Need to setup and account properly for IsSentinel and IsAdvocate.
+                //if (Session.AccessLevel == AccessLevel.Sentinel)
+                //    character.IsSentinel = true;
+                //if (Session.AccessLevel == AccessLevel.Advocate)
+                //    character.IsAdvocate= true;
+            }
+
             Position = character.Position;
             IsOnline = true;
 


### PR DESCRIPTION
Improved best of both worlds scenario.

Server operators have the choice to emulate access permissions via more complicated system used on official worlds or they can choose to use simplified account based permissions which would become the default install option for ACEmulator.