### PR TITLE
Inventory Part 2 - Create, Drop and Pickup

### DIFF
--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -218,7 +218,9 @@
     <Compile Include="Network\GameMessages\GameMessage.cs" />
     <Compile Include="Network\GameMessages\GameMessageAttribute.cs" />
     <Compile Include="Network\GameMessages\GameMessageOpcode.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessagePickupEvent.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessagePutObjectIn3d.cs" />
+    <Compile Include="Network\GameMessages\Messages\GameMessagePutObjectInContainer.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageUpdateInstanceId.cs" />
     <Compile Include="Network\GameMessages\Messages\MotionItem.cs" />
     <Compile Include="Network\GameMessages\Messages\GameMessageAutonomousPosition.cs" />

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -314,7 +314,7 @@ namespace ACE.Command.Handlers
                         }
                     case "ground":
                         {
-                            LootGenerationFactory.Spawn(loot, session.Player.Location.InFrontOf(2.0f));
+                            LootGenerationFactory.Spawn(loot, session.Player.Location.InFrontOf(1.0f));
                             LandblockManager.AddObject(loot);
                             break;
                         }

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -157,8 +157,9 @@ namespace ACE.Entity
 
             lock (objectCacheLocker)
             {
-                allObjects = this.worldObjects.Values.ToList();
-                this.worldObjects[wo.Guid] = wo;
+                allObjects = worldObjects.Values.ToList();
+                if (!worldObjects.ContainsKey(wo.Guid))                                
+                    worldObjects[wo.Guid] = wo;                
             }
 
             var args = BroadcastEventArgs.CreateAction(BroadcastAction.AddOrUpdate, wo);

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -281,7 +281,7 @@ namespace ACE.Entity
             {
                 case BroadcastAction.Delete:
                     {
-                        Parallel.ForEach(players, p => p.StopTrackingObject(wo.Guid));
+                        Parallel.ForEach(players, p => p.StopTrackingObject(wo));
                         break;
                     }
                 case BroadcastAction.AddOrUpdate:

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -281,6 +281,8 @@ namespace ACE.Entity
             {
                 case BroadcastAction.Delete:
                     {
+                        // Added filter to not include the container in this message Og II
+                        players = players.Where(p => p.Guid.Full != wo.GameData.ContainerId).ToList();
                         Parallel.ForEach(players, p => p.StopTrackingObject(wo));
                         break;
                     }

--- a/Source/ACE/Entity/PhysicsData.cs
+++ b/Source/ACE/Entity/PhysicsData.cs
@@ -144,7 +144,7 @@ namespace ACE.Entity
             writer.Write(sequences.GetCurrentSequence(SequenceType.ObjectServerControl));
             writer.Write(sequences.GetCurrentSequence(SequenceType.ObjectForcePosition));
             writer.Write(sequences.GetCurrentSequence(SequenceType.ObjectVisualDesc));
-            writer.Write(sequences.GetCurrentSequence(SequenceType.ObjectInstance));
+            writer.Write(sequences.GetNextSequence(SequenceType.ObjectInstance));
 
             writer.Align();
         }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -995,9 +995,12 @@ namespace ACE.Entity
                 sendUpdate = clientObjectList.ContainsKey(worldObject.Guid);
 
                 // check for a short circuit.  if we don't need to update, don't!
-                if (sendUpdate)
-                    if (worldObject.LastUpdatedTicks < clientObjectList[worldObject.Guid])
-                        return;
+                // TODO: Fix this
+                // I had to comment this optimization out for the moment - not sure how it works but it never lets us update or add. Og
+                
+                // if (sendUpdate)
+                //   if (worldObject.LastUpdatedTicks < clientObjectList[worldObject.Guid])
+                //       return;
 
                 if (!sendUpdate)
                 {

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1051,22 +1051,22 @@ namespace ACE.Entity
             }
         }
 
-        public void StopTrackingObject(ObjectGuid objectId)
+        public void StopTrackingObject(WorldObject worldObject)
         {
             bool sendUpdate = true;
             lock (clientObjectMutex)
             {
-                sendUpdate = clientObjectList.ContainsKey(objectId);
+                sendUpdate = clientObjectList.ContainsKey(worldObject.Guid);
 
                 if (!sendUpdate)
                 {
-                    clientObjectList.Remove(objectId);
+                    clientObjectList.Remove(worldObject.Guid);
                 }
             }
 
             if (sendUpdate)
             {
-                Session.Network.EnqueueSend(new GameMessageRemoveObject(objectId));
+                Session.Network.EnqueueSend(new GameMessageRemoveObject(worldObject));
             }
         }
 

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -159,17 +159,16 @@ namespace ACE.Entity
             // TODO: I need to look at the PCAPS to see the delta in position from the dropper and the item dropped.   Temp position.
             obj.PositionFlag = UpdatePositionFlag.Contact | UpdatePositionFlag.Placement |
                 UpdatePositionFlag.ZeroQy | UpdatePositionFlag.ZeroQx;
