### PR TITLE
Option to send Internal IP as World Host to client

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -10,6 +10,8 @@ namespace ACE.Common
         public string Host { get; set; }
         public uint LoginPort { get; set; }
         public uint WorldPort { get; set; }
+        public string InternalHost { get; set; }
+        public bool SendInternalHostOnLocalNetwork { get; set; }
     }
 
     public struct ConfigAccountDefaults
@@ -52,6 +54,7 @@ namespace ACE.Common
     {
         public static Config Config { get; private set; }
         public static byte[] Host { get; } = new byte[4];
+        public static byte[] InternalHost { get; } = new byte[4];
 
         public static void Initialise()
         {
@@ -63,6 +66,9 @@ namespace ACE.Common
                 string[] hostSplit = Config.Server.Network.Host.Split('.');
                 for (uint i = 0; i < 4; i++)
                     Host[i] = Convert.ToByte(hostSplit[i]);
+                hostSplit = Config.Server.Network.InternalHost.Split('.');
+                for (uint i = 0; i < 4; i++)
+                    InternalHost[i] = Convert.ToByte(hostSplit[i]);
             }
             catch (Exception exception)
             {

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -4,6 +4,8 @@
         "Welcome": "Welcome to this ACE server!\nFor more information visit http://www.acemulator.org.",
         "Network": {
             "Host": "127.0.0.1",
+            "InternalHost": "127.0.0.1",
+            "SendInternalHostOnLocalNetwork":  false,
             "LoginPort": 9000,
             "WorldPort": 9008
         },

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -48,7 +48,9 @@ namespace ACE.Network.Handlers
             RandomNumberGenerator.Create().GetNonZeroBytes(connectionKey);
             session.WorldConnectionKey = BitConverter.ToUInt64(connectionKey, 0);
 
-            session.LoginSession.EnqueueSend(new PacketOutboundReferral(session.WorldConnectionKey));
+            string[] sessionIPAddress = session.EndPoint.Address.ToString().Split('.');
+
+            session.LoginSession.EnqueueSend(new PacketOutboundReferral(session.WorldConnectionKey, sessionIPAddress));
 
             session.State = SessionState.WorldLoginRequest;
         }

--- a/Source/ACE/Network/Packets/PacketOutboundReferral.cs
+++ b/Source/ACE/Network/Packets/PacketOutboundReferral.cs
@@ -13,14 +13,25 @@ namespace ACE.Network.Packets
     {
         private ulong worldConnectionKey;
 
-        public PacketOutboundReferral(ulong worldConnectionKey) : base()
+        private string[] sessionIPAddress;
+
+        public PacketOutboundReferral(ulong worldConnectionKey, string[] sessionIPAddress) : base()
         {
             this.Header.Flags = PacketHeaderFlags.EncryptedChecksum | PacketHeaderFlags.Referral;
             this.worldConnectionKey = worldConnectionKey;
+            this.sessionIPAddress = sessionIPAddress;
             BodyWriter.Write(worldConnectionKey);
             BodyWriter.Write((ushort)2);
             BodyWriter.WriteUInt16BE((ushort)ConfigManager.Config.Server.Network.WorldPort);
-            BodyWriter.Write(ConfigManager.Host);
+
+            if (ConfigManager.Config.Server.Network.SendInternalHostOnLocalNetwork &&
+                (sessionIPAddress[0] == "10"
+                || (sessionIPAddress[0] == "172" && System.Convert.ToInt16(sessionIPAddress[1]) >= 16 && System.Convert.ToInt16(sessionIPAddress[1]) <= 31)
+                || (sessionIPAddress[0] == "192" && sessionIPAddress[1] == "168")))
+                BodyWriter.Write(ConfigManager.InternalHost);
+            else
+                BodyWriter.Write(ConfigManager.Host);
+
             BodyWriter.Write(0ul);
             BodyWriter.Write((ushort)0x18);
             BodyWriter.Write((ushort)0);


### PR DESCRIPTION
Allows a server operator to configure their external IP for clients connecting from the internet as well as allowing clients connecting on the intranet to use the local network IP address of the server remaining on local network instead of going out to come back in.

The options are configurable via config.json and set to false by default.