### PR TITLE
Feature: ORM Driven Character Positions for Issue #166

### DIFF
--- a/Database/Updates/Character/2017_03_26_character_positions_positiontype.sql
+++ b/Database/Updates/Character/2017_03_26_character_positions_positiontype.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `character_position`
+	ADD COLUMN `positionType` TINYINT UNSIGNED NULL DEFAULT '0' BEFORE `cell`;

--- a/Database/Updates/Character/2017_03_27_character_positions_change.sql
+++ b/Database/Updates/Character/2017_03_27_character_positions_change.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `character_position`
+CHANGE COLUMN `id` `character_id` INT(10) UNSIGNED NOT NULL DEFAULT '0' FIRST;
+ALTER TABLE `character_position`
+	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' BEFORE `cell`,
+	DROP PRIMARY KEY,
+	ADD PRIMARY KEY (`character_id`, `positionType`);
+ALTER TABLE `character_position`
+	ALTER `character_id` DROP DEFAULT,
+	ALTER `positionType` DROP DEFAULT;
+ALTER TABLE `character_position`
+	CHANGE COLUMN `character_id` `character_id` INT(10) UNSIGNED NOT NULL FIRST,
+	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL BEFORE `cell`;

--- a/Database/Updates/Character/2017_03_29_character_vw_character_positions.sql
+++ b/Database/Updates/Character/2017_03_29_character_vw_character_positions.sql
@@ -1,0 +1,5 @@
+DROP VIEW IF EXISTS `vw_character_positions`;
+CREATE OR REPLACE VIEW `vw_character_positions` AS (
+  SELECT CP.character_id, CP.positionType, CP.cell, CP.positionX, CP.positionY, CP.positionZ, CP.rotationX, CP.rotationY, CP.rotationZ, CP.rotationW
+  FROM `character_position` CP
+  INNER JOIN `character` CH ON CP.character_id = CH.guid)

