### PR TITLE
Added currentMotionState and support within ACE

### DIFF
--- a/Database/Updates/World/009_2017_04_24_add_currentmotionstate.sql
+++ b/Database/Updates/World/009_2017_04_24_add_currentmotionstate.sql
@@ -1,0 +1,154 @@
+ALTER TABLE `base_ace_object` 
+ADD COLUMN `currentMotionState` TEXT NOT NULL AFTER `translucency`;
+
+ALTER TABLE `base_ace_object` 
+CHANGE COLUMN `location` `location` INT(10) UNSIGNED NOT NULL DEFAULT '0' ;
+
+
+USE `ace_world`;
+CREATE 
+     OR REPLACE ALGORITHM = UNDEFINED 
+    DEFINER = `root`@`localhost` 
+    SQL SECURITY DEFINER
+VIEW `ace_world`.`vw_ace_creature_object` AS
+    (SELECT 
+        `bao`.`baseAceObjectId` AS `baseAceObjectId`,
+        `bao`.`name` AS `name`,
+        `bao`.`typeId` AS `typeId`,
+        `bao`.`paletteId` AS `paletteId`,
+        `bao`.`ammoType` AS `ammoType`,
+        `bao`.`blipColor` AS `blipColor`,
+        `bao`.`bitField` AS `bitField`,
+        `bao`.`burden` AS `burden`,
+        `bao`.`combatUse` AS `combatUse`,
+        `bao`.`cooldownDuration` AS `cooldownDuration`,
+        `bao`.`cooldownId` AS `cooldownId`,
+        `bao`.`effects` AS `effects`,
+        `bao`.`containersCapacity` AS `containersCapacity`,
+        `bao`.`header` AS `header`,
+        `bao`.`hookTypeId` AS `hookTypeId`,
+        `bao`.`iconId` AS `iconId`,
+        `bao`.`iconOverlayId` AS `iconOverlayId`,
+        `bao`.`iconUnderlayId` AS `iconUnderlayId`,
+        `bao`.`hookItemTypes` AS `hookItemTypes`,
+        `bao`.`itemsCapacity` AS `itemsCapacity`,
+        `bao`.`location` AS `location`,
+        `bao`.`materialType` AS `materialType`,
+        `bao`.`maxStackSize` AS `maxStackSize`,
+        `bao`.`maxStructure` AS `maxStructure`,
+        `bao`.`radar` AS `radar`,
+        `bao`.`pscript` AS `pscript`,
+        `bao`.`spellId` AS `spellId`,
+        `bao`.`stackSize` AS `stackSize`,
+        `bao`.`structure` AS `structure`,
+        `bao`.`targetTypeId` AS `targetTypeId`,
+        `bao`.`usability` AS `usability`,
+        `bao`.`useRadius` AS `useRadius`,
+        `bao`.`validLocations` AS `validLocations`,
+        `bao`.`value` AS `value`,
+        `bao`.`workmanship` AS `workmanship`,
+        `bao`.`animationFrameId` AS `animationFrameId`,
+        `bao`.`defaultScript` AS `defaultScript`,
+        `bao`.`defaultScriptIntensity` AS `defaultScriptIntensity`,
+        `bao`.`elasticity` AS `elasticity`,
+        `bao`.`friction` AS `friction`,
+        `bao`.`locationId` AS `locationId`,
+        `bao`.`modelTableId` AS `modelTableId`,
+        `bao`.`motionTableId` AS `motionTableId`,
+        `bao`.`objectScale` AS `objectScale`,
+        `bao`.`physicsBitField` AS `physicsBitField`,
+        `bao`.`physicsState` AS `physicsState`,
+        `bao`.`physicsTableId` AS `physicsTableId`,
+        `bao`.`soundTableId` AS `soundTableId`,
+        `bao`.`translucency` AS `translucency`,
+        `bao`.`currentMotionState` AS `currentMotionState`,
+        `wcd`.`weenieClassId` AS `weenieClassId`,
+        `wcd`.`level` AS `level`,
+        `wcd`.`strength` AS `strength`,
+        `wcd`.`endurance` AS `endurance`,
+        `wcd`.`coordination` AS `coordination`,
+        `wcd`.`quickness` AS `quickness`,
+        `wcd`.`focus` AS `focus`,
+        `wcd`.`self` AS `self`,
+        `wcd`.`health` AS `health`,
+        `wcd`.`stamina` AS `stamina`,
+        `wcd`.`mana` AS `mana`,
+        `wcd`.`baseExperience` AS `baseExperience`,
+        `wcd`.`luminance` AS `luminance`,
+        `wcd`.`lootTier` AS `lootTier`
+    FROM
+        ((`ace_world`.`weenie_creature_data` `wcd`
+        JOIN `ace_world`.`weenie_class` `wc` ON ((`wcd`.`weenieClassId` = `wc`.`weenieClassId`)))
+        JOIN `ace_world`.`base_ace_object` `bao` ON ((`wc`.`baseAceObjectId` = `bao`.`baseAceObjectId`))));
+        
+USE `ace_world`;
+CREATE 
+     OR REPLACE ALGORITHM = UNDEFINED 
+    DEFINER = `root`@`localhost` 
+    SQL SECURITY DEFINER
+VIEW `ace_world`.`vw_ace_object` AS
+    (SELECT 
+        `bao`.`baseAceObjectId` AS `baseAceObjectId`,
+        `bao`.`name` AS `name`,
+        `bao`.`typeId` AS `typeId`,
+        `bao`.`paletteId` AS `paletteId`,
+        `bao`.`ammoType` AS `ammoType`,
+        `bao`.`blipColor` AS `blipColor`,
+        `bao`.`bitField` AS `bitField`,
+        `bao`.`burden` AS `burden`,
+        `bao`.`combatUse` AS `combatUse`,
+        `bao`.`cooldownDuration` AS `cooldownDuration`,
+        `bao`.`cooldownId` AS `cooldownId`,
+        `bao`.`effects` AS `effects`,
+        `bao`.`containersCapacity` AS `containersCapacity`,
+        `bao`.`header` AS `header`,
+        `bao`.`hookTypeId` AS `hookTypeId`,
+        `bao`.`iconId` AS `iconId`,
+        `bao`.`iconOverlayId` AS `iconOverlayId`,
+        `bao`.`iconUnderlayId` AS `iconUnderlayId`,
+        `bao`.`hookItemTypes` AS `hookItemTypes`,
+        `bao`.`itemsCapacity` AS `itemsCapacity`,
+        `bao`.`location` AS `location`,
+        `bao`.`materialType` AS `materialType`,
+        `bao`.`maxStackSize` AS `maxStackSize`,
+        `bao`.`maxStructure` AS `maxStructure`,
+        `bao`.`radar` AS `radar`,
+        `bao`.`pscript` AS `pscript`,
+        `bao`.`spellId` AS `spellId`,
+        `bao`.`stackSize` AS `stackSize`,
+        `bao`.`structure` AS `structure`,
+        `bao`.`targetTypeId` AS `targetTypeId`,
+        `bao`.`usability` AS `usability`,
+        `bao`.`useRadius` AS `useRadius`,
+        `bao`.`validLocations` AS `validLocations`,
+        `bao`.`value` AS `value`,
+        `bao`.`workmanship` AS `workmanship`,
+        `bao`.`animationFrameId` AS `animationFrameId`,
+        `bao`.`defaultScript` AS `defaultScript`,
+        `bao`.`defaultScriptIntensity` AS `defaultScriptIntensity`,
+        `bao`.`elasticity` AS `elasticity`,
+        `bao`.`friction` AS `friction`,
+        `bao`.`locationId` AS `locationId`,
+        `bao`.`modelTableId` AS `modelTableId`,
+        `bao`.`motionTableId` AS `motionTableId`,
+        `bao`.`objectScale` AS `objectScale`,
+        `bao`.`physicsBitField` AS `physicsBitField`,
+        `bao`.`physicsState` AS `physicsState`,
+        `bao`.`physicsTableId` AS `physicsTableId`,
+        `bao`.`soundTableId` AS `soundTableId`,
+        `bao`.`translucency` AS `translucency`,
+        `bao`.`currentMotionState` AS `currentMotionState`,
+        `ao`.`weenieClassId` AS `weenieClassId`,
+        `ao`.`landblock` AS `landblock`,
+        `ao`.`cell` AS `cell`,
+        `ao`.`posX` AS `posX`,
+        `ao`.`posY` AS `posY`,
+        `ao`.`posZ` AS `posZ`,
+        `ao`.`qW` AS `qW`,
+        `ao`.`qX` AS `qX`,
+        `ao`.`qY` AS `qY`,
+        `ao`.`qZ` AS `qZ`
+    FROM
+        (`ace_world`.`ace_object` `ao`
+        JOIN `ace_world`.`base_ace_object` `bao` ON ((`ao`.`baseAceObjectId` = `bao`.`baseAceObjectId`))));
+

