### PR TITLE
Fix IsDerivedPlayer logic to allow smite to work

### DIFF
--- a/Source/ACE/Entity/Creature.cs
+++ b/Source/ACE/Entity/Creature.cs
@@ -155,10 +155,7 @@ namespace ACE.Entity
         {
             IsAlive = false;
             // This will determine if the derived type is a player
-            var isDerivedPlayer = typeof(Player).GetMember("OnKill",
-                   BindingFlags.NonPublic
-                 | BindingFlags.Instance
-                 | BindingFlags.DeclaredOnly).Length == 0;
+            var isDerivedPlayer = Guid.IsPlayer();
             // TODO: Implement some proper respawn timers, check the generators for that
             RespawnTime = WorldManager.PortalYearTicks + 10;
 


### PR DESCRIPTION
This was always true, due to a changes I made last night to the Creature Kill command. The changes made the Creatures also work like a player, but after I made this change, the types can now differentiate; allowing `@smite` and `@smite all` began to work correctly again. 