### PR TITLE
Feature: Spend Skill Credits

### DIFF
--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -183,6 +183,21 @@ namespace ACE.Entity
         }
 
         /// <summary>
+        /// Sets the skill to trained status for a character
+        /// </summary>
+        /// <param name="skill"></param>
+        public bool TrainSkill(Skill skill, uint creditsSpent)
+        {
+            if(Skills[skill].Status != SkillStatus.Trained && Skills[skill].Status != SkillStatus.Specialized)
+                if(PropertiesInt[PropertyInt.AvailableSkillCredits] >= creditsSpent) { 
+                    Skills[skill] = new CharacterSkill(this, skill, SkillStatus.Trained, 0, 0);
+                    AvailableSkillCredits = PropertiesInt[PropertyInt.AvailableSkillCredits] - creditsSpent;
+                    return true;
+                }
+            return false;
+        }
+
+        /// <summary>
         /// gives avaiable xp and total xp of the amount specified
         /// </summary>
         public void GrantXp(ulong amount)

--- a/Source/ACE.Entity/Enum/Skill.cs
+++ b/Source/ACE.Entity/Enum/Skill.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Linq;
+
 namespace ACE.Entity.Enum
 {
     /// <summary>
@@ -237,6 +239,17 @@ namespace ACE.Entity.Enum
         {
             return Enum.EnumHelper.GetAttributeOfType<SkillUsableUntrainedAttribute>(skill);
         }
+
+        /// <summary>
+        /// Will add a space infront of capital letter words in a string
+        /// </summary>
+        /// <param name="skill"></param>
+        /// <returns>string with spaces infront of capital letters</returns>
+        public static string ToSentence(this Skill skill)
+        {
+            return new string(skill.ToString().ToCharArray().SelectMany((c, i) => i > 0 && char.IsUpper(c) ? new char[] { ' ', c } : new char[] { c }).ToArray());
+        }
+
     }
 
     public enum SkillStatus : uint

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Network\GameAction\Actions\GameActionIdentifyObject.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionQueryAge.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionQueryBirth.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionTrainSkill.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionRemoveAllFriends.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionRemoveChannel.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionSetCharacterOptions.cs" />

--- a/Source/ACE/Network/GameAction/Actions/GameActionTrainSkill.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionTrainSkill.cs
@@ -1,0 +1,26 @@
+﻿
+using ACE.Entity.Enum;
+
+namespace ACE.Network.GameAction.Actions
+{
+    [GameAction(GameActionType.TrainSkill)]
+    public class GameActionTrainSkill : GameActionPacket
+    {
+        private Skill skill;
+        private uint creditsSpent;
+
+        public GameActionTrainSkill(Session session, ClientPacketFragment fragment) : base(session, fragment) { }
+        
+        public override void Read()
+        {
+            skill = (Skill)Fragment.Payload.ReadUInt32();
+            creditsSpent = Fragment.Payload.ReadUInt32();
+        }
+
+        public override void Handle()
+        {
+            //train skills
+            Session.Player.TrainSkill(skill, creditsSpent);
+        }
+    }
+}

--- a/Source/ACE/Network/GameAction/GameActionType.cs
+++ b/Source/ACE/Network/GameAction/GameActionType.cs
@@ -13,6 +13,7 @@ namespace ACE.Network.GameAction
         RaiseVital                  = 0x0044,
         RaiseAbility                = 0x0045,
         RaiseSkill                  = 0x0046,
+        TrainSkill                  = 0x0047,
         Tell                        = 0x005D,
         LoginComplete               = 0x00A1,
         IdentifyObject              = 0x00C8,


### PR DESCRIPTION
Within this request I've sent code that will allow the client to attempt too spend skill credits. If enough skill credits are available, the server will grant the skill to the the character. If the skill credits are not available or the skill has already been trained, then the server makes sure to send the correct game messages with Skill.None, to keep the client from locking up.

On the bottom of the Skill.cs, I've added an extension that allows for skills with proper names, example:
 `Sneak Attack` instead of `SneakAttack`.