### PR TITLE
Fix: Position missing update and LandblockId db object fix

### DIFF
--- a/Source/ACE.Database/CharacterDatabase.cs
+++ b/Source/ACE.Database/CharacterDatabase.cs
@@ -279,26 +279,7 @@ namespace ACE.Database
                 LoadCharacterPositions(c);
 
                 // Load the best location from the database
-                // This may be needed if a position is removed from the database, after a character has been created.
-                // But should now be totally un-neccssary.
-                var invalidPosition = CharacterPositionExtensions.InvalidPosition(c.Id, PositionType.Undef);
-
-                if (c.Positions.ContainsKey(PositionType.Location))
-                    c.Location = c.Positions[PositionType.Location];
-                else if (c.Positions.ContainsKey(PositionType.LastPortal))
-                    c.Location = c.Positions[PositionType.LastPortal];
-                else if (c.Positions.ContainsKey(PositionType.Sanctuary))
-                    c.Location = c.Positions[PositionType.Sanctuary];
-
-                // Check to see if the database position is valid
-                if (c.Location.PositionX == invalidPosition.PositionX && 
-                    c.Location.PositionY == invalidPosition.PositionY && 
-                    c.Location.PositionZ == invalidPosition.PositionZ)
-                {
-                    // If the cell is also invalid, we will set to initial character starting location.
-                    if (c.Location.LandblockId.Raw == 0x0 || c.Location.LandblockId.Raw == 0x255)
-                        c.Location = CharacterPositionExtensions.StartingPosition(c.Id);
-                }
+                c.Location = c.Positions[PositionType.Location];
 
                 uint characterOptions1Flag = result.Read<uint>(0, "characterOptions1");
                 uint characterOptions2Flag = result.Read<uint>(0, "characterOptions2");
@@ -446,13 +427,27 @@ namespace ACE.Database
                 dbObject.SetPropertyString(results.Read<PropertyString>(i, "propertyId"), results.Read<string>(i, "propertyValue"));
         }
 
-        public List<Position> GetCharacterPositions(Character character)
+        /// <summary>
+        /// Returns all positions from the database in a dictionary. Positions for each character should always be unique.
+        /// </summary>
+        public Dictionary<PositionType, Position> GetCharacterPositions(Character character)
         {
             Dictionary<string, object> criteria = new Dictionary<string, object>();
             criteria.Add("character_id", character.Id);
-            return ExecuteConstructedGetListStatement<CharacterPreparedStatement, Position>(CharacterPreparedStatement.CharacterPositionList, criteria);
+            List<Position> availablePositions = ExecuteConstructedGetListStatement<CharacterPreparedStatement, Position>(CharacterPreparedStatement.CharacterPositionList, criteria);
+            Dictionary<PositionType, Position> characterPositions = new Dictionary<PositionType, Position>();
+            foreach (Position position in availablePositions)
+            {
+                characterPositions.Add(position.PositionType, position);
+            }
+
+            return characterPositions;
         }
 