--- a/Source/ACE.DatLoader/Entity/ClothingBaseEffect.cs
+++ b/Source/ACE.DatLoader/Entity/ClothingBaseEffect.cs
@@ -6,7 +6,7 @@ namespace ACE.DatLoader.Entity
 {
     public class ClothingBaseEffect
     {
-        public uint SetupModel{ get; set; }
+        public uint SetupModel { get; set; }
         public List<CloObjectEffect> CloObjectEffects { get; set; } = new List<CloObjectEffect>();
 
         public ClothingBaseEffect()

--- a/Source/ACE.DatLoader/FileTypes/ClothingTable.cs
+++ b/Source/ACE.DatLoader/FileTypes/ClothingTable.cs
@@ -23,19 +23,19 @@ namespace ACE.DatLoader.Entity
 
             uint numClothingEffects = datReader.ReadUInt16();
             datReader.Offset += 2;
-            for (uint i = 0; i<numClothingEffects; i++)
+            for (uint i = 0; i < numClothingEffects; i++)
             {
                 ClothingBaseEffect cb = new ClothingBaseEffect();
                 cb.SetupModel = datReader.ReadUInt32();
                 int numObjectEffects = datReader.ReadInt32();
-                for (int j = 0; j<numObjectEffects; j++)
+                for (int j = 0; j < numObjectEffects; j++)
                 {
                     CloObjectEffect cloObjEffect = new CloObjectEffect();
                     cloObjEffect.Index = datReader.ReadUInt32();
                     cloObjEffect.ModelId = datReader.ReadUInt32();
                     uint numTextureEffects = datReader.ReadUInt32();
 
-                    for( uint k = 0; k < numTextureEffects; k++)
+                    for (uint k = 0; k < numTextureEffects; k++)
                     {
                         CloTextureEffect cloTexEffect = new CloTextureEffect();
                         cloTexEffect.OldTexture = datReader.ReadUInt32();

--- a/Source/ACE.Entity/BaseAceObject.cs
+++ b/Source/ACE.Entity/BaseAceObject.cs
@@ -183,6 +183,9 @@ namespace ACE.Entity
         [DbField("translucency", (int)MySqlDbType.Float)]
         public float Translucency { get; set; }
 
+        [DbField("currentMotionState", (int)MySqlDbType.Text)]
+        public string CurrentMotionState { get; set; }
+
         public List<PaletteOverride> PaletteOverrides { get; set; } = new List<PaletteOverride>();
 
         public List<TextureMapOverride> TextureOverrides { get; set; } = new List<TextureMapOverride>();

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -171,7 +171,8 @@
 
             float xOffset = ((baseX & 7) * 24.0f) + 12;
             float yOffset = ((baseY & 7) * 24.0f) + 12;
-            float zOffset = GetZFromCellXY(LandblockId.Raw, xOffset, yOffset);
+            // float zOffset = GetZFromCellXY(LandblockId.Raw, xOffset, yOffset);
+            float zOffset = 0.0f;
 
             LandblockId = new LandblockId(GetCellFromBase(baseX, baseY));
             // Offset 

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Entity\CollidableObject.cs" />
     <Compile Include="Entity\Container.cs" />
     <Compile Include="Entity\Creature.cs" />
+    <Compile Include="Entity\DebugObject.cs" />
     <Compile Include="Entity\Door.cs" />
     <Compile Include="Entity\Events\BroadcastEventArgs.cs" />
     <Compile Include="Entity\Events\DeathMessageArgs.cs" />

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -1,0 +1,82 @@
+﻿using ACE.Entity.Enum;
+using ACE.Network.Enum;
+using ACE.Network.Motion;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Entity
+{
+    public class DebugObject : CollidableObject
+    {
+        public DebugObject(ObjectType type, ObjectGuid guid, string name, ushort weenieClassId, ObjectDescriptionFlag descriptionFlag, WeenieHeaderFlag weenieFlag, Position position)
+            : base(type, guid, name, weenieClassId, descriptionFlag, weenieFlag, position)
+        {
+        }
+
+        public DebugObject(AceObject aceO)
+            : base((ObjectType)aceO.TypeId, new ObjectGuid(aceO.AceObjectId))
+        {
+            this.Name = aceO.Name;
+            if (this.Name == null)
+                this.Name = "NULL";
+
+            this.DescriptionFlags = (ObjectDescriptionFlag)aceO.WdescBitField;
+            this.Location = aceO.Position;
+            this.WeenieClassid = aceO.WeenieClassId;
+            this.WeenieFlags = (WeenieHeaderFlag)aceO.WeenieFlags;
+
+            this.PhysicsData.MTableResourceId = aceO.MotionTableId;
+            this.PhysicsData.Stable = aceO.SoundTableId;
+            this.PhysicsData.CSetup = aceO.ModelTableId;
+            this.PhysicsData.Petable = aceO.PhysicsTableId;
+
+            // this should probably be determined based on the presence of data.
+            this.PhysicsData.PhysicsDescriptionFlag = (PhysicsDescriptionFlag)aceO.PhysicsBitField;
+            this.PhysicsData.PhysicsState = (PhysicsState)aceO.PhysicsState;
+
+            if (aceO.CurrentMotionState == "0")
+                this.PhysicsData.CurrentMotionState = null;
+            else
+                this.PhysicsData.CurrentMotionState = new GeneralMotion(Convert.FromBase64String(aceO.CurrentMotionState));
+
+            // this.PhysicsData.CurrentMotionState = new GeneralMotion(MotionStance.Standing, new MotionItem(MotionCommand.Off));
+            // this.PhysicsData.CurrentMotionState = new GeneralMotion(MotionStance.Standing, new MotionItem(MotionCommand.Dead));
+
+            this.PhysicsData.ObjScale = aceO.ObjectScale;
+            this.PhysicsData.AnimationFrame = aceO.AnimationFrameId;
+
+            // game data min required flags;
+            this.Icon = aceO.IconId;
+
+            if (this.GameData.NamePlural == null)
+                this.GameData.NamePlural = "NULLs";
+
+            this.GameData.Type = aceO.WeenieClassId;
+
+            this.GameData.Usable = (Usable)aceO.Usability;
+            this.GameData.RadarColour = (RadarColor)aceO.BlipColor;
+            this.GameData.RadarBehavior = (RadarBehavior)aceO.Radar;
+            this.GameData.UseRadius = aceO.UseRadius;
+
+            this.GameData.HookType = (ushort)aceO.HookTypeId;
+            this.GameData.HookItemTypes = aceO.HookItemTypes;
+            this.GameData.Burden = (ushort)aceO.Burden;
+            this.GameData.Value = aceO.Value;
+            this.GameData.ItemCapacity = aceO.ItemsCapacity;
+
+            aceO.AnimationOverrides.ForEach(ao => this.ModelData.AddModel(ao.Index, ao.AnimationId));
+            aceO.TextureOverrides.ForEach(to => this.ModelData.AddTexture(to.Index, to.OldId, to.NewId));
+            aceO.PaletteOverrides.ForEach(po => this.ModelData.AddPalette(po.SubPaletteId, po.Offset, po.Length));
+            // aceO.PaletteOverrides.ForEach(po => this.ModelData.AddPalette(po.SubPaletteId, (byte)(po.Offset / 8), (byte)(po.Length / 8)));
+            this.ModelData.PaletteGuid = aceO.PaletteId;
+        }
+
+        public override void OnCollide(Player player)
+        {
+            // TODO: Implement
+        }
+    }
+}

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -540,7 +540,7 @@ namespace ACE.Entity
                     if (dc.RespawnTime < WorldManager.PortalYearTicks)
                     {
                         dc.IsAlive = true;
-                        HandleParticleEffectEvent(dc, PlayScript.Create);
+                        // HandleParticleEffectEvent(dc, PlayScript.Create);
                         this.AddWorldObject(dc);
                     }
                 });

--- a/Source/ACE/Factories/GenericObjectFactory.cs
+++ b/Source/ACE/Factories/GenericObjectFactory.cs
@@ -25,6 +25,12 @@ namespace ACE.Factories
                     case ObjectType.Portal:
                         results.Add(new Portal(aceO));
                         break;
+#if DEBUG
+                    default:
+                        // Use the DebugObject to assist in building proper objects for weenies
+                        results.Add(new DebugObject(aceO));
+                        break;
+#endif
                 }
             }
 

--- a/Source/ACE/Network/Motion/GeneralMotion.cs
+++ b/Source/ACE/Network/Motion/GeneralMotion.cs
@@ -61,5 +61,87 @@ namespace ACE.Network.Motion
             }
             return stream.ToArray();
         }
