### PR TITLE
Landblocks, logging, object factory prep work

### DIFF
--- a/Source/ACE.Common/ACE.Common.csproj
+++ b/Source/ACE.Common/ACE.Common.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/Source/ACE.DatLoader.Tests/ACE.DatLoader.Tests.csproj
+++ b/Source/ACE.DatLoader.Tests/ACE.DatLoader.Tests.csproj
@@ -35,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -58,6 +62,9 @@
       <Project>{21d1aa6d-7bec-4ee5-b503-41e6e6f3480a}</Project>
       <Name>ACE.DatLoader</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Source/ACE.DatLoader.Tests/packages.config
+++ b/Source/ACE.DatLoader.Tests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>

--- a/Source/ACE.DatLoader/ACE.DatLoader.csproj
+++ b/Source/ACE.DatLoader/ACE.DatLoader.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -58,6 +62,9 @@
       <Project>{136e260e-b4a8-4e6f-b9cb-6ae7fc368dc8}</Project>
       <Name>ACE.Common</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -9,6 +9,8 @@ namespace ACE.DatLoader
 {
     public class DatManager
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         private static CellDatDatabase cellDat;
 
         private static PortalDatDatabase portalDat;

--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.IO;
 
 using ACE.Common;
+using log4net;
 
 namespace ACE.DatLoader
 {
@@ -27,12 +28,12 @@ namespace ACE.DatLoader
                 datFile = ConfigManager.Config.Server.DatFilesDirectory + "\\client_cell_1.dat";
                 cellDat = new CellDatDatabase(datFile);
                 count = cellDat.AllFiles.Count();
-                Console.WriteLine($"Successfully opened {datFile} file, containing {count} records");
+                log.Info($"Successfully opened {datFile} file, containing {count} records");
             }
             catch (FileNotFoundException ex)
             {
-                Console.WriteLine($"An exception occured while attempting to open {datFile} file!");
-                Console.WriteLine($"Exception: {ex.Message}");
+                log.Info($"An exception occured while attempting to open {datFile} file!");
+                log.Info($"Exception: {ex.Message}");
                 Environment.Exit(-1);
             }
 
@@ -41,12 +42,12 @@ namespace ACE.DatLoader
                 datFile = ConfigManager.Config.Server.DatFilesDirectory + "\\client_portal.dat";
                 portalDat = new PortalDatDatabase(datFile);
                 count = portalDat.AllFiles.Count();
-                Console.WriteLine($"Successfully opened {datFile} file, containing {count} records");
+                log.Info($"Successfully opened {datFile} file, containing {count} records");
             }
             catch (FileNotFoundException ex)
             {
-                Console.WriteLine($"An exception occured while attempting to open {datFile} file!");
-                Console.WriteLine($"Exception: {ex.Message}");
+                log.Info($"An exception occured while attempting to open {datFile} file!");
+                log.Info($"Exception: {ex.Message}");
                 Environment.Exit(-1);
             }
         }

--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -22,8 +22,8 @@ namespace ACE.DatLoader
         public static CellDatDatabase CellDat { get { return cellDat; } }
 
         public static PortalDatDatabase PortalDat { get { return portalDat; } }
-
-        static DatManager()
+        
+        public static void Initialize()
         {
             try
             {
@@ -34,9 +34,8 @@ namespace ACE.DatLoader
             }
             catch (FileNotFoundException ex)
             {
-                log.Info($"An exception occured while attempting to open {datFile} file!");
+                log.Info($"An exception occured while attempting to open {datFile} file!  This needs to be corrected in order for Landblocks to load!");
                 log.Info($"Exception: {ex.Message}");
-                Environment.Exit(-1);
             }
 
             try
@@ -48,9 +47,8 @@ namespace ACE.DatLoader
             }
             catch (FileNotFoundException ex)
             {
-                log.Info($"An exception occured while attempting to open {datFile} file!");
+                log.Info($"An exception occured while attempting to open {datFile} file!  This needs to be corrected in order for Landblocks to load!");
                 log.Info($"Exception: {ex.Message}");
-                Environment.Exit(-1);
             }
         }
     }

--- a/Source/ACE.DatLoader/Properties/AssemblyInfo.cs
+++ b/Source/ACE.DatLoader/Properties/AssemblyInfo.cs
@@ -35,3 +35,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("ACE.DatLoader.Tests")]
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config", Watch = true)]

--- a/Source/ACE.DatLoader/packages.config
+++ b/Source/ACE.DatLoader/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.8" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>

--- a/Source/ACE.Database.Tests/ACE.Database.Tests.csproj
+++ b/Source/ACE.Database.Tests/ACE.Database.Tests.csproj
@@ -35,6 +35,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
       <Private>True</Private>

--- a/Source/ACE.Database.Tests/packages.config
+++ b/Source/ACE.Database.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.Numerics.Vectors" version="4.3.0" targetFramework="net452" />

--- a/Source/ACE.Database/ACE.Database.csproj
+++ b/Source/ACE.Database/ACE.Database.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
       <Private>True</Private>

--- a/Source/ACE.Database/CharacterDatabase.cs
+++ b/Source/ACE.Database/CharacterDatabase.cs
@@ -153,7 +153,7 @@ namespace ACE.Database
 
         public Task UpdateCharacter(Character character)
         {
-            ExecutePreparedStatement(CharacterPreparedStatement.CharacterPositionInsert, character.Id, character.Position.Cell, character.Position.Offset.X, character.Position.Offset.Y, character.Position.Offset.Z, character.Position.Facing.X, character.Position.Facing.Y, character.Position.Facing.Z, character.Position.Facing.W);
+            ExecutePreparedStatement(CharacterPreparedStatement.CharacterPositionInsert, character.Id, character.Position.LandblockId.Raw, character.Position.Offset.X, character.Position.Offset.Y, character.Position.Offset.Z, character.Position.Facing.X, character.Position.Facing.Y, character.Position.Facing.Z, character.Position.Facing.W);
 
             // TODO: implement saving a character
             return Task.Delay(0);

--- a/Source/ACE.Database/packages.config
+++ b/Source/ACE.Database/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.Numerics.Vectors" version="4.3.0" targetFramework="net452" />

--- a/Source/ACE.Entity/ACE.Entity.csproj
+++ b/Source/ACE.Entity/ACE.Entity.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -69,6 +73,7 @@
     <Compile Include="Enum\ChatMessageType.cs" />
     <Compile Include="Enum\EnumHelper.cs" />
     <Compile Include="Enum\GroupChatType.cs" />
+    <Compile Include="Enum\MapScope.cs" />
     <Compile Include="Enum\ObjectBehaviorFlag.cs" />
     <Compile Include="Enum\ObjectType.cs" />
     <Compile Include="Enum\PhysicsState.cs" />
@@ -83,11 +88,13 @@
     <Compile Include="Enum\TurbineChatType.cs" />
     <Compile Include="ExperienceExpenditure.cs" />
     <Compile Include="Friend.cs" />
+    <Compile Include="LandblockId.cs" />
     <Compile Include="LevelingChart.cs" />
     <Compile Include="ObjectGuid.cs" />
     <Compile Include="PersistedPropertyAttribute.cs" />
     <Compile Include="Position.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Quadrant.cs" />
     <Compile Include="SkillCostAttribute.cs" />
     <Compile Include="SkillUsableUntrainedAttribute.cs" />
     <Compile Include="ExperienceExpenditureChart.cs" />

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -14,6 +14,7 @@ namespace ACE.Entity
         protected Dictionary<Enum.Ability, CharacterAbility> abilities = new Dictionary<Enum.Ability, CharacterAbility>();
 
         private List<Friend> friends;
+
         public ReadOnlyCollection<Friend> Friends { get; set; }
 
         public uint AccountId { get; set; }

--- a/Source/ACE.Entity/Enum/MapScope.cs
+++ b/Source/ACE.Entity/Enum/MapScope.cs
@@ -1,0 +1,9 @@
+﻿namespace ACE.Entity.Enum
+{
+    public enum MapScope : byte
+    {
+        Outdoors = 0,
+        IndoorsSmall = 1,
+        IndoorsLarge = 2
+    }
+}

--- a/Source/ACE.Entity/LandblockId.cs
+++ b/Source/ACE.Entity/LandblockId.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using ACE.Entity.Enum;
+
+namespace ACE.Entity
+{
+    public struct LandblockId
+    {
+        private uint rawValue;
+
+        public LandblockId(uint raw)
+        {
+            rawValue = raw;
+        }
+
+        public LandblockId(byte x, byte y)
+        {
+            rawValue = (uint)x << 24 | (uint)y << 16;
+        }
+
+        public LandblockId East
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX + 1), LandblockY); }
+        }
+
+        public LandblockId West
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX - 1), LandblockY); }
+        }
+
+        public LandblockId North
+        {
+            get { return new LandblockId(LandblockX, Convert.ToByte(LandblockY + 1)); }
+        }
+
+        public LandblockId South
+        {
+            get { return new LandblockId(LandblockX, Convert.ToByte(LandblockY - 1)); }
+        }
+
+        public LandblockId NorthEast
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX + 1), Convert.ToByte(LandblockY + 1)); }
+        }
+
+        public LandblockId NorthWest
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX - 1), Convert.ToByte(LandblockY + 1)); }
+        }
+
+        public LandblockId SouthEast
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX + 1), Convert.ToByte(LandblockY - 1)); }
+        }
+
+        public LandblockId SouthWest
+        {
+            get { return new LandblockId(Convert.ToByte(LandblockX - 1), Convert.ToByte(LandblockY - 1)); }
+        }
+
+        public uint Raw
+        {
+            get { return rawValue; }
+        }
+
+        public ushort Landblock
+        {
+            get { return (ushort)((rawValue >> 16) & 0xFFFF); }
+        }
+
+        public byte LandblockX
+        {
+            get { return (byte)((rawValue >> 24) & 0xFF); }
+        }
+
+        public byte LandblockY
+        {
+            get { return (byte)((rawValue >> 16) & 0xFF); }
+        }
+
+        public ushort Landcell
+        {
+            get { return (byte)((rawValue & 0x3F) - 1); }
+        }
+
+        public byte LandcellX
+        {
+            get { return Convert.ToByte((Landcell >> 3) & 0x7); }
+        }
+
+        public byte LandcellY
+        {
+            get { return Convert.ToByte(Landcell & 0x7); }
+        }
+
+        public MapScope MapScope
+        {
+            get { return (MapScope)((rawValue & 0x0F00) >> 8); }
+        }
+
+        public static bool operator ==(LandblockId c1, LandblockId c2)
+        {
+            return c1.Landblock == c2.Landblock;
+        }
+        
+        public static bool operator !=(LandblockId c1, LandblockId c2)
+        {
+            return c1.Landblock != c2.Landblock;
+        }
+
+        public bool IsAdjacentTo(LandblockId block)
+        {
+            return (Math.Abs(this.LandblockX - block.LandblockX) <= 1 && Math.Abs(this.LandblockY - block.LandblockY) <= 1);
+        }
+    }
+}

