### PR TITLE
Dat Path Updates

### DIFF
--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -25,9 +25,10 @@ namespace ACE.DatLoader
         
         public static void Initialize()
         {
+            var DatDir = Path.GetFullPath(Path.Combine(ConfigManager.Config.Server.DatFilesDirectory));
             try
             {
-                datFile = ConfigManager.Config.Server.DatFilesDirectory + "client_cell_1.dat";
+                datFile = Path.Combine(DatDir,"client_cell_1.dat");
                 cellDat = new CellDatDatabase(datFile);
                 count = cellDat.AllFiles.Count();
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
@@ -40,7 +41,7 @@ namespace ACE.DatLoader
 
             try
             {
-                datFile = ConfigManager.Config.Server.DatFilesDirectory + "client_portal.dat";
+                datFile = Path.Combine(DatDir, "client_portal.dat");
                 portalDat = new PortalDatDatabase(datFile);
                 count = portalDat.AllFiles.Count();
                 log.Info($"Successfully opened {datFile} file, containing {count} records");

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -10,7 +10,7 @@
             "OverrideCharacterPermissions": true,
             "DefaultAccessLevel": 0
         },
-        "DatFilesDirectory": "c:\\ACE"
+        "DatFilesDirectory": "c:\\ACE\\"
     },
     "MySql": {
         "Authentication": {


### PR DESCRIPTION
Update to Yesterday's Path support PR. The path support push broke the loading of dats without trailing slashes in the config. Here are the changes in this PR that address this issue:

- Updated example DatFileDirectory with a trailing slash at the end of the value

- Changed DatLoader to use Path.Combine, trailing slash is no longer needed.

`ServerTime initialized to Date: Wintersebb 22, 28 P.Y.  Time: Warmtide
2017-03-22 10:04:22,672 INFO : Successfully opened C:\ACE\client_cell_1.dat file, containing 1 records
2017-03-22 10:04:22,781 INFO : Successfully opened C:\ACE\client_portal.dat file, containing 1 records`