+
+        public GeneralMotion(byte[] currentMotionState)
+        {
+            MemoryStream stream = new MemoryStream(currentMotionState);
+            BinaryReader reader = new BinaryReader(stream);
+            MovementTypes movementType = (MovementTypes)reader.ReadByte(); // movement_type
+
+            // MotionFlags flags = MotionFlags.None;
+            // if (HasTarget)
+            //    flags |= MotionFlags.HasTarget;
+            // if (Jumping)
+            //    flags |= MotionFlags.Jumping;
+
+            MotionFlags flags = (MotionFlags)reader.ReadByte(); // these can be or and has sticky object | is long jump mode |
+
+            if ((flags & MotionFlags.HasTarget) != 0)
+                HasTarget = true;
+            if ((flags & MotionFlags.Jumping) != 0)
+                Jumping = true;
+
+            Stance = (MotionStance)reader.ReadUInt16(); // called command in the client
+            // MovementStateFlag generalFlags = MovementData.MovementStateFlag;
+
+            // generalFlags += (uint)Commands.Count << 7;
+            MovementStateFlag generalFlags = (MovementStateFlag)reader.ReadUInt32();
+
+            // MovementData.Serialize(writer);
+
+            MovementData = new MovementData();
+
+            if ((generalFlags & MovementStateFlag.CurrentStyle) != 0)
+                MovementData.CurrentStyle = (ushort)reader.ReadUInt32();
+
+            if ((generalFlags & MovementStateFlag.ForwardCommand) != 0)
+                MovementData.ForwardCommand = (ushort)reader.ReadUInt32();
+                
+            if ((generalFlags & MovementStateFlag.ForwardSpeed) != 0)
+                MovementData.ForwardSpeed = (float)reader.ReadSingle();
+
+            if ((generalFlags & MovementStateFlag.SideStepCommand) != 0)
+                MovementData.SideStepCommand = (ushort)reader.ReadUInt32();
+
+            if ((generalFlags & MovementStateFlag.SideStepSpeed) != 0)
+                MovementData.SideStepSpeed = (float)reader.ReadSingle();
+
+            if ((generalFlags & MovementStateFlag.TurnCommand) != 0)
+                MovementData.TurnCommand = (ushort)reader.ReadUInt32();
+
+            if ((generalFlags & MovementStateFlag.TurnSpeed) != 0)
+                MovementData.TurnSpeed = (float)reader.ReadSingle();
+
+            // foreach (var item in Commands)
+            // {
+            //    writer.Write((ushort)item.Motion);
+            //    writer.Write(animationTarget.Sequences.GetNextSequence(Sequence.SequenceType.Motion));
+            //    writer.Write(item.Speed);
+            // }
+
+            // if ((generalFlags & MovementStateFlag.ForwardCommand) != 0)
+            // {
+            //    MotionItem item = new MotionItem();
+            //    item.Motion = (MotionCommand)reader.ReadUInt16();
+            //    item.Speed = reader.ReadSingle();
+            //    Commands.Add(item);
+            // }
+            // if ((generalFlags & MovementStateFlag.SideStepCommand) != 0)
+            // {
+            //    MotionItem item = new MotionItem();
+            //    item.Motion = (MotionCommand)reader.ReadUInt16();
+            //    item.Speed = reader.ReadSingle();
+            //    Commands.Add(item);
+            // }
+            // if ((generalFlags & MovementStateFlag.TurnCommand) != 0)
+            // {
+            //    MotionItem item = new MotionItem();
+            //    item.Motion = (MotionCommand)reader.ReadUInt16();
+            //    item.Speed = reader.ReadSingle();
+            //    Commands.Add(item);
+            // }
+
+            // return stream.ToArray();
+        }
     }
 }

