### PR TITLE
Time-based updates to creature vitals

### DIFF
--- a/Source/ACE.Entity/ACE.Entity.csproj
+++ b/Source/ACE.Entity/ACE.Entity.csproj
@@ -83,6 +83,7 @@
     <Compile Include="CharacterLevel.cs" />
     <Compile Include="CharacterSkill.cs" />
     <Compile Include="CreatureAbility.cs" />
+    <Compile Include="CreatureVital.cs" />
     <Compile Include="DbObject.cs" />
     <Compile Include="Enum\Ability.cs" />
     <Compile Include="Enum\AccessLevel.cs" />

--- a/Source/ACE.Entity/Character.cs
+++ b/Source/ACE.Entity/Character.cs
@@ -82,11 +82,11 @@ namespace ACE.Entity
 
         public CreatureAbility SelfAbility { get; set; }
 
-        public CreatureAbility Health { get; set; }
+        public CreatureVital Health { get; set; }
 
-        public CreatureAbility Stamina { get; set; }
+        public CreatureVital Stamina { get; set; }
 
-        public CreatureAbility Mana { get; set; }
+        public CreatureVital Mana { get; set; }
 
         public Appearance Appearance { get; set; } = new Appearance();
 
@@ -181,16 +181,17 @@ namespace ACE.Entity
 
         private Character()
         {
-            StrengthAbility = new CreatureAbility(this, Enum.Ability.Strength);
-            EnduranceAbility = new CreatureAbility(this, Enum.Ability.Endurance);
-            CoordinationAbility = new CreatureAbility(this, Enum.Ability.Coordination);
-            QuicknessAbility = new CreatureAbility(this, Enum.Ability.Quickness);
-            FocusAbility = new CreatureAbility(this, Enum.Ability.Focus);
-            SelfAbility = new CreatureAbility(this, Enum.Ability.Self);
+            StrengthAbility = new CreatureAbility(Enum.Ability.Strength);
+            EnduranceAbility = new CreatureAbility(Enum.Ability.Endurance);
+            CoordinationAbility = new CreatureAbility(Enum.Ability.Coordination);
+            QuicknessAbility = new CreatureAbility(Enum.Ability.Quickness);
+            FocusAbility = new CreatureAbility(Enum.Ability.Focus);
+            SelfAbility = new CreatureAbility(Enum.Ability.Self);
 
-            Health = new CreatureAbility(this, Enum.Ability.Health);
-            Stamina = new CreatureAbility(this, Enum.Ability.Stamina);
-            Mana = new CreatureAbility(this, Enum.Ability.Mana);
+            // TODO: Real regen rates?
+            Health = new CreatureVital(this, Enum.Ability.Health, .5);
+            Stamina = new CreatureVital(this, Enum.Ability.Stamina, 1.0);
+            Mana = new CreatureVital(this, Enum.Ability.Mana, .7);
 
             abilities.Add(Enum.Ability.Strength, StrengthAbility);
             abilities.Add(Enum.Ability.Endurance, EnduranceAbility);

--- a/Source/ACE.Entity/CreatureAbility.cs
+++ b/Source/ACE.Entity/CreatureAbility.cs
@@ -4,10 +4,6 @@ namespace ACE.Entity
 {
     public class CreatureAbility
     {
-        // because health/stam/mana values are determined from stats, we need a reference to the WeenieCreatureData
-        // so we can calculate.  this could be refactored into a better pattern, but it will do for now.
-        private ICreatureStats creature;
-
         public Ability Ability { get; private set; }
 
         /// <summary>
@@ -21,11 +17,6 @@ namespace ACE.Entity
         public uint Ranks { get; set; }
 
         /// <summary>
-        /// only applies to Health/Stam/Mana
-        /// </summary>
-        public uint Current { get; set; }
-
-        /// <summary>
         /// For Primary Abilities, Returns the Base Value Plus the Ranked Value
         /// For Secondary Abilities, Returns the adjusted Value depending on the current Abiliy formula
         /// </summary>
@@ -34,30 +25,7 @@ namespace ACE.Entity
             get
             {
                 // TODO: buffs?  not sure where they will go
-
-                var formula = this.Ability.GetFormula();
-
-                uint derivationTotal = 0;
-                uint abilityTotal = 0;
-
-                if (formula != null)
-                {
-                    // restricted to endurance and self because those are the only 2 used by abilities
-
-                    Ability abilities = formula.Abilities;
-                    uint end = (uint)((abilities & Ability.Endurance) > 0 ? 1 : 0);
-                    uint wil = (uint)((abilities & Ability.Self) > 0 ? 1 : 0);
-
-                    derivationTotal += end * this.creature.Endurance;
-                    derivationTotal += wil * this.creature.Self;
-
-                    derivationTotal *= formula.AbilityMultiplier;
-                    abilityTotal = derivationTotal / formula.Divisor;
-                }
-
-                abilityTotal += this.Ranks + this.Base;
-
-                return abilityTotal;
+                return this.Ranks + this.Base;
             }
         }
 
@@ -80,9 +48,8 @@ namespace ACE.Entity
         /// </summary>
         public uint ExperienceSpent { get; set; }
 
-        public CreatureAbility(ICreatureStats creature, Ability ability)
+        public CreatureAbility(Ability ability)
         {
-            this.creature = creature;
             Ability = ability;
         }
     }

--- a/Source/ACE.Entity/CreatureVital.cs
+++ b/Source/ACE.Entity/CreatureVital.cs
@@ -45,12 +45,7 @@ namespace ACE.Entity
             }
         }
 