--- a/Source/ACE.Entity/ObjectGuid.cs
+++ b/Source/ACE.Entity/ObjectGuid.cs
@@ -8,7 +8,7 @@ namespace ACE.Entity
         Player = 0x50,
     }
 
-    public class ObjectGuid
+    public struct ObjectGuid
     {
         public uint Full { get; }
         public uint Low => Full & 0xFFFFFF;
@@ -23,5 +23,15 @@ namespace ACE.Entity
         }
 
         public bool IsPlayer() { return High == GuidType.Player; }
+
+        public static bool operator ==(ObjectGuid g1, ObjectGuid g2)
+        {
+            return g1.Full == g2.Full;
+        }
+
+        public static bool operator !=(ObjectGuid g1, ObjectGuid g2)
+        {
+            return g1.Full != g2.Full;
+        }
     }
 }

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -74,14 +74,16 @@ namespace ACE.Entity
             Facing = new Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
         }
 
-        public void Serialize(BinaryWriter payload, bool quaternion = true)
+        public void Serialize(BinaryWriter payload, bool writeQuaternion = true, bool writeLandblock = true)
         {
-            payload.Write(LandblockId.Raw);
+            if (writeLandblock)
+                payload.Write(LandblockId.Raw);
+
             payload.Write(Offset.X);
             payload.Write(Offset.Y);
             payload.Write(Offset.Z);
 
-            if (quaternion)
+            if (writeQuaternion)
             {
                 payload.Write(Facing.W);
                 payload.Write(Facing.X);
@@ -123,6 +125,11 @@ namespace ACE.Entity
             uint cell = (uint)((cellX << 3) | cellY);
 
             return (block << 16) | (cell + 1);
+        }
+
+        public override string ToString()
+        {
+            return $"{LandblockId.Landblock.ToString("X")}: {Offset.X} {Offset.Y} {Offset.Z}";
         }
     }
 }

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -6,28 +6,50 @@ namespace ACE.Entity
 {
     public class Position
     {
-        public uint Cell { get; set; }
-        public uint Dungeon { get; set; }
+        private const float xyMidPoint = 96f;
+
+        public LandblockId LandblockId { get; set; }
+
         public Vector3 Offset { get; set; }
+
         public Quaternion Facing { get; set; }
 
-        public Position(uint cell, float x, float y, float z, float qx = 0.0f, float qy = 0.0f, float qz = 0.0f, float qw = 0.0f)
+        public Position(uint landblock, float x, float y, float z, float qx = 0.0f, float qy = 0.0f, float qz = 0.0f, float qw = 0.0f)
         {
-            Cell    = cell;
-            Dungeon = cell >> 16;
+            LandblockId = new LandblockId(landblock);
             Offset  = new Vector3(x, y, z);
             Facing  = new Quaternion(qx, qy, qz, qw);
         }
 
         public Position(BinaryReader payload)
         {
-            Cell    = payload.ReadUInt32();
-            Dungeon = Cell >> 16;
+            LandblockId = new LandblockId(payload.ReadUInt32());
             Offset  = new Vector3(payload.ReadSingle(), payload.ReadSingle(), payload.ReadSingle());
 
             // packet stream isn't the same order as the quaternion constructor
             float qw = payload.ReadSingle();
             Facing  = new Quaternion(payload.ReadSingle(), payload.ReadSingle(), payload.ReadSingle(), qw);
+        }
+
+        public bool IsInQuadrant(Quadrant q)
+        {
+            // check for easy short circuit
+            if (q == Quadrant.All)
+                return true;
+
+            if ((q & Quadrant.NorthEast) > 0 && Offset.X > xyMidPoint && Offset.Y > xyMidPoint)
+                return true;
+
+            if ((q & Quadrant.NorthWest) > 0 && Offset.X <= xyMidPoint && Offset.Y > xyMidPoint)
+                return true;
+
+            if ((q & Quadrant.SouthEast) > 0 && Offset.X <= xyMidPoint && Offset.Y <= xyMidPoint)
+                return true;
+
+            if ((q & Quadrant.SouthWest) > 0 && Offset.X <= xyMidPoint && Offset.Y <= xyMidPoint)
+                return true;
+
+            return false;
         }
 
         public Position(float northSouth, float eastWest)
@@ -45,16 +67,16 @@ namespace ACE.Entity
 
             float xOffset = ((baseX & 7) * 24.0f) + 12;
             float yOffset = ((baseY & 7) * 24.0f) + 12;
-            float zOffset = GetZFromCellXY(Cell, xOffset, yOffset);
+            float zOffset = GetZFromCellXY(LandblockId.Raw, xOffset, yOffset);
 
-            Cell = GetCellFromBase(baseX, baseY);
+            LandblockId = new LandblockId(GetCellFromBase(baseX, baseY));
             Offset = new Vector3(xOffset, yOffset, zOffset);
             Facing = new Quaternion(0.0f, 0.0f, 0.0f, 1.0f);
         }
 
         public void Serialize(BinaryWriter payload, bool quaternion = true)
         {
-            payload.Write(Cell);
+            payload.Write(LandblockId.Raw);
             payload.Write(Offset.X);
             payload.Write(Offset.Y);
             payload.Write(Offset.Z);
@@ -66,6 +88,22 @@ namespace ACE.Entity
                 payload.Write(Facing.Y);
                 payload.Write(Facing.Z);
             }
+        }
+
+        public Position InFrontOf(double distanceInFront = 3.0f)
+        {
+            float qw = Facing.W; // north
+            float qz = Facing.Z; // south
+
+            double x = 2 * qw * qz;
+            double y = 1 - 2 * qz * qz;
+
+            var heading = Math.Atan2(x, y);
+            var dx = -1 * Convert.ToSingle(Math.Sin(heading) * distanceInFront);
+            var dy = Convert.ToSingle(Math.Cos(heading) * distanceInFront);
+
+            // move the Z slightly up and let gravity pull it down.  just makes things easier.
+            return new Position(LandblockId.Raw, Offset.X + dx, Offset.Y + dy, Offset.Z + 0.5f, 0f, 0f, 0f, 0f);
         }
 
         private float GetZFromCellXY(uint cell, float xOffset, float yOffset)

--- a/Source/ACE.Entity/Quadrant.cs
+++ b/Source/ACE.Entity/Quadrant.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ACE.Entity
+{
+    [Flags]
+    public enum Quadrant
+    {
+        None            = 0,
+        NorthWest       = 1,
+        NorthEast       = 2,
+        SouthEast       = 4,
+        SouthWest       = 8,
+        All             = 15
+    }
+}

--- a/Source/ACE.Entity/packages.config
+++ b/Source/ACE.Entity/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.Numerics.Vectors" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/Source/ACE/ACE.cs
+++ b/Source/ACE/ACE.cs
@@ -21,6 +21,9 @@ namespace ACE
             SocketManager.Initialise();
             WorldManager.Initialise();
             CommandManager.Initialise();
+
+            // force loading of the dat files
+            var throwaway = new DatLoader.DatManager();
         }
     }
 }

--- a/Source/ACE/ACE.cs
+++ b/Source/ACE/ACE.cs
@@ -5,6 +5,7 @@ using ACE.Common;
 using ACE.Database;
 using ACE.Managers;
 using ACE.Network.Managers;
+using ACE.DatLoader;
 
 namespace ACE
 {
@@ -20,10 +21,8 @@ namespace ACE
             InboundMessageManager.Initialise();
             SocketManager.Initialise();
             WorldManager.Initialise();
+            DatManager.Initialize();
             CommandManager.Initialise();
-
-            // force loading of the dat files
-            var throwaway = new DatLoader.DatManager();
         }
     }
 }

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -51,6 +51,10 @@
     <CodeAnalysisRuleSet>default.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
       <Private>True</Private>
@@ -82,8 +86,14 @@
     <Compile Include="Command\Handlers\CharacterCommands.cs" />
     <Compile Include="Command\Handlers\ConsoleCommands.cs" />
     <Compile Include="Command\Handlers\DebugCommands.cs" />
+    <Compile Include="Entity\Adjacency.cs" />
+    <Compile Include="Entity\BroadcastAction.cs" />
+    <Compile Include="Entity\Events\BroadcastEventArgs.cs" />
+    <Compile Include="Entity\Events\ChatMessageArgs.cs" />
+    <Compile Include="Entity\Events\SpellCastArgs.cs" />
     <Compile Include="Entity\ImmutableWorldObject.cs" />
     <Compile Include="Entity\Landblock.cs" />
+    <Compile Include="Entity\Landcell.cs" />
     <Compile Include="Entity\MutableWorldObject.cs" />
     <Compile Include="Entity\EquippedItem.cs" />
     <Compile Include="Entity\Model.cs" />
@@ -91,6 +101,10 @@
     <Compile Include="Entity\ModelTexture.cs" />
     <Compile Include="Entity\ModelData.cs" />
     <Compile Include="Entity\PhysicsData.cs" />
+    <Compile Include="Factories\AdminObjectFactory.cs" />
+    <Compile Include="Factories\CommonObjectFactory.cs" />
+    <Compile Include="Factories\LootGenerationFactory.cs" />
+    <Compile Include="Factories\MonsterFactory.cs" />
     <Compile Include="Managers\AssetManager.cs" />
     <Compile Include="Managers\GuidManager.cs" />
     <Compile Include="Managers\LandblockManager.cs" />
@@ -183,6 +197,7 @@
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdatePropertyInt64.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateSkill.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePrivateUpdateVital.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessageRemoveObject.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageSound.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterList.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageServerName.cs" />
@@ -195,6 +210,7 @@
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterError.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterEnterWorldServerReady.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCreateLifestone.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessageUpdateObject.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageUpdatePosition.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageSystemChat.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageTurbineChat.cs" />
@@ -207,6 +223,7 @@
     <Compile Include="Network\Extensions.cs" />
     <Compile Include="Network\Managers\SocketManager.cs" />
     <Compile Include="Network\GameMessageGroup.cs" />
+    <Compile Include="Network\PackedDWORD.cs" />
     <Compile Include="Network\Packets\PacketOutboundReferral.cs" />
     <Compile Include="Network\Packets\PacketOutboundServerSwitch.cs" />
     <Compile Include="Network\Packets\PacketOutboundConnectRequest.cs" />
@@ -240,6 +257,9 @@
     <None Include="levels.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="log4net.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -252,7 +252,9 @@
     <None Include="abilityXp.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Config.json.example" />
     <None Include="default.ruleset" />
     <None Include="levels.json">

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Network\GameMessages\GameMessage.cs" />
     <Compile Include="Network\GameMessages\GameMessageAttribute.cs" />
     <Compile Include="Network\GameMessages\GameMessageOpcode.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessageAutonomousPosition.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterCreateResponse.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterLogOff.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageCharacterRestore.cs" />

