### PR TITLE
Renamed the new db statement constructor label

### DIFF
--- a/Source/ACE.Database.Tests/ConstructedStatementTests.cs
+++ b/Source/ACE.Database.Tests/ConstructedStatementTests.cs
@@ -42,9 +42,9 @@ namespace ACE.Database.Tests
             o.AceObjectId = 1;
             o.Name = "foo";
 
-            worldDb.ContructStatement(TestEnum.FooInsert, typeof(BaseAceObject), ConstructedStatementType.Insert);
-            worldDb.ContructStatement(TestEnum.FooUpdate, typeof(BaseAceObject), ConstructedStatementType.Update);
-            worldDb.ContructStatement(TestEnum.FooGet, typeof(BaseAceObject), ConstructedStatementType.Get);
+            worldDb.ConstructStatement(TestEnum.FooInsert, typeof(BaseAceObject), ConstructedStatementType.Insert);
+            worldDb.ConstructStatement(TestEnum.FooUpdate, typeof(BaseAceObject), ConstructedStatementType.Update);
+            worldDb.ConstructStatement(TestEnum.FooGet, typeof(BaseAceObject), ConstructedStatementType.Get);
 
             worldDb.ExecuteConstructedInsertStatement(TestEnum.FooInsert, typeof(BaseAceObject), o);
             
@@ -68,7 +68,7 @@ namespace ACE.Database.Tests
         [TestMethod]
         public void ExecuteGetListStatement_SimpleCase_DoesNotThrow()
         {
-            worldDb.ContructStatement(TestEnum.GetLifestonesByLandblock, typeof(AceObject), ConstructedStatementType.GetList);
+            worldDb.ConstructStatement(TestEnum.GetLifestonesByLandblock, typeof(AceObject), ConstructedStatementType.GetList);
 
             Dictionary<string, object> criteria = new Dictionary<string, object>();
             criteria.Add("landblock", (ushort)458);

--- a/Source/ACE.Database/Database.cs
+++ b/Source/ACE.Database/Database.cs
@@ -238,7 +238,7 @@ namespace ACE.Database
             PrepareStatement(statementId, query, types);
         }
 
-        public void ContructStatement<T1>(T1 id, Type type, ConstructedStatementType statementType)
+        public void ConstructStatement<T1>(T1 id, Type type, ConstructedStatementType statementType)
         {
             if (statementType == ConstructedStatementType.GetList)
             {

--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -21,7 +21,7 @@ namespace ACE.Database
         {
             AddPreparedStatement(WorldPreparedStatement.TeleportLocationSelect, "SELECT `location`, `cell`, `x`, `y`, `z`, `qx`, `qy`, `qz`, `qw` FROM `teleport_location`;");
             // ContructStatement(WorldPreparedStatement.GetWeenieClass, typeof(BaseAceObject), ConstructedStatementType.Get);
-            ContructStatement(WorldPreparedStatement.GetObjectsByLandblock, typeof(AceObject), ConstructedStatementType.GetList);
+            ConstructStatement(WorldPreparedStatement.GetObjectsByLandblock, typeof(AceObject), ConstructedStatementType.GetList);
         }
 
         public List<TeleportLocation> GetLocations()


### PR DESCRIPTION
- Renamed a function to cut down on confusion. Fixes an assumed typo in name for new function `ConstructStatement`.