### PR TITLE
Fix for ci & create complete and tested.   Ready for merge if approved.  

### DIFF
--- a/Source/ACE.Database/IWorldDatabase.cs
+++ b/Source/ACE.Database/IWorldDatabase.cs
@@ -20,6 +20,8 @@ namespace ACE.Database
 
         BaseAceObject GetBaseAceObjectDataByWeenie(uint weenieClassId);
 
+        BaseAceObject GetRandomBaseAceObjectByTypeId(uint typeId);
+
         bool InsertStaticCreatureLocation(AceCreatureStaticLocation acsl);
     }
 }

--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -22,7 +22,8 @@ namespace ACE.Database
             InsertCreatureStaticLocation,
             GetCreatureGeneratorByLandblock,
             GetCreatureGeneratorData,
-            GetPortalObjectsByAceObjectId
+            GetPortalObjectsByAceObjectId,
+            GetItemsByTypeId
         }
 
         protected override Type PreparedStatementType => typeof(WorldPreparedStatement);
@@ -44,6 +45,21 @@ namespace ACE.Database
             ConstructStatement(WorldPreparedStatement.InsertCreatureStaticLocation, typeof(AceCreatureStaticLocation), ConstructedStatementType.Insert);
             ConstructStatement(WorldPreparedStatement.GetCreatureGeneratorByLandblock, typeof(AceCreatureGeneratorLocation), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetCreatureGeneratorData, typeof(AceCreatureGeneratorData), ConstructedStatementType.GetList);
+            ConstructStatement(WorldPreparedStatement.GetItemsByTypeId, typeof(BaseAceObject), ConstructedStatementType.GetList);
+        }
+
+        public BaseAceObject GetRandomBaseAceObjectByTypeId(uint typeId)
+        {
+            // TODO: Og II - pick up here
+            var criteria = new Dictionary<string, object> { { "typeId", typeId } };
+            var objects = ExecuteConstructedGetListStatement<WorldPreparedStatement, BaseAceObject>(WorldPreparedStatement.GetItemsByTypeId, criteria);
+            if (objects.Count > 0)
+            {
+                var rnd = new Random();
+                var r = rnd.Next(objects.Count);
+                return objects[r];
+            }
+            return null;
         }
 
         public List<TeleportLocation> GetLocations()

--- a/Source/ACE.Entity/BaseAceObject.cs
+++ b/Source/ACE.Entity/BaseAceObject.cs
@@ -5,6 +5,7 @@ using MySql.Data.MySqlClient;
 namespace ACE.Entity
 {
     [DbTable("base_ace_object")]
+    [DbGetList("base_ace_object", 15, "typeId")]
     public class BaseAceObject
     {
         [DbField("baseAceObjectId", (int)MySqlDbType.UInt32, Update = false, IsCriteria = true)]

--- a/Source/ACE/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE/Command/Handlers/AdminCommands.cs
@@ -647,7 +647,7 @@ namespace ACE.Command.Handlers
                 var positionMessage = new GameMessageSystemChat($"Set: {playerPosition.PositionType} to Loc: {playerPosition.ToString()}", ChatMessageType.Broadcast);
                 session.Network.EnqueueSend(positionMessage);
                 return;
-                
+
             }
             // Error parsing the text input, from parameter[0]
             var positionErrorMessage = new GameMessageSystemChat($"Could not determine the correct PositionType. Please use an integer value from 1 to 9; or omit the parmeter entirely.", ChatMessageType.Broadcast);
@@ -1027,6 +1027,28 @@ namespace ACE.Command.Handlers
             session.Player.TrackObject(loot);
         }
 