--- a/Source/ACE/App.config
+++ b/Source/ACE/App.config
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-<system.data>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+  </configSections>
+  <log4net configSource="log4net.config" />
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <system.data>
     <DbProviderFactories>
       <remove invariant="MySql.Data.MySqlClient" />
       <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
     </DbProviderFactories>
-  </system.data></configuration>
+  </system.data>
+</configuration>

--- a/Source/ACE/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE/Command/Handlers/AdminCommands.cs
@@ -456,7 +456,7 @@ namespace ACE.Command
 
             // TODO: Check if water block?
 
-            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.Cell.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
+            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
 
             session.Player.Teleport(position);
         }
@@ -904,7 +904,7 @@ namespace ACE.Command
                 message = $"Character {fixupOldName} has been renamed to {fixupNewName}.";
             else
                 message = $"Rename failed because either there is no character by the name {fixupOldName} currently in the database or the name {fixupNewName} is already taken.";
-                        
+
             if (session == null)
                 Console.WriteLine(message);
             else

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -8,6 +8,7 @@ using ACE.Network.GameMessages;
 using ACE.Network.GameMessages.Messages;
 using ACE.Network.GameEvent.Events;
 using ACE.Network.Managers;
+using ACE.Factories;
 
 namespace ACE.Command.Handlers
 {
@@ -37,7 +38,7 @@ namespace ACE.Command.Handlers
         public static void HandleDebugGPS(Session session, params string[] parameters)
         {
             var position = session.Player.Position;
-            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.Cell.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
+            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
         }
 
         // telexyz cell x y z qx qy qz qw
@@ -110,15 +111,14 @@ namespace ACE.Command.Handlers
         [CommandHandler("spacejump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
         public static void spacejump(Session session, params string[] parameters)
         {
-            Position newPosition = new Position(session.Player.Position.Cell, session.Player.Position.Offset.X, session.Player.Position.Offset.Y, session.Player.Position.Offset.Z + 8000f, session.Player.Position.Facing.X, session.Player.Position.Facing.Y, session.Player.Position.Facing.Z, session.Player.Position.Facing.W);
+            Position newPosition = new Position(session.Player.Position.LandblockId.Landblock, session.Player.Position.Offset.X, session.Player.Position.Offset.Y, session.Player.Position.Offset.Z + 8000f, session.Player.Position.Facing.X, session.Player.Position.Facing.Y, session.Player.Position.Facing.Z, session.Player.Position.Facing.W);
             session.Player.Teleport(newPosition);
         }
 
         [CommandHandler("createlifestone", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
         public static void CreateLifeStone(Session session, params string[] parameters)
         {
-            session.Network.EnqueueSend(new GameMessageCreateLifestone(session.Player));
+            LandblockManager.AddObject(AdminObjectFactory.CreateLifestone(session.Player.Position.InFrontOf(3.0f)));
         }
-
     }
 }

--- a/Source/ACE/Entity/Adjacency.cs
+++ b/Source/ACE/Entity/Adjacency.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace ACE.Entity
+{
+    /// <summary>
+    /// not sure if this is going to be used.  i thought it was, but now i'm not sure
+    /// </summary>
+    public enum Adjacency : int
+    {
+        NorthWest       = 0,
+        North           = 1,
+        NorthEast       = 2,
+        East            = 3,
+        SouthEast       = 4,
+        South           = 5,
+        SouthWest       = 6,
+        West            = 7            
+    }
+
+    /// <summary>
+    /// original thoughts on adjacency were to split landblocks into 16 segments for ghost 
+    /// broadcasting.  leaving this here in case I want to come back to it.
+    /// </summary>
+    //[Flags]
+    //public enum Adjacency
+    //{
+    //    None = 0x0000,
+    //    NorthWest = 0x0001,
+    //    NorthNorthWest = 0x0002,
+    //    NorthNorthEast = 0x0004,
+    //    NorthEast = 0x0008,
+    //    EastNorthEast = 0x0010,
+    //    EastSouthEast = 0x0020,
+    //    SouthEast = 0x0040,
+    //    SouthSouthEast = 0x0080,
+    //    SouthSouthWest = 0x0100,
+    //    SouthWest = 0x0200,
+    //    WestSouthWest = 0x0400,
+    //    WestNorthWest = 0x0800,
+    //    All = 0x0FFF,
+
+    //    // predefine the relevant adjacencies of the 4 quadrants of a landblock
+    //    OfNorthEast = NorthNorthWest | NorthNorthEast | NorthEast | EastNorthEast | EastSouthEast,
+    //    OfSouthEast = EastNorthEast | EastSouthEast | SouthEast | SouthSouthEast | SouthSouthWest,
+    //    OfSouthWest = SouthSouthEast | SouthSouthWest | SouthWest | WestSouthWest | WestNorthWest,
+    //    OfNorthWest = WestSouthWest | WestNorthWest | NorthWest | NorthNorthWest | NorthNorthEast
+    //}
+
+}

--- a/Source/ACE/Entity/BroadcastAction.cs
+++ b/Source/ACE/Entity/BroadcastAction.cs
@@ -1,0 +1,11 @@
+﻿namespace ACE.Entity
+{
+    public enum BroadcastAction
+    {
+        AddOrUpdate,
+
+        Delete,
+
+        LocalChat
+    }
+}

--- a/Source/ACE/Entity/Events/BroadcastEventArgs.cs
+++ b/Source/ACE/Entity/Events/BroadcastEventArgs.cs
@@ -1,0 +1,41 @@
+﻿using ACE.Entity.Enum;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Entity.Events
+{
+    public class BroadcastEventArgs
+    {
+        private BroadcastEventArgs()
+        {
+        }
+
+        public static BroadcastEventArgs CreateAction(BroadcastAction actionType, WorldObject sender)
+        {
+            return new BroadcastEventArgs()
+            {
+                ActionType = actionType,
+                Sender = sender
+            };
+        }
+
+        public static BroadcastEventArgs CreateChatAction(WorldObject sender, ChatMessageArgs chatMessage)
+        {
+            return new BroadcastEventArgs()
+            {
+                ActionType = BroadcastAction.LocalChat,
+                Sender = sender,
+                ChatMessage = chatMessage
+            };
+        }
+
+        public BroadcastAction ActionType { get; private set; }
+
+        public WorldObject Sender { get; private set; }
+
+        public ChatMessageArgs ChatMessage { get; private set; }
+    }
+}

--- a/Source/ACE/Entity/Events/ChatMessageArgs.cs
+++ b/Source/ACE/Entity/Events/ChatMessageArgs.cs
@@ -1,0 +1,18 @@
+﻿using ACE.Entity.Enum;
+using System;
+
+namespace ACE.Entity.Events
+{
+    public class ChatMessageArgs : EventArgs
+    {
+        public string Message { get; set; }
+
+        public ChatMessageType MessageType { get; set; }
+
+        public ChatMessageArgs(string message, ChatMessageType type)
+        {
+            this.Message = message;
+            this.MessageType = type;
+        }
+    }
+}

--- a/Source/ACE/Entity/Events/SpellCastArgs.cs
+++ b/Source/ACE/Entity/Events/SpellCastArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace ACE.Entity.Events
+{
+    /// <summary>
+    /// this may or may not end up being used.  a spell casting is really a combination of animation, sound, and effects
+    /// </summary>
+    public class SpellCastArgs : EventArgs
+    {
+        /// <summary>
+        /// TODO: replace with Spell enumeration type
+        /// </summary>
+        public uint SpellId { get; set; }
+
+        /// <summary>
+        /// id of the target of the spell
+        /// </summary>
+        public ObjectGuid Target { get; set; }
+    }
+}

--- a/Source/ACE/Entity/ImmutableWorldObject.cs
+++ b/Source/ACE/Entity/ImmutableWorldObject.cs
@@ -13,13 +13,13 @@ namespace ACE.Entity
     /// </summary>
     public class ImmutableWorldObject : WorldObject
     {
-        public ImmutableWorldObject(ObjectType type, ObjectGuid guid, string name, ushort wccid, ObjectDescriptionFlag descriptionFlag, WeenieHeaderFlag weenieFlag, Position position) : base(type, guid)
+        public ImmutableWorldObject(ObjectType type, ObjectGuid guid, string name, ushort weenieClassId, ObjectDescriptionFlag descriptionFlag, WeenieHeaderFlag weenieFlag, Position position) : base(type, guid)
         {
             this.Name = name;
             this.DescriptionFlags = descriptionFlag;
             this.WeenieFlags = weenieFlag;
             this.Position = position;
-            this.Wcid = wccid;
+            this.WeenieClassid = weenieClassId;
         }
     }
 }

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -1,39 +1,345 @@
-﻿using System;
+﻿using ACE.Entity.Events;
+using ACE.Managers;
+using log4net;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ACE.Entity
 {
     /// <summary>
-    /// Rule #1: ACE Landblock != Real AC Landblock.  Grok that now.
-    /// As of implementation time, the entire world is going to function as
-    /// a single landblock.  We will carve this off later.
-    /// 
     /// the gist of a landblock is that, generally, everything on it publishes
-    /// to and subscribes to everything else in the landblock.
+    /// to and subscribes to everything else in the landblock.  x/y in an outdoor
+    /// landblock goes from 0 to 192.  "indoor" (dungeon) landblocks have no
+    /// functional limit as players can't freely roam in/out of them
     /// </summary>
-    internal class Landblock
+    internal class Landblock : IDisposable
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private const float adjacencyLoadRange = 96f;
+        private const float outDoorChatRange = 75f;
+        private const float indoorChatRange = 25f;
+        private const float maxXY = 192f;
+
+        private LandblockId id;
+
+        private object objectCacheLocker = new object();
         private Dictionary<ObjectGuid, WorldObject> worldObjects = new Dictionary<ObjectGuid, WorldObject>();
+        
+        private Dictionary<Adjacency, Landblock> adjacencies = new Dictionary<Adjacency, Landblock>();
 
-        public Landblock()
+        private byte cellGridMaxX = 8; // todo: load from cell.dat
+        private byte cellGridMaxY = 8; // todo: load from cell.dat
+
+        // not sure if a full object is necessary here.  I don't think a Landcell has any
+        // inherent functionality that needs to be modelled in an object.
+        private Landcell[,] cellGrid; // todo: load from cell.dat
+
+        public LandblockId Id
         {
+            get { return id; }
+        }
 
+        public Landblock(LandblockId id)
+        {
+            this.id = id;
+
+            // initialize adjacency array
+            this.adjacencies.Add(Adjacency.North, null);
+            this.adjacencies.Add(Adjacency.NorthEast, null);
+            this.adjacencies.Add(Adjacency.East, null);
+            this.adjacencies.Add(Adjacency.SouthEast, null);
+            this.adjacencies.Add(Adjacency.South, null);
+            this.adjacencies.Add(Adjacency.SouthWest, null);
+            this.adjacencies.Add(Adjacency.West, null);
+            this.adjacencies.Add(Adjacency.NorthWest, null);
+
+            // TODO: Load cell.dat contents
+            //   1. landblock cell structure
+            //   2. terrain data
+            // TODO: Load portal.dat contents (as/if needed)
+            // TODO: Load spawn data
+
+            // TODO: load objects from world database such as lifestones, doors, player corpses, NPCs, Vendors
+        }
+
+        public void SetAdjacency(Adjacency adjacency, Landblock landblock)
+        {
+            adjacencies[adjacency] = landblock;
+        }
+
+        public Landblock NorthAdjacency
+        {
+            get { return adjacencies[Adjacency.North]; }
+            set { adjacencies[Adjacency.North] = value; }
+        }
+
+        public Landblock NorthEastAdjacency
+        {
+            get { return adjacencies[Adjacency.NorthEast]; }
+            set { adjacencies[Adjacency.NorthEast] = value; }
+        }
+
+        public Landblock EastAdjacency
+        {
+            get { return adjacencies[Adjacency.East]; }
+            set { adjacencies[Adjacency.East] = value; }
+        }
+
+        public Landblock SouthEastAdjacency
+        {
+            get { return adjacencies[Adjacency.SouthEast]; }
+            set { adjacencies[Adjacency.SouthEast] = value; }
+        }
+
+        public Landblock SouthAdjacency
+        {
+            get { return adjacencies[Adjacency.South]; }
+            set { adjacencies[Adjacency.South] = value; }
+        }
+
+        public Landblock SouthWestAdjacency
+        {
+            get { return adjacencies[Adjacency.SouthWest]; }
+            set { adjacencies[Adjacency.SouthWest] = value; }
+        }
+
+        public Landblock WestAdjacency
+        {
+            get { return adjacencies[Adjacency.West]; }
+            set { adjacencies[Adjacency.West] = value; }
+        }
+
+        public Landblock NorthWestAdjacency
+        {
+            get { return adjacencies[Adjacency.NorthWest]; }
+            set { adjacencies[Adjacency.NorthWest] = value; }
+        }
+
+        /// <summary>
+        /// called when a landblock is to be unloaded
+        /// </summary>
+        public void Dispose()
+        {
+            // save all mutable objects, release memory
+            // TODO: implement
         }
 
         public void AddWorldObject(WorldObject wo)
         {
-            this.worldObjects.Add(wo.Guid, wo);
-        }
+            List<WorldObject> allObjects;
 
-        public void RemoveWorldObject(ObjectGuid objectId)
+            Log($"adding {wo.Guid.Full.ToString("X")}");
+
+            lock (objectCacheLocker)
+            {
+                allObjects = this.worldObjects.Values.ToList();
+                this.worldObjects[wo.Guid] = wo;
+            }
+            
+            var args = BroadcastEventArgs.CreateAction(BroadcastAction.AddOrUpdate, wo);
+            Broadcast(args, true, Quadrant.All);
+
+            // if this is a player, tell them about everything else we have.
+            if (wo is Player)
+            {
+                // send them the initial burst of objects
+                Log($"blasting player \"{(wo as Player).Name}\" with {allObjects.Count} objects.");
+                Parallel.ForEach(allObjects, (o) => (wo as Player).TrackObject(o));
+            }
+        }
+        
+        public void SendChatMessage(WorldObject sender, ChatMessageArgs chatMessage)
         {
-            if (this.worldObjects.ContainsKey(objectId))
-                this.worldObjects.Remove(objectId);
+            // only players receive this
+            List<Player> players = null;
+
+            lock (objectCacheLocker)
+            {
+                players = this.worldObjects.Values.OfType<Player>().ToList();
+            }
+            
+            BroadcastEventArgs args = BroadcastEventArgs.CreateChatAction(sender, chatMessage);
+            Broadcast(args, true, Quadrant.All);
         }
 
+        public void RemoveWorldObject(ObjectGuid objectId, bool adjacencyMove)
+        {
+            WorldObject wo = null;
 
+            Log($"removing {objectId.Full.ToString("X")}");
+
+            lock (objectCacheLocker)
+            {
+                if (this.worldObjects.ContainsKey(objectId))
+                {
+                    wo = this.worldObjects[objectId];
+                    this.worldObjects.Remove(objectId);
+                }
+            }
+
+            // suppress broadcasting when it's just an adjacency move.  clients will naturally just stop
+            // tracking stuff if they're too far, or the new landblock will broadcast to them if they're
+            // close enough.
+            if (!adjacencyMove && this.id.MapScope == Enum.MapScope.Outdoors && wo != null)
+            {
+                var args = BroadcastEventArgs.CreateAction(BroadcastAction.Delete, wo);
+                Broadcast(args, true, Quadrant.All);
+            }
+        }
+
+        /// <summary>
+        /// handles broadcasting an event to the players in this landblock and to the proper adjacencies
+        /// </summary>
+        private void Broadcast(BroadcastEventArgs args, bool propogate, Quadrant quadrant)
+        {
+            WorldObject wo = args.Sender;
+            List<Player> players = null;
+
+            Log($"broadcasting object {args.Sender.Guid.Full.ToString("X")} - {args.ActionType}");
+
+            lock (objectCacheLocker)
+            {
+                players = this.worldObjects.Values.OfType<Player>().ToList();
+            }
+
+            // filter to applicable players
+            players = players.Where(p => p.Position?.IsInQuadrant(quadrant) ?? false).ToList();
+
+            switch (args.ActionType)
+            {
+                case BroadcastAction.Delete:
+                    {
+                        Parallel.ForEach(players, p => p.StopTrackingObject(wo.Guid));
+                        break;
+                    }
+                case BroadcastAction.AddOrUpdate:
+                    {
+                        Player player = args.Sender as Player;
+                        if (player != null)
+                        {
+                            player.SendUpdatePosition();
+                            players = players.Where(p => p.Guid != args.Sender.Guid).ToList();
+                        }
+                        Parallel.ForEach(players, p => p.TrackObject(wo));
+                        break;
+                    }
+                case BroadcastAction.LocalChat:
+                    {
+                        // TODO: implement range dectection for chat events
+                        Parallel.ForEach(players, p => p.ReceiveChat(wo, args.ChatMessage));
+                        break;
+                    }
+            }
+
+            // short circuit when there's no functional adjacency
+            if (!propogate || wo?.Position?.LandblockId.MapScope == Enum.MapScope.IndoorsSmall)
+                return;
+
+            if (propogate)
+            {
+
+                Log($"propogating broadcasting object {args.Sender.Guid.Full.ToString("X")} - {args.ActionType} to adjacencies");
+
+                if (wo.Position.Offset.X < adjacencyLoadRange)
+                {
+                    WestAdjacency?.Broadcast(args, false, Quadrant.NorthEast | Quadrant.SouthEast);
+
+                    if (wo.Position.Offset.Y < adjacencyLoadRange)
+                        SouthWestAdjacency?.Broadcast(args, false, Quadrant.NorthEast);
+
+                    if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                        NorthWestAdjacency?.Broadcast(args, false, Quadrant.SouthEast);
+                }
+
+                if (wo.Position.Offset.Y < adjacencyLoadRange)
+                    SouthAdjacency?.Broadcast(args, false, Quadrant.NorthEast | Quadrant.NorthWest);
+
+                if (wo.Position.Offset.X > (maxXY - adjacencyLoadRange))
+                {
+                    EastAdjacency?.Broadcast(args, false, Quadrant.NorthWest | Quadrant.SouthWest);
+
+                    if (wo.Position.Offset.Y < adjacencyLoadRange)
+                        SouthEastAdjacency?.Broadcast(args, false, Quadrant.NorthWest);
+
+                    if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                        NorthEastAdjacency?.Broadcast(args, false, Quadrant.SouthWest);
+                }
+
+                if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                    NorthAdjacency?.Broadcast(args, false, Quadrant.SouthEast | Quadrant.SouthWest);
+            }
+        }
+
+        /// <summary>
+        /// main game loop
+        /// </summary>
+        public void UseTime(double lastTick)
+        {
+            // here we'd move server objects in motion (subject to landscape) and do physics collision detection
+
+            // for now, we'll move players around
+            List<MutableWorldObject> movedObjects = null;
+
+            lock (objectCacheLocker)
+            {
+                // TODO: Improve the efficiency of this line
+                movedObjects = this.worldObjects.Values.Where(o => (o as MutableWorldObject) != null).Cast<MutableWorldObject>().ToList();
+            }
+
+            movedObjects = movedObjects.Where(p => p.LastMovedTicks > p.LastMovementBroadcastTicks).ToList();
+
+            if (this.id.MapScope == Enum.MapScope.Outdoors)
+            {
+                // check to see if a player or other mutable object "roamed" to an adjacent landblock
+                var objectsToRelocate = movedObjects.Where(m => m.Position.LandblockId.IsAdjacentTo(this.id) && m.Position.LandblockId != this.id).ToList();
+
+                // so, these objects moved to an adjacent block.  they could have recalled to that block, died and bounced to a lifestone on that block, or
+                // just simply walked accross the border line.  in any case, we won't delete them, we'll just transfer them.  the trick, though, is to
+                // figure out how to treat it in adjacent landblocks.  if the player walks across the southern border, the north adjacency needs to remove
+                // them, but the south is actually getting them.  we need to avoid sending Delete+Create to clients that already know about it, though.
+
+                objectsToRelocate.ForEach(o => Log($"attempting to relocate object {o.Name} ({o.Guid.Full.ToString("X")})"));
+
+                // RelocateObject will put them in the right landblock
+                objectsToRelocate.ForEach(o => LandblockManager.RelocateObject(o));
+
+                // Remove has logic to make sure it doesn't double up the delete+create when "true" is passed.
+                objectsToRelocate.ForEach(o => RemoveWorldObject(o.Guid, true));
+            }
+
+            // broadcast
+            Parallel.ForEach(movedObjects, mo =>
+            {
+                if (mo.Position.LandblockId == this.id)
+                {
+                    // update if it's still here
+                    Broadcast(BroadcastEventArgs.CreateAction(BroadcastAction.AddOrUpdate, mo), true, Quadrant.All);
+                }
+                else
+                {
+                    // remove and readd if it's not
+                    this.RemoveWorldObject(mo.Guid, false);
+                    LandblockManager.AddObject(mo);
+                }
+            });
+
+            // TODO: figure out if this landblock can be unloaded
+        }
+
+        /// <summary>
+        /// would be used to find out if a landblock was idle
+        /// </summary>
+        public int GetPlayerCount()
+        {
+            return this.worldObjects.Values.OfType<Player>().Count();
+        }
+
+        private void Log(string message)
+        {
+            log.Debug($"LB {id.Landblock.ToString("X")}: {message}");
+        }
     }
 }

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -327,17 +327,11 @@ namespace ACE.Entity
                 });
 
                 // TODO: figure out if this landblock can be unloaded
