### PR TITLE
Add in support for the old global Admin channels

### DIFF
--- a/Source/ACE.Entity/Enum/ChatMessageType.cs
+++ b/Source/ACE.Entity/Enum/ChatMessageType.cs
@@ -35,10 +35,22 @@ namespace ACE.Entity.Enum
         /// 
         /// The Mana Stone gives 3,123 points of mana to the following items: Frigid Bracelet, Silifi of Crimson Night, Tunic, Sleeves of Inexhaustibility, Breeches
         /// You need 3,640 more mana to fully charge your items.
+        /// 
+        /// LogTextTypeEnumMapper: Default
         /// </summary>
         Broadcast           = 0x00,
 
-        PublicChat          = 0x02,
+        /// <summary>
+        /// Green Text - No idea what this does, It's not labeled but is handled in the client????
+        /// 
+        /// LogTextTypeEnumMapper: ????
+        /// </summary>
+        x01                 = 0x01,
+
+        /// <summary>
+        /// LogTextTypeEnumMapper: Speech
+        /// </summary>
+        Speech              = 0x02,
 
         /// <summary>
         /// 
@@ -46,26 +58,34 @@ namespace ACE.Entity.Enum
         /// Buff Dude has added you to their home's guest list.  You now have access to their home.,
         /// Buff Dude has granted you access to their home's storage.,
         /// Buff DudeRipley has removed all house guests, including yourself.,
+        /// 
+        /// LogTextTypeEnumMapper: Tell
         /// </summary>
-        PrivateTell         = 0x03,
+        Tell                = 0x03,
 
         /// <summary>
         /// You tell ...
+        /// 
+        /// LogTextTypeEnumMapper: Speech_Direct_Send
         /// </summary>
         OutgoingTell        = 0x04,
 
         /// <summary>
         /// Warning!  You have not paid your maintenance costs for the last 30 day maintenance period.  Please pay these costs by this deadline or you will lose your house, and all your items within it.
         /// Some Guy has discovered the Wayfarer's Pearl!
+        /// 
+        /// LogTextTypeEnumMapper: System
         /// </summary>
-        x05                 = 0x05,
+        System              = 0x05,
 
         /// <summary>
         /// You receive 18 points of periodic nether damage.
         /// You suffer 4 points of minor impact damage.
         /// Dirty Fighting! Big Guy delivers a Unbalancing Blow to Armored Tusker!,
+        /// 
+        /// LogTextTypeEnumMapper: Combat
         /// </summary>
-        x06                 = 0x06,
+        Combat              = 0x06,
 
         /// <summary>
         /// Prismatic Amuli Leggings cast Epic Quickness on you
@@ -73,24 +93,35 @@ namespace ACE.Entity.Enum
         /// You resist the spell cast by Someone
         /// Some Guy tried and failed to cast a spell at you!
         /// You cast Incantation of Revitalize Self and restore 172 points of your stamina.
+        /// 
+        /// LogTextTypeEnumMapper: Magic
         /// </summary>
-        MagicSpellResults   = 0x07,
+        Magic                = 0x07,
 
         /// <summary>
-        /// Light Pink Text - One or both of the following two was associated with the following channels: admin, audit, av1, av2, av3, sentinel
+        /// Light Pink Text - Both of the following two were associated with the following channels: admin, audit, av1, av2, av3, sentinel
         /// output: You say on the [channel name] channel, "message here"
+        /// 
+        /// LogTextTypeEnumMapper: Channel
         /// </summary>
-        OutgoingAdminSay    = 0x08, // I'm picking this one to represent the You say Light pink (originally called x08) -Ripley
-        x09                 = 0x09,
+        Channel             = 0x08,
+                
+        /// <summary>
+        /// LogTextTypeEnumMapper: Channel_Send
+        /// </summary>
+        ChannelSend         = 0x09,
 
         /// <summary>
-        /// Bright Yellow Text - Unknown purpose/filter?
+        /// Bright Yellow Text
+        /// LogTextTypeEnumMapper: Social
         /// </summary>
-        x0A                 = 0x0A,
+        Social              = 0x0A,
+
         /// <summary>
-        /// Light Yellow Text - Unknown purpose/filter?
+        /// Light Yellow Text
+        /// LogTextTypeEnumMapper: Social_Send
         /// </summary>
-        x0B                 = 0x0B,
+        SocialSend          = 0x0B,
 
         /// <summary>
         /// Via 0x02BB:
@@ -114,8 +145,10 @@ namespace ACE.Entity.Enum
         /// Have you a drudge charm, swamp stone, rat tail, or such? I'll pay you good money or items if you give them to me. They're hard to come by.
         /// Have you the skins of armoredillos, gromnies, or reedsharks?  I can use them in my craft.
         /// Damnable Mukkir...  They get everywhere...
+        /// 
+        /// LogTextTypeEnumMapper: Emote
         /// </summary>
-        NPCChat             = 0x0C,
+        Emote               = 0x0C,
 
         /// <summary>
         /// You are now level 5!
@@ -124,24 +157,32 @@ namespace ACE.Entity.Enum
         /// You are now level 68!
         /// You have 100,647,873 experience points and 3 skill credits available to raise skills and attributes.
         /// You will earn another skill credit at level 70.,
+        /// 
+        /// LogTextTypeEnumMapper: Advancement
         /// </summary>