-        new public uint MaxValue {
-            get
-            {
-                return UnbuffedValue;
-            }
-        }
+        new public uint MaxValue { get { return UnbuffedValue; } }
 
         /// <summary>
         /// only applies to Health/Stam/Mana

--- a/Source/ACE.Entity/CreatureVital.cs
+++ b/Source/ACE.Entity/CreatureVital.cs
@@ -1,0 +1,99 @@
+﻿using System;
+
+using ACE.Entity.Enum;
+
+namespace ACE.Entity
+{
+    public class CreatureVital : CreatureAbility
+    {
+        // because health/stam/mana values are determined from stats, we need a reference to the WeenieCreatureData
+        // so we can calculate.  this could be refactored into a better pattern, but it will do for now.
+        private ICreatureStats creature;
+
+        private double lastTick = double.NegativeInfinity;
+
+        public double RegenRate { set; get; }
+
+        new public uint UnbuffedValue
+        {
+            get
+            {
+                // TODO: buffs?  not sure where they will go
+                var formula = this.Ability.GetFormula();
+
+                uint derivationTotal = 0;
+                uint abilityTotal = 0;
+
+                if (formula != null)
+                {
+                    // restricted to endurance and self because those are the only 2 used by abilities
+
+                    Ability abilities = formula.Abilities;
+                    uint end = (uint)((abilities & Ability.Endurance) > 0 ? 1 : 0);
+                    uint wil = (uint)((abilities & Ability.Self) > 0 ? 1 : 0);
+
+                    derivationTotal += end * this.creature.Endurance;
+                    derivationTotal += wil * this.creature.Self;
+
+                    derivationTotal *= formula.AbilityMultiplier;
+                    abilityTotal = derivationTotal / formula.Divisor;
+                }
+
+                abilityTotal += this.Ranks + this.Base;
+
+                return abilityTotal;
+            }
+        }
+
+        new public uint MaxValue {
+            get
+            {
+                return UnbuffedValue;
+            }
+        }
+
+        /// <summary>
+        /// only applies to Health/Stam/Mana
+        /// </summary>
+        public uint Current { get; set; }
+
+        /// <summary>
+        /// Used to determine if health/stamina/mana updates need to be sent periodically
+        /// Returns the "last time" the vitals were updated
+        /// Takes the vital to update, the lastTime it was updated, and the update rate
+        /// </summary>
+        public void Tick(double tickTime)
+        {
+            if (lastTick == double.NegativeInfinity)
+            {
+                lastTick = tickTime;
+                return;
+            }
+
+            // This shouldn't happen?  maybe?
+            if (tickTime <= lastTick)
+            {
+                return;
+            }
+
+            double timeDiff = tickTime - lastTick;
+
+            uint numTicks = (uint)(timeDiff * RegenRate);
+
+            if (numTicks > 0)
+            {
+                // lastTime is the time at which the last tick would have happened
+                lastTick = lastTick + numTicks / RegenRate;
+
+                // Now, update our value
+                Current = System.Math.Min(MaxValue, Current + numTicks);
+            }
+        }
+
+        public CreatureVital(ICreatureStats creature, Ability ability, double regenRate) : base(ability)
+        {
+            this.creature = creature;
+            this.RegenRate = regenRate;
+        }
+    }
+}

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -266,67 +266,67 @@ namespace ACE.Command.Handlers
         }
         
         // This function 