+        // ci wclassid (number)
+        [CommandHandler("cirand", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Creates an random object in your inventory.", "typeId (number)")]
+        public static void HandleCIRandom(Session session, params string[] parameters)
+        {
+            uint typeId;
+            try
+            {
+                typeId = Convert.ToUInt32(parameters[0]);
+            }
+            catch (Exception)
+            {
+                ChatPacket.SendServerMessage(session, "Not a valid type id - must be a number between 0 - 2,147,483,647", ChatMessageType.Broadcast);
+                return;
+            }
+            var loot = LootGenerationFactory.CreateRandomTestWorldObject(session.Player, typeId);
+            if (loot != null)
+            {
+                LootGenerationFactory.AddToContainer(loot, session.Player);
+                session.Player.TrackObject(loot);
+            }
+        }
         // cm <material type> <quantity> <ave. workmanship>
         [CommandHandler("cm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 3)]
         public static void HandleCM(Session session, params string[] parameters)

--- a/Source/ACE/Entity/CollidableObject.cs
+++ b/Source/ACE/Entity/CollidableObject.cs
@@ -40,15 +40,42 @@ namespace ACE.Entity
 
             // this should probably be determined based on the presence of data.
             this.PhysicsData.PhysicsDescriptionFlag = (PhysicsDescriptionFlag)aceO.PhysicsBitField;
+            // Creating from weenie - the pcap may have had a container or a position
+            // but if we are creating new that will be sent when we place ground or container not at create
+            this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Parent;
+            this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Position;
             this.PhysicsData.PhysicsState = (PhysicsState)aceO.PhysicsState;
 
             // game data min required flags;
             this.Icon = aceO.IconId;
 
-            this.GameData.Usable = (Usable)aceO.Usability;
-            this.GameData.RadarColour = (RadarColor)aceO.BlipColor;
+            this.GameData.AmmoType = (AmmoType)aceO.AmmoType;
+            this.GameData.Burden = (ushort)aceO.Burden;
+            this.GameData.CombatUse = (CombatUse)aceO.CombatUse;
+            this.GameData.ContainerCapacity = aceO.ContainersCapacity;
+            this.GameData.Cooldown = aceO.CooldownId;
+            this.GameData.CooldownDuration = (decimal)aceO.CooldownDuration;
+            this.GameData.HookItemTypes = aceO.HookItemTypes;
+            this.GameData.HookType = (ushort)aceO.HookTypeId;
+            this.GameData.IconOverlay = (ushort)aceO.IconOverlayId;
+            this.GameData.IconUnderlay = (ushort)aceO.IconUnderlayId;
+            this.GameData.ItemCapacity = aceO.ItemsCapacity;
+            this.GameData.Material = (Material)aceO.MaterialType;
+            this.GameData.MaxStackSize = aceO.MaxStackSize;
+            this.GameData.MaxStructure = aceO.MaxStructure;
+            // GameData.Name = aceO.Name;  I think this is redundant and should be removed from Game Data or from world object
             this.GameData.RadarBehavior = (RadarBehavior)aceO.Radar;
+            this.GameData.RadarColour = (RadarColor)aceO.Radar;
             this.GameData.UseRadius = aceO.UseRadius;
+            this.GameData.Spell = (Spell)aceO.SpellId;
+            this.GameData.Script = aceO.PScript;
+            this.GameData.ValidLocations = (EquipMask)aceO.ValidLocations;
+            this.GameData.StackSize = aceO.StackSize;
+            this.GameData.Struture = aceO.Structure;
+            this.GameData.Value = aceO.Value;
+            this.GameData.Type = (ushort)aceO.AceObjectId;
+            this.GameData.TargetType = aceO.TargetTypeId;
+            this.GameData.Usable = (Usable)aceO.Usability;
 
             aceO.AnimationOverrides.ForEach(ao => this.ModelData.AddModel(ao.Index, (ushort)ao.AnimationId));
             aceO.TextureOverrides.ForEach(to => this.ModelData.AddTexture(to.Index, (ushort)to.OldId, (ushort)to.NewId));

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -38,6 +38,7 @@ namespace ACE.Entity
                 inventoryItem.GameData.ContainerId = Guid.Full;
                 inventoryItem.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Position;
                 inventoryItem.PositionFlag = UpdatePositionFlag.None;
+                inventoryItem.PhysicsData.Position = null;
             }
         }
 
@@ -45,13 +46,12 @@ namespace ACE.Entity
         {
             var inventoryItem = GetInventoryItem(inventoryItemGuid);
             GameData.Burden -= inventoryItem.GameData.Burden;
-            inventoryItem.PhysicsData.PhysicsDescriptionFlag |=
-            PhysicsDescriptionFlag.Position;
+            inventoryItem.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.Position;
             inventoryItem.PositionFlag = UpdatePositionFlag.Contact
                                            | UpdatePositionFlag.Placement
                                            | UpdatePositionFlag.ZeroQy
                                            | UpdatePositionFlag.ZeroQx;
-            inventoryItem.PhysicsData.Position = PhysicsData.Position.InFrontOf(0.50f);
+            inventoryItem.PhysicsData.Position = PhysicsData.Position.InFrontOf(1.0f);
             inventoryItem.GameData.ContainerId = 0;
             inventoryItem.GameData.Wielder = 0;
 

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -76,6 +76,7 @@ namespace ACE.Entity
 
                 // Creating from a pcap of the weenie - this will be set by the loot generation factory. Og II
                 this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Parent;
+                this.GameData.ValidLocations = (EquipMask)baseAceObject.ValidLocations;
             }
             if (this.PhysicsData.AnimationFrame != 0)
             {

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -15,45 +15,33 @@ namespace ACE.Entity
         public DebugObject(ObjectGuid guid,  BaseAceObject baseAceObject)
             : base((ObjectType)baseAceObject.TypeId, guid)
         {
-            this.Type = (ObjectType)baseAceObject.TypeId;
-            this.WeenieClassid = baseAceObject.AceObjectId;
-            this.Icon = baseAceObject.IconId;
-            this.DescriptionFlags = (ObjectDescriptionFlag)baseAceObject.WdescBitField;
             this.Name = baseAceObject.Name;
             if (this.Name == null)
                 this.Name = "NULL";
+
+            this.DescriptionFlags = (ObjectDescriptionFlag)baseAceObject.WdescBitField;
+            this.WeenieClassid = baseAceObject.AceObjectId;
             this.WeenieFlags = (WeenieHeaderFlag)baseAceObject.WeenieFlags;
-            // Even if we spawn on the ground, we have the potential to have a container.
-            // Container will always be 0 or a value and we should write it.
-            // Not sure if the align packs us out with 0's may be redundant Og II
-            this.WeenieFlags |= WeenieHeaderFlag.Container;
 
-            this.PhysicsData.AnimationFrame = baseAceObject.AnimationFrameId;
-            this.PhysicsData.PhysicsState = (PhysicsState)baseAceObject.PhysicsState;
-            this.PhysicsData.PhysicsDescriptionFlag = (PhysicsDescriptionFlag)baseAceObject.PhysicsBitField;
-
-            // Creating from a pcap of the weenie - this will be set by the loot generation factory. Og II
-            this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Parent;
-            if (this.PhysicsData.AnimationFrame != 0)
-            {
-                this.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.AnimationFrame;
-            }
+            this.PhysicsData.MTableResourceId = baseAceObject.MotionTableId;
+            this.PhysicsData.Stable = baseAceObject.SoundTableId;
             this.PhysicsData.CSetup = baseAceObject.ModelTableId;
+            this.PhysicsData.Petable = baseAceObject.PhysicsTableId;
+
+            // this should probably be determined based on the presence of data.
+            this.PhysicsData.PhysicsDescriptionFlag = (PhysicsDescriptionFlag)baseAceObject.PhysicsBitField;
+            this.PhysicsData.PhysicsState = (PhysicsState)baseAceObject.PhysicsState;
+
             if (baseAceObject.CurrentMotionState == "0")
                 this.PhysicsData.CurrentMotionState = null;
             else
                 this.PhysicsData.CurrentMotionState = new UniversalMotion(Convert.FromBase64String(baseAceObject.CurrentMotionState));
-            this.PhysicsData.DefaultScript = baseAceObject.DefaultScript;
-            this.PhysicsData.DefaultScriptIntensity = baseAceObject.DefaultScriptIntensity;
-            this.PhysicsData.Elastcity = baseAceObject.Elasticity;
-            this.PhysicsData.EquipperPhysicsDescriptionFlag = EquipMask.Wand;
-            this.PhysicsData.Friction = baseAceObject.Friction;
-            this.PhysicsData.MTableResourceId = baseAceObject.MotionTableId;
-            this.PhysicsData.ObjScale = baseAceObject.ObjectScale;
-            this.PhysicsData.Petable = baseAceObject.PhysicsTableId;
-            this.PhysicsData.Stable = baseAceObject.SoundTableId;
 
-            // game data slighly adjusted for pcap origins Og II;
+            this.PhysicsData.ObjScale = baseAceObject.ObjectScale;
+            this.PhysicsData.AnimationFrame = baseAceObject.AnimationFrameId;
+            this.PhysicsData.Translucency = baseAceObject.Translucency;
+
+            // game data min required flags;
             this.Icon = baseAceObject.IconId;
 
             if (this.GameData.NamePlural == null)
@@ -71,6 +59,33 @@ namespace ACE.Entity
             this.GameData.Burden = (ushort)baseAceObject.Burden;
             this.GameData.Value = baseAceObject.Value;
             this.GameData.ItemCapacity = baseAceObject.ItemsCapacity;
+
+            // Put is in for Ripley - these are the fields I want to write that he was concerned with.
+            if ((this.Type & (ObjectType.Creature | ObjectType.LifeStone | ObjectType.Portal)) == 0)
+            {
+                // because this comes from PCAP data - on create we are not animating.
+                this.PhysicsData.AnimationFrame = 0x65;
+
+                // I think this is wrong - we need the weenieClassId from weenie_class   Leaving it for now
+                // TODO: use view to return the correct value.
+                this.WeenieClassid = baseAceObject.AceObjectId;
+
+                // Container will always be 0 or a value and we should write it.
+                // Not sure if the align packs us out with 0's may be redundant Og II
+                this.WeenieFlags |= WeenieHeaderFlag.Container;
+
+                // Creating from a pcap of the weenie - this will be set by the loot generation factory. Og II
+                this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Parent;
+            }
+            if (this.PhysicsData.AnimationFrame != 0)
+            {
+                this.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.AnimationFrame;
+            }
+            this.PhysicsData.DefaultScript = baseAceObject.DefaultScript;
+            this.PhysicsData.DefaultScriptIntensity = baseAceObject.DefaultScriptIntensity;
+            this.PhysicsData.Elastcity = baseAceObject.Elasticity;
+            this.PhysicsData.EquipperPhysicsDescriptionFlag = EquipMask.Wand;
+            this.PhysicsData.Friction = baseAceObject.Friction;
 
             baseAceObject.AnimationOverrides.ForEach(ao => this.ModelData.AddModel(ao.Index, ao.AnimationId));
             baseAceObject.TextureOverrides.ForEach(to => this.ModelData.AddTexture(to.Index, to.OldId, to.NewId));

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -33,7 +33,7 @@ namespace ACE.Entity
             this.PhysicsData.PhysicsDescriptionFlag = (PhysicsDescriptionFlag)baseAceObject.PhysicsBitField;
 
             // Creating from a pcap of the weenie - this will be set by the loot generation factory. Og II
-            this.PhysicsData.PhysicsDescriptionFlag &= PhysicsDescriptionFlag.Parent;
+            this.PhysicsData.PhysicsDescriptionFlag &= ~PhysicsDescriptionFlag.Parent;
             if (this.PhysicsData.AnimationFrame != 0)
             {
                 this.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.AnimationFrame;

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -653,8 +653,8 @@ namespace ACE.Entity
                                     new GameMessageSound(aPlayer.Guid, Sound.PickUpItem, (float)1.0));
 
                                 // Add to the inventory list.
-                                aPlayer.AddToInventory(inventoryItem);
                                 LandblockManager.RemoveObject(inventoryItem);
+                                aPlayer.AddToInventory(inventoryItem);
 
                                 motion = new UniversalMotion(MotionStance.Standing);
                                 aPlayer.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(aPlayer.Session,

--- a/Source/ACE/Factories/LootGenerationFactory.cs
+++ b/Source/ACE/Factories/LootGenerationFactory.cs
@@ -32,7 +32,14 @@
         public static WorldObject CreateTestWorldObject(Player player, ushort weenieId)
         {
             var aceObject = DatabaseManager.World.GetBaseAceObjectDataByWeenie(weenieId);
+            var wo = new DebugObject(new ObjectGuid(CommonObjectFactory.DynamicObjectId, GuidType.None), aceObject);
+            return wo;
+        }
 
+        public static WorldObject CreateRandomTestWorldObject(Player player, uint typeId)
+        {
+            var aceObject = DatabaseManager.World.GetRandomBaseAceObjectByTypeId(typeId);
+            if (aceObject == null) return null;
             var wo = new DebugObject(new ObjectGuid(CommonObjectFactory.DynamicObjectId, GuidType.None), aceObject);
             return wo;
         }

--- a/Source/ACE/Factories/LootGenerationFactory.cs
+++ b/Source/ACE/Factories/LootGenerationFactory.cs
@@ -16,9 +16,6 @@
         public static void AddToContainer(WorldObject inventoryItem, Container container)
         {
             inventoryItem.GameData.ContainerId = container.Guid.Full;
-            // I think this is right Og II
-            inventoryItem.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.Parent & ~PhysicsDescriptionFlag.Position;
-            inventoryItem.PhysicsData.Position = null;
             container.GameData.Burden += inventoryItem.GameData.Burden;
             container.AddToInventory(inventoryItem);
         }

--- a/Source/ACE/Factories/LootGenerationFactory.cs
+++ b/Source/ACE/Factories/LootGenerationFactory.cs
@@ -16,6 +16,9 @@
         public static void AddToContainer(WorldObject inventoryItem, Container container)
         {
             inventoryItem.GameData.ContainerId = container.Guid.Full;
+            // I think this is right Og II
+            inventoryItem.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.Parent & ~PhysicsDescriptionFlag.Position;
+            inventoryItem.PhysicsData.Position = null;
             container.GameData.Burden += inventoryItem.GameData.Burden;
             container.AddToInventory(inventoryItem);
         }
@@ -25,8 +28,7 @@
             inventoryItem.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
             inventoryItem.Sequences.GetNextSequence(SequenceType.ObjectVector);
             inventoryItem.PhysicsData.Position = position.InFrontOf(1.00f);
-            inventoryItem.PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.Position |
-                                                               inventoryItem.PhysicsData.PhysicsDescriptionFlag;
+            inventoryItem.PhysicsData.PhysicsDescriptionFlag |= PhysicsDescriptionFlag.Position;
             LandblockManager.AddObject(inventoryItem);
         }
 
@@ -34,9 +36,7 @@
         {
             var aceObject = DatabaseManager.World.GetBaseAceObjectDataByWeenie(weenieId);
 
-            var wo = new DebugObject(new ObjectGuid(CommonObjectFactory.DynamicObjectId, GuidType.None),
-               ObjectDescriptionFlag.Inscribable,
-               aceObject);
+            var wo = new DebugObject(new ObjectGuid(CommonObjectFactory.DynamicObjectId, GuidType.None), aceObject);
             return wo;
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 2017-05-06
+[Og II]
+* I fixed both admin functions, ci and create.   I added some logic to leave, NPC's, portals and creatures with the same code as prior to my fix.
+* Added Admin command cirand <typeId> to allow you to fully test and exercise the test ci command.
+
 ### 2017-05-03
 [Jyrus]
 * Changed the structure of the table that contains the Portal Destinations to include other portal properties


### PR DESCRIPTION
Fixed
I fixed a lot of the issue with these two create object calls.    I modify some of the flags because the base ace object was made from a pcap - I think the logic is sound and it is how I had it working before.   I also put in some code to exclude the extra information from baseAceObject for portals, creatures and life stones.   We can expand that exclusion list if and when it is found necessary.

I added a new admin function cirand <typeId> that will allow you to easily test and exercise the ci function to insure it works for various itemTypes