--- a/Source/ACE.Database/Database.cs
+++ b/Source/ACE.Database/Database.cs
@@ -31,11 +31,10 @@ namespace ACE.Database
     public class Database
     {
         private static readonly Dictionary<Type, List<Tuple<PropertyInfo, DbFieldAttribute>>> propertyCache = new Dictionary<Type, List<Tuple<PropertyInfo, DbFieldAttribute>>>();
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         public class DatabaseTransaction
         {
-            private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
             private readonly Database database;
             private readonly List<Tuple<StoredPreparedStatement, object[]>> queries = new List<Tuple<StoredPreparedStatement, object[]>>();
 
@@ -76,7 +75,7 @@ namespace ACE.Database
                                 for (int i = 0; i < query.Item2.Length; i++)
                                 {
                                     command.Parameters.Add("", query.Item1.Types[i]).Value = query.Item2[i];
-#if NETWORKDEBUG
+#if DBDEBUG
                                     foreach (MySqlParameter p in command.Parameters)
                                     {
                                         log.Info(p.Value);
@@ -263,6 +262,9 @@ namespace ACE.Database
             var properties = GetPropertyCache(type);
             foreach (var p in properties)
             {
+#if DBDEBUG
+                log.Debug("P1: " + p.Item1  + " P2: " + p.Item2);
+#endif
                 if (p.Item2.Get)
                 {
                     if (selectList != null)
@@ -316,7 +318,13 @@ namespace ACE.Database
                     query = $"UPDATE `{tableName}` SET {updateList} WHERE {whereList}";
                     break;
             }
-
+#if DBDEBUG
+            log.Debug("Id: " + Convert.ToUInt32(id) + "Query: " + query);
+            foreach(var name in types)
+            {
+                log.Debug("Types: + " + name.ToString());
+            }
+#endif
             PrepareStatement(Convert.ToUInt32(id), query, types);
         }
 
@@ -426,6 +434,7 @@ namespace ACE.Database
             // Debug.Assert(typeof(T1) == preparedStatementType);
 
             StoredPreparedStatement preparedStatement;
+
             if (!preparedStatements.TryGetValue(Convert.ToUInt32(id), out preparedStatement))
             {
                 Debug.Assert(preparedStatement != null);
@@ -521,9 +530,22 @@ namespace ACE.Database
                 {
                     using (var command = new MySqlCommand(preparedStatement.Query, connection))
                     {
-                        for (int i = 0; i < preparedStatement.Types.Count; i++)
+#if DBDEBUG
+                        log.Debug(preparedStatement.Query);
+#endif
+                        for (int i = 0; i < preparedStatement.Types.Count; i++) {
+#if DBDEBUG
+                            log.Debug(preparedStatement.Types[i]);
+                            foreach (MySqlParameter p in command.Parameters)
+                            {
+                                log.Debug(p.Value);
+                            }
+#endif
                             command.Parameters.Add("", preparedStatement.Types[i]).Value = parameters[i];
-
+#if DBDEBUG
+                            log.Debug(command.Parameters);
+#endif
+                        }
                         if (async)
                         {
                             await connection.OpenAsync();
@@ -658,7 +680,10 @@ namespace ACE.Database
                     using (var command = new MySqlCommand(query, connection))
                     {
                         types.ForEach(t => command.Parameters.Add("", t));
-
+#if DBDEBUG
+                        log.Debug(types);
+                        log.Debug(query);
+#endif
                         command.Prepare();
 
                         uint uintId = Convert.ToUInt32(id);

--- a/Source/ACE.Database/ICharacterDatabase.cs
+++ b/Source/ACE.Database/ICharacterDatabase.cs
@@ -8,7 +8,9 @@ namespace ACE.Database
 {
     public interface ICharacterDatabase
     {
-        Task<Position> GetPosition(uint id);
+        Position GetLocation(uint id);
+
+        List<Position> GetCharacterPositions(Character character);
 
         void DeleteOrRestore(ulong unixTime, uint id);
 
@@ -32,16 +34,26 @@ namespace ACE.Database
         Task DeleteFriend(uint characterId, uint friendCharacterId);
         Task AddFriend(uint characterId, uint friendCharacterId);
         Task RemoveAllFriends(uint characterId);
-        
+
         /// <summary>
         /// loads object properties into the provided db object
         /// </summary>
         Task LoadCharacterProperties(DbObject dbObject);
 
         /// <summary>
+        /// loads positons into the provided db object
+        /// </summary>
+        void LoadCharacterPositions(Character character);
+
+        /// <summary>
         /// Saves character options (F11 tab)
         /// </summary>
         void SaveCharacterOptions(Character character);
+
+        /// <summary>
+        /// Saves character options (F11 tab)
+        /// </summary>
+        void InitCharacterPositions(Character character);
 
         /// <summary>
         /// saves all object properties in the provided db object

--- a/Source/ACE.Entity/ACE.Entity.csproj
+++ b/Source/ACE.Entity/ACE.Entity.csproj
@@ -76,6 +76,7 @@
   <ItemGroup>
     <Compile Include="AbilityFormulaAttribute.cs" />
     <Compile Include="Account.cs" />
+    <Compile Include="CharacterPositionExtensions.cs" />
     <Compile Include="AceObject.cs" />
     <Compile Include="AnimationOverride.cs" />
     <Compile Include="Appearance.cs" />
@@ -92,6 +93,7 @@
     <Compile Include="Enum\CharacterOption.cs" />
     <Compile Include="Enum\CharacterOptions1.cs" />
     <Compile Include="Enum\CharacterOptions2.cs" />
+    <Compile Include="Enum\PositionType.cs" />
     <Compile Include="Enum\ChatDisplayMask.cs" />
     <Compile Include="Enum\ChatFilterMask.cs" />
     <Compile Include="Enum\ChatMessageType.cs" />

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -69,7 +69,7 @@ namespace ACE.Entity
         public uint TotalSkillPoints { get; set; }
 
         public uint TotalLogins { get; set; } = 1u;  // total amount of times the player has logged into this character
-        
+
         public CharacterAbility Strength { get; set; }
 
         public CharacterAbility Endurance { get; set; }
@@ -90,13 +90,17 @@ namespace ACE.Entity
 
         public Appearance Appearance { get; set; } = new Appearance();
 
-        public Position Position { get; set; }
+        public Position Location { get; set; }
 
         public Dictionary<Skill, CharacterSkill> Skills { get; private set; } = new Dictionary<Skill, CharacterSkill>();
 
         private Dictionary<CharacterOption, bool> characterOptions;
         public ReadOnlyDictionary<CharacterOption, bool> CharacterOptions { get; }
-        
+
+        private Dictionary<PositionType, Position> positions;
+
+        public ReadOnlyDictionary<PositionType, Position> Positions { get; }
+
         public ulong AvailableExperience
         {
             get { return propertiesInt64[PropertyInt64.AvailableExperience]; }
@@ -173,6 +177,10 @@ namespace ACE.Entity
 
             InitializeCharacterOptions();
             CharacterOptions = new ReadOnlyDictionary<CharacterOption, bool>(characterOptions);
+
+            // initialize the blank character positions
+            InitializeCharacterPositions();
+            Positions = new ReadOnlyDictionary<PositionType, Position>(positions);
         }
 
         public Character(uint id, uint accountId)
@@ -188,8 +196,9 @@ namespace ACE.Entity
         /// <param name="skill"></param>
         public bool TrainSkill(Skill skill, uint creditsSpent)
         {
-            if(Skills[skill].Status != SkillStatus.Trained && Skills[skill].Status != SkillStatus.Specialized)
-                if(PropertiesInt[PropertyInt.AvailableSkillCredits] >= creditsSpent) { 
+            if (Skills[skill].Status != SkillStatus.Trained && Skills[skill].Status != SkillStatus.Specialized)
+                if (PropertiesInt[PropertyInt.AvailableSkillCredits] >= creditsSpent)
+                {
                     Skills[skill] = new CharacterSkill(this, skill, SkillStatus.Trained, 0, 0);
                     AvailableSkillCredits = PropertiesInt[PropertyInt.AvailableSkillCredits] - creditsSpent;
                     return true;
@@ -239,7 +248,7 @@ namespace ACE.Entity
         {
             Friend friend = friends.SingleOrDefault(f => f.Id.Low == lowId);
 
-            if(friend != null)
+            if (friend != null)
                 friends.Remove(friend);
         }
 
@@ -263,6 +272,32 @@ namespace ACE.Entity
             {
                 characterOptions.Add(characterOption, false);
             }
+        }
+
+        public void SetCharacterPositions(PositionType positionType, Position setPosition)
+        {
+            if (positionType == PositionType.Undef)
+                return;
+
+            setPosition.character_id = Id;
+            setPosition.positionType = positionType;
+
+            if (positions.ContainsKey(positionType))
+            {
+                if(positions[positionType] != setPosition)
+                    positions[positionType] = setPosition;
+            }
+            else
+            {
+                positions.Add(positionType, setPosition);
+            }
+        }
+
+        private void InitializeCharacterPositions()
+        {
+
+            positions = new Dictionary<PositionType, Position>(System.Enum.GetValues(typeof(PositionType)).Length);
+
         }
 
         /// <summary>

--- a/Source/ACE.Entity/Enum/PositionType.cs
+++ b/Source/ACE.Entity/Enum/PositionType.cs
@@ -1,0 +1,63 @@
+﻿namespace ACE.Entity.Enum
+{
+    public enum PositionType
+    {
+        // S_CONSTANT: Type:             0x108E, Value: 11, CRASH_AND_TURN_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 17, SAVE_1_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 14, LAST_OUTSIDE_DEATH_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 10, PORTAL_STORM_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 18, SAVE_2_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 19, SAVE_3_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 20, SAVE_4_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 1, LOCATION_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 13, HOUSE_BOOT_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 21, SAVE_5_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 3, INSTANTIATION_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 9, LAST_PORTAL_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 16, LINKED_PORTAL_TWO_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 2, DESTINATION_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 22, SAVE_6_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 7, TARGET_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 23, SAVE_7_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 26, RELATIVE_DESTINATION_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 24, SAVE_8_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 25, SAVE_9_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 0, UNDEF_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 15, LINKED_LIFESTONE_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 27, TELEPORTED_CHARACTER_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 12, PORTAL_SUMMON_LOC_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 6, ACTIVATION_MOVE_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 4, SANCTUARY_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 5, HOME_POSITION
+        // S_CONSTANT: Type:             0x108E, Value: 8, LINKED_PORTAL_ONE_POSITION
+
+        Undef = 0,
+        Location = 1, // Current Position
+        Destination = 2,
+        Instantiation = 3,
+        Sanctuary = 4, // Last Lifestone Used? (@ls)? | @home | @save | @recall
+        Home = 5,
+        ActivationMove = 6,
+        Target = 7,
+        LinkedPortalOne = 8, // Primary Portal Recall | Summon Primary Portal | Primary Portal Tie
+        LastPortal = 9, // Portal Recall (Last Used Portal that can be recalled to)
+        PortalStorm = 10,
+        CrashAndTurn = 11,
+        PortalSummonLOC = 12,
+        HouseBoot = 13,
+        LastOutsideDeath = 14, // Location of Corpse
+        LinkedLifestone = 15, // Lifestone Recall | Lifestone Tie
+        LinkedPortalTwo = 16, // Secondary Portal Recall | Summon Secondary Portal | Secondary Portal Tie
+        Save1 = 17, // @save 1 | @home 1 | @recall 1
+        Save2 = 18, // @save 2 | @home 2 | @recall 2
+        Save3 = 19, // @save 3 | @home 3 | @recall 3
+        Save4 = 20, // @save 4 | @home 4 | @recall 4
+        Save5 = 21, // @save 5 | @home 5 | @recall 5
+        Save6 = 22, // @save 6 | @home 6 | @recall 6
+        Save7 = 23, // @save 7 | @home 7 | @recall 7
+        Save8 = 24, // @save 8 | @home 8 | @recall 8
+        Save9 = 25, // @save 9 | @home 9 | @recall 9
+        RelativeDestination = 26,
+        TeleportedCharacter = 27
+    }
+}

--- a/Source/ACE/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE/Command/Handlers/AdminCommands.cs
@@ -458,7 +458,7 @@ namespace ACE.Command
 
             // TODO: Check if water block?
 
-            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
+            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.positionX}, {position.positionY}, {position.positionZ} | Facing: {position.rotationX}, {position.rotationY}, {position.rotationZ}, {position.rotationW}]", ChatMessageType.Broadcast);
 
             session.Player.Teleport(position);
         }

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -39,7 +39,7 @@ namespace ACE.Command.Handlers
         public static void HandleDebugGPS(Session session, params string[] parameters)
         {
             var position = session.Player.Position;
-            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.Offset.X}, {position.Offset.Y}, {position.Offset.Z} | Facing: {position.Facing.X}, {position.Facing.Y}, {position.Facing.Z}, {position.Facing.W}]", ChatMessageType.Broadcast);
+            ChatPacket.SendServerMessage(session, $"Position: [Cell: 0x{position.LandblockId.Landblock.ToString("X4")} | Offset: {position.positionX}, {position.positionY}, {position.positionZ} | Facing: {position.rotationX}, {position.rotationY}, {position.rotationZ}, {position.rotationW}]", ChatMessageType.Broadcast);
         }
 
         // telexyz cell x y z qx qy qz qw
@@ -191,7 +191,7 @@ namespace ACE.Command.Handlers
         [CommandHandler("spacejump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
         public static void spacejump(Session session, params string[] parameters)
         {
-            Position newPosition = new Position(session.Player.Position.LandblockId.Landblock, session.Player.Position.Offset.X, session.Player.Position.Offset.Y, session.Player.Position.Offset.Z + 8000f, session.Player.Position.Facing.X, session.Player.Position.Facing.Y, session.Player.Position.Facing.Z, session.Player.Position.Facing.W);
+            Position newPosition = new Position(session.Player.Position.LandblockId.Landblock, session.Player.Position.positionX, session.Player.Position.positionY, session.Player.Position.positionZ + 8000f, session.Player.Position.rotationX, session.Player.Position.rotationY, session.Player.Position.rotationZ, session.Player.Position.rotationW);
             session.Player.Teleport(newPosition);
         }
 
@@ -205,6 +205,62 @@ namespace ACE.Command.Handlers
         public static void CreatePortal(Session session, params string[] parameters)
         {
             LandblockManager.AddObject(PortalObjectFactory.CreatePortal(1234, session.Player.Position.InFrontOf(3.0f), "Test Portal", PortalType.Purple));
+        }
+
+        /// <summary>
+        /// Debug command to saves the character from in-game.
+        /// </summary>
+        /// <remarks>Added a quick way to invoke the character save routine.</remarks>
+        [CommandHandler("save-now", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        public static void HandleSaveNow(Session session, params string[] parameters)
+        {
+            session.SaveSession();
+        }
+
+        /// <summary>
+        /// Returns the Player's GUID
+        /// </summary>
+        /// <remarks>Added a quick way to access the player GUID.</remarks>
+        [CommandHandler("whoami", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        public static void HandleWhoAmI(Session session, params string[] parameters)
+        {
+            ChatPacket.SendServerMessage(session, $"GUID: {session.Player.Guid.Full} ID(low): {session.Player.Guid.Low} High:{session.Player.Guid.High}", ChatMessageType.Broadcast);
+        }
+
+        /// <summary>
+        /// Debug command to set an invalid character position for a position type. Used to test the logic and saving data to the database.
+        /// </summary>
+        [CommandHandler("reset-pos", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
+        public static void HandleResetPosition(Session session, params string[] parameters)
+        {
+            try
+            {
+                // if (parameters.Length > 1)
+                //    if (parameters[1] != "")
+                //        scale = float.Parse(parameters[1]);
+
+                string message = "Error saving position.";
+
+                PositionType type = new PositionType();
+
+                if (Enum.TryParse(parameters[0], true, out type))
+                {
+                    if (Enum.IsDefined(typeof(PositionType), type))
+                    {
+                        message = $"Saving position {Enum.GetName(typeof(PositionType), type)}";
+                        session.Player.SetCharacterPosition(type, CharacterPositionExtensions.InvalidPosition(session.Id, type));
+                    }
+                }
+
+                float scale = 1f;
+                var effectEvent = new GameMessageEffect(session.Player.Guid, Network.Enum.Effect.AttribDownRed, scale);
+                var sysChatMessage = new GameMessageSystemChat(message, ChatMessageType.Broadcast);
+                session.Network.EnqueueSend(effectEvent, sysChatMessage);
+            }
+            catch (Exception)
+            {
+                // Do Nothing
+            }
         }
     }
 }

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -286,32 +286,32 @@ namespace ACE.Entity
             {
                 Log($"propogating broadcasting object {args.Sender.Guid.Full.ToString("X")} - {args.ActionType} to adjacencies");
 
-                if (wo.Position.Offset.X < adjacencyLoadRange)
+                if (wo.Position.positionX < adjacencyLoadRange)
                 {
                     WestAdjacency?.Broadcast(args, false, Quadrant.NorthEast | Quadrant.SouthEast);
 
-                    if (wo.Position.Offset.Y < adjacencyLoadRange)
+                    if (wo.Position.positionY < adjacencyLoadRange)
                         SouthWestAdjacency?.Broadcast(args, false, Quadrant.NorthEast);
 
-                    if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                    if (wo.Position.positionY > (maxXY - adjacencyLoadRange))
                         NorthWestAdjacency?.Broadcast(args, false, Quadrant.SouthEast);
                 }
 
-                if (wo.Position.Offset.Y < adjacencyLoadRange)
+                if (wo.Position.positionY < adjacencyLoadRange)
                     SouthAdjacency?.Broadcast(args, false, Quadrant.NorthEast | Quadrant.NorthWest);
 
-                if (wo.Position.Offset.X > (maxXY - adjacencyLoadRange))
+                if (wo.Position.positionX > (maxXY - adjacencyLoadRange))
                 {
                     EastAdjacency?.Broadcast(args, false, Quadrant.NorthWest | Quadrant.SouthWest);
 
-                    if (wo.Position.Offset.Y < adjacencyLoadRange)
+                    if (wo.Position.positionY < adjacencyLoadRange)
                         SouthEastAdjacency?.Broadcast(args, false, Quadrant.NorthWest);
 
-                    if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                    if (wo.Position.positionY > (maxXY - adjacencyLoadRange))
                         NorthEastAdjacency?.Broadcast(args, false, Quadrant.SouthWest);
                 }
 
-                if (wo.Position.Offset.Y > (maxXY - adjacencyLoadRange))
+                if (wo.Position.positionY > (maxXY - adjacencyLoadRange))
                     NorthAdjacency?.Broadcast(args, false, Quadrant.SouthEast | Quadrant.SouthWest);
             }
         }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -56,6 +56,11 @@ namespace ACE.Entity
             get { return character.CharacterOptions; }
         }
 
+        public ReadOnlyDictionary<PositionType, Position> Positions
+        {
+            get { return character.Positions; }
+        }
+
         public ReadOnlyCollection<Friend> Friends
         {
             get { return character.Friends; }
@@ -240,7 +245,9 @@ namespace ACE.Entity
                 //    character.IsAdvocate= true;
             }
 
-            Position = character.Position;
+            Position = character.Positions[PositionType.Location];
+            // TODO: copy object to prevent dataloss here, resetting position inline; character_id and LandblockId may also be missing
+            Position.positionType = PositionType.Location;
             IsOnline = true;
 
             // SendSelf will trigger the entrance into portal space
@@ -765,15 +772,31 @@ namespace ACE.Entity
         }
 
         /// <summary>
+        /// Set the currenly position of the character, to later save in the database.
+        /// </summary>
+        public void SetPhysicalCharacterPosition()
+        {
+            // Saves the current player position after converting from a Position Object, to a CharacterPosition object
+            character.SetCharacterPositions(PositionType.Location, Session.Player.Position);
+        }
+
+        /// <summary>
+        /// Saves a CharacterPosition to the character position dictionary
+        /// </summary>
+        public void SetCharacterPosition(PositionType type, Position newPosition)
+        {
+            character.SetCharacterPositions(type, newPosition);
+        }
+
+        /// <summary>
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.
         /// </summary>
         public void SaveCharacter()
         {
             if (character != null)
             {
-                // save the player position to the database blob
-                character.Position = Session.Player.Position;
-
+                // Save the current position to persistent storage
+                SetPhysicalCharacterPosition();
                 DatabaseManager.Character.UpdateCharacter(character);
 #if DEBUG
                 if (Session.Player != null)

--- a/Source/ACE/Managers/LandblockManager.cs
+++ b/Source/ACE/Managers/LandblockManager.cs
@@ -26,7 +26,7 @@ namespace ACE.Managers
 
             await session.Player.Load(c);
 
-            Landblock block = GetLandblock(c.Position.LandblockId, true);
+            Landblock block = GetLandblock(c.Location.LandblockId, true);
             block.AddWorldObject(session.Player);
         }
 

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -140,7 +140,9 @@ namespace ACE.Network.Handlers
             }
 
             CharacterCreateSetDefaultCharacterOptions(character);
+            CharacterCreateSetDefaultCharacterPositions(character);
             DatabaseManager.Character.SaveCharacterOptions(character);
+            DatabaseManager.Character.InitCharacterPositions(character);
 
             var guid = new ObjectGuid(lowGuid, GuidType.Player);
             session.AccountCharacters.Add(new CachedCharacter(guid, (byte)session.AccountCharacters.Count, character.Name, 0));
@@ -166,6 +168,12 @@ namespace ACE.Network.Handlers
             character.SetCharacterOption(CharacterOption.ListenToGeneralChat, true);
             character.SetCharacterOption(CharacterOption.ListenToTradeChat, true);
             character.SetCharacterOption(CharacterOption.ListenToLFGChat, true);
+        }
+
+        public static void CharacterCreateSetDefaultCharacterPositions(Character character)
+        {
+            character.SetCharacterPositions(PositionType.Location, CharacterPositionExtensions.StartingPosition(character.Id));
+            character.SetCharacterPositions(PositionType.LastPortal, CharacterPositionExtensions.InvalidPosition(character.Id, PositionType.LastPortal));
         }
 
         private static void SendCharacterCreateResponse(Session session, CharacterGenerationVerificationResponse response, ObjectGuid guid = default(ObjectGuid), string charName = "")

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,45 @@
 # ACEmulator Change Log
+### 2017-03-31
+[fantoms]
+* Added debug command to test positions.
+* Changed SQL syntax to use BEFORE instead of AFTER for the `positionType` column, in the `character_positions` table.
+* Removed the github friendly enums from the `PositionTypes`.
+* Changed a log4net debug line.
+* Changed the name class name `CharacterPositionType` to `PositionType`
+* Reworked `Position.cs` with ORM.
+
+### 2017-03-29
+[fantoms]
+* Changed the Player.Position to Player.PhysicalPosition to match the Developer meeting video and Issue #166.
+* Created `CharacterPostion` and `CharacterPositionType` classes to store the Database types requested in Issue #166.
+* Added `CharacterPostion` ORM logic.
+* Built out helper extension functions to serve the `StartingLocation`, until we pull from the database. Also included an Invalid location as a default (0).
+* Changed the `character_positions` table and Added `positionType` column.
+* Set the primary key to include `positionType` column.
+* Added `positionType` to required Critera for `character_positions`.
+* Added `CharacterPositionInsert` and `CharacterPositionUpdate` to the Character Database.
+* Created `CharacterPositionInsert` and `CharacterPositionUpdate` prepared SQL statements by utilizing the `ConstructStatement` function.
+* Added the required `positionType` clause to the `CharacterPositionSelect` prepared statement.
+* Added a position update statement for updating the player position.
+* Reworked GetPosition to include the `CharacterPositionType`.
+* Added function for getting a `CharacterPostion` from the database, requires a character Id and `CharacterPositionType`.
+* Added logic to get location function to insert a location into the database, if not present.
+* Reworked the UpdateCharacter and Update functions to save positions.
+* Added functions for inserting new character positions on character creation.
+* Added functions for saving/loading the character positions from the database on joining the World.
+* Attempted to get log4net working properly and moved some code to logging.
+* Added DBDEBUG project constant for debugging the database calls.
+* Changed the `CharacterPositionSelect` prepared statement to a `ConstructStatement`.
++ Updates after PR review: +
+* Changed the `LoadCharacterPositions` to ORM OUT of the database.
+* Changed the introduced @save command to @save-now to avoid conflict
+* Changed CharacterPositionType to PositionTypes and merged in Ripley's enums
+* Changed PhyiscalPosition to Location
+* Removed plural in function name for position types; broke the character loading
+* Added database view for all list positions
+* Added GetList statement for all positions
+* Migrated GetPosition to GetLocation, Seporated Logic, added ORM calls on selecting data
+* Moved the Character.Location to Character.CharacterPositions[PositionType.Location] dictionary
 
 [Mogwai]
 * Added changelog.md to clearly identify changes from 1 commit to another.


### PR DESCRIPTION
This huge PR is related to Issue #166. The code has been changed to allow more then one position type. A class was added for Character position types that match the requirements listed in the issue. A secondary Position Type class was added to match the client, provided by @LtRipley36706.

To work with the ORM code introduced during the developer meeting, I've attempted to copy the pseudo 1:1 mapping into `CharacterPosition.cs`. In order to allow for more then one position, the `Character.Position` member was changed to dictionary containing a list of character positions by type. `Player.Position` was changed to `Player.PhysicalPosition` and when the server decides to save the positions to the database, the data is saved through the ORM object in `CharacterPosition.cs`. 

There were a few things left to do, that were not accomplished for Issue #166:
* Hook up /lifestone and /ls commands

Changelog with this PR: 

### 2017-03-31
[fantoms]
* Added debug command to test positions.
* Changed SQL syntax to use BEFORE instead of AFTER for the `positionType` column, in the `character_positions` table.
* Removed the github friendly enums from the `PositionTypes`.
* Changed a log4net debug line.
* Changed the name class name `CharacterPositionType` to `PositionType`
* Reworked `Position.cs` with ORM.

### 2017-03-29
[fantoms]
* Changed the Player.Position to Player.PhysicalPosition to match the Developer meeting video and Issue #166.
* Created `CharacterPostion` and `CharacterPositionType` classes to store the Database types requested in Issue #166.
* Added `CharacterPostion` ORM logic.
* Built out helper extension functions to serve the `StartingLocation`, until we pull from the database. Also included an Invalid location as a default (0).
* Changed the `character_positions` table and Added `positionType` column.
* Set the primary key to include `positionType` column.
* Added `positionType` to required Critera for `character_positions`.
* Added `CharacterPositionInsert` and `CharacterPositionUpdate` to the Character Database.
* Created `CharacterPositionInsert` and `CharacterPositionUpdate` prepared SQL statements by utilizing the `ConstructStatement` function.
* Added the required `positionType` clause to the `CharacterPositionSelect` prepared statement.
* Added a position update statement for updating the player position.
* Reworked GetPosition to include the `CharacterPositionType`.
* Added function for getting a `CharacterPostion` from the database, requires a character Id and `CharacterPositionType`.
* Added logic to get location function to insert a location into the database, if not present.
* Reworked the UpdateCharacter and Update functions to save positions.
* Added functions for inserting new character positions on character creation.
* Added functions for saving/loading the character positions from the database on joining the World.
* Attempted to get log4net working properly and moved some code to logging.
* Added DBDEBUG project constant for debugging the database calls.
* Changed the `CharacterPositionSelect` prepared statement to a `ConstructStatement`.
+ Updates after PR review: +
* Changed the `LoadCharacterPositions` to ORM OUT of the database.
* Changed the introduced @save command to @save-now to avoid conflict
* Changed CharacterPositionType to PositionTypes and merged in Ripley's enums
* Changed PhyiscalPosition to Location
* Removed plural in function name for position types; broke the character loading
* Added database view for all list positions
* Added GetList statement for all positions
* Migrated GetPosition to GetLocation, Seporated Logic, added ORM calls on selecting data
* Moved the Character.Location to Character.CharacterPositions[PositionType.Location] dictionary



### Git Log:
- Changed position to phsysical/logical and added logical positions
- Updated comments on CharacterPositionType
- Added the sql for altering the positions table, to add the positionType
- Added ripleys Position Types
- Added Character Position Database Object
- Renamed Position types to Positions to Match Ripley's original code. Looks better in character, also.
- Changed to the correct function when Executing constructed statements
- Added another debug command
- Added Position update to the Character Data object
- Changed the positiontype to a keyed column in mysql
- DB Updates
- Morning updates - working position inserts at character creation
- Updated constructstatement, positions are saving to the right columns
- Load all available character positions from the database or create a new if missing
- Fixed unused GetCharacterPhysicalPosition
- Made the server use the correct insert function
- Fixed position save
- Cleaned up code and removed the unnecessary SQL statement
- Moved Character Prepared Statement for Selecting position to the ConstructedStatement Get function
- Changed the LoadCharacterPositions to ORM OUT of the database.
- Changed the introduced @save command to @save-now to avoid conflict
- Changed CharacterPositionType to PositionTypes and moved in Ripley's code
- Changed PhyiscalPosition to Location
- Removed plural in function name for position types; broke the character loading
- Added GetList statement for all positions
- Migrated GetPosition to GetLocation, Seporated Logic, added ORM calls on selecting data
- Moved the Character.Location to Character.CharacterPositions[PositionType.Location] dictionary
- Added debug command to test positions
- Migrated enums to ripleys position only - took out the labels from github
- Updated SQL to use BEFORE instead of AFTER
- Changed DBDEBUG line to use log4net
- Began working on position
- Changed the name from CharacterPositionType to PositionType
- Converted Position to rely on floats instead of vectors and began adding ORM logic
- Renamed variables to go inline with code style
- Moved character helper extensions and migrated to Positions
- Migrated positions to orm
- Adding Character Positions view for the GetList query
- Swapped column order for Ripley
- Reworked landblock positions - there is some data loss happening that i would like help locating
- Fixed up comments and updated changelog