-        [CommandHandler("setstat", AccessLevel.Developer, CommandHandlerFlag.None, 2,
-             "Sets the specified stat to a specified value",
-            "Usage: @setstat <stat> <value>\n" +
-            "<stat> is one of the following strings:\n" +
+        [CommandHandler("setvital", AccessLevel.Developer, CommandHandlerFlag.None, 2,
+             "Sets the specified vital to a specified value",
+            "Usage: @setvital <vital> <value>\n" +
+            "<vital> is one of the following strings:\n" +
             "    health, hp\n" +
             "    stamina, stam, sp\n" +
             "    mana, mp\n" +
             "<value> is an integral value [0-9]+, or a relative value [-+][0-9]+")]
-        public static void SetStat(Session session, params string[] parameters)
+        public static void SetVital(Session session, params string[] parameters)
         {
-            string paramStat = parameters[0].ToLower();
+            string paramVital = parameters[0].ToLower();
             string paramValue = parameters[1];
 
             bool relValue = paramValue[0] == '+' || paramValue[0] == '-';
             int value = int.MaxValue;
 
             if (!int.TryParse(paramValue, out value)) {
-                ChatPacket.SendServerMessage(session, "setstat Error: Invalid set value", ChatMessageType.Broadcast);
+                ChatPacket.SendServerMessage(session, "setvital Error: Invalid set value", ChatMessageType.Broadcast);
                 return;
             }
 
             Entity.Enum.Ability ability;
             // Parse args...
-            CreatureAbility stat = null;
-            if (paramStat == "health" || paramStat == "hp")
+            CreatureAbility vital = null;
+            if (paramVital == "health" || paramVital == "hp")
             {
                 ability = Entity.Enum.Ability.Health;
-                stat = session.Player.Health;
+                vital = session.Player.Health;
             }
-            else if (paramStat == "stamina" || paramStat == "stam" || paramStat == "sp")
+            else if (paramVital == "stamina" || paramVital == "stam" || paramVital == "sp")
             {
                 ability = Entity.Enum.Ability.Stamina;
-                stat = session.Player.Stamina;
+                vital = session.Player.Stamina;
             }
-            else if (paramStat == "mana" || paramStat == "mp")
+            else if (paramVital == "mana" || paramVital == "mp")
             {
                 ability = Entity.Enum.Ability.Mana;
-                stat = session.Player.Mana;
+                vital = session.Player.Mana;
             }
             else
             {
-                ChatPacket.SendServerMessage(session, "setstat Error: Invalid stat", ChatMessageType.Broadcast);
+                ChatPacket.SendServerMessage(session, "setvital Error: Invalid vital", ChatMessageType.Broadcast);
                 return;
             }
 
             long targetValue = 0;
             if (relValue)
-                targetValue = stat.Current + value;
+                targetValue = vital.Current + value;
             else
                 targetValue = value;
 
-            if (targetValue < 0 || targetValue > stat.MaxValue)
+            if (targetValue < 0 || targetValue > vital.MaxValue)
             {
-                ChatPacket.SendServerMessage(session, "setstat Error: Value over/underflow", ChatMessageType.Broadcast);
+                ChatPacket.SendServerMessage(session, "setvital Error: Value over/underflow", ChatMessageType.Broadcast);
                 return;
             }
 
-            stat.Current = (uint)targetValue;
+            vital.Current = (uint)targetValue;
 
             // Send an update packet
-            session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(session, ability, stat));
+            session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(session, ability, vital));
         }
 
         [CommandHandler("spacejump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0,

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -289,7 +289,7 @@ namespace ACE.Command.Handlers
 
             Entity.Enum.Ability ability;
             // Parse args...
-            CreatureAbility vital = null;
+            CreatureVital vital = null;
             if (paramVital == "health" || paramVital == "hp")
             {
                 ability = Entity.Enum.Ability.Health;

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -265,7 +265,7 @@ namespace ACE.Command.Handlers
                                         session.Player.Sequences, newMotion));
         }
         