-            obj.PhysicsData.Position = PhysicsData.Position;
+            obj.PhysicsData.Position = PhysicsData.Position.InFrontOf(0.50f);
 
             // TODO: need to find out if these are needed or if there is a better way to do this. This probably should have been set at object creation Og II
             obj.GameData.ContainerId = 0;
             obj.GameData.Wielder = 0;
-            obj.PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.Position;
-            obj.PhysicsData.PhysicsState = PhysicsState.Gravity;
-            obj.GameData.RadarBehavior = RadarBehavior.ShowAlways;
-            obj.GameData.RadarColour = RadarColor.White;
-
+       
             // Tell the landblock so it can tell everyone around what just hit the ground.
+            // This is the sequence magic - adds back into 3d space seem to be treated like teleports.   
+            obj.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
+            obj.Sequences.GetNextSequence(SequenceType.ObjectVector);
             LandblockManager.AddObject(obj);
 
             // Let the client know our response.
@@ -194,12 +193,13 @@ namespace ACE.Entity
 
             // let's move to pick up the item
 
-            obj.PositionFlag = UpdatePositionFlag.Contact | UpdatePositionFlag.ZeroQy | UpdatePositionFlag.ZeroQx;
+            obj.PositionFlag = UpdatePositionFlag.Contact | UpdatePositionFlag.ZeroQy | UpdatePositionFlag.ZeroQx;            
 
             session.Network.EnqueueSend(new GameMessageUpdatePosition(this));
 
             // Bend over and pick that puppy up.
             var movement1 = new MovementData { ForwardCommand = 24, MovementStateFlag = MovementStateFlag.ForwardCommand };
+            
             session.Network.EnqueueSend(new GameMessageMotion(session.Player, session, MotionAutonomous.False, MovementTypes.Invalid, MotionFlags.None, MotionStance.Standing, movement1));
             session.Network.EnqueueSend(
                 new GameMessageSound(session.Player.Guid, Sound.PickUpItem, (float)1.0));

--- a/Source/ACE/Factories/LootGenerationFactory.cs
+++ b/Source/ACE/Factories/LootGenerationFactory.cs
@@ -19,7 +19,7 @@
 
         public static void Spawn(WorldObject inventoryItem, Position position)
         {
-            inventoryItem.PhysicsData.Position = position.InFrontOf(2.00f);
+            inventoryItem.PhysicsData.Position = position.InFrontOf(1.00f);
             inventoryItem.PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.Position |
                                                                inventoryItem.PhysicsData.PhysicsDescriptionFlag;
         }

--- a/Source/ACE/Network/GameEvent/GameEventType.cs
+++ b/Source/ACE/Network/GameEvent/GameEventType.cs
@@ -6,6 +6,7 @@
         PlayerDescription                   = 0x0013,
         AllegianceUpdate                    = 0x0020,
         FriendsListUpdate                   = 0x0021,
+        InventoryPutObjInContainer          = 0x0022,
         CharacterTitle                      = 0x0029,
         UpdateTitle                         = 0x002B,
          

