### PR TITLE
Fix: Reverted SQL syntax to use AFTER, instead of BEFORE

### DIFF
--- a/Database/Updates/Character/2017_03_26_character_positions_positiontype.sql
+++ b/Database/Updates/Character/2017_03_26_character_positions_positiontype.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `character_position`
-	ADD COLUMN `positionType` TINYINT UNSIGNED NULL DEFAULT '0' BEFORE `cell`;
+	ADD COLUMN `positionType` TINYINT UNSIGNED NULL DEFAULT '0' AFTER `cell`;

--- a/Database/Updates/Character/2017_03_27_character_positions_change.sql
+++ b/Database/Updates/Character/2017_03_27_character_positions_change.sql
@@ -1,7 +1,7 @@
 ALTER TABLE `character_position`
 CHANGE COLUMN `id` `character_id` INT(10) UNSIGNED NOT NULL DEFAULT '0' FIRST;
 ALTER TABLE `character_position`
-	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' BEFORE `cell`,
+	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL DEFAULT '0' AFTER `character_id`,
 	DROP PRIMARY KEY,
 	ADD PRIMARY KEY (`character_id`, `positionType`);
 ALTER TABLE `character_position`
@@ -9,4 +9,4 @@ ALTER TABLE `character_position`
 	ALTER `positionType` DROP DEFAULT;
 ALTER TABLE `character_position`
 	CHANGE COLUMN `character_id` `character_id` INT(10) UNSIGNED NOT NULL FIRST,
-	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL BEFORE `cell`;
+	CHANGE COLUMN `positionType` `positionType` TINYINT(3) UNSIGNED NOT NULL AFTER `character_id`;


### PR DESCRIPTION
- Changed `2017_03_27_character_positions_change.sql` and `2017_03_26_character_positions_positiontype.sql` to use AFTER instead of BEFORE, when aligning the column.  The `positionType` column has been moved after the `id` column.