-        LevelAndSkills      = 0x0D,
+        Advancement         = 0x0D,
 
         /// <summary>
         /// Light Cyan (skyblue?) Text - Would seem to be associated with the following channel: Abuse
         /// output: You say on the Abuse channel, "message here"
+        /// 
+        /// LogTextTypeEnumMapper: Abuse
         /// </summary>
-        OutgoingAbuseSay    = 0x0E, // I'm picking this one to represent the You say Light cyan (originally called x0E) -Ripley
+        Abuse               = 0x0E,
 
         /// <summary>
-        /// Red Text - Unknown purpose/filter? Possibly OutgoingHelpSay, not even sure if that showed up on the client when you sent out an urgent help command
+        /// Red Text - Possibly OutgoingHelpSay, not even sure if that showed up on the client when you sent out an urgent help command
+        /// 
+        /// LogTextTypeEnumMapper: Help
         /// </summary>
-        x0F                 = 0x0F,
+        Help                = 0x0F,
 
         /// <summary>
         /// Mr Sneaky tried and failed to assess you!
+        /// 
+        /// LogTextTypeEnumMapper: Appraisal
         /// </summary>
-        CreatureAssess      = 0x10,
+        Appraisal           = 0x10,
 
         /// <summary>
         /// Via 02BB:
@@ -151,52 +192,72 @@ namespace ACE.Entity.Enum
         /// Via F7E0:
         /// Aetheria surges on Pyreal Target Drudge with the power of Surge of Affliction!
         /// The cloak of Some Guy weaves the magic of Cloaked in Skill!
+        /// 
+        /// LogTextTypeEnumMapper: Spellcasting
         /// </summary>
-        PlayerSpellcasting  = 0x11,
+        Spellcasting        = 0x11,
 
         /// <summary>
         /// Fellow warriors, aid me!
+        /// 
+        /// LogTextTypeEnumMapper: Allegiance
         /// </summary>
-        CreatureChat        = 0x12,
+        Allegiance           = 0x12,
 
         /// <summary>
-        /// Bright Yellow Text - Unknown purpose/filter?
+        /// Bright Yellow Text
+        /// 
+        /// LogTextTypeEnumMapper: Fellowship
         /// </summary>
-        x13                 = 0x13,
-        
-        /// <summary>
-        /// Green Text - Unknown purpose/filter?
-        /// </summary>
-        x14                 = 0x14,
+        Fellowship           = 0x13,
 
         /// <summary>
-        /// Red Text - Would seem to be associated with the following channels: help
-        /// output: PlayerName says on the [channel name] channel, "message here"
+        /// Green Text
+        /// 
+        /// LogTextTypeEnumMapper: World_Broadcast
         /// </summary>
-        IncomingHelpSay     = 0x15, // I'm picking this one to represent the SoinSo says on.. red text because it is near AdminSay (originally called x15) -Ripley
+        WorldBroadcast      = 0x14,
 
         /// <summary>
-        /// Pink Text - Would seem to be associated with the following channels: admin, audit, av1, av2, av3, sentinel
-        /// output: PlayerName says on the [channel name] channel, "message here"
+        /// Red Text
+        /// 
+        /// LogTextTypeEnumMapper: Combat_Enemy
         /// </summary>
-        IncomingAdminSay    = 0x16, // I'm picking this one to represent the SoinSo says on.. pink text because it is double x08 (originally called x16) -Ripley
+        CombatEnemy         = 0x15,
+
+        /// <summary>
+        /// Pink Text
+        /// 
+        /// LogTextTypeEnumMapper: Combat_Self
+        /// </summary>
+        CombatSelf          = 0x16,
 
         /// <summary>
         /// Player is recalling home.
+        /// 
+        /// LogTextTypeEnumMapper: Recall
         /// </summary>
         Recall              = 0x17,
 
         /// <summary>
         /// Super Tink fails to apply the Fire Opal Salvage (workmanship 10.00) to the White Sapphire Fire Baton. The target is destroyed.
         /// Super Tink successfully applies the Steel Salvage (workmanship 10.00) to the Silver Signet Crown.,
+        /// 
+        /// LogTextTypeEnumMapper: Craft
         /// </summary>
-        Tinkering           = 0x18,
+        Craft               = 0x18,
 
 
         /// <summary>
-        /// Green Text - Unknown purpose/filter?
+        /// Green Text
+        /// LogTextTypeEnumMapper: Salvaging
         /// </summary>
-        x19                 = 0x19,
+        Salvaging           = 0x19,
+
+        /// <summary>
+        /// Light cyan(sky blue) - Unknown purpose/filter?
+        /// </summary>
+        x1A                 = 0x1A,
 
         /// <summary>
         /// Light cyan(sky blue) - Unknown purpose/filter?
@@ -206,14 +267,15 @@ namespace ACE.Entity.Enum
         x1D                 = 0x1D,
 
         /// <summary>
-        /// Light Cyan (skyblue?) Text - Would seem to be associated with the following channel: Abuse
-        /// output: PlayerName says on the Abuse channel, "message here"
+        /// Light Cyan (skyblue?) Text - Unknown purpose/filter?
         /// </summary>
-        IncomingAbuseSay    = 0x1E, // I'm picking this one to represent the SoinSo says on.. light cyan text because it is double x0E (originally called x1E) -Ripley
+        x1E                 = 0x1E, 
 
         /// <summary>
