### PR TITLE
Level up on xp change, PropertyInt Message Types and skill credits

### DIFF
--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -169,14 +169,6 @@ namespace ACE.Entity
         }
 
         /// <summary>
-        /// adds only avaiable xp when user has already gained max level
-        /// </summary>
-        public void GrantAdditionalXp(ulong amount)
-        {
-            propertiesInt64[PropertyInt64.AvailableExperience] += amount;
-        }
-
-        /// <summary>
         /// spends the amount of xp specified, deducting it from avaiable experience
         /// </summary>
         public void SpendXp(ulong amount)

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -112,6 +112,8 @@ namespace ACE.Entity
             set { propertiesInt[PropertyInt.Level] = value; }
         }
 
+        public uint AvailableSkillCredits { get; set; }
+
         public ReadOnlyDictionary<Enum.Ability, CharacterAbility> Abilities;
 
         private Character()

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -158,7 +158,7 @@ namespace ACE.Entity
             Id = id;
             AccountId = accountId;
         }
-        
+
         /// <summary>
         /// gives avaiable xp and total xp of the amount specified
         /// </summary>
@@ -166,6 +166,14 @@ namespace ACE.Entity
         {
             propertiesInt64[PropertyInt64.AvailableExperience] += amount;
             propertiesInt64[PropertyInt64.TotalExperience] += amount;
+        }
+
+        /// <summary>
+        /// adds only avaiable xp when user has already gained max level
+        /// </summary>
+        public void GrantAdditionalXp(ulong amount)
+        {
+            propertiesInt64[PropertyInt64.AvailableExperience] += amount;
         }
 
         /// <summary>

--- a/Source/ACE.Entity/CharacterLevel.cs
+++ b/Source/ACE.Entity/CharacterLevel.cs
@@ -6,7 +6,7 @@ namespace ACE.Entity
     public class CharacterLevel
     {
         [JsonProperty("level")]
-        public int Level { get; set; }
+        public uint Level { get; set; }
 
         [JsonProperty("totalXp")]
         public ulong TotalXp { get; set; }

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Network\GameMessages\Messages\GameMessageEmoteText.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateAbility.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateBool.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdatePropertyInt.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdatePropertyInt64.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateSkill.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateVital.cs" />

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -65,9 +65,9 @@ namespace ACE.Command.Handlers
         [CommandHandler("grantxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
         public static void HandleGrantXp(Session session, params string[] parameters)
         {
-            uint xp = 0;
+            ulong xp = 0;
 
-            if (parameters?.Length > 0 && uint.TryParse(parameters[0], out xp))
+            if (parameters?.Length > 0 && ulong.TryParse(parameters[0], out xp))
             {
                 session.Player.GrantXp(xp);
             }

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -65,17 +65,19 @@ namespace ACE.Command.Handlers
         [CommandHandler("grantxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
         public static void HandleGrantXp(Session session, params string[] parameters)
         {
-            ulong xp = 0;
-
-            if (parameters?.Length > 0 && ulong.TryParse(parameters[0], out xp))
+            if (parameters?.Length > 0)
             {
-                session.Player.GrantXp(xp);
+                ulong xp = 0;
+                string xpAmountToParse = parameters[0].Length > 12 ? parameters[0].Substring(0, 12) : parameters[0];
+                //12 characters : xxxxxxxxxxxx : 191,226,310,247 for 275
+                if (ulong.TryParse(xpAmountToParse, out xp))
+                {
+                    session.Player.GrantXp(xp);
+                    return;
+                }
             }
-            else
-            {
-                ChatPacket.SendServerMessage(session, "Usage: /grantxp 1234", ChatMessageType.Broadcast);
-                return;
-            }
+            ChatPacket.SendServerMessage(session, "Usage: /grantxp 1234 (max 999999999999)", ChatMessageType.Broadcast);
+            return;
         }
 
 

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -249,9 +249,23 @@ namespace ACE.Entity
         /// <param name="amount">A unsigned long containing the desired XP amount to raise</param>
         public void GrantXp(ulong amount)
         {
-            var test = amount.ToString().Length;
-            character.GrantXp(amount);
-            CheckForLevelup();
+            //until we are max level we must make sure that we send 
+            var chart = DatabaseManager.Charts.GetLevelingXpChart();
+            CharacterLevel maxLevel = chart.Levels.Last();
+            if (character.Level == maxLevel.Level)
+            {
+                character.GrantAdditionalXp(amount);
+            }
+            else
+            {
+                ulong amountLeftToEnd = maxLevel.TotalXp - character.TotalExperience;
+                if (amount > amountLeftToEnd)
+                {
+                    amount = amountLeftToEnd;
+                }
+                character.GrantXp(amount);
+                CheckForLevelup();
+            }
             var xpTotalUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.TotalExperience, character.TotalExperience);
             var xpAvailUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.AvailableExperience, character.AvailableExperience);
             var message = new GameMessageSystemChat($"{amount} experience granted.", ChatMessageType.Broadcast);
@@ -287,12 +301,15 @@ namespace ACE.Entity
                 if (newLevel.GrantsSkillPoint)
                 {
                     character.AvailableSkillCredits++;
-                    var grantCredit = new GameMessagePrivateUpdatePropertyInt(Session, PropertyInt.AvailableSkillCredits, character.AvailableSkillCredits);
-                    Session.WorldSession.EnqueueSend(grantCredit);
                     creditEarned = true;
                 }
                 //break if we reach max
-                if (character.Level == maxLevel.Level) break;
+                if (character.Level == maxLevel.Level)
+                {
+                    //new enum soon ;)
+                    PlayParticleEffect(0x8d);
+                    break;
+                }
             }
 
             if (character.Level > startingLevel)
@@ -305,14 +322,16 @@ namespace ACE.Entity
                 var levelUpMessage = new GameMessageSystemChat(levelUpMessageText, ChatMessageType.Advancement);
                 string xpUpdateText = (character.AvailableSkillCredits > 0) ? $"You have {xpAvailable} experience points and {skillCredits} skill credits available to raise skills and attributes." : $"You have {xpAvailable} experience points available to raise skills and attributes."; ;
                 var xpUpdateMessage = new GameMessageSystemChat(xpUpdateText, ChatMessageType.Advancement);
-                PlayParticleEffect(0x8a); //play level up effect
+                var currentCredits = new GameMessagePrivateUpdatePropertyInt(Session, PropertyInt.AvailableSkillCredits, character.AvailableSkillCredits);
                 if (character.Level != maxLevel.Level && !creditEarned)
                 {
                     string nextCreditAtText = $"You will earn another skill credit at {chart.Levels.Where(item => item.Level > character.Level).OrderBy(item => item.Level).First(item => item.GrantsSkillPoint).Level}";
                     var nextCreditMessage = new GameMessageSystemChat(nextCreditAtText, ChatMessageType.Advancement);
-                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, nextCreditMessage);
+                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits, nextCreditMessage);
                 } else
-                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage);
+                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits);
+                //play level up effect
+                PlayParticleEffect(0x8a);
             }
         }
 