+        /// <summary>
+        /// Returns an available character positions from the database that match the PositionType.
+        /// If no position is found, an invalid position is returned.
+        /// </summary>
         public Position GetCharacterPosition(Character character, PositionType positionType)
         {
             Dictionary<string, object> criteria = new Dictionary<string, object>();
@@ -467,35 +462,44 @@ namespace ACE.Database
         /// <summary>
         /// Attempts to load characters positions from the database. If no position is available, a new position will be created to allow the player to spawn.
         /// </summary>
+        /// <remarks>
+        /// TODO:
+        ///     1. Confirm the order/position usage when restoring a position from database. Should this always be the lifestone if "Location" is unavailable?
+        /// </remarks>
         public void LoadCharacterPositions(Character character)
         {
             // get a list of positions from the vw_character_positions view
-            var dbPositionList = GetCharacterPositions(character);
+            var dbPositions = GetCharacterPositions(character);
 
-            bool containsLocation = false;
-
-            if (dbPositionList.Count > 0)
+            // Check for positions and insert position for the Position type Locaiont, if missing:
+            if (dbPositions.Count == 0 || !dbPositions.ContainsKey(PositionType.Location))
             {
-                foreach (Position checkPosition in dbPositionList)
+                Position swapToWorkingLocation = new Position();
+
+                // This checks for the best location available from the database
+                // When the first suitable position is found, it will be set as the current location.
+                if (dbPositions.ContainsKey(PositionType.LastPortal)) 
+                    // Use the lastportal position
+                    swapToWorkingLocation = dbPositions[PositionType.LastPortal]; 
+                else if (dbPositions.ContainsKey(PositionType.Sanctuary)) 
+                    // Use lifestone recall position
+                    swapToWorkingLocation = dbPositions[PositionType.Sanctuary]; 
+                else
                 {
-                    if (checkPosition.PositionType == PositionType.Location)
-                        containsLocation = true;
+                    // No suitable database position is available
+                    swapToWorkingLocation = CharacterPositionExtensions.StartingPosition(character.Id); //Use default position
                 }
-            }
 
-            // Check for positions and insert defaults if missing:
-            if (dbPositionList.Count == 0 || !containsLocation)
-            {
-                // load the default position
-                Position newCharacterPosition = CharacterPositionExtensions.StartingPosition(character.Id);
-                dbPositionList.Add(newCharacterPosition);
-                ExecuteConstructedInsertStatement(CharacterPreparedStatement.CharacterPositionInsert, typeof(Position), newCharacterPosition);
+                // force the position type to location
+                swapToWorkingLocation.PositionType = PositionType.Location;
+                dbPositions.Add(swapToWorkingLocation.PositionType, swapToWorkingLocation);
+                ExecuteConstructedInsertStatement(CharacterPreparedStatement.CharacterPositionInsert, typeof(Position), swapToWorkingLocation);
             }
 
             // This will load each available position from the database, into the object's positions
-            foreach (Position item in dbPositionList)
+            foreach (KeyValuePair<PositionType, Position> position in dbPositions)
             {
-                character.SetCharacterPosition(item);
+                character.SetCharacterPosition(position.Value);
             }
         }
 

--- a/Source/ACE.Database/ICharacterDatabase.cs
+++ b/Source/ACE.Database/ICharacterDatabase.cs
@@ -10,7 +10,7 @@ namespace ACE.Database
     {
         Position GetLocation(uint id);
 
-        List<Position> GetCharacterPositions(Character character);
+        Dictionary<PositionType, Position> GetCharacterPositions(Character character);
 
         Position GetCharacterPosition(Character character, PositionType positionType);
 

--- a/Source/ACE.Entity/CharacterPositionExtensions.cs
+++ b/Source/ACE.Entity/CharacterPositionExtensions.cs
@@ -15,6 +15,7 @@ namespace ACE.Entity
             var invalidPosition = new Position();
             invalidPosition.CharacterId = characterId;
             invalidPosition.PositionType = type;
+            invalidPosition.LandblockId = new LandblockId();
             return invalidPosition;
         }
     }

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -10,7 +10,17 @@
     [DbGetList("vw_character_positions", 23, "character_id")]
     public class Position
     {
-        public LandblockId LandblockId { get; set; }
+        public LandblockId LandblockId
+        {
+            get
+            {
+                return new LandblockId(Cell);
+            }
+            set
+            {
+                Cell = value.Raw;
+            }
+        }
 
         [DbField("character_id", (int)MySqlDbType.UInt32, Update = false, IsCriteria = true)]
         public virtual uint CharacterId { get; set; }
@@ -97,8 +107,7 @@
 
         public Position(uint characterId, PositionType type, uint newCell, float newPositionX, float newPositionY, float newPositionZ, float newRotationX, float newRotationY, float newRotationZ, float newRotationW)
         {
-            LandblockId = new LandblockId(Cell);
-            
+            LandblockId = new LandblockId(newCell);
             CharacterId = characterId;
             PositionType = type;
             Cell = newCell;

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -10,15 +10,21 @@
     [DbGetList("vw_character_positions", 23, "character_id")]
     public class Position
     {
+        private LandblockId landblockId;
+
         public LandblockId LandblockId
         {
             get
             {
-                return new LandblockId(Cell);
+                // When the landblockId is not set, we will instantiate it when needed.
+                if (landblockId.Raw == 0 && Cell != 0)
+                    landblockId = new LandblockId(Cell);
+                return landblockId;
             }
             set
             {
                 Cell = value.Raw;
+                landblockId = value;
             }
         }
 

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -235,42 +235,6 @@ namespace ACE.Command.Handlers
             ChatPacket.SendServerMessage(session, $"GUID: {session.Player.Guid.Full} ID(low): {session.Player.Guid.Low} High:{session.Player.Guid.High}", ChatMessageType.Broadcast);
         }
 
-        /// <summary>
-        /// Debug command to set an invalid character position for a position type. Used to test the logic and saving data to the database.
-        /// </summary>
-        [CommandHandler("reset-pos", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
-        public static void HandleResetPosition(Session session, params string[] parameters)
-        {
-            try
-            {
-                // if (parameters.Length > 1)
-                //    if (parameters[1] != "")
-                //        scale = float.Parse(parameters[1]);
-
-                string message = "Error saving position.";
-
-                PositionType type = new PositionType();
-
-                if (Enum.TryParse(parameters[0], true, out type))
-                {
-                    if (Enum.IsDefined(typeof(PositionType), type))
-                    {
-                        message = $"Saving position {Enum.GetName(typeof(PositionType), type)}";
-                        session.Player.SetCharacterPosition(type, CharacterPositionExtensions.InvalidPosition(session.Id, type));
-                    }
-                }
-
-                float scale = 1f;
-                var effectEvent = new GameMessageScript(session.Player.Guid, Network.Enum.PlayScript.AttribDownRed, scale);
-                var sysChatMessage = new GameMessageSystemChat(message, ChatMessageType.Broadcast);
-                session.Network.EnqueueSend(effectEvent, sysChatMessage);
-            }
-            catch (Exception)
-            {
-                // Do Nothing
-        }
-            }
-
         // @testspell 0 10 10 10 10 20
         [CommandHandler("testspell", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 3)]
         public static void TestSpell(Session session, params string[] parameters)

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -173,7 +173,6 @@ namespace ACE.Network.Handlers
         public static void CharacterCreateSetDefaultCharacterPositions(Character character)
         {
             character.SetCharacterPosition(CharacterPositionExtensions.StartingPosition(character.Id));
-            character.SetCharacterPosition(CharacterPositionExtensions.InvalidPosition(character.Id, PositionType.LastPortal));
         }
 
         private static void SendCharacterCreateResponse(Session session, CharacterGenerationVerificationResponse response, ObjectGuid guid = default(ObjectGuid), string charName = "")

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 # ACEmulator Change Log
+### 2017-04-17
+[fantoms]
+* Removed `@reset-pos` command and also removed another default that set last portal upon character creation.
+* Changed `GetPositions` to return a dictionary.
+* Changed `Position LandblockId` to have a private value that will create a new objected when needed.
+* Moved the position check logic into the CharacterDatabase.cs file, to simply things.
+
 ### 2017-04-16
 [fantoms]
 * Fixed 2 bugs in landblock where the landblock was becoming invalid on load.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # ACEmulator Change Log
+### 2017-04-16
+[fantoms]
+* Fixed 2 bugs in landblock where the landblock was becoming invalid on load.
+* Added checks to prevent missing Positions in the database from crashing the server or preventing character load.
+* Removed Lastportal from Position creation, as it will be created on demand when portals are introduced.
 
 ### 2017-04-13
 [Og II]


### PR DESCRIPTION
This code was created to address issue #242.

-Fixed bugs in `LandblockId` in position and server now resets the  position if missing.
-Added checks to prevent a missing location from crashing the server.
-Removed unnecessary `lastportal` recall position save, this is set on demand, this also prevents invalid data from entering the database.

Please give this a test by deleting a previously created character's position location (position type 1) and then try logging in, you should be at the current starting dungeon.