+
+                Thread.Sleep(1);
             }
 
             // TODO: release resources
-        }
-
-        /// <summary>
-        /// would be used to find out if a landblock was idle
-        /// </summary>
-        public int GetPlayerCount()
-        {
-            return this.worldObjects.Values.OfType<Player>().Count();
         }
 
         private void Log(string message)

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -286,7 +286,7 @@ namespace ACE.Entity
                     movedObjects = this.worldObjects.Values.OfType<MutableWorldObject>().ToList();
                 }
 
-                movedObjects = movedObjects.Where(p => p.LastUpdatedTicks > p.LastMovementBroadcastTicks).ToList();
+                movedObjects = movedObjects.Where(p => p.LastUpdatedTicks >= p.LastMovementBroadcastTicks).ToList();
 
                 // flag them as updated now in order to reduce chance of missing an update
                 movedObjects.ForEach(m => m.LastMovementBroadcastTicks = WorldManager.PortalYearTicks);

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -235,12 +235,11 @@ namespace ACE.Entity
             }
 
             // short circuit when there's no functional adjacency
-            if (!propogate || wo?.Position?.LandblockId.MapScope == Enum.MapScope.IndoorsSmall)
+            if (!propogate || wo?.Position?.LandblockId.MapScope != Enum.MapScope.Outdoors)
                 return;
 
             if (propogate)
             {
-
                 Log($"propogating broadcasting object {args.Sender.Guid.Full.ToString("X")} - {args.ActionType} to adjacencies");
 
                 if (wo.Position.Offset.X < adjacencyLoadRange)

--- a/Source/ACE/Entity/Landcell.cs
+++ b/Source/ACE/Entity/Landcell.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace ACE.Entity
+{
+    public class Landcell
+    {
+    }
+}

--- a/Source/ACE/Entity/MutableWorldObject.cs
+++ b/Source/ACE/Entity/MutableWorldObject.cs
@@ -5,25 +5,21 @@ using System.Text;
 using System.Threading.Tasks;
 using ACE.Entity.Enum;
 using ACE.Managers;
+using log4net;
 
 namespace ACE.Entity
 {
-
     /// <summary>
     /// any world object that can change a state of some sort that requires clients be updated.  players, monsters,
     /// doors, etc.
     /// </summary>
     public abstract class MutableWorldObject : WorldObject
-   
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public MutableWorldObject(ObjectType type, ObjectGuid guid) : base(type, guid)
         {
         }
-
-        /// <summary>
-        /// tick-stamp for the last time the player moved
-        /// </summary>
-        public double LastMovedTicks { get; set; }
 
         /// <summary>
         /// tick-stamp for the last time a movement update was sent
@@ -42,7 +38,9 @@ namespace ACE.Entity
             protected set
             {
                 if (base.Position != null)
-                    LastMovedTicks = WorldManager.PortalYearTicks;
+                    LastUpdatedTicks = WorldManager.PortalYearTicks;
+
+                log.Debug($"{Name} moved to {Position}");
 
                 base.Position = value;                
             }

--- a/Source/ACE/Entity/MutableWorldObject.cs
+++ b/Source/ACE/Entity/MutableWorldObject.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ACE.Entity.Enum;
+using ACE.Managers;
 
 namespace ACE.Entity
 {
@@ -18,6 +19,33 @@ namespace ACE.Entity
         public MutableWorldObject(ObjectType type, ObjectGuid guid) : base(type, guid)
         {
         }
+
+        /// <summary>
+        /// tick-stamp for the last time the player moved
+        /// </summary>
+        public double LastMovedTicks { get; set; }
+
+        /// <summary>
+        /// tick-stamp for the last time a movement update was sent
+        /// </summary>
+        public double LastMovementBroadcastTicks { get; set; }
+
+        /// <summary>
+        /// tick-stamp for the server time of the last time the player moved.
+        /// TODO: implement
+        /// </summary>
+        public double LastAnimatedTicks { get; set; }
         
+        public override Position Position
+        {
+            get { return base.Position; }
+            protected set
+            {
+                if (base.Position != null)
+                    LastMovedTicks = WorldManager.PortalYearTicks;
+
+                base.Position = value;                
+            }
+        }
     }
 }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using ACE.Database;
@@ -14,14 +15,12 @@ using ACE.Network.GameEvent.Events;
 using ACE.Network.Managers;
 using ACE.Managers;
 using ACE.Network.Enum;
+using ACE.Entity.Events;
 
 namespace ACE.Entity
 {
     public class Player : MutableWorldObject
     {
-        // all the objects being tracked
-        private Dictionary<ObjectGuid, MutableWorldObject> subscribedObjects = new Dictionary<ObjectGuid, MutableWorldObject>();
-
         public Session Session { get; }
 
 
@@ -40,7 +39,15 @@ namespace ACE.Entity
         /// </summary>
         public uint PortalIndex { get; set; } = 1u;
 
+        /// <summary>
+        /// tick-stamp for the server time of the last time the player changed state (combat state?)
+        /// </summary>
+        public double LastStateChangeTicks { get; set; }
+
         private Character character;
+        
+        private object clientObjectMutex = new object();
+        private List<ObjectGuid> clientObjectList = new List<ObjectGuid>();
 
         public ReadOnlyDictionary<CharacterOption, bool> CharacterOptions
         {
@@ -200,6 +207,7 @@ namespace ACE.Entity
             PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.CSetup | PhysicsDescriptionFlag.MTable | PhysicsDescriptionFlag.Stable | PhysicsDescriptionFlag.Petable | PhysicsDescriptionFlag.Position;
             WeenieFlags = WeenieHeaderFlag.ItemCapacity | WeenieHeaderFlag.ContainerCapacity | WeenieHeaderFlag.Usable | WeenieHeaderFlag.BlipColour | WeenieHeaderFlag.Radar;
 
+            // apply defaults.  "Load" should be overwriting these with values specific to the character
             PhysicsData.MTableResourceId = 0x09000001u;
             PhysicsData.Stable = 0x20000001u;
             PhysicsData.Petable = 0x34000004u;
@@ -209,9 +217,9 @@ namespace ACE.Entity
             ListeningRadius = 5f;
         }
 
-        public async void Load()
+        public async Task Load(Character preloadedCharacter = null)
         {
-            character = await DatabaseManager.Character.LoadCharacter(Guid.Low);
+            character = preloadedCharacter ?? await DatabaseManager.Character.LoadCharacter(Guid.Low);
 
             if (Common.ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions)
             {
@@ -231,6 +239,7 @@ namespace ACE.Entity
             Position = character.Position;
             IsOnline = true;
 
+            // SendSelf will trigger the entrance into portal space
             SendSelf();
             SendFriendStatusUpdates();
 
@@ -628,8 +637,18 @@ namespace ACE.Entity
 
             Session.Network.EnqueueSend(new GameMessagePlayerTeleport(++TeleportIndex));
 
-            // must be sent after the teleport packet
-            UpdatePosition(newPosition);
+            DelayedUpdatePosition(newPosition);
+        }
+
+        public void UpdatePosition(Position newPosition)
+        {
+            this.Position = newPosition;
+        }
+
+        private void DelayedUpdatePosition(Position newPosition)
+        {
+            var t = new Thread(() => { Thread.Sleep(100); this.Position = newPosition; });
+            t.Start();
         }
 
         public void SetTitle(uint title)
@@ -639,18 +658,42 @@ namespace ACE.Entity
             Session.Network.EnqueueSend(updateTitle, message);
         }
 
-        public void Subscribe(MutableWorldObject worldObject)
+        public void ObjectMoved(MutableWorldObject sender)
         {
-            subscribedObjects.Add(worldObject.Guid, worldObject);
+            Session.WorldSession.EnqueueSend(new GameMessageUpdatePosition(sender));
         }
 
-        public void Unsubscribe(ObjectGuid objectId)
+        public void ReceiveChat(WorldObject sender, ChatMessageArgs e)
         {
-            if (subscribedObjects.ContainsKey(objectId))
-            {
-                subscribedObjects.Remove(objectId);
+            // TODO: Implement
+        }
 
-                // TODO: send a destroy packet
+        /// <summary>
+        /// TODO: use or remove the sendWeenie flag
+        /// </summary>
+        public void TrackObject(WorldObject worldObject, bool sendWeenie = true)
+        {
+            bool sendUpdate = true;
+
+            lock (clientObjectMutex)
+            {
+                sendUpdate = clientObjectList.Contains(worldObject.Guid);
+
+                if (!sendUpdate)
+                {
+                    clientObjectList.Add(worldObject.Guid);
+                }
+            }
+
+            if (sendUpdate)
+            {
+                // send a normal update
+                Session.WorldSession.EnqueueSend(new GameMessageUpdateObject(worldObject));
+            }
+            else
+            {
+                clientObjectList.Add(worldObject.Guid);
+                Session.WorldSession.EnqueueSend(new GameMessageCreateObject(worldObject));
             }
         }
 
@@ -667,6 +710,9 @@ namespace ACE.Entity
             IsOnline = false;
 
             SendFriendStatusUpdates();
+
+            // remove the player from landblock management
+            LandblockManager.RemoveObject(this);
 
             // NOTE: Adding this here for now because some chracter options do not trigger the GameActionSetCharacterOptions packet to fire when apply is clicked (which is where we are currently saving to the db).
             // Once we get a CharacterSave method, we might consider removing this and putting it in that method instead.
@@ -689,6 +735,31 @@ namespace ACE.Entity
                 var roleplay = new GameEventDisplayParameterizedStatusMessage(Session, StatusMessageType2.YouHaveLeftThe_Channel, "Roleplay");
                 Session.Network.EnqueueSend(general, trade, lfg, roleplay);
             }
+        }
+
+        public void StopTrackingObject(ObjectGuid objectId)
+        {
+            bool sendUpdate = true;
+            lock (clientObjectMutex)
+            {
+                sendUpdate = clientObjectList.Contains(objectId);
+
+                if (!sendUpdate)
+                {
+                    clientObjectList.Remove(objectId);
+                }
+            }
+
+            if (sendUpdate)
+            {
+                Session.WorldSession.EnqueueSend(new GameMessageRemoveObject(objectId));
+            }
+        }
+
+        public void SendUpdatePosition()
+        {
+            this.LastMovementBroadcastTicks = WorldManager.PortalYearTicks;
+            Session.WorldSession.EnqueueSend(new GameMessageUpdatePosition(this));
         }
     }
 }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -23,7 +23,6 @@ namespace ACE.Entity
     {
         public Session Session { get; }
 
-
         /// <summary>
         /// This will be false when in portal space
         /// </summary>
@@ -636,6 +635,11 @@ namespace ACE.Entity
             SetPhysicsState(PhysicsState.IgnoreCollision | PhysicsState.Gravity | PhysicsState.Hidden | PhysicsState.EdgeSlide);
 
             Session.Network.EnqueueSend(new GameMessagePlayerTeleport(++TeleportIndex));
+
+            lock(clientObjectMutex)
+            {
+                clientObjectList.Clear();
+            }
 
             DelayedUpdatePosition(newPosition);
         }

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -21,8 +21,7 @@ namespace ACE.Entity
 
         public string Name { get; protected set; }
 
