### PR TITLE
Added Path support for Mono applications (Linux)

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -55,7 +55,7 @@ namespace ACE.Common
         {
             try
             {
-                Config = JsonConvert.DeserializeObject<Config>(File.ReadAllText(@".\Config.json"));
+                Config = JsonConvert.DeserializeObject<Config>(File.ReadAllText(@"Config.json"));
             }
             catch (Exception exception)
             {

--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -27,7 +27,7 @@ namespace ACE.DatLoader
         {
             try
             {
-                datFile = ConfigManager.Config.Server.DatFilesDirectory + "\\client_cell_1.dat";
+                datFile = ConfigManager.Config.Server.DatFilesDirectory + "client_cell_1.dat";
                 cellDat = new CellDatDatabase(datFile);
                 count = cellDat.AllFiles.Count();
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
@@ -40,7 +40,7 @@ namespace ACE.DatLoader
 
             try
             {
-                datFile = ConfigManager.Config.Server.DatFilesDirectory + "\\client_portal.dat";
+                datFile = ConfigManager.Config.Server.DatFilesDirectory + "client_portal.dat";
                 portalDat = new PortalDatDatabase(datFile);
                 count = portalDat.AllFiles.Count();
                 log.Info($"Successfully opened {datFile} file, containing {count} records");

--- a/Source/ACE.Database/ChartDatabase.cs
+++ b/Source/ACE.Database/ChartDatabase.cs
@@ -33,7 +33,7 @@ namespace ACE.Database
 
         public ExperienceExpenditureChart GetAbilityXpChart()
         {
-            return LoadRankChart(@".\abilityXp.json");
+            return LoadRankChart(@"abilityXp.json");
         }
 
         public LevelingChart GetLevelingXpChart()
@@ -43,17 +43,17 @@ namespace ACE.Database
         
         public ExperienceExpenditureChart GetSpecializedSkillXpChart()
         {
-            return LoadRankChart(@".\skillXp-Specialized.json");
+            return LoadRankChart(@"skillXp-Specialized.json");
         }
 
         public ExperienceExpenditureChart GetTrainedSkillXpChart()
         {
-            return LoadRankChart(@".\skillXp-Trained.json");
+            return LoadRankChart(@"skillXp-Trained.json");
         }
 
         public ExperienceExpenditureChart GetVitalXpChart()
         {
-            return LoadRankChart(@".\vitalXp.json");
+            return LoadRankChart(@"vitalXp.json");
         }
 
         private LevelingChart LoadLevelChartFromFile(string filename)


### PR DESCRIPTION
Added Mono Path compatibility (Linux support) to the following objects by removing the prefixed slashes in file paths:
- ConfigManager
- Charts
- Dat Loading

Note: This was tested and working correctly on `Ubuntu 16.04`. No bugs were observed when play testing.

Installation Hint: The server currently requires _at least_ installing `mono-complete` with the `apt-get` package manager.