--- a/Source/AppVeyor/MySqlInstall.bat
+++ b/Source/AppVeyor/MySqlInstall.bat
@@ -6,3 +6,4 @@
 "C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\006_2017_04_18_portal_locations.sql
 "C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\007_2017_04_21_portal_destination.sql
 "C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\008_2017_04_23_Gharu_town_Part_1_portal_destination.sql
+"C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\009_2017_04_24_add_currentmotionstate.sql

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,18 @@
 # ACEmulator Change Log
+
+### 2017-04-24
+[Ripley]
+* Added currentMotionState to base_ace_object in ace_world database.
+* Changed location in base_ace_object to an INT(10) in ace_world database.
+* Changed vw_ace_creature_object and vw_ace_object to include currentMotionState.
+* Added CurrentMotionState to BaseAceObject and linked it to currentMotionState.
+* Added a method to GeneralMotion to convert from a byte array to GeneralMotion object.
+* Added DebugObject to assist with building and testing out real objects for world.
+* Changed GenericObjectFactory to spawn DebugObjects as a default if running server in DEBUG.
+* Fixed Code Style issues within ClothingTable.cs and ClothingBaseEffect.cs in ACE.DatLoader.
+* Changed Position to set Z to 0 to fix @tele command.
+* Removed PlayScript.Create from landblock respawn section. Players should not have that effect applied to them.
+
 ### 2017-04-23
 [fantoms]
 * Changed the `Character` Stats from the `Current` `ICreatureStats` interface member, too `UnbuffedValue` in attempt at fixing the Player Vitals.