-
-        public Position Position
+        public virtual Position Position
         { 
             get { return PhysicsData.Position; }
             protected set { PhysicsData.Position = value; }
@@ -63,6 +62,12 @@ namespace ACE.Entity
             GameData = new GameData();
             ModelData = new ModelData();
             PhysicsData = new PhysicsData();
+        }
+
+        public virtual void SerializeUpdateObject(BinaryWriter writer)
+        {
+            // content of these 2 is the same? TODO: Validate that?
+            SerializeCreateObject(writer);
         }
 
         public virtual void SerializeCreateObject(BinaryWriter writer)
@@ -192,19 +197,6 @@ namespace ACE.Entity
                 writer.Write(0u);*/
 
             writer.Align();
-        }
-
-        public void UpdatePosition(Position newPosition)
-        {
-            // TODO: sanity checks
-            Position = newPosition;
-
-            // TODO: this packet needs to be broadcast to the grid system, just send to self for now
-            if (Guid.IsPlayer())
-            {
-                Session session = (this as Player).Session;
-                session.Network.EnqueueSend(new GameMessageUpdatePosition(this));
-            }
         }
 
         public void WriteUpdatePositionPayload(BinaryWriter writer)

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -15,7 +15,10 @@ namespace ACE.Entity
 
         public ObjectType Type { get; protected set; }
 
