### PR TITLE
Reveresed the logic for the distance check on lifestone usage

### DIFF
--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -431,7 +431,7 @@ namespace ACE.Entity
                                         // validate within use range
                                         float radiusSquared = obj.GameData.UseRadius * obj.GameData.UseRadius;
 
-                                        if (player.Location.SquaredDistanceTo(obj.Location) <= radiusSquared)
+                                        if (player.Location.SquaredDistanceTo(obj.Location) >= radiusSquared)
                                         {
                                             serverMessage = "You wandered too far to attune with the lifestone!";
                                         }
@@ -443,7 +443,7 @@ namespace ACE.Entity
                                             serverMessage = "You have attuned your spirit to this lifestone. You will ressurect here after you die.";
                                         }
 
-                                        var lifestoneBindMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.Broadcast);
+                                        var lifestoneBindMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.Advancement);
                                         // always send useDone event
                                         var sendUseDoneEvent = new GameEventUseDone(player.Session);
                                         player.Session.Network.EnqueueSend(lifestoneBindMessage, sendUseDoneEvent);

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 ### 2017-04-06
+[fantoms]
+* Reversed the logic for distance checking, in the Queued Action code that @Mogwai introduced today on Item Usage for `Landblocks` owned Lifestones. 
+* Changed the Lifestone usage text to be `Light Blue`.
+
 [Zegeger]
 * Got 9 CreateObject sequences in correct order and named according to client code.
 * Changed many sequences over to SequenceManager.


### PR DESCRIPTION
- After performing some empirical visual client testing with:
 `
float squaredDistance = player.Location.SquaredDistanceTo(obj.Location);
                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat(squaredDistance.ToString(), ChatMessageType.Broadcast));
`, I found that a static use distance of at least `4.9f` worked _well_. I did not change this float, but I am noting it here.

- I also changed the `Lifestone Use` text to blue.