--- a/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
+++ b/Source/ACE/Network/GameMessages/GameMessageOpcode.cs
@@ -3,9 +3,7 @@ namespace ACE.Network.GameMessages
     public enum GameMessageOpcode
     {
         None                            = 0x0000,
-
         EmoteText                       = 0x01E2,
-
         CreatureMessage                 = 0x02BB,
         PrivateUpdatePropertyInt        = 0x02CD,
         PublicUpdatePropertyInt         = 0x02CE,
@@ -27,6 +25,8 @@ namespace ACE.Network.GameMessages
         PrivateUpdateVital              = 0x02E7,
         PublicUpdateVital               = 0x02E8,
         PrivateUpdateAttribute2ndLevel  = 0x02E9,
+        PositionAndMovement             = 0xF619,
+        ObjDescEvent                    = 0xF625,
         CharacterCreateResponse         = 0xF643,
         CharacterRestoreResponse        = 0xF643, // This is a duplicate...
         CharacterLogOff                 = 0xF653,
@@ -39,11 +39,16 @@ namespace ACE.Network.GameMessages
         PlayerCreate                    = 0xF746,
         ObjectDelete                    = 0xF747,
         UpdatePosition                  = 0xF748,
+        ParentEvent                     = 0xF749,
+        PickupEvent                     = 0xF74A,
         SetState                        = 0xF74B,
+        MovementEvent                   = 0xF74C,
         Motion                          = 0xF74C,
+        VectorUpdate                    = 0xF74E,
         Sound                           = 0xF750,
         PlayerTeleport                  = 0xF751,
         AutonomousPosition              = 0xF753,
+        PlayScriptId                    = 0xF754,
         PlayEffect                      = 0xF755,
         GameEvent                       = 0xF7B0,
         GameAction                      = 0xF7B1,

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePickupEvent.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePickupEvent.cs
@@ -1,0 +1,18 @@
+﻿using ACE.Entity;
+using ACE.Network.GameEvent;
+using ACE.Network.Sequence;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessagePickupEvent : GameMessage
+    {
+        public GameMessagePickupEvent(Session session, WorldObject targetItem)
+            : base(GameMessageOpcode.PickupEvent, GameMessageGroup.Group0A)
+        {
+            Writer.Write(targetItem.Guid.Full);
+            Writer.Write(session.Player.Guid.Full);
+            Writer.Write(targetItem.Sequences.GetCurrentSequence(SequenceType.ObjectInstance));
+            Writer.Write(targetItem.Sequences.GetCurrentSequence(SequenceType.ObjectPosition));
+        }
+    }
+}

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePutObjectInContainer.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePutObjectInContainer.cs
@@ -1,0 +1,20 @@
+﻿using ACE.Entity;
+
+namespace ACE.Network.GameMessages.Messages
+{
+    public class GameMessagePutObjectInContainer : GameMessage
+    {
+        public GameMessagePutObjectInContainer(Session session, WorldObject worldObject, ObjectGuid itemGuid)
+            : base(GameMessageOpcode.GameEvent, GameMessageGroup.Group09)
+        {
+            Writer.WriteGuid(worldObject.Guid);
+            Writer.Write(session.GameEventSequence++);
+            Writer.Write((uint)GameEvent.GameEventType.InventoryPutObjInContainer);
+            Writer.Write(itemGuid.Full);
+            Writer.Write(session.Player.Guid.Full); // TODO: They could be draging to a pack would need the guid of the pack
+            Writer.Write((uint)(0)); // TODO: This is the slot - 0 based. 0 lets us drop it in the 0 slot of the main pack.
+            Writer.Write((uint)0); // TODO: make enum 0 item, 1 pack, 2 foci
+            Writer.Align();
+        }
+    }
+}

--- a/Source/ACE/Network/GameMessages/Messages/GameMessageRemoveObject.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageRemoveObject.cs
@@ -2,12 +2,15 @@
 
 namespace ACE.Network.GameMessages.Messages
 {
+    using global::ACE.Network.Sequence;
+
     public class GameMessageRemoveObject : GameMessage
     {
-        public GameMessageRemoveObject(ObjectGuid guid) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.Group0A)
+        public GameMessageRemoveObject(WorldObject worldObject) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.Group0A)
         {
             // TODO: Verify.  this was done without referencing the protocol spec
-            Writer.WriteGuid(guid);
+            Writer.WriteGuid(worldObject.Guid);
+            Writer.Write(worldObject.Sequences.GetCurrentSequence(SequenceType.ObjectInstance));
         }
     }
 }


### PR DESCRIPTION
This is a minor extension of the work I was doing previously, but it did turn up a number of good to know items.   

1.  When you are dropping an item, you have to increment the portal sequence - the client treats items being added to 3D space like a teleport.   It is on overloaded flag.   God, do I hate that.

1. There was some optimization code in player that was checking "check for a short circuit.  if we don't need to update, don't!"   This has a bug in it that I could not quite fix.   I commented it out for now with a big TODO.   It never sends an update on object create or update after the initial object creation.   We are missing updating the LastUpdatedTicks somewhere.

1. In Landblock - I added a lambda expression to omit sending the stop tracking message if we are the one putting the item into our container.   Everyone else needs to forget about it, but it is still mine. 

Next steps:

- [ ] Put in code to move to the object being picked up.

- [ ] Check for success and respond to item no longer there

- [ ] Save off player inventory items to the database

- [ ] Load inventory items on player load.