-        public ushort Wcid { get; protected set; }
+        /// <summary>
+        /// wcid - stands for weenie class id
+        /// </summary>
+        public ushort WeenieClassid { get; protected set; }
 
         public ushort Icon { get; protected set; }
 
@@ -62,7 +65,6 @@ namespace ACE.Entity
         {
             Type = type;
             Guid = guid;
-            ///Wcid = wcid;
 
             GameData = new GameData();
             ModelData = new ModelData();
@@ -84,7 +86,7 @@ namespace ACE.Entity
             
             writer.Write((uint)WeenieFlags);
             writer.WriteString16L(Name);
-            writer.Write((ushort)Wcid);
+            writer.Write((ushort)WeenieClassid);
             writer.Write((ushort)Icon);
             writer.Write((uint)Type);
             writer.Write((uint)DescriptionFlags);

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -21,6 +21,11 @@ namespace ACE.Entity
 
         public string Name { get; protected set; }
 
+        /// <summary>
+        /// tick-stamp for the last time this object changed in any way.
+        /// </summary>
+        public double LastUpdatedTicks { get; set; }
+
         public virtual Position Position
         { 
             get { return PhysicsData.Position; }

--- a/Source/ACE/Factories/AdminObjectFactory.cs
+++ b/Source/ACE/Factories/AdminObjectFactory.cs
@@ -1,0 +1,44 @@
+﻿using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Network.Enum;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Factories
+{
+    /// <summary>
+    /// factory class for creating objects related to administration or content-recreation
+    /// </summary>
+    public class AdminObjectFactory
+    {
+        /// <summary>
+        /// creates a lifestone directly in fron of the player's position provided
+        /// </summary>
+        public static WorldObject CreateLifestone(Position newPosition)
+        {
+            var weenie = WeenieHeaderFlag.Usable | WeenieHeaderFlag.BlipColour | WeenieHeaderFlag.Radar | WeenieHeaderFlag.UseRadius;
+            ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(CommonObjectFactory.NextObjectId, GuidType.None), "Life Stone", ObjectDescriptionFlag.LifeStone, weenie, newPosition);
+
+            // model id 0x000026 is one of several lifestone IDs
+            wo.PhysicsData.MTableResourceId = 0x09000026u;
+            wo.PhysicsData.Stable = 0x20000014u;
+            wo.PhysicsData.CSetup = (uint)0x020002EEu;
+
+            wo.PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.CSetup | PhysicsDescriptionFlag.MTable | PhysicsDescriptionFlag.Stable | PhysicsDescriptionFlag.Position;
+
+            //game data min required flags;
+            wo.GameData.Type = (ushort)0x1355;
+            wo.GameData.Icon = (ushort)0x1036;
+
+            wo.GameData.Usable = Usable.UsableRemote;
+            wo.GameData.RadarColour = RadarColor.Blue;
+            wo.GameData.RadarBehavior = RadarBehavior.ShowAlways;
+            wo.GameData.UseRadius = 4f;
+
+            return wo;
+        }
+    }
+}

--- a/Source/ACE/Factories/AdminObjectFactory.cs
+++ b/Source/ACE/Factories/AdminObjectFactory.cs
@@ -20,7 +20,7 @@ namespace ACE.Factories
         public static WorldObject CreateLifestone(Position newPosition)
         {
             var weenie = WeenieHeaderFlag.Usable | WeenieHeaderFlag.BlipColour | WeenieHeaderFlag.Radar | WeenieHeaderFlag.UseRadius;
-            ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(CommonObjectFactory.NextObjectId, GuidType.None), "Life Stone", 0, ObjectDescriptionFlag.LifeStone, weenie, newPosition);
+            ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(CommonObjectFactory.DynamicObjectId, GuidType.None), "Life Stone", 0, ObjectDescriptionFlag.LifeStone, weenie, newPosition);
 
             // model id 0x000026 is one of several lifestone IDs
             wo.PhysicsData.MTableResourceId = 0x09000026u;

--- a/Source/ACE/Factories/AdminObjectFactory.cs
+++ b/Source/ACE/Factories/AdminObjectFactory.cs
@@ -20,7 +20,7 @@ namespace ACE.Factories
         public static WorldObject CreateLifestone(Position newPosition)
         {
             var weenie = WeenieHeaderFlag.Usable | WeenieHeaderFlag.BlipColour | WeenieHeaderFlag.Radar | WeenieHeaderFlag.UseRadius;
-            ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(CommonObjectFactory.NextObjectId, GuidType.None), "Life Stone", ObjectDescriptionFlag.LifeStone, weenie, newPosition);
+            ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(CommonObjectFactory.NextObjectId, GuidType.None), "Life Stone", 0, ObjectDescriptionFlag.LifeStone, weenie, newPosition);
 
             // model id 0x000026 is one of several lifestone IDs
             wo.PhysicsData.MTableResourceId = 0x09000026u;

--- a/Source/ACE/Factories/CommonObjectFactory.cs
+++ b/Source/ACE/Factories/CommonObjectFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Factories
+{
+    public class CommonObjectFactory
+    {
+        private static uint nextObjectId = 0x00000001;
+
+        public static uint NextObjectId
+        {
+            get { return nextObjectId++; }
+        }
+    }
+}

--- a/Source/ACE/Factories/CommonObjectFactory.cs
+++ b/Source/ACE/Factories/CommonObjectFactory.cs
@@ -8,9 +8,9 @@ namespace ACE.Factories
 {
     public class CommonObjectFactory
     {
-        private static uint nextObjectId = 0x00000001;
+        private static uint nextObjectId = 0x80000001;
 
-        public static uint NextObjectId
+        public static uint DynamicObjectId
         {
             get { return nextObjectId++; }
         }

--- a/Source/ACE/Factories/LootGenerationFactory.cs
+++ b/Source/ACE/Factories/LootGenerationFactory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Factories
+{
+    public class LootGenerationFactory
+    {
+    }
+}

--- a/Source/ACE/Factories/MonsterFactory.cs
+++ b/Source/ACE/Factories/MonsterFactory.cs
@@ -1,0 +1,24 @@
+﻿using ACE.Entity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Factories
+{
+    public class MonsterFactory
+    {
+        public static WorldObject CreateMonster(uint templateId, Position position)
+        {
+            // TODO: Implement
+
+            // read template from the database, create an object
+            // do whatever else it takes to make a monster
+
+            // assign it the position
+
+            return null;
+        }
+    }
+}

--- a/Source/ACE/Managers/GuidManager.cs
+++ b/Source/ACE/Managers/GuidManager.cs
@@ -9,26 +9,26 @@ namespace ACE.Managers
     /// </summary>
     public static class GuidManager
     {
-        //thanks pea for good ranges!
+        // thanks pea for good ranges!
 
-        //players
-        private const uint playerMin        = 0x50000001;
-        private const uint playerMax        = 0x59999999;
-        private static uint player         = 0x50000001;
+        // players
+        private const uint playerMin = 0x50000001;
+        private const uint playerMax = 0x59999999;
+        private static uint player = 0x50000001;
         private static Hashtable usedplayerguids;
         private static Hashtable avaliableplayerguids;
 
-        //Npc / Doors / Portals / Etc
-        private const uint staticObjextMin      = 0x6000001;
-        private const uint staticObjextMax      = 0x6999999;
-        private static uint staticObject         = 0x6000001;
+        // Npc / Doors / Portals / Etc
+        private const uint staticObjextMin = 0x6000001;
+        private const uint staticObjextMax = 0x6999999;
+        private static uint staticObject = 0x6000001;
 
         // Monsters /
-        private const uint monsterMin         = 0x8000001;
+        private const uint monsterMin = 0x8000001;
         private const uint monsterMax = 0x8999999;
         private static uint monsterObject = 0x8000001;
 
-        //Items / Player Items
+        // Items / Player Items
         private const uint itemMin = 0x9000001;
         private const uint itemMax = 0x9999999;
         private static uint item = 0x9000001;
@@ -84,8 +84,5 @@ namespace ACE.Managers
             item++;
             return item;
         }
-
-
     }
-
 }

--- a/Source/ACE/Managers/LandblockManager.cs
+++ b/Source/ACE/Managers/LandblockManager.cs
@@ -44,21 +44,7 @@ namespace ACE.Managers
             Landblock block = GetLandblock(worldObject.Position.LandblockId, true);
             block.RemoveWorldObject(worldObject.Guid, false);
         }
-
-        public static void UseTime(double lastTick)
-        {
-            List<Landblock> activeBlocks = new List<Landblock>();
-
-            for (int x = 0; x < 256; x++)
-                for (int y = 0; y < 256; y++)
-                    if (landblocks[x, y] != null)
-                        activeBlocks.Add(landblocks[x, y]);
-
-            Parallel.ForEach(activeBlocks, b => b.UseTime(lastTick));
-
-            // TODO: figure out if landblocks can be spun down / terminated
-        }
-
+        
         /// <summary>
         /// gets the landblock specified, creating it if it is not already loaded.  will create all
         /// adjacent landblocks if propogate is true (outdoor world roaming).
@@ -107,6 +93,9 @@ namespace ACE.Managers
 
                         if (y < 255)
                             SetAdjacency(landblockId, landblockId.North, Adjacency.North, autoLoad);
