### PR TITLE
Fixed Hash32, which corrects Attribute raise issue

### DIFF
--- a/Source/ACE.Common/Cryptography/Hash32.cs
+++ b/Source/ACE.Common/Cryptography/Hash32.cs
@@ -8,13 +8,13 @@ namespace ACE.Common.Cryptography
         {
             uint checksum = (uint)length << 16;
             for (int i = 0; i < length && i + 4 <= length; i += 4)
-                checksum += BitConverter.ToUInt32(data, i);    
+                checksum += BitConverter.ToUInt32(data, i);
 
-            int shift = 24;
-            for (int i = (length / 4) * 4; i < length; i++)
+            int shift = 3;
+            int j = (length / 4) * 4;
+            while (j < length)
             {
-                checksum += (byte)(data[i] << shift);
-                shift -= 8;
+                checksum += (uint)(data[j++] << (8 * shift--));
             }
 
             return checksum;


### PR DESCRIPTION
Fixed error in shift logic of Hash32, preventing certain packets from calculating correct checksum