-        /// Bright Yellow Text - Unknown purpose/filter?
+        /// Bright Yellow Text
+        /// 
+        /// Admin_Tell
         /// </summary>
-        x1F                 = 0x1F,
+        AdminTell           = 0x1F,
     }
 }

--- a/Source/ACE.Entity/Enum/ChatMessageType.cs
+++ b/Source/ACE.Entity/Enum/ChatMessageType.cs
@@ -255,9 +255,10 @@ namespace ACE.Entity.Enum
         Salvaging           = 0x19,
 
         /// <summary>
-        /// Light cyan(sky blue) - Unknown purpose/filter?
+        /// Does Nothing - Unknown purpose/filter?
+        /// Client doesn't display it. Commenting out because why offer it as an option?
         /// </summary>
-        x1A                 = 0x1A,
+        //x1A                 = 0x1A,
 
         /// <summary>
         /// Light cyan(sky blue) - Unknown purpose/filter?

--- a/Source/ACE.Entity/Enum/ChatMessageType.cs
+++ b/Source/ACE.Entity/Enum/ChatMessageType.cs
@@ -275,7 +275,7 @@ namespace ACE.Entity.Enum
         /// <summary>
         /// Bright Yellow Text
         /// 
-        /// Admin_Tell
+        /// LogTextTypeEnumMapper: Admin_Tell
         /// </summary>
         AdminTell           = 0x1F,
     }

--- a/Source/ACE.Entity/Enum/ChatMessageType.cs
+++ b/Source/ACE.Entity/Enum/ChatMessageType.cs
@@ -77,6 +77,22 @@ namespace ACE.Entity.Enum
         MagicSpellResults   = 0x07,
 
         /// <summary>
+        /// Light Pink Text - One or both of the following two was associated with the following channels: admin, audit, av1, av2, av3, sentinel
+        /// output: You say on the [channel name] channel, "message here"
+        /// </summary>
+        OutgoingAdminSay    = 0x08, // I'm picking this one to represent the You say Light pink (originally called x08) -Ripley
+        x09                 = 0x09,
+
+        /// <summary>
+        /// Bright Yellow Text - Unknown purpose/filter?
+        /// </summary>
+        x0A                 = 0x0A,
+        /// <summary>
+        /// Light Yellow Text - Unknown purpose/filter?
+        /// </summary>
+        x0B                 = 0x0B,
+
+        /// <summary>
         /// Via 0x02BB:
         /// All's quiet on this front!Enum_000C = 0x000C 
         /// Lemme alone.  And keep my door closed!
@@ -112,6 +128,17 @@ namespace ACE.Entity.Enum
         LevelAndSkills      = 0x0D,
 
         /// <summary>
+        /// Light Cyan (skyblue?) Text - Would seem to be associated with the following channel: Abuse
+        /// output: You say on the Abuse channel, "message here"
+        /// </summary>
+        OutgoingAbuseSay    = 0x0E, // I'm picking this one to represent the You say Light cyan (originally called x0E) -Ripley
+
+        /// <summary>
+        /// Red Text - Unknown purpose/filter? Possibly OutgoingHelpSay, not even sure if that showed up on the client when you sent out an urgent help command
+        /// </summary>
+        x0F                 = 0x0F,
+
+        /// <summary>
         /// Mr Sneaky tried and failed to assess you!
         /// </summary>
         CreatureAssess      = 0x10,
@@ -125,12 +152,34 @@ namespace ACE.Entity.Enum
         /// Aetheria surges on Pyreal Target Drudge with the power of Surge of Affliction!
         /// The cloak of Some Guy weaves the magic of Cloaked in Skill!
         /// </summary>
-        PlayerSpellcasting = 0x11,
+        PlayerSpellcasting  = 0x11,
 
         /// <summary>
         /// Fellow warriors, aid me!
         /// </summary>
         CreatureChat        = 0x12,
+
+        /// <summary>
+        /// Bright Yellow Text - Unknown purpose/filter?
+        /// </summary>
+        x13                 = 0x13,
+        
+        /// <summary>
+        /// Green Text - Unknown purpose/filter?
+        /// </summary>
+        x14                 = 0x14,
+
+        /// <summary>
+        /// Red Text - Would seem to be associated with the following channels: help
+        /// output: PlayerName says on the [channel name] channel, "message here"
+        /// </summary>
+        IncomingHelpSay     = 0x15, // I'm picking this one to represent the SoinSo says on.. red text because it is near AdminSay (originally called x15) -Ripley
+
+        /// <summary>
+        /// Pink Text - Would seem to be associated with the following channels: admin, audit, av1, av2, av3, sentinel
+        /// output: PlayerName says on the [channel name] channel, "message here"
+        /// </summary>
+        IncomingAdminSay    = 0x16, // I'm picking this one to represent the SoinSo says on.. pink text because it is double x08 (originally called x16) -Ripley
 
         /// <summary>
         /// Player is recalling home.
@@ -142,5 +191,29 @@ namespace ACE.Entity.Enum
         /// Super Tink successfully applies the Steel Salvage (workmanship 10.00) to the Silver Signet Crown.,
         /// </summary>
         Tinkering           = 0x18,
