### PR TITLE
Bring WritePackedDWORD to ACE

### DIFF
--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -156,8 +156,8 @@ namespace ACE.Entity
 
             writer.Write((uint)WeenieFlags);
             writer.WriteString16L(Name);
-            writer.Write((ushort)WeenieClassid);
-            writer.Write((ushort)Icon);
+            writer.WritePackedDWORD(WeenieClassid);
+            writer.WritePackedDWORD(Icon);
             writer.Write((uint)Type);
             writer.Write((uint)DescriptionFlags);
 

--- a/Source/ACE/Network/Extensions.cs
+++ b/Source/ACE/Network/Extensions.cs
@@ -24,6 +24,20 @@ namespace ACE.Network
             writer.Write(beValue);
         }
 
+        public static void WritePackedDWORD(this BinaryWriter writer, uint rawValue)
+        {
+            if (rawValue <= 32767)
+            {
+                ushort networkValue = Convert.ToUInt16(rawValue);
+                writer.Write(BitConverter.GetBytes(networkValue));
+            }
+            else
+            {
+                uint packedValue = (0x8000000 | ((rawValue << 16) & 0x7FFF0000)) | (rawValue >> 15);
+                writer.Write(BitConverter.GetBytes(packedValue));
+            }
+        }
+
         public static void Pad(this BinaryWriter writer, uint pad) { writer.Write(new byte[pad]); }
 
         public static void Align(this BinaryWriter writer)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 # ACEmulator Change Log
 
 ### 2017-04-19
+[Mogwai-AC]
+* Added PackedDWORD
 [Ripley]
+* Changed WeenieClassid and Icon to use PackedDWORD in WorldObject.SerializeCreateObject
 * Updated PhysicsData to create and send a new currentMotionState when encountering a null one when flag PhysicsDescriptionFlag.Movement is set.
 
 ### 2017-04-18


### PR DESCRIPTION
This continues to address issue #246 

More things will need to be converted to PackedDWORD to fully squash the createobject errors.