@@ -7,7 +21,6 @@
 
 [MiachofTD]
 * Added 64 ports in the destination_portal for Gharu towns. 
-
 
 ### 2017-04-22
 [OptimShi]
@@ -24,7 +37,7 @@
 * Add 88 more working portal destinations, including most of the Town Network
 
 [fantoms]
-* Removed `@reset-pos` after it was incorrectly re-added in another members commit.\
+* Removed `@reset-pos` after it was incorrectly re-added in another members commit.
 
 [StackOverFlow]
 * Added Landblock Streaming Objects.


### PR DESCRIPTION
* Added currentMotionState to base_ace_object in ace_world database.
* Changed location in base_ace_object to an INT(10) in ace_world database.
* Changed vw_ace_creature_object and vw_ace_object to include currentMotionState.
* Added CurrentMotionState to BaseAceObject and linked it to currentMotionState.
* Added a method to GeneralMotion to convert from a byte array to GeneralMotion object.
* Added DebugObject to assist with building and testing out real objects for world.
* Changed GenericObjectFactory to spawn DebugObjects as a default if running server in DEBUG.
* Fixed Code Style issues within ClothingTable.cs and ClothingBaseEffect.cs in ACE.DatLoader.
* Changed Position to set Z to 0 to fix @tele command.
* Removed PlayScript.Create from landblock respawn section. Players should not have that effect applied to them.