+
+
+        /// <summary>
+        /// Green Text - Unknown purpose/filter?
+        /// </summary>
+        x19                 = 0x19,
+
+        /// <summary>
+        /// Light cyan(sky blue) - Unknown purpose/filter?
+        /// </summary>
+        x1B                 = 0x1B,
+        x1C                 = 0x1C,
+        x1D                 = 0x1D,
+
+        /// <summary>
+        /// Light Cyan (skyblue?) Text - Would seem to be associated with the following channel: Abuse
+        /// output: PlayerName says on the Abuse channel, "message here"
+        /// </summary>
+        IncomingAbuseSay    = 0x1E, // I'm picking this one to represent the SoinSo says on.. light cyan text because it is double x0E (originally called x1E) -Ripley
+
+        /// <summary>
+        /// Bright Yellow Text - Unknown purpose/filter?
+        /// </summary>
+        x1F                 = 0x1F,
     }
 }

--- a/Source/ACE.Entity/Enum/GroupChatType.cs
+++ b/Source/ACE.Entity/Enum/GroupChatType.cs
@@ -10,6 +10,48 @@ namespace ACE.Entity.Enum
     public enum GroupChatType
     {
         /// <summary>
+        /// @abuse - Abuse Channel
+        /// </summary>
+        TellAbuse           = 0x00000001,
+
+        /// <summary>
+        /// @admin - Admin Channel (@ad)
+        /// </summary>
+        TellAdmin           = 0x00000002,
+
+        /// <summary>
+        /// @audit - Audit Channel (@au)
+        /// This channel was used to echo copies of enforcement commands (such as: ban, gag, boot) to all other online admins
+        /// </summary>
+        TellAudit           = 0x00000004,
+
+        /// <summary>
+        /// @av1 - Advocate Channel (@advocate) (@advocate1)
+        /// </summary>
+        TellAdvocate        = 0x00000008,
+
+        /// <summary>
+        /// @av2 - Advocate2 Channel (@advocate2)
+        /// </summary>
+        TellAdvocate2       = 0x00000010,
+
+        /// <summary>
+        /// @av3 - Advocate3 Channel (@advocate3)
+        /// </summary>
+        TellAdvocate3       = 0x000000020,
+
+        /// <summary>
+        /// @sent - Sentinel Channel (@sentinel)
+        /// </summary>
+        TellSentinel        = 0x000000200,
+
+        /// <summary>
+        /// @[command name tbd] - Help Channel
+        /// </summary>
+        TellHelp            = 0x000000400,
+
+
+        /// <summary>
         /// @f - Tell Fellowship
         /// </summary>
         TellFellowship      = 0x00000800,

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Network\GameEvent\Events\GameEventTell.cs" />
     <Compile Include="Network\GameEvent\Events\GameEventUpdateTitle.cs" />
     <Compile Include="Network\GameEvent\GameEventMessage.cs" />
+    <Compile Include="Network\GameEvent\GameEventOpcode.cs" />
     <Compile Include="Network\GameEvent\GameEventType.cs" />
     <Compile Include="Network\GameMessages\GameMessage.cs" />
     <Compile Include="Network\GameMessages\GameMessageAttribute.cs" />
@@ -161,6 +162,7 @@
     <Compile Include="Network\GameMessages\Messages\GameMessageEffect.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageEmoteText.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateAbility.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateBool.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdatePropertyInt64.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateSkill.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateVital.cs" />

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -100,12 +100,16 @@
     <Compile Include="Network\Enum\Sound.cs" />
     <Compile Include="Network\Enum\UpdatePositionFlag.cs" />
     <Compile Include="Network\Enum\Vital.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionAddChannel.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAddFriend.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAdvocateTeleport.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAllegianceUpdateRequest.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionChannelIndex.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionChannelList.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionChatChannel.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionIdentifyObject.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionRemoveAllFriends.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionRemoveChannel.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionSetSingleCharacterOption.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionAutonomousPosition.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionEmote.cs" />
@@ -130,6 +134,9 @@
     <Compile Include="Network\GameAction\Actions\GameActionMoveToState.cs" />
     <Compile Include="Network\GameAction\GameActionPacket.cs" />
     <Compile Include="Network\GameEvent\Events\GameEventAllegianceUpdate.cs" />
+    <Compile Include="Network\GameEvent\Events\GameEventChannelBroadcast.cs" />
+    <Compile Include="Network\GameEvent\Events\GameEventChannelIndex.cs" />
+    <Compile Include="Network\GameEvent\Events\GameEventChannelList.cs" />
     <Compile Include="Network\GameEvent\Events\GameEventDisplayParameterizedStatusMessage.cs" />
     <Compile Include="Network\GameEvent\Events\GameEventCharacterTitle.cs" />
     <Compile Include="Network\GameEvent\Events\GameEventDisplayStatusMessage.cs" />

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -13,6 +13,25 @@ namespace ACE.Command.Handlers
 {
     public static class DebugCommands
     {
+        // echo "text to send back to yourself" [ChatMessageType]
+        [CommandHandler("echo", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        public static void HandleDebugEcho(Session session, params string[] parameters)
+        {
+            try
+            {
+                ChatMessageType cmt = ChatMessageType.Broadcast;
+                if (Enum.TryParse(parameters[1], true, out cmt))
+                    if (Enum.IsDefined(typeof(ChatMessageType), cmt))
+                        ChatPacket.SendServerMessage(session, parameters[0], cmt);
+                    else
+                        ChatPacket.SendServerMessage(session, parameters[0], ChatMessageType.Broadcast);
+            }
+            catch (Exception)
+            {
+                ChatPacket.SendServerMessage(session, parameters[0], ChatMessageType.Broadcast);
+            }
+        }
+
         // gps
         [CommandHandler("gps", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
         public static void HandleDebugGPS(Session session, params string[] parameters)

--- a/Source/ACE/Network/GameAction/Actions/GameActionAddChannel.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionAddChannel.cs
@@ -1,0 +1,29 @@
+﻿
+using ACE.Common.Extensions;
+using ACE.Entity;
+using ACE.Entity.Enum;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.AddChannel)]
+    public class GameActionAddChannel : GameActionPacket
+    {
+        private GroupChatType chatChannelID;
+
+        public GameActionAddChannel(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        public override void Read()
+        {
+            chatChannelID = (GroupChatType)Fragment.Payload.ReadUInt32();
+        }
+
+        public override void Handle()
+        {
+            // Probably need some IsAdvocate and IsSentinel type thing going on here as well. leaving for now
+            if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
+                return;
+
+            //TODO: Subscribe to channel (chatChannelID) and save to db. Channel subscriptions are meant to persist between sessions.
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/Actions/GameActionChannelIndex.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChannelIndex.cs
@@ -25,7 +25,7 @@ namespace ACE.Network.GameAction.Actions
             if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
                 return;
 
-            NetworkManager.SendWorldMessage(Session, new GameEventChannelIndex(Session));
+            Session.WorldSession.EnqueueSend(new GameEventChannelIndex(Session));
         }
     }
 }

--- a/Source/ACE/Network/GameAction/Actions/GameActionChannelIndex.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChannelIndex.cs
@@ -1,0 +1,31 @@
+﻿
+using ACE.Common.Extensions;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Network.GameEvent.Events;
+using ACE.Network.Managers;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.IndexChannels)]
+    public class GameActionChannelIndex : GameActionPacket
+    {
+        //private GroupChatType chatChannelID;
+
+        public GameActionChannelIndex(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        //public override void Read()
+        //{
+        //    chatChannelID = (GroupChatType)Fragment.Payload.ReadUInt32();
+        //}
+
+        public override void Handle()
+        {
+            // Probably need some IsAdvocate and IsSentinel type thing going on here as well. leaving for now
+            if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
+                return;
+
+            NetworkManager.SendWorldMessage(Session, new GameEventChannelIndex(Session));
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/Actions/GameActionChannelList.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChannelList.cs
@@ -25,7 +25,7 @@ namespace ACE.Network.GameAction.Actions
             if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
                 return;
 
-            NetworkManager.SendWorldMessage(Session, new GameEventChannelList(Session, chatChannelID));
+            Session.WorldSession.EnqueueSend(new GameEventChannelList(Session, chatChannelID));
         }
     }
 }

--- a/Source/ACE/Network/GameAction/Actions/GameActionChannelList.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChannelList.cs
@@ -1,0 +1,31 @@
+﻿
+using ACE.Common.Extensions;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Network.GameEvent.Events;
+using ACE.Network.Managers;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.ListChannels)]
+    public class GameActionChannelList : GameActionPacket
+    {
+        private GroupChatType chatChannelID;
+
+        public GameActionChannelList(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        public override void Read()
+        {
+            chatChannelID = (GroupChatType)Fragment.Payload.ReadUInt32();
+        }
+
+        public override void Handle()
+        {
+            // Probably need some IsAdvocate and IsSentinel type thing going on here as well. leaving for now
+            if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
+                return;
+
+            NetworkManager.SendWorldMessage(Session, new GameEventChannelList(Session, chatChannelID));
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -2,6 +2,7 @@
 
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
+using ACE.Managers;
 using ACE.Network.GameEvent.Events;
 using ACE.Network.GameMessages;
 using ACE.Network.Managers;
@@ -26,6 +27,136 @@ namespace ACE.Network.GameAction.Actions
         {
             switch (groupChatType)
             {
+                case GroupChatType.TellAbuse:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character with AccessLevel.Advocate or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellAdmin:
+                    {
+                        if (!Session.Player.IsAdmin)
+                            break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                        //NetworkManager.SendWorldMessage(recipient, gameMessageSystemChat);
+                    }
+                    break;
+                case GroupChatType.TellAudit:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character AccessLevel.Sentinel or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellAdvocate:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character AccessLevel.Advocate or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellAdvocate2:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character AccessLevel.Advocate or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellAdvocate3:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character AccessLevel.Advocate or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellSentinel:
+                    {
+                        //TODO: Proper permissions check. This command should work for any character with AccessLevel.Sentinel or higher
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                            else
+                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+                case GroupChatType.TellHelp:
+                    {
+                        ChatPacket.SendServerMessage(Session, "GameActionChatChannel TellHelp Needs work.", ChatMessageType.Broadcast);
+                        //TODO: I don't remember exactly how this was triggered. I don't think it sent back a "You say" message to the person who triggered it
+                        //TODO: Proper permissions check. Requesting urgent help should work for any character but only displays the "says" mesage for those subscribed to the Help channel
+                        //      which would be Advocates and above.
+                        //if (!Session.Player.IsAdmin)
+                        //    break;
+                        string onTheWhatChannel = "on the " + System.Enum.GetName(typeof(GroupChatType), groupChatType).Replace("Tell", "") + " channel";
+                        string whoSays = Session.Player.Name + " says ";
+
+                        //ChatPacket.SendServerMessage(Session, $"You say {onTheWhatChannel}, \"{message}\"", ChatMessageType.OutgoingHelpSay);
+
+                        var gameMessageSystemChat = new GameMessages.Messages.GameMessageSystemChat(whoSays + onTheWhatChannel + ", \"" + message + "\"", ChatMessageType.IncomingHelpSay);
+
+                        // TODO This should check if the recipient is subscribed to the channel
+                        foreach (var recipient in WorldManager.GetAll())
+                            if (recipient != Session)
+                                NetworkManager.SendWorldMessage(recipient, gameMessageSystemChat);
+
+                        // again not sure what way to go with this.. the code below was added after I realized I should be handling things differently
+                        // and by handling differently I mean letting the client do all of the work it was already designed to do.
+                        
+                        //foreach (var recipient in WorldManager.GetAll())
+                        //    if (recipient != Session)
+                        //        NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                        //    else
+                        //        NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                    }
+                    break;
+
+
                 case GroupChatType.TellFellowship:
                     {
                         var statusMessage = new GameEventDisplayStatusMessage(Session, StatusMessageType1.YouDoNotBelongToAFellowship);

--- a/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -36,9 +36,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellAdmin:
@@ -49,9 +49,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                         //NetworkManager.SendWorldMessage(recipient, gameMessageSystemChat);
                     }
                     break;
@@ -64,9 +64,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellAdvocate:
@@ -78,9 +78,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellAdvocate2:
@@ -92,9 +92,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellAdvocate3:
@@ -106,9 +106,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellSentinel:
@@ -120,9 +120,9 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, Session.Player.Name, message));
                             else
-                                NetworkManager.SendWorldMessage(recipient, new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
+                                Session.WorldSession.EnqueueSend(new GameEvent.Events.GameEventChannelBroadcast(recipient, groupChatType, "", message));
                     }
                     break;
                 case GroupChatType.TellHelp:
@@ -143,7 +143,7 @@ namespace ACE.Network.GameAction.Actions
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())
                             if (recipient != Session)
-                                NetworkManager.SendWorldMessage(recipient, gameMessageSystemChat);
+                                Session.WorldSession.EnqueueSend(gameMessageSystemChat);
 
                         // again not sure what way to go with this.. the code below was added after I realized I should be handling things differently
                         // and by handling differently I mean letting the client do all of the work it was already designed to do.

--- a/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionChatChannel.cs
@@ -138,7 +138,7 @@ namespace ACE.Network.GameAction.Actions
 
                         //ChatPacket.SendServerMessage(Session, $"You say {onTheWhatChannel}, \"{message}\"", ChatMessageType.OutgoingHelpSay);
 
-                        var gameMessageSystemChat = new GameMessages.Messages.GameMessageSystemChat(whoSays + onTheWhatChannel + ", \"" + message + "\"", ChatMessageType.IncomingHelpSay);
+                        var gameMessageSystemChat = new GameMessages.Messages.GameMessageSystemChat(whoSays + onTheWhatChannel + ", \"" + message + "\"", ChatMessageType.Help);
 
                         // TODO This should check if the recipient is subscribed to the channel
                         foreach (var recipient in WorldManager.GetAll())

--- a/Source/ACE/Network/GameAction/Actions/GameActionRemoveChannel.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionRemoveChannel.cs
@@ -1,0 +1,29 @@
+﻿
+using ACE.Common.Extensions;
+using ACE.Entity;
+using ACE.Entity.Enum;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionOpcode.RemoveChannel)]
+    public class GameActionRemoveChannel : GameActionPacket
+    {
+        private GroupChatType chatChannelID;
+
+        public GameActionRemoveChannel(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+
+        public override void Read()
+        {
+            chatChannelID = (GroupChatType)Fragment.Payload.ReadUInt32();
+        }
+
+        public override void Handle()
+        {
+            // Probably need some IsAdvocate and IsSentinel type thing going on here as well. leaving for now
+            if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
+                return;
+
+            //TODO: Unsubscribe from channel (chatChannelID) and save to db. Channel subscriptions are meant to persist between sessions.
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/Actions/GameActionTalk.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionTalk.cs
@@ -58,7 +58,7 @@ namespace ACE.Network.GameAction.Actions
             }
             else
             {
-                var creatureMessage = new GameMessageCreatureMessage(message, Session.Player.Name, Session.Player.Guid.Full, ChatMessageType.PublicChat);
+                var creatureMessage = new GameMessageCreatureMessage(message, Session.Player.Name, Session.Player.Guid.Full, ChatMessageType.Speech);
 
                 // TODO: This needs to be changed to a different method. GetByRadius or GetNear, however we decide to do proximity updates...
                 var targets = WorldManager.GetAll();

--- a/Source/ACE/Network/GameAction/Actions/GameActionTell.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionTell.cs
@@ -37,7 +37,7 @@ namespace ACE.Network.GameAction.Actions
                 if (Session.Player != targetSession.Player)
                     ChatPacket.SendServerMessage(Session, $"You tell {target}, \"'{message}'\"", ChatMessageType.OutgoingTell);
 
-                var tell = new GameEventTell(targetSession, message, Session.Player.Name, Session.Player.Guid.Full, targetSession.Player.Guid.Full, ChatMessageType.PrivateTell);
+                var tell = new GameEventTell(targetSession, message, Session.Player.Name, Session.Player.Guid.Full, targetSession.Player.Guid.Full, ChatMessageType.Tell);
                 targetSession.WorldSession.EnqueueSend(tell);
             }
         }

--- a/Source/ACE/Network/GameAction/GameActionOpcode.cs
+++ b/Source/ACE/Network/GameAction/GameActionOpcode.cs
@@ -18,7 +18,12 @@ namespace ACE.Network.GameAction
         IdentifyObject              = 0x00C8,
         AdvocateTeleport            = 0x00D6,
 
+        AddChannel                  = 0x0145,
+        RemoveChannel               = 0x0146,
         ChatChannel                 = 0x0147,
+        ListChannels                = 0x0148,
+        IndexChannels               = 0x0149,
+
         Emote                       = 0x01E1,
         PingRequest                 = 0x01E9,
 

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelBroadcast.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelBroadcast.cs
@@ -5,7 +5,7 @@ namespace ACE.Network.GameEvent.Events
 {
     public class GameEventChannelBroadcast : GameEventMessage
     {
-        public GameEventChannelBroadcast(Session session, GroupChatType chatChannel, string senderName, string messageText) : base(GameEventType.ChannelBroadcast, session)
+        public GameEventChannelBroadcast(Session session, GroupChatType chatChannel, string senderName, string messageText) : base(GameEventType.ChannelBroadcast, GameMessageGroup.Group09, session)
         {
             Writer.Write((uint)chatChannel);
             Writer.WriteString16L(senderName); // This should be "" when sending back to initiator which makes client go "You Say..." instead of "PlayerName says..."

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelBroadcast.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelBroadcast.cs
@@ -1,0 +1,16 @@
+﻿
+using ACE.Entity.Enum;
+
+namespace ACE.Network.GameEvent.Events
+{
+    public class GameEventChannelBroadcast : GameEventMessage
+    {
+        public GameEventChannelBroadcast(Session session, GroupChatType chatChannel, string senderName, string messageText) : base(GameEventType.ChannelBroadcast, session)
+        {
+            Writer.Write((uint)chatChannel);
+            Writer.WriteString16L(senderName); // This should be "" when sending back to initiator which makes client go "You Say..." instead of "PlayerName says..."
+            Writer.WriteString16L(messageText);
+        }
+    }
+}
+

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelIndex.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelIndex.cs
@@ -7,7 +7,7 @@ namespace ACE.Network.GameEvent.Events
 {
     public class GameEventChannelIndex : GameEventMessage
     {
-        public GameEventChannelIndex(Session session) : base(GameEventType.ChannelIndex, session)
+        public GameEventChannelIndex(Session session) : base(GameEventType.ChannelIndex, GameMessageGroup.Group09, session)
         {
             WriteEventBody();
         }

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelIndex.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelIndex.cs
@@ -1,0 +1,68 @@
+﻿
+using ACE.Entity;
+using ACE.Entity.Enum;
+using System.Collections.Generic;
+
+namespace ACE.Network.GameEvent.Events
+{
+    public class GameEventChannelIndex : GameEventMessage
+    {
+        public GameEventChannelIndex(Session session) : base(GameEventType.ChannelIndex, session)
+        {
+            WriteEventBody();
+        }
+
+        private void WriteEventBody()
+        {
+
+            //TODO: this probably could be done better but I'm not sure if there's a point, it's not like the client out of the box supports making up new channels
+
+            //Admin
+            //Abuse
+            //Audit
+            //Av1
+            //Av2
+            //Av3
+            //Sentinel
+            //Help
+
+            //uint channelCount = 0;
+
+            if (Session.Player.IsAdmin)
+            {
+                Writer.Write(8u);
+                Writer.WriteString16L("Abuse");
+                Writer.WriteString16L("Admin");
+                Writer.WriteString16L("Audit");
+                Writer.WriteString16L("Av1");
+                Writer.WriteString16L("Av2");
+                Writer.WriteString16L("Av3");
+                Writer.WriteString16L("Sentinel");
+                Writer.WriteString16L("Help");
+            }
+
+            if (Session.Player.IsArch || Session.Player.IsEnvoy || Session.Player.IsPsr)
+            {
+                Writer.Write(7u);
+                Writer.WriteString16L("Abuse");
+                Writer.WriteString16L("Audit");
+                Writer.WriteString16L("Av1");
+                Writer.WriteString16L("Av2");
+                Writer.WriteString16L("Av3");
+                Writer.WriteString16L("Sentinel");
+                Writer.WriteString16L("Help");
+            }
+
+            //TODO: Needs an IsAdvocate thing to work like it should
+            //if (Session.Player.IsAdvocate)
+            //{
+            //    Writer.Write(5u);
+            //    Writer.WriteString16L("Abuse");
+            //    Writer.WriteString16L("Av1");
+            //    Writer.WriteString16L("Av2");
+            //    Writer.WriteString16L("Av3");
+            //    Writer.WriteString16L("Help");
+            //}
+        }
+    }
+}

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelList.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelList.cs
@@ -1,0 +1,34 @@
+﻿
+using ACE.Entity.Enum;
+using ACE.Managers;
+using ACE.Network.Managers;
+using System.Collections.Generic;
+
+namespace ACE.Network.GameEvent.Events
+{
+    public class GameEventChannelList : GameEventMessage
+    {
+        public GameEventChannelList(Session session, GroupChatType chatChannel) : base(GameEventType.ChannelList, session)
+        {
+            //TODO: This should send back to the client a correct count followed by name strings of the channel requested.
+            //      Obviously this would be based on who was subscribed to the channel at the time
+
+            //Writer.Write(1u);
+            //Writer.WriteString16L("+Sentinel Nostromo");
+
+            // For now, since everyone is subscribed and unable to alter, let's just list every character connected.
+            uint numClientsConnected = 0;
+            List<string> playerNames = new List<string>();
+            foreach (var client in WorldManager.GetAll())
+            {
+                numClientsConnected++;
+                playerNames.Add(client.Player.Name);
+            }
+
+            Writer.Write(numClientsConnected);
+            foreach (var name in playerNames.ToArray())
+                Writer.WriteString16L(name);
+
+        }
+    }
+}

--- a/Source/ACE/Network/GameEvent/Events/GameEventChannelList.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventChannelList.cs
@@ -8,7 +8,7 @@ namespace ACE.Network.GameEvent.Events
 {
     public class GameEventChannelList : GameEventMessage
     {
-        public GameEventChannelList(Session session, GroupChatType chatChannel) : base(GameEventType.ChannelList, session)
+        public GameEventChannelList(Session session, GroupChatType chatChannel) : base(GameEventType.ChannelList, GameMessageGroup.Group09, session)
         {
             //TODO: This should send back to the client a correct count followed by name strings of the channel requested.
             //      Obviously this would be based on who was subscribed to the channel at the time

--- a/Source/ACE/Network/GameEvent/GameEventType.cs
+++ b/Source/ACE/Network/GameEvent/GameEventType.cs
@@ -3,22 +3,26 @@ namespace ACE.Network.GameEvent
 {
     public enum GameEventType
     {
-        PopupString                     = 0x0004,
-        PlayerDescription               = 0x0013,
-        AllegianceUpdate                = 0x0020,
-        FriendsListUpdate               = 0x0021,
-        CharacterTitle                  = 0x0029,
-        UpdateTitle                     = 0x002B,
+        PopupString                         = 0x0004,
+        PlayerDescription                   = 0x0013,
+        AllegianceUpdate                    = 0x0020,
+        FriendsListUpdate                   = 0x0021,
+        CharacterTitle                      = 0x0029,
+        UpdateTitle                         = 0x002B,
 
-        IdentifyObjectResponse          = 0x00C9,
+        IdentifyObjectResponse              = 0x00C9,
 
-        Emote                           = 0x01E2,
-        PingResponse                    = 0x01EA,
+        ChannelBroadcast                    = 0x0147,
+        ChannelList                         = 0x0148,
+        ChannelIndex                        = 0x0149,
 
-        HouseStatus                     = 0x0226,
-        DisplayStatusMessage            = 0x028A,
-        DisplayParameterizedStatusMessage = 0x028B,
-        SetTurbineChatChannels          = 0x0295,
-        Tell                            = 0x02BD
+        Emote                               = 0x01E2,
+        PingResponse                        = 0x01EA,
+
+        HouseStatus                         = 0x0226,
+        DisplayStatusMessage                = 0x028A,
+        DisplayParameterizedStatusMessage   = 0x028B,
+        SetTurbineChatChannels              = 0x0295,
+        Tell                                = 0x02BD
     }
 }

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
@@ -5,11 +5,9 @@ namespace ACE.Network.GameMessages.Messages
 {
     public class GameMessagePrivateUpdateBool : GameMessage
     {
-        public GameMessagePrivateUpdateBool(Session session, PropertyBool property, bool value) : base(GameMessageOpcode.PrivateUpdatePropertyBool)
+        public GameMessagePrivateUpdateBool(Session session, PropertyBool property, bool value) : base(GameMessageOpcode.PrivateUpdatePropertyBool, GameMessageGroup.Group09)
         {
             Writer.Write(session.UpdatePropertyBoolSequence++);
-            //Writer.Write(0x19u);
-            //Writer.Write(1u);
             Writer.Write((uint)property);
             Writer.Write(Convert.ToUInt32(value));
         }

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using ACE.Entity.Enum.Properties;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessagePrivateUpdateBool : GameMessage
+    {
+        public GameMessagePrivateUpdateBool(Session session, PropertyBool property, bool value) : base(GameMessageOpcode.PrivateUpdatePropertyBool)
+        {
+            Writer.Write(session.UpdatePropertyBoolSequence++);
+            Writer.Write(0x19u);
+            Writer.Write(1u);
+        }
+    }
+}

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateBool.cs
@@ -8,8 +8,10 @@ namespace ACE.Network.GameMessages.Messages
         public GameMessagePrivateUpdateBool(Session session, PropertyBool property, bool value) : base(GameMessageOpcode.PrivateUpdatePropertyBool)
         {
             Writer.Write(session.UpdatePropertyBoolSequence++);
-            Writer.Write(0x19u);
-            Writer.Write(1u);
+            //Writer.Write(0x19u);
+            //Writer.Write(1u);
+            Writer.Write((uint)property);
+            Writer.Write(Convert.ToUInt32(value));
         }
     }
 }


### PR DESCRIPTION
Resurrected the various Admin global channels used by the Advocates, Sentinels, Envoys, and Admins, stubbed the @on and @off commands and added support for @index and @clist commands.

Some TODOs have been put into the code for when we get a plan in place for for db loading/saving of channel subscriptions, as well as properly set subscriptions for that matter.