@@ -335,6 +354,7 @@ namespace ACE.Entity
                 {
                     abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, character.Abilities[ability].Current);
                 }
+
                 var soundEvent = new GameMessageSound(this.Guid, Network.Enum.Sound.AbilityIncrease, 1f);
                 var message = new GameMessageSystemChat($"Your base {ability} is now {newValue}!", ChatMessageType.Broadcast);
                 Session.Network.EnqueueSend(xpUpdate, abilityUpdate, soundEvent, message);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -252,11 +252,7 @@ namespace ACE.Entity
             //until we are max level we must make sure that we send 
             var chart = DatabaseManager.Charts.GetLevelingXpChart();
             CharacterLevel maxLevel = chart.Levels.Last();
-            if (character.Level == maxLevel.Level)
-            {
-                character.GrantAdditionalXp(amount);
-            }
-            else
+            if (character.Level != maxLevel.Level)
             {
                 ulong amountLeftToEnd = maxLevel.TotalXp - character.TotalExperience;
                 if (amount > amountLeftToEnd)
@@ -265,11 +261,11 @@ namespace ACE.Entity
                 }
                 character.GrantXp(amount);
                 CheckForLevelup();
+                var xpTotalUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.TotalExperience, character.TotalExperience);
+                var xpAvailUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.AvailableExperience, character.AvailableExperience);
+                var message = new GameMessageSystemChat($"{amount} experience granted.", ChatMessageType.Broadcast);
+                Session.Network.EnqueueSend(xpTotalUpdate, xpAvailUpdate, message);
             }
-            var xpTotalUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.TotalExperience, character.TotalExperience);
-            var xpAvailUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.AvailableExperience, character.AvailableExperience);
-            var message = new GameMessageSystemChat($"{amount} experience granted.", ChatMessageType.Broadcast);
-            Session.Network.EnqueueSend(xpTotalUpdate, xpAvailUpdate, message);
         }
 
         /// <summary>
@@ -327,9 +323,9 @@ namespace ACE.Entity
                 {
                     string nextCreditAtText = $"You will earn another skill credit at {chart.Levels.Where(item => item.Level > character.Level).OrderBy(item => item.Level).First(item => item.GrantsSkillPoint).Level}";
                     var nextCreditMessage = new GameMessageSystemChat(nextCreditAtText, ChatMessageType.Advancement);
-                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits, nextCreditMessage);
+                    Session.Network.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits, nextCreditMessage);
                 } else