-        // This function is just used to exercise the ability to have player movement without animation.   Once we are solid on this it can be removed.   Og II
+        // This function 
         [CommandHandler("setstat", AccessLevel.Developer, CommandHandlerFlag.None, 2,
              "Sets the specified stat to a specified value",
             "Usage: @setstat <stat> <value>\n" +
@@ -287,26 +287,22 @@ namespace ACE.Command.Handlers
                 return;
             }
 
-            string statname;
             Entity.Enum.Ability ability;
             // Parse args...
             CreatureAbility stat = null;
             if (paramStat == "health" || paramStat == "hp")
             {
                 ability = Entity.Enum.Ability.Health;
-                statname = "Health";
                 stat = session.Player.Health;
             }
             else if (paramStat == "stamina" || paramStat == "stam" || paramStat == "sp")
             {
                 ability = Entity.Enum.Ability.Stamina;
-                statname = "Stamina";
                 stat = session.Player.Stamina;
             }
             else if (paramStat == "mana" || paramStat == "mp")
             {
                 ability = Entity.Enum.Ability.Mana;
-                statname = "Mana";
                 stat = session.Player.Mana;
             }
             else
@@ -329,7 +325,6 @@ namespace ACE.Command.Handlers
 
             stat.Current = (uint)targetValue;
 
-            // ChatPacket.SendServerMessage(session, $"{statname} is now: {stat.Current}", ChatMessageType.Broadcast);
             // Send an update packet
             session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(session, ability, stat));
         }

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -506,11 +506,12 @@ namespace ACE.Entity
                 });
                 UpdateStatus(allplayers.Count);
 
+                double tickTime = WorldManager.PortalYearTicks;
                 // per-creature update on landblock.
-                Parallel.ForEach(allcreatures, creature =>
+                Parallel.ForEach(allworldobj, wo =>
                 {
                     // Process the creatures
-                    creature.GameLoopUpdate();
+                    wo.Tick(tickTime);
                 });
 
                 // broadcast moving objects to the world..

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -446,6 +446,7 @@ namespace ACE.Entity
 
                 List<WorldObject> allworldobj = null;
                 List<Player> allplayers = null;
+                List<Creature> allcreatures = null;
                 List<WorldObject> movedObjects = null;
                 List<WorldObject> despawnObjects = null;
                 List<Creature> deadCreatures = null;
@@ -457,6 +458,7 @@ namespace ACE.Entity
 
                 // all players on this land block
                 allplayers = allworldobj.OfType<Player>().ToList();
+                allcreatures = allworldobj.OfType<Creature>().ToList();
 
                 despawnObjects = allworldobj.ToList();
                 despawnObjects = despawnObjects.Where(x => x.DespawnTime > -1).ToList();
@@ -503,6 +505,13 @@ namespace ACE.Entity
                         HandleGameAction(examination, player);
                 });
                 UpdateStatus(allplayers.Count);