+
+                        // kick off the landblock use time thread
+                        block.StartUseTime();
                     }
                 }
             }

--- a/Source/ACE/Managers/LandblockManager.cs
+++ b/Source/ACE/Managers/LandblockManager.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿using ACE.Database;
+using ACE.Entity;
+using ACE.Entity.Events;
+using ACE.Network;
+using log4net;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,5 +13,145 @@ namespace ACE.Managers
 {
     public class LandblockManager
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        private static object landblockMutex = new object();
+
+        // debating during this into a dictionary keyed on LandblockId.  would be functionally equivalent
+        // and get rid of the 2D array shenanigans
+        private static Landblock[,] landblocks = new Landblock[256, 256];
+
+        public static async void PlayerEnterWorld(Session session)
+        {
+            var task = DatabaseManager.Character.LoadCharacter(session.Player.Guid.Low);
+            task.Wait();
+            Character c = task.Result;
+
+            await session.Player.Load(c);
+
+            Landblock block = GetLandblock(c.Position.LandblockId, true);
+            block.AddWorldObject(session.Player);
+        }
+
+        public static void AddObject(WorldObject worldObject)
+        {
+            Landblock block = GetLandblock(worldObject.Position.LandblockId, true);
+            block.AddWorldObject(worldObject);
+        }
+
+        public static void RemoveObject(WorldObject worldObject)
+        {
+            Landblock block = GetLandblock(worldObject.Position.LandblockId, true);
+            block.RemoveWorldObject(worldObject.Guid, false);
+        }
+
+        public static void UseTime(double lastTick)
+        {
+            List<Landblock> activeBlocks = new List<Landblock>();
+
+            for (int x = 0; x < 256; x++)
+                for (int y = 0; y < 256; y++)
+                    if (landblocks[x, y] != null)
+                        activeBlocks.Add(landblocks[x, y]);
+
+            Parallel.ForEach(activeBlocks, b => b.UseTime(lastTick));
+
+            // TODO: figure out if landblocks can be spun down / terminated
+        }
+
+        /// <summary>
+        /// gets the landblock specified, creating it if it is not already loaded.  will create all
+        /// adjacent landblocks if propogate is true (outdoor world roaming).
+        /// </summary>
+        private static Landblock GetLandblock(LandblockId landblockId, bool propogate)
+        {
+            int x = landblockId.LandblockX;
+            int y = landblockId.LandblockY;
+
+            // standard check/lock/recheck pattern
+            if (landblocks[x, y] == null)
+            {
+                lock(landblockMutex)
+                {
+                    if (landblocks[x, y] == null)
+                    {
+                        // load up this landblock
+                        Landblock block = new Landblock(landblockId);
+                        landblocks[x, y] = block;
+                        bool autoLoad = propogate && landblockId.MapScope == Entity.Enum.MapScope.Outdoors;
+
+                        if (x > 0)
+                        {
+                            SetAdjacency(landblockId, landblockId.West, Adjacency.West, autoLoad);
+
+                            if (y > 0)
+                                SetAdjacency(landblockId, landblockId.SouthWest, Adjacency.SouthWest, autoLoad);
+
+                            if (y < 255)
+                                SetAdjacency(landblockId, landblockId.NorthWest, Adjacency.NorthWest, autoLoad);
+                        }
+
+                        if (x < 255)
+                        {
+                            SetAdjacency(landblockId, landblockId.East, Adjacency.East, autoLoad);
+
+                            if (y > 0)
+                                SetAdjacency(landblockId, landblockId.SouthEast, Adjacency.SouthEast, autoLoad);
+
+                            if (y < 255)
+                                SetAdjacency(landblockId, landblockId.NorthEast, Adjacency.NorthEast, autoLoad);
+                        }
+
+                        if (y > 0)
+                            SetAdjacency(landblockId, landblockId.South, Adjacency.South, autoLoad);
+
+                        if (y < 255)
+                            SetAdjacency(landblockId, landblockId.North, Adjacency.North, autoLoad);
+                    }
+                }
+            }
+
+            return landblocks[x, y];
+        }
+
+        public static void RelocateObject(WorldObject wo)
+        {
+            // relocates an object to the appropriate landblock
+            var newBlock = GetLandblock(wo.Position.LandblockId, true);
+            newBlock.AddWorldObject(wo);
+        }
+
+        /// <summary>
+        /// sets the adjacencies of the specified landblocks.  nulls are allowed in the use case of deleting
+        /// or unloading a landblock.  Landblock2 is {adjacency} of Landblock1.  if autoLoad is true, and
+        /// landblock2 is null, it will be auto loaded.
+        /// 
+        /// NOTE: ASSUMES A LOCK ON landblockMutex
+        /// </summary>
+        /// <param name="landblock1">a landblock</param>
+        /// <param name="landblock2">a landblock</param>
+        /// <param name="adjacency">the adjacency of landblock2 relative to landblock1</param>
+        private static void SetAdjacency(LandblockId landblock1, LandblockId landblock2, Adjacency adjacency, bool autoLoad = false)
+        {
+            // suppress adjacency logic for indoor areas
+            if (landblock1.MapScope != Entity.Enum.MapScope.Outdoors || landblock2.MapScope != Entity.Enum.MapScope.Outdoors)
+                return;
+
+            Landblock lb1 = landblocks[landblock1.LandblockX, landblock1.LandblockY];
+            Landblock lb2 = landblocks[landblock2.LandblockX, landblock2.LandblockY];
+
+            if (autoLoad && lb2 == null)
+            {
+                lb2 = GetLandblock(landblock2, false);
+            }
+            lb1.SetAdjacency(adjacency, lb2);
+
+            if (lb2 != null)
+            {
+                int inverse = (((int)adjacency) + 4) % 8; // go halfway around the horn (+4) and mod 8 to wrap around
+                Adjacency inverseAdjacency = (Adjacency)Enum.ToObject(typeof(Adjacency), inverse);
+                lb2.SetAdjacency(inverseAdjacency, lb1);
+            }
+        }
     }
 }

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using ACE.Network;
 using ACE.Entity;
 using ACE.Common;
+using System.Threading.Tasks;
 
 namespace ACE.Managers
 {
@@ -172,8 +173,8 @@ namespace ACE.Managers
                 sessionLock.EnterReadLock();
                 try
                 {
-                    foreach (var session in sessionStore)
-                        session.Update(lastTick);
+                    Parallel.ForEach(sessionStore, s => s.Update(lastTick));
+                    LandblockManager.UseTime(lastTick);
                 }
                 finally
                 {

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -174,7 +174,6 @@ namespace ACE.Managers
                 try
                 {
                     Parallel.ForEach(sessionStore, s => s.Update(lastTick));
-                    LandblockManager.UseTime(lastTick);
                 }
                 finally
                 {

--- a/Source/ACE/Network/ConnectionListener.cs
+++ b/Source/ACE/Network/ConnectionListener.cs
@@ -76,6 +76,7 @@ namespace ACE.Network
 
             IPEndPoint ipEndpoint = (IPEndPoint)clientEndPoint;
             var session = WorldManager.Find(ipEndpoint);
+
 #if NETWORKDEBUG
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(String.Format("Received Packet (Len: {0}) [{1}:{2}=>{3}:{4}]", data.Length, ipEndpoint.Address, ipEndpoint.Port, listenerEndpoint.Address, listenerEndpoint.Port));

--- a/Source/ACE/Network/Extensions.cs
+++ b/Source/ACE/Network/Extensions.cs
@@ -84,6 +84,6 @@ namespace ACE.Network
 
         public static ObjectGuid ReadGuid(this BinaryReader reader) { return new ObjectGuid(reader.ReadUInt32()); }
 
-        public static void WriteGuid(this BinaryWriter writer, ObjectGuid guid) { writer.Write(guid?.Full ?? 0u); }
+        public static void WriteGuid(this BinaryWriter writer, ObjectGuid guid) { writer.Write(guid.Full); }
     }
 }

--- a/Source/ACE/Network/GameAction/Actions/GameActionAdvocateTeleport.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionAdvocateTeleport.cs
@@ -25,7 +25,7 @@ namespace ACE.Network.GameAction.Actions
             if (!Session.Player.IsAdmin && !Session.Player.IsArch && !Session.Player.IsPsr)
                 return;
 
-            uint cell  = position.Cell;
+            uint cell  = position.LandblockId.Raw;
             uint cellX = (cell >> 3);
 
             //TODO: Wrap command in a check to confirm session.character IsAdvocate or higher access level

--- a/Source/ACE/Network/GameMessageGroup.cs
+++ b/Source/ACE/Network/GameMessageGroup.cs
@@ -5,6 +5,7 @@ namespace ACE.Network
     {
         Group04 = 0x04,
         Group05 = 0x05,
+        Group07 = 0x07, // Autonomous Position
         Group09 = 0x09,
         Group0A = 0x0A
     }

--- a/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
+++ b/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
@@ -50,6 +50,7 @@ namespace ACE.Network.GameMessages
         CharacterEnterWorldRequest      = 0xF7C8,
         FriendsOld                      = 0xF7CD,
         CharacterRestore                = 0xF7D9,
+        UpdateObject                    = 0xF7DB,
         TurbineChat                     = 0xF7DE,
         CharacterEnterWorldServerReady  = 0xF7DF,
         ServerMessage                   = 0xF7E0,

--- a/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
+++ b/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
@@ -42,6 +42,7 @@ namespace ACE.Network.GameMessages
         SetState                        = 0xF74B,
         Sound                           = 0xF750,
         PlayerTeleport                  = 0xF751,
+        AutonomousPosition              = 0xF753,
         PlayEffect                      = 0xF755,
 
         GameEvent                       = 0xF7B0,

--- a/Source/ACE/Network/GameMessages/Messages/GameMessageAutonomousPosition.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageAutonomousPosition.cs
@@ -1,0 +1,28 @@
+﻿using ACE.Entity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessageAutonomousPosition : GameMessage
+    {
+        public GameMessageAutonomousPosition(WorldObject worldObject)
+            : base(GameMessageOpcode.AutonomousPosition, GameMessageGroup.Group07)
+        {
+            if (worldObject is Player)
+            {
+                Player p = worldObject as Player;
+                Writer.WriteGuid(p.Guid);
+                p.Position.Serialize(Writer, true, false);
+                Writer.Write((ushort)1); // instance_timestamp - always 1 in my pcaps
+                Writer.Write((ushort)0); // server_control_timestamp - always 0 in my pcaps
+                Writer.Write((ushort)0); // teleport_timestamp - always 0 in my pcaps
+                Writer.Write((ushort)0); // force_position_timestamp - always 0 in my pcaps
+                Writer.Write(1u); // contact - always "true" / 1 in my pcaps
+            }
+        }
+    }
+}

