### PR TITLE
Update: Prevent Welcome Message/Motd when string is empty

### DIFF
--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -47,7 +47,11 @@ namespace ACE.Network.Handlers
 
             session.State = SessionState.WorldConnected;
 
-            session.Network.EnqueueSend(new GameEventPopupString(session, ConfigManager.Config.Server.Welcome));
+            // check the value of the welcome message. Only display it if it is not empty
+            if (!String.IsNullOrEmpty(ConfigManager.Config.Server.Welcome))
+            {
+                session.Network.EnqueueSend(new GameEventPopupString(session, ConfigManager.Config.Server.Welcome));
+            }
 
             LandblockManager.PlayerEnterWorld(session);
         }


### PR DESCRIPTION
- Thanks to Miach for coding and testing this PR.

- If the `Config.json` file includes an EMPTY `Welcome` config variable, then the server will not send the Popup dialog box, upon logging into a server.

Example: 
```
{
    "Server": {
        "WorldName": "Darktiphoid",
        "Welcome": "",
        "Network": {
            "Host": "0.0.0.0"
       },
    },
}
```