+
+                // per-creature update on landblock.
+                Parallel.ForEach(allcreatures, creature =>
+                {
+                    // Process the creatures
+                    creature.GameLoopUpdate();
+                });
 
                 // broadcast moving objects to the world..
                 // players and creatures can move.

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -780,7 +780,7 @@ namespace ACE.Entity
                 }
                 else
                 {
-                    abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, character.Abilities[ability].Current);
+                    abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, character.Abilities[ability].MaxValue);
                 }
 
                 // checks if max rank is achieved and plays fireworks w/ special text
@@ -880,7 +880,12 @@ namespace ACE.Entity
 
             if (rankUps > 0)
             {
-                ability.Current += addToCurrentValue ? rankUps : 0u;
+                // FIXME(ddevec): This needs to be done for vitals only? Someone verify -- 
+                //      Really AddRank() should probably be a method of CreatureAbility/CreatureVital
+                CreatureVital vital = ability as CreatureVital;
+                if (vital != null) {
+                    vital.Current += addToCurrentValue ? rankUps : 0u;
+                }
                 ability.Ranks += rankUps;
                 ability.ExperienceSpent += amount;
                 character.SpendXp(amount);
@@ -1606,28 +1611,28 @@ namespace ACE.Entity
             WaitingForDelayedTeleport = false;
         }
 
-        override public void GameLoopUpdate()
+        override public void Tick(double tickTime)
         {
             uint oldHealth = Health.Current;
             uint oldStamina = Stamina.Current;
             uint oldMana = Mana.Current;
 
-            base.GameLoopUpdate();
+            base.Tick(tickTime);
 
             // If the game loop changed a vital -- send an update message to the client
             if (Health.Current != oldHealth)
             {
-                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Health, Health));
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(Session, Vital.Health, Health.Current));
             }
 
             if (Stamina.Current != oldStamina)
             {
-                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Stamina, Stamina));
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(Session, Vital.Stamina, Stamina.Current));
             }
 
             if (Mana.Current != oldMana)
             {
-                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Mana, Mana));
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(Session, Vital.Mana, Mana.Current));
             }
         }
     }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1608,38 +1608,26 @@ namespace ACE.Entity
 
         override public void GameLoopUpdate()
         {
-            // Update vitals
-            uint healthVal = healthUpdater.Update();
-            if (healthVal > 0)
+            uint oldHealth = Health.Current;
+            uint oldStamina = Stamina.Current;
+            uint oldMana = Mana.Current;
+
+            base.GameLoopUpdate();
+
+            // If the game loop changed a vital -- send an update message to the client
+            if (Health.Current != oldHealth)
             {
-                uint oldHealth = Health.Current;
-                Health.Current = System.Math.Min(Health.MaxValue, Health.Current + healthVal);
-                if (oldHealth != Health.Current)
-                {
-                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Health, Health));
-                }
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Health, Health));
             }
 
-            uint stamVal = staminaUpdater.Update();
-            if (stamVal > 0)
+            if (Stamina.Current != oldStamina)
             {
-                uint oldStamina = Stamina.Current;
-                Stamina.Current = System.Math.Min(Stamina.MaxValue, Stamina.Current + stamVal);
-                if (oldStamina != Stamina.Current)
-                {
-                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Stamina, Stamina));
-                }
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Stamina, Stamina));
             }
 
-            uint manaVal = staminaUpdater.Update();
-            if (manaVal > 0)
+            if (Mana.Current != oldMana)
             {
-                uint oldMana = Mana.Current;
-                Mana.Current = System.Math.Min(Mana.MaxValue, Mana.Current + manaVal);
-                if (oldMana != Mana.Current)
-                {
-                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Mana, Mana));
-                }
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Mana, Mana));
             }
         }
     }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1605,5 +1605,42 @@ namespace ACE.Entity
             DelayedTeleportTime = DateTime.MinValue;
             WaitingForDelayedTeleport = false;
         }
