### PR TITLE
Update: SQL Where Syntax for ConstructStatement

### DIFF
--- a/Source/ACE.Database/Database.cs
+++ b/Source/ACE.Database/Database.cs
@@ -227,7 +227,7 @@ namespace ACE.Database
                 if (getList.ParameterFields.Contains(p.Item2.DbFieldName))
                 {
                     if (whereList != null)
-                        whereList += ", ";
+                        whereList += " AND ";
                     whereList += "`" + p.Item2.DbFieldName + "` = ?";
                     types.Add((MySqlDbType)p.Item2.DbFieldType);
                 }
@@ -294,7 +294,7 @@ namespace ACE.Database
                 if (p.Item2.IsCriteria)
                 {
                     if (whereList != null)
-                        whereList += ", ";
+                        whereList += " AND ";
                     whereList += "`" + p.Item2.DbFieldName + "` = ?";
 
                     if (statementType == ConstructedStatementType.Get || statementType == ConstructedStatementType.Update)


### PR DESCRIPTION
- Updated the `wherelist` text to include the proper SQL syntax, for a WHERE clause.