-                    Session.WorldSession.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits);
+                    Session.Network.EnqueueSend(levelUp, levelUpMessage, xpUpdateMessage, currentCredits);
                 //play level up effect
                 PlayParticleEffect(0x8a);
             }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -243,20 +243,59 @@ namespace ACE.Entity
             Session.Network.EnqueueSend(setTurbineChatChannels, general, trade, lfg, roleplay);
         }
 
+        /// <summary>
+        /// Raise the available XP by a specified amount
+        /// </summary>
+        /// <param name="amount">A unsigned long containing the desired XP amount to raise</param>
         public void GrantXp(ulong amount)
         {
             character.GrantXp(amount);
+            //TODO: Ask for an Answer: Does CheckForLevelup() go before or after the xp message?
+            CheckForLevelup();
             var xpTotalUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.TotalExperience, character.TotalExperience);
             var xpAvailUpdate = new GameMessagePrivateUpdatePropertyInt64(Session, PropertyInt64.AvailableExperience, character.AvailableExperience);
             var message = new GameMessageSystemChat($"{amount} experience granted.", ChatMessageType.Broadcast);
             Session.Network.EnqueueSend(xpTotalUpdate, xpAvailUpdate, message);
         }
 
+        /// <summary>
+        /// Determines if the player has advanced a level
+        /// </summary>
+        /// <remarks>
+        /// Known issues:
+        ///         1. Have not tested up to max level, so there isn't any special text or fireworks for max level yet.
+        /// </remarks>
         private void CheckForLevelup()
         {
-            var chart = DatabaseManager.Charts.GetLevelingXpChart();
+            // Question: Where do *we* call CheckForLevelup()? : 
+            //      From within the player.cs file, the options might be:
+            //           GrantXp()
+            //      From outside of the player.cs file, we may call CheckForLevelup() durring? :
+            //           XP Updates?
 
-            // TODO: implement.  just stubbing for now, will implement later.
+            var chart = DatabaseManager.Charts.GetLevelingXpChart();
+            var currentLevel = character.Level;
+            int maxLevel = chart.Levels.Count;
+
+            if (character.Level == maxLevel) return;
+
+            // this will check against the xp chart to see if the xp is greater then the last level
+            // increases until the correct level is found
+            while (chart.Levels[Convert.ToInt32(character.Level)].TotalXp <= character.TotalExperience)
+            {
+                character.Level++;
+                if (character.Level == maxLevel) break;
+            }
+
+            // if we have advanced a level send an update to the client
+            if (character.Level > currentLevel)
+            {
+                var level = character.Level.ToString();
+                var levelUp = new GameMessagePrivateUpdatePropertyInt(Session, PropertyInt.Level, character.Level);
+                var message = new GameMessageSystemChat($"You are now level {level}!", ChatMessageType.Advancement);
+                PlayParticleEffect(0x8a);
+                Session.WorldSession.EnqueueSend(levelUp, message);
+            }
         }
 
         public void SpendXp(Enum.Ability ability, uint amount)
@@ -278,7 +317,6 @@ namespace ACE.Entity
                 {
                     abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, character.Abilities[ability].Current);
                 }
-
                 var soundEvent = new GameMessageSound(this.Guid, Network.Enum.Sound.AbilityIncrease, 1f);
                 var message = new GameMessageSystemChat($"Your base {ability} is now {newValue}!", ChatMessageType.Broadcast);
                 Session.Network.EnqueueSend(xpUpdate, abilityUpdate, soundEvent, message);

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdatePropertyInt.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdatePropertyInt.cs
@@ -1,0 +1,15 @@
+﻿using ACE.Entity.Enum.Properties;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessagePrivateUpdatePropertyInt : GameMessage
+    {
+        public GameMessagePrivateUpdatePropertyInt(Session session, PropertyInt property, uint value) 
+            : base(GameMessageOpcode.PrivateUpdatePropertyInt, GameMessageGroup.Group09)
+        {
+            Writer.Write(session.UpdatePropertyIntSequence++);
+            Writer.Write((uint)property);
+            Writer.Write(value);
+        }
+    }
+}


### PR DESCRIPTION
- Changed the Character.Level variable from an int to a uint.

- Added leveling up on grantxp. Since we don't get XP anywhere else, this is the only way so far.

- Added skill credits. You cannot spend them to add skills yet. AvailableSkillCredits.

- Changed the /grantxp command to allow up too 999,999,999,999 xp.

- Followed @Zegeger and created a Network Message Type for PropertyInt

- Allow for Max Level locking, set from the XP chart.

- Added effects on leveling up.