--- a/Source/ACE/Network/GameMessages/Messages/GameMessageCreateLifestone.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageCreateLifestone.cs
@@ -28,7 +28,7 @@ namespace ACE.Network.GameMessages.Messages
             var dx = -1 * Convert.ToSingle(Math.Sin(heading) * scalar);
             var dy = Convert.ToSingle(Math.Cos(heading) * scalar);
 
-            Position newPosition = new Position(player.Position.Cell, player.Position.Offset.X + dx, player.Position.Offset.Y + dy, player.Position.Offset.Z + 0.5f, 0f, 0f, 0f, 0f);
+            Position newPosition = new Position(player.Position.LandblockId.Raw, player.Position.Offset.X + dx, player.Position.Offset.Y + dy, player.Position.Offset.Z + 0.5f, 0f, 0f, 0f, 0f);
             
             var weenie = WeenieHeaderFlag.Usable | WeenieHeaderFlag.BlipColour | WeenieHeaderFlag.Radar | WeenieHeaderFlag.UseRadius;
             ImmutableWorldObject wo = new ImmutableWorldObject(ObjectType.LifeStone, new ObjectGuid(GuidManager.NewStaticObjectGuid()), "Life Stone", 1, ObjectDescriptionFlag.LifeStone, weenie, newPosition);

--- a/Source/ACE/Network/GameMessages/Messages/GameMessageRemoveObject.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageRemoveObject.cs
@@ -1,0 +1,13 @@
+﻿using ACE.Entity;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessageRemoveObject : GameMessage
+    {
+        public GameMessageRemoveObject(ObjectGuid guid) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.Group0A)
+        {
+            // TODO: Verify.  this was done without referencing the protocol spec
+            Writer.WriteGuid(guid);
+        }
+    }
+}

--- a/Source/ACE/Network/GameMessages/Messages/GameMessageUpdateObject.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageUpdateObject.cs
@@ -1,0 +1,18 @@
+﻿using ACE.Entity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessageUpdateObject : GameMessage
+    {
+        public GameMessageUpdateObject(WorldObject worldObject)
+            : base(GameMessageOpcode.UpdateObject, GameMessageGroup.Group0A)
+        {
+            worldObject.SerializeUpdateObject(this.Writer);
+        }
+    }
+}

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -10,6 +10,7 @@ using ACE.Network.Enum;
 using ACE.Network.GameMessages;
 using ACE.Network.GameMessages.Messages;
 using ACE.Network.GameEvent.Events;
+using ACE.Managers;
 
 namespace ACE.Network.Handlers
 {
@@ -47,7 +48,8 @@ namespace ACE.Network.Handlers
             session.State = SessionState.WorldConnected;
 
             session.Network.EnqueueSend(new GameEventPopupString(session, ConfigManager.Config.Server.Welcome));
-            session.Player.Load();
+            
+            LandblockManager.PlayerEnterWorld(session);
         }
 
         [GameMessageAttribute(GameMessageOpcode.CharacterDelete, SessionState.AuthConnected)]

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -33,7 +33,7 @@ namespace ACE.Network.Handlers
                 return;
             }
 
-            var cachedCharacter = session.CachedCharacters.SingleOrDefault(c => c.Guid.Full == guid.Full);
+            var cachedCharacter = session.AccountCharacters.SingleOrDefault(c => c.Guid.Full == guid.Full);
             if (cachedCharacter == null)
             {
                 session.SendCharacterError(CharacterError.EnterGameCharacterNotOwned);
@@ -62,7 +62,7 @@ namespace ACE.Network.Handlers
                 return;
             }
 
-            var cachedCharacter = session.CachedCharacters.SingleOrDefault(c => c.SlotId == characterSlot);
+            var cachedCharacter = session.AccountCharacters.SingleOrDefault(c => c.SlotId == characterSlot);
             if (cachedCharacter == null)
             {
                 session.SendCharacterError(CharacterError.Delete);
@@ -85,7 +85,7 @@ namespace ACE.Network.Handlers
         {
             ObjectGuid guid = fragment.Payload.ReadGuid();
 
-            var cachedCharacter = session.CachedCharacters.SingleOrDefault(c => c.Guid.Full == guid.Full);
+            var cachedCharacter = session.AccountCharacters.SingleOrDefault(c => c.Guid.Full == guid.Full);
             if (cachedCharacter == null)
                 return;
 
@@ -137,7 +137,7 @@ namespace ACE.Network.Handlers
             DatabaseManager.Character.SaveCharacterOptions(character);
 
             var guid = new ObjectGuid(lowGuid, GuidType.Player);
-            session.CachedCharacters.Add(new CachedCharacter(guid, (byte)session.CachedCharacters.Count, character.Name, 0));
+            session.AccountCharacters.Add(new CachedCharacter(guid, (byte)session.AccountCharacters.Count, character.Name, 0));
 
             SendCharacterCreateResponse(session, CharacterGenerationVerificationResponse.Ok, guid, character.Name);
         }
@@ -159,10 +159,10 @@ namespace ACE.Network.Handlers
             character.SetCharacterOption(CharacterOption.ListenToAllegianceChat, true);
             character.SetCharacterOption(CharacterOption.ListenToGeneralChat, true);
             character.SetCharacterOption(CharacterOption.ListenToTradeChat, true);
-            character.SetCharacterOption(CharacterOption.ListenToLFGChat, true);            
+            character.SetCharacterOption(CharacterOption.ListenToLFGChat, true);
         }
 
-        private static void SendCharacterCreateResponse(Session session, CharacterGenerationVerificationResponse response, ObjectGuid guid = null, string charName = "")
+        private static void SendCharacterCreateResponse(Session session, CharacterGenerationVerificationResponse response, ObjectGuid guid = default(ObjectGuid), string charName = "")
         {
             session.Network.EnqueueSend(new GameMessageCharacterCreateResponse(response, guid, charName));
         }

--- a/Source/ACE/Network/PackedDWORD.cs
+++ b/Source/ACE/Network/PackedDWORD.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Network
+{
+    public struct PackedDWORD
+    {
+        private uint rawValue;
+        
+        public PackedDWORD(uint value)
+        {
+            rawValue = value;
+        }
+        
+        public static implicit operator PackedDWORD(uint value)
+        {
+            return new PackedDWORD(value);
+        }
+
+        public byte[] NetworkValue
+        {
+            get
+            {
+                if (rawValue <= 32767)
+                {
+                    ushort networkValue = Convert.ToUInt16(rawValue);
+                    return BitConverter.GetBytes(networkValue);
+                }
+                else
+                {
+                    uint crazyValue = (rawValue << 16) | (rawValue >> 16);
+                    return BitConverter.GetBytes(crazyValue);
+                }
+            }
+        }
+    }
+}

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -15,25 +15,37 @@ namespace ACE.Network
     public class Session
     {
         public uint Id { get; private set; }
+
         public string Account { get; private set; }
+
         public AccessLevel AccessLevel { get; private set; }
         public SessionState State { get; set; }
 
-        public List<CachedCharacter> CachedCharacters { get; } = new List<CachedCharacter>();
+        public List<CachedCharacter> AccountCharacters { get; } = new List<CachedCharacter>();
+
         public CachedCharacter CharacterRequested { get; set; }
+
         public Player Player { get; set; }
 
         private DateTime logOffRequestTime;
 
         // connection related
         public IPEndPoint EndPoint { get; }
+
         public uint GameEventSequence { get; set; }
+
         public byte UpdateAttributeSequence { get; set; }
+
         public byte UpdateSkillSequence { get; set; }
+
         public byte UpdatePropertyInt64Sequence { get; set; }
+
         public byte UpdatePropertyIntSequence { get; set; }
+
         public byte UpdatePropertyStringSequence { get; set; }
+
         public byte UpdatePropertyBoolSequence { get; set; }
+
         public byte UpdatePropertyDoubleSequence { get; set; } 
 
         public NetworkSession Network { get; set; }
@@ -68,10 +80,10 @@ namespace ACE.Network
 
         public void UpdateCachedCharacters(IEnumerable<CachedCharacter> characters)
         {
-            CachedCharacters.Clear();
+            AccountCharacters.Clear();
             foreach (var character in characters)
             {
-                CachedCharacters.Add(character);
+                AccountCharacters.Add(character);
             }
         }
 

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -19,6 +19,7 @@ namespace ACE.Network
         public string Account { get; private set; }
 
         public AccessLevel AccessLevel { get; private set; }
+
         public SessionState State { get; set; }
 
         public List<CachedCharacter> AccountCharacters { get; } = new List<CachedCharacter>();

--- a/Source/ACE/Properties/AssemblyInfo.cs
+++ b/Source/ACE/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config", Watch = true)]

--- a/Source/ACE/log4net.config
+++ b/Source/ACE/log4net.config
@@ -1,0 +1,25 @@
+﻿<log4net>
+  <appender name="Console" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date %-5level: %message%newline" />
+    </layout>
+  </appender>
+
+  <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+    <file value="Log.txt" />
+    <appendToFile value="false" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="10" />
+    <maximumFileSize value="50MB" />
+    <staticLogFileName value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date %-5level[%logger]: %message%newline" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="DEBUG" />
+    <appender-ref ref="Console" />
+    <appender-ref ref="RollingFileAppender" />
+  </root>
+</log4net>

--- a/Source/ACE/log4net.config
+++ b/Source/ACE/log4net.config
@@ -4,22 +4,8 @@
       <conversionPattern value="%date %-5level: %message%newline" />
     </layout>
   </appender>
-
-  <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
-    <file value="Log.txt" />
-    <appendToFile value="false" />
-    <rollingStyle value="Size" />
-    <maxSizeRollBackups value="10" />
-    <maximumFileSize value="50MB" />
-    <staticLogFileName value="true" />
-    <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%date %-5level[%logger]: %message%newline" />
-    </layout>
-  </appender>
-
   <root>
     <level value="DEBUG" />
     <appender-ref ref="Console" />
-    <appender-ref ref="RollingFileAppender" />
   </root>
 </log4net>

--- a/Source/ACE/packages.config
+++ b/Source/ACE/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.8" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta001" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
there are a lot of // TODO comments all over this thing.

here's what I know works:
/telepoi town1
/createlifestone
/telepoi town2
/telepoi town1
... and the lifestone is still there.

Features:
* Landblock Management
* Landblock Handoff of teleporting objects
* Broadcasting of objects on a landblock based on existence
* Update of objects in a landblock based on Movement
* Landblock adjacency broadcasting
* basic object factories
* log4net - not having console output was killing me and we needed a logging framework anyway. nuget to the rescue.
* moved "in front of" calculations to hang off the Position object for better reuse
* PackedDWORD object
* Delayed update of position after entering portal space seems to have helped porting stability.

Known Issues
* Adjacency matrix has issues broadcasting to the correct adjacencies. Shouldn't be a big deal - I'll fix it later.
* local chat is untested and possibly/likely broken.

Mag is showing up in the commit log because I squashed a commit with his name on it when attempting a rebase.  Ended up just cherrypicking into a new branch.