### PR TITLE
Changed SetupModel.ReadFromDat function to be more user-friendly. 

### DIFF
--- a/Source/ACE.DatLoader/FileTypes/SetupModel.cs
+++ b/Source/ACE.DatLoader/FileTypes/SetupModel.cs
@@ -38,8 +38,9 @@ namespace ACE.DatLoader.FileTypes
         public uint DefaultSoundTable { get; set; }
         public uint DefaultScriptTable { get; set; }
 
-        public static SetupModel ReadFromDat(DatReader datReader)
+        public static SetupModel ReadFromDat(uint fileId)
         {
+            DatReader datReader = DatManager.PortalDat.GetReaderForFile(fileId);
             SetupModel m = new SetupModel();
             m.ModelId = datReader.ReadUInt32();
 

--- a/Source/ACE/Entity/Lifestone.cs
+++ b/Source/ACE/Entity/Lifestone.cs
@@ -3,6 +3,7 @@ using ACE.Network.GameMessages.Messages;
 using ACE.Network.Motion;
 using ACE.Entity.Enum;
 using ACE.Network.Enum;
+using ACE.DatLoader.FileTypes;
 
 namespace ACE.Entity
 {
@@ -46,8 +47,9 @@ namespace ACE.Entity
         public override void OnUse(Player player)
         {
             string serverMessage = null;
-            // validate within use range
-            float radiusSquared = this.GameData.UseRadius * this.GameData.UseRadius;
+            // validate within use range, taking into account the radius of the model itself, as well
+            SetupModel csetup = SetupModel.ReadFromDat(this.PhysicsData.CSetup);
+            float radiusSquared = (this.GameData.UseRadius + csetup.Radius) * (this.GameData.UseRadius + csetup.Radius);
 
             var motionSanctuary = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Sanctuary));
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # ACEmulator Change Log
 
-### 2017-05-30
+### 2017-05-01
 [OptimShi]
 * Modified DatLoader.SetupModel to be easier to initiate (got missed when other items had the same changes applied). Also added working example to the Lifestone.cs OnUse function to take model radius into account.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2017-05-30
+[OptimShi]
+* Modified DatLoader.SetupModel to be easier to initiate (got missed when other items had the same changes applied). Also added working example to the Lifestone.cs OnUse function to take model radius into account.
+
 ### 2017-04-30
 [OptimShi]
 * Add client_cell.dat reading for landblocks in CellLandblock.cs (named so as to avoid confusion with existing Landblock class)


### PR DESCRIPTION
Added a functional example of its usage to Lifestone.OnUse to properly take the model's radius and the object's use-radius into account when determining if a player is "close enough".