+
+        override public void GameLoopUpdate()
+        {
+            // Update vitals
+            uint healthVal = healthUpdater.Update();
+            if (healthVal > 0)
+            {
+                uint oldHealth = Health.Current;
+                Health.Current = System.Math.Min(Health.MaxValue, Health.Current + healthVal);
+                if (oldHealth != Health.Current)
+                {
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Health, Health));
+                }
+            }
+
+            uint stamVal = staminaUpdater.Update();
+            if (stamVal > 0)
+            {
+                uint oldStamina = Stamina.Current;
+                Stamina.Current = System.Math.Min(Stamina.MaxValue, Stamina.Current + stamVal);
+                if (oldStamina != Stamina.Current)
+                {
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Stamina, Stamina));
+                }
+            }
+
+            uint manaVal = staminaUpdater.Update();
+            if (manaVal > 0)
+            {
+                uint oldMana = Mana.Current;
+                Mana.Current = System.Math.Min(Mana.MaxValue, Mana.Current + manaVal);
+                if (oldMana != Mana.Current)
+                {
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateVital(Session, Enum.Ability.Mana, Mana));
+                }
+            }
+        }
     }
 }

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -279,5 +279,9 @@ namespace ACE.Entity
             writer.Write(Sequences.GetCurrentSequence(SequenceType.ObjectTeleport));
             writer.Write(Sequences.GetCurrentSequence(SequenceType.ObjectForcePosition));
         }
+
+        public virtual void Tick(double tickTime)
+        {
+        }
     }
 }

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateVital.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateVital.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using ACE.Network.Enum;
+using ACE.Entity;
 
 namespace ACE.Network.GameMessages.Messages
 {
     public class GameMessagePrivateUpdateVital : GameMessage
     {
+        public GameMessagePrivateUpdateVital(Session session, Entity.Enum.Ability ability, CreatureAbility ca) :
+            this(session, ability, ca.Ranks, ca.Base, ca.ExperienceSpent, ca.Current) { }
+
         public GameMessagePrivateUpdateVital(Session session, Entity.Enum.Ability ability, uint ranks, uint baseValue, uint totalInvestment, uint currentValue)
             : base(GameMessageOpcode.PrivateUpdateVital, GameMessageGroup.Group09)
         {

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateVital.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateVital.cs
@@ -6,8 +6,8 @@ namespace ACE.Network.GameMessages.Messages
 {
     public class GameMessagePrivateUpdateVital : GameMessage
     {
-        public GameMessagePrivateUpdateVital(Session session, Entity.Enum.Ability ability, CreatureAbility ca) :
-            this(session, ability, ca.Ranks, ca.Base, ca.ExperienceSpent, ca.Current) { }
+        public GameMessagePrivateUpdateVital(Session session, Entity.Enum.Ability ability, CreatureVital cv) :
+            this(session, ability, cv.Ranks, cv.Base, cv.ExperienceSpent, cv.Current) { }
 
         public GameMessagePrivateUpdateVital(Session session, Entity.Enum.Ability ability, uint ranks, uint baseValue, uint totalInvestment, uint currentValue)
             : base(GameMessageOpcode.PrivateUpdateVital, GameMessageGroup.Group09)


### PR DESCRIPTION
Trying to take a small piece for my first commit -- hopefully this is reasonable.

Goal is to add basic functionality required for time based updates of creature's vitals (health, mana, stamina).  This is a subset of the challenge for issue #254 .  Current update rates do not reflect original game's update algorithm.

Summary of changes:
- Added setvital debug function -- sets a vital (hp mp stam) to a specified or relative value
- Added per-creature update function to landblock main loop
- Added vital update code per creature
- Added UI notification messages to player, so UI updates when vitals are changed.

I'm new to working on distributed teams via github, please let me know if there is anything I need to correct.