### PR TITLE
Cleanup backing AceObject

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -354,11 +354,11 @@ namespace ACE.Database
             return ret;
         }
 
-        private List<AceObjectPropertiesPosition> GetAceObjectPropertiesPositions(uint aceObjectId)
+        private Dictionary<PositionType, Position> GetAceObjectPropertiesPositions(uint aceObjectId)
         {
             var criteria = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
             var objects = ExecuteConstructedGetListStatement<ShardPreparedStatement, AceObjectPropertiesPosition>(ShardPreparedStatement.GetAceObjectPropertiesPositions, criteria);
-            return objects;
+            return objects.ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
         }
 
 
@@ -380,7 +380,7 @@ namespace ACE.Database
                 o.TextureOverrides = GetAceObjectTextureMaps(o.AceObjectId);
                 o.AnimationOverrides = GetAceObjectAnimations(o.AceObjectId);
                 o.PaletteOverrides = GetAceObjectPalettes(o.AceObjectId);
-                o.Positions = GetAceObjectPropertiesPositions(o.AceObjectId);
+                o.AceObjectPropertiesPositions = GetAceObjectPropertiesPositions(o.AceObjectId);
                 ret.Add(o);
             });
             return ret;

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -229,10 +229,14 @@ namespace ACE.Database
             aceObject.TextureOverrides = GetAceObjectTextureMaps(aceObject.AceObjectId);
             aceObject.AnimationOverrides = GetAceObjectAnimations(aceObject.AceObjectId);
             aceObject.PaletteOverrides = GetAceObjectPalettes(aceObject.AceObjectId);
-            aceObject.Positions = GetAceObjectPostions(aceObject.AceObjectId);
-            aceObject.AceObjectPropertiesAttributes = GetAceObjectPropertiesAttribute(aceObject.AceObjectId);
-            aceObject.AceObjectPropertiesAttributes2nd = GetAceObjectPropertiesAttribute2nd(aceObject.AceObjectId);
-            aceObject.AceObjectPropertiesSkills = GetAceObjectPropertiesSkill(aceObject.AceObjectId);
+            aceObject.AceObjectPropertiesPositions = GetAceObjectPostions(aceObject.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType,
+                x => new Position(x));
+            aceObject.AceObjectPropertiesAttributes = GetAceObjectPropertiesAttribute(aceObject.AceObjectId).ToDictionary(x => (Ability)x.AttributeId,
+                x => new CreatureAbility(aceObject, x));
+            aceObject.AceObjectPropertiesAttributes2nd = GetAceObjectPropertiesAttribute2nd(aceObject.AceObjectId).ToDictionary(x => (Ability)x.Attribute2ndId,
+                x => new CreatureAbility(aceObject, x));
+            aceObject.AceObjectPropertiesSkills = GetAceObjectPropertiesSkill(aceObject.AceObjectId).ToDictionary(x => (Skill)x.SkillId,
+                x => new CreatureSkill(aceObject, x));
         }
 
         private List<AceObjectPropertiesPosition> GetAceObjectPostions(uint aceObjectId)
@@ -428,10 +432,10 @@ namespace ACE.Database
             DeleteAceObjectAnimations(transaction, aceObject.AceObjectId, aceObject.AnimationOverrides);
             DeleteAceObjectPalettes(transaction, aceObject.AceObjectId, aceObject.PaletteOverrides);
 
-            DeleteAceObjectPropertiesPositions(transaction, aceObject.AceObjectId, aceObject.Positions);
-            DeleteAceObjectPropertiesAttributes(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesAttributes);
-            DeleteAceObjectPropertiesAttribute2nd(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesAttributes2nd);
-            DeleteAceObjectPropertiesSkill(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesSkills);
+            DeleteAceObjectPropertiesPositions(transaction, aceObject.AceObjectId);
+            DeleteAceObjectPropertiesAttributes(transaction, aceObject.AceObjectId);
+            DeleteAceObjectPropertiesAttribute2nd(transaction, aceObject.AceObjectId);
+            DeleteAceObjectPropertiesSkill(transaction, aceObject.AceObjectId);
 
             DeleteAceObjectBase(transaction, aceObject);
 
@@ -454,10 +458,14 @@ namespace ACE.Database
             SaveAceObjectAnimations(transaction, aceObject.AceObjectId, aceObject.AnimationOverrides);
             SaveAceObjectPalettes(transaction, aceObject.AceObjectId, aceObject.PaletteOverrides);
 
-            SaveAceObjectPropertiesPositions(transaction, aceObject.AceObjectId, aceObject.Positions);
-            SaveAceObjectPropertiesAttributes(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesAttributes);
-            SaveAceObjectPropertiesAttribute2nd(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesAttributes2nd);
-            SaveAceObjectPropertiesSkill(transaction, aceObject.AceObjectId, aceObject.AceObjectPropertiesSkills);
+            SaveAceObjectPropertiesPositions(transaction, aceObject.AceObjectId,
+                aceObject.AceObjectPropertiesPositions.Select(x => x.Value.GetAceObjectPosition(aceObject.AceObjectId, x.Key)).ToList());
+            SaveAceObjectPropertiesAttributes(transaction, aceObject.AceObjectId,
+                aceObject.AceObjectPropertiesAttributes.Select(x => x.Value.GetAttribute(aceObject.AceObjectId)).ToList());
+            SaveAceObjectPropertiesAttribute2nd(transaction, aceObject.AceObjectId,
+                aceObject.AceObjectPropertiesAttributes2nd.Select(x => x.Value.GetVital(aceObject.AceObjectId)).ToList());
+            SaveAceObjectPropertiesSkill(transaction, aceObject.AceObjectId,
+                aceObject.AceObjectPropertiesSkills.Select(x => x.Value.GetAceObjectSkill(aceObject.AceObjectId)).ToList());
 
             return true;
         }
@@ -631,21 +639,21 @@ namespace ACE.Database
             return true;
         }
 
-        private bool DeleteAceObjectPropertiesPositions(DatabaseTransaction transaction, uint aceObjectId, List<AceObjectPropertiesPosition> properties)
+        private bool DeleteAceObjectPropertiesPositions(DatabaseTransaction transaction, uint aceObjectId)
         {
             var critera = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
             transaction.AddPreparedDeleteListStatement<ShardPreparedStatement, AceObjectPropertiesPosition>(ShardPreparedStatement.DeleteAceObjectPropertiesPositions, critera);
             return true;
         }
 
-        private bool DeleteAceObjectPropertiesAttributes(DatabaseTransaction transaction, uint aceObjectId, List<AceObjectPropertiesAttribute> properties)
+        private bool DeleteAceObjectPropertiesAttributes(DatabaseTransaction transaction, uint aceObjectId)
         {
             var critera = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
             transaction.AddPreparedDeleteListStatement<ShardPreparedStatement, AceObjectPropertiesAttribute>(ShardPreparedStatement.DeleteAceObjectPropertiesAttributes, critera);
             return true;
         }
 
-        private bool DeleteAceObjectPropertiesAttribute2nd(DatabaseTransaction transaction, uint aceObjectId, List<AceObjectPropertiesAttribute2nd> properties)
+        private bool DeleteAceObjectPropertiesAttribute2nd(DatabaseTransaction transaction, uint aceObjectId)
         {
             var critera = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
             transaction.AddPreparedDeleteListStatement<ShardPreparedStatement, AceObjectPropertiesAttribute2nd>(ShardPreparedStatement.DeleteAceObjectPropertiesAttributes2nd, critera);
@@ -653,7 +661,7 @@ namespace ACE.Database
         }
 
         // SaveAceObjectPropertiesSkill(transaction, aceObject.AceObjectPropertiesSkills);
-        private bool DeleteAceObjectPropertiesSkill(DatabaseTransaction transaction, uint aceObjectId, List<AceObjectPropertiesSkill> properties)
+        private bool DeleteAceObjectPropertiesSkill(DatabaseTransaction transaction, uint aceObjectId)
         {
             var critera = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
             transaction.AddPreparedDeleteListStatement<ShardPreparedStatement, AceObjectPropertiesSkill>(ShardPreparedStatement.DeleteAceObjectPropertiesSkills, critera);

--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 using ACE.Entity;
+using ACE.Entity.Enum;
 
 namespace ACE.Database
 {
@@ -13,6 +15,9 @@ namespace ACE.Database
             GetWeenieClass = 1,
             GetObjectsByLandblock = 2,
             GetCreaturesByLandblock = 3,
+            GetWeeniePalettes = 4,
+            GetWeenieTextureMaps = 5,
+            GetWeenieAnimations = 6,
             GetPaletteOverridesByObject = 7,
             GetAnimationOverridesByObject = 8,
             GetTextureOverridesByObject = 9,
@@ -40,8 +45,12 @@ namespace ACE.Database
             ConstructStatement(WorldPreparedStatement.GetPointsOfInterest, typeof(TeleportLocation), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetWeenieClass, typeof(AceObject), ConstructedStatementType.Get);
 
+            // ConstructStatement(WorldPreparedStatement.GetPortalObjectsByAceObjectId, typeof(AcePortalObject), ConstructedStatementType.Get);
             // ConstructStatement(WorldPreparedStatement.GetObjectsByLandblock, typeof(AceObject), ConstructedStatementType.GetList);
             // ConstructStatement(WorldPreparedStatement.GetCreaturesByLandblock, typeof(AceCreatureStaticLocation), ConstructedStatementType.GetList);
+            // ConstructStatement(WorldPreparedStatement.GetWeeniePalettes, typeof(WeeniePaletteOverride), ConstructedStatementType.GetList);
+            // ConstructStatement(WorldPreparedStatement.GetWeenieTextureMaps, typeof(WeenieTextureMapOverride), ConstructedStatementType.GetList);
+            // ConstructStatement(WorldPreparedStatement.GetWeenieAnimations, typeof(WeenieAnimationOverride), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetTextureOverridesByObject, typeof(TextureMapOverride), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetPaletteOverridesByObject, typeof(PaletteOverride), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetAnimationOverridesByObject, typeof(AnimationOverride), ConstructedStatementType.GetList);
@@ -50,7 +59,10 @@ namespace ACE.Database
             // ConstructStatement(WorldPreparedStatement.InsertCreatureStaticLocation, typeof(AceCreatureStaticLocation), ConstructedStatementType.Insert);
             // ConstructStatement(WorldPreparedStatement.GetCreatureGeneratorByLandblock, typeof(AceCreatureGeneratorLocation), ConstructedStatementType.GetList);
             // ConstructStatement(WorldPreparedStatement.GetCreatureGeneratorData, typeof(AceCreatureGeneratorData), ConstructedStatementType.GetList);
-            // ConstructStatement(WorldPreparedStatement.GetItemsByTypeId, typeof(AceObject), ConstructedStatementType.GetList);
+            // ConstructStatement(
+            //     WorldPreparedStatement.GetItemsByTypeId,
+            //     typeof(AceObject),
+            //     ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetAceObjectPropertiesInt, typeof(AceObjectPropertiesInt), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetAceObjectPropertiesBigInt, typeof(AceObjectPropertiesInt64), ConstructedStatementType.GetList);
             ConstructStatement(WorldPreparedStatement.GetAceObjectPropertiesBool, typeof(AceObjectPropertiesBool), ConstructedStatementType.GetList);
@@ -72,6 +84,44 @@ namespace ACE.Database
             var r = rnd.Next(objects.Count);
             return GetBaseAceObjectDataByWeenie(objects[r].WeenieClassId);
         }
+
+        // public List<TeleportLocation> GetLocations()
+        // {
+        //     var result = SelectPreparedStatement(WorldPreparedStatement.TeleportLocationSelect);
+        //     var locations = new List<TeleportLocation>();
+        //
+        //     for (var i = 0u; i < result.Count; i++)
+        //     {
+        //         locations.Add(new TeleportLocation
+        //         {
+        //             Location = result.Read<string>(i, "name"),
+        //             Position = new Position(result.Read<uint>(i, "landblock"), result.Read<float>(i, "posX"), result.Read<float>(i, "posY"),
+        //                 result.Read<float>(i, "posZ"), result.Read<float>(i, "qx"), result.Read<float>(i, "qy"), result.Read<float>(i, "qz"), result.Read<float>(i, "qw"))
+        //         });
+        //     }
+        //
+        //     return locations;
+        // }
+
+        ////public AcePortalObject GetPortalObjectsByAceObjectId(uint aceObjectId)
+        ////{
+        ////    var apo = new AcePortalObject();
+        ////    var criteria = new Dictionary<string, object> { { "AceObjectId", aceObjectId } };
+        ////    if (ExecuteConstructedGetStatement(WorldPreparedStatement.GetPortalObjectsByAceObjectId, typeof(AcePortalObject), criteria, apo))
+        ////    {
+        ////        apo.IntProperties = GetAceObjectPropertiesInt(apo.AceObjectId);
+        ////        apo.Int64Properties = GetAceObjectPropertiesBigInt(apo.AceObjectId);
+        ////        apo.BoolProperties = GetAceObjectPropertiesBool(apo.AceObjectId);
+        ////        apo.DoubleProperties = GetAceObjectPropertiesDouble(apo.AceObjectId);
+        ////        apo.StringProperties = GetAceObjectPropertiesString(apo.AceObjectId);
+        ////        apo.TextureOverrides = GetAceObjectTextureMaps(apo.AceObjectId);
+        ////        apo.AnimationOverrides = GetAceObjectAnimations(apo.AceObjectId);
+        ////        apo.PaletteOverrides = GetAceObjectPalettes(apo.AceObjectId);
+
+        ////        return apo;
+        ////    }
+        ////    return null;
+        ////}
 
         public List<AceObject> GetObjectsByLandblock(ushort landblock)
         {
@@ -113,7 +163,7 @@ namespace ACE.Database
         {
             var criteria = new Dictionary<string, object> { { "landblock", landblock } };
             var objects = ExecuteConstructedGetListStatement<WorldPreparedStatement, AceCreatureStaticLocation>(WorldPreparedStatement.GetCreaturesByLandblock, criteria);
-            objects.ForEach(o => o.WeenieObject = GetBaseAceObjectDataByWeenie(o.WeenieClassId));
+            objects.ForEach(o => o.WeenieObject = GetWeenie(o.WeenieClassId));
 
             return objects;
         }
@@ -133,6 +183,24 @@ namespace ACE.Database
             return ExecuteConstructedGetListStatement<WorldPreparedStatement, AceCreatureGeneratorData>(WorldPreparedStatement.GetCreatureGeneratorData, criteria);
         }
 
+        private List<PaletteOverride> GetWeeniePalettes(uint aceObjectId)
+        {
+            var criteria = new Dictionary<string, object>();
+            criteria.Add("aceObjectId", aceObjectId);
+            return ExecuteConstructedGetListStatement<WorldPreparedStatement, PaletteOverride>(WorldPreparedStatement.GetWeeniePalettes, criteria);
+        }
+
+        private List<TextureMapOverride> GetWeenieTextureMaps(uint aceObjectId)
+        {
+            var criteria = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
+            return ExecuteConstructedGetListStatement<WorldPreparedStatement, TextureMapOverride>(WorldPreparedStatement.GetWeenieTextureMaps, criteria);
+        }
+
+        private List<AnimationOverride> GetWeenieAnimations(uint aceObjectId)
+        {
+            var criteria = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
+            return ExecuteConstructedGetListStatement<WorldPreparedStatement, AnimationOverride>(WorldPreparedStatement.GetWeenieAnimations, criteria);
+        }
         private List<TextureMapOverride> GetAceObjectTextureMaps(uint aceObjectId)
         {
             var criteria = new Dictionary<string, object> { { "aceObjectId", aceObjectId } };
@@ -246,6 +314,12 @@ namespace ACE.Database
         public async Task<bool> SaveObject(AceObject aceObject)
         {
             throw new NotImplementedException();
+        }
+
+        // TODO: this needs to be refactored to just replace all calls to GetWeenie with the other method which should be renamed.
+        public AceObject GetWeenie(uint weenieClassId)
+        {
+            return GetBaseAceObjectDataByWeenie(weenieClassId);
         }
 
         public List<TeleportLocation> GetPointsOfInterest()

--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -91,7 +91,7 @@ namespace ACE.Database
                 o.TextureOverrides = GetAceObjectTextureMaps(o.AceObjectId);
                 o.AnimationOverrides = GetAceObjectAnimations(o.AceObjectId);
                 o.PaletteOverrides = GetAceObjectPalettes(o.AceObjectId);
-                o.Positions = GetAceObjectPositions(o.AceObjectId);
+                o.AceObjectPropertiesPositions = GetAceObjectPositions(o.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
                 ret.Add(o);
             });
             return ret;
@@ -180,7 +180,7 @@ namespace ACE.Database
             bao.TextureOverrides = GetAceObjectTextureMaps(bao.AceObjectId);
             bao.AnimationOverrides = GetAceObjectAnimations(bao.AceObjectId);
             bao.PaletteOverrides = GetAceObjectPalettes(bao.AceObjectId);
-            bao.Positions = GetAceObjectPositions(bao.AceObjectId);
+            bao.AceObjectPropertiesPositions = GetAceObjectPositions(bao.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
             return bao;
         }
 

--- a/Source/ACE.Entity/AceCharacter.cs
+++ b/Source/ACE.Entity/AceCharacter.cs
@@ -30,6 +30,12 @@ namespace ACE.Entity
             Level = 1;
             AvailableExperience = 0;
             TotalExperience = 0;
+
+            IconId = 0x1036;
+            WeenieClassId = 1; // Human
+            //GameDataType = (uint)ObjectType.Creature;
+            Burden = 0;
+            SpellId = 0;
         }
 
         public ReadOnlyCollection<Friend> Friends { get; set; }

--- a/Source/ACE.Entity/AceCharacter.cs
+++ b/Source/ACE.Entity/AceCharacter.cs
@@ -325,19 +325,19 @@ namespace ACE.Entity
             }
         }
 
-        public AceObjectPropertiesPosition LastPortal
+        public Position LastPortal
         {
             get { return GetPosition(PositionType.LastPortal); }
             set { SetPosition(PositionType.LastPortal, value); }
         }
 
-        public AceObjectPropertiesPosition Sanctuary
+        public Position Sanctuary
         {
             get { return GetPosition(PositionType.Sanctuary); }
             set { SetPosition(PositionType.Sanctuary, value); }
         }
 
-        public AceObjectPropertiesPosition LastOutsideDeath
+        public Position LastOutsideDeath
         {
             get { return GetPosition(PositionType.LastOutsideDeath); }
             set { SetPosition(PositionType.LastOutsideDeath, value); }
@@ -357,18 +357,13 @@ namespace ACE.Entity
         /// <param name="skill"></param>
         public bool TrainSkill(Skill skill, uint creditsSpent)
         {
-            AceObjectPropertiesSkill cs = GetSkillProperty(skill);
-            if (cs != null && cs.SkillStatus != (uint)SkillStatus.Trained && cs.SkillStatus != (uint)SkillStatus.Specialized)
+            CreatureSkill cs = GetSkillProperty(skill);
+            if (cs != null && cs.Status != SkillStatus.Trained && cs.Status != SkillStatus.Specialized)
             {
                 if (AvailableSkillCredits >= creditsSpent)
                 {
-                    var newSkill = new AceObjectPropertiesSkill();
-                    newSkill.AceObjectId = AceObjectId;
-                    newSkill.SkillId = (ushort)skill;
-                    newSkill.SkillPoints = 0;
-                    newSkill.SkillStatus = (ushort)SkillStatus.Trained;
-                    newSkill.SkillXpSpent = 0;
-                    SetAceObjectPropertiesSkill(newSkill);
+                    var newSkill = new CreatureSkill(this, skill, SkillStatus.Trained, 0, 0);
+                    SetSkillProperty(skill, newSkill);
                     AvailableSkillCredits -= creditsSpent;
                     return true;
                 }
@@ -383,19 +378,14 @@ namespace ACE.Entity
         /// <param name="skill"></param>
         public bool SpecializeSkill(Skill skill, uint creditsSpent)
         {
-            AceObjectPropertiesSkill cs = GetSkillProperty(skill);
-            if (cs != null && cs.SkillStatus == (uint)SkillStatus.Trained)
+            CreatureSkill cs = GetSkillProperty(skill);
+            if (cs != null && cs.Status == SkillStatus.Trained)
             {
                 if (AvailableSkillCredits >= creditsSpent)
                 {
-                    RefundXp(cs.SkillXpSpent);
-                    var newSkill = new AceObjectPropertiesSkill();
-                    newSkill.AceObjectId = AceObjectId;
-                    newSkill.SkillId = (ushort)skill;
-                    newSkill.SkillPoints = 0;
-                    newSkill.SkillStatus = (ushort)SkillStatus.Specialized;
-                    newSkill.SkillXpSpent = 0;
-                    SetAceObjectPropertiesSkill(newSkill);
+                    RefundXp(cs.ExperienceSpent);
+                    var newSkill = new CreatureSkill(this, skill, SkillStatus.Specialized, 0, 0);
+                    SetSkillProperty(skill, newSkill);
                     AvailableSkillCredits -= creditsSpent;
                     return true;
                 }

--- a/Source/ACE.Entity/AceObject.cs
+++ b/Source/ACE.Entity/AceObject.cs
@@ -57,7 +57,7 @@ namespace ACE.Entity
 
         public uint? AnimationFrameId
         {
-            get { return IntProperties.Find(x => x.PropertyId == (uint)PropertyInt.PlacementPosition)?.PropertyValue; }
+            get { return GetIntProperty(PropertyInt.PlacementPosition); }
             set { SetIntProperty(PropertyInt.PlacementPosition, value); }
         }
 
@@ -66,19 +66,19 @@ namespace ACE.Entity
 
         public uint? IconId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.Icon)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.Icon); }
             set { SetDataIdProperty(PropertyDataId.Icon, value); }
         }
 
         public uint? IconOverlayId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.IconOverlay)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.IconOverlay); }
             set { SetDataIdProperty(PropertyDataId.IconOverlay, value); }
         }
 
         public uint? IconUnderlayId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.IconUnderlay)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.IconUnderlay); }
             set { SetDataIdProperty(PropertyDataId.IconUnderlay, value); }
         }
 
@@ -87,117 +87,117 @@ namespace ACE.Entity
         /// </summary>
         public uint? ModelTableId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.Setup)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.Setup); }
             set { SetDataIdProperty(PropertyDataId.Setup, value); }
         }
 
         public uint? MotionTableId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.MotionTable)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.MotionTable); }
             set { SetDataIdProperty(PropertyDataId.MotionTable, value); }
         }
 
         public ushort? PhysicsScript
         {
-            get { return (ushort?)DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.PhysicsScript)?.PropertyValue; }
+            get { return (ushort?)GetDataIdProperty(PropertyDataId.PhysicsScript); }
             set { SetDataIdProperty(PropertyDataId.PhysicsScript, value); }
         }
 
         public uint? PhysicsTableId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.PhysicsEffectTable)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.PhysicsEffectTable); }
             set { SetDataIdProperty(PropertyDataId.PhysicsEffectTable, value); }
         }
 
         public uint? SoundTableId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.SoundTable)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.SoundTable); }
             set { SetDataIdProperty(PropertyDataId.SoundTable, value); }
         }
 
         public ushort? SpellId
         {
-            get { return (ushort?)DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.Spell)?.PropertyValue; }
+            get { return (ushort?)GetDataIdProperty(PropertyDataId.Spell); }
             set { SetDataIdProperty(PropertyDataId.Spell, value); }
         }
 
         public uint? DefaultScript
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.UseUserAnimation)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.UseUserAnimation); }
             set { SetDataIdProperty(PropertyDataId.UseUserAnimation, value); }
         }
 
-        public AceObjectPropertiesAttribute StrengthAbility
+        public CreatureAbility StrengthAbility
         {
             get { return GetAttributeProperty(Ability.Strength); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Strength, value); }
         }
 
-        public AceObjectPropertiesAttribute EnduranceAbility
+        public CreatureAbility EnduranceAbility
         {
             get { return GetAttributeProperty(Ability.Endurance); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Endurance, value); }
         }
 
-        public AceObjectPropertiesAttribute CoordinationAbility
+        public CreatureAbility CoordinationAbility
         {
             get { return GetAttributeProperty(Ability.Coordination); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Coordination, value); }
         }
 
-        public AceObjectPropertiesAttribute QuicknessAbility
+        public CreatureAbility QuicknessAbility
         {
             get { return GetAttributeProperty(Ability.Quickness); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Quickness, value); }
         }
 
-        public AceObjectPropertiesAttribute FocusAbility
+        public CreatureAbility FocusAbility
         {
             get { return GetAttributeProperty(Ability.Focus); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Focus, value); }
         }
 
-        public AceObjectPropertiesAttribute SelfAbility
+        public CreatureAbility SelfAbility
         {
             get { return GetAttributeProperty(Ability.Self); }
-            set { SetAttributeProperty(value); }
+            set { SetAttributeProperty(Ability.Self, value); }
         }
 
-        public AceObjectPropertiesAttribute2nd Health
+        public CreatureAbility Health
         {
             get { return GetAttribute2ndProperty(Ability.Health); }
-            set { SetAttribute2ndProperty(value); }
+            set { SetAttribute2ndProperty(Ability.Health, value); }
         }
 
-        public AceObjectPropertiesAttribute2nd Stamina
+        public CreatureAbility Stamina
         {
             get { return GetAttribute2ndProperty(Ability.Stamina); }
-            set { SetAttribute2ndProperty(value); }
+            set { SetAttribute2ndProperty(Ability.Stamina, value); }
         }
 
-        public AceObjectPropertiesAttribute2nd Mana
+        public CreatureAbility Mana
         {
             get { return GetAttribute2ndProperty(Ability.Mana); }
-            set { SetAttribute2ndProperty(value); }
+            set { SetAttribute2ndProperty(Ability.Mana, value); }
         }
 
         public uint Strength
-        { get { return StrengthAbility.ActiveValue; } }
+        { get { return StrengthAbility.MaxValue; } }
 
         public uint Endurance
-        { get { return EnduranceAbility.ActiveValue; } }
+        { get { return EnduranceAbility.MaxValue; } }
 
         public uint Coordination
-        { get { return CoordinationAbility.ActiveValue; } }
+        { get { return CoordinationAbility.MaxValue; } }
 
         public uint Quickness
-        { get { return QuicknessAbility.ActiveValue; } }
+        { get { return QuicknessAbility.MaxValue; } }
 
         public uint Focus
-        { get { return FocusAbility.ActiveValue; } }
+        { get { return FocusAbility.MaxValue; } }
 
         public uint Self
-        { get { return SelfAbility.ActiveValue; } }
+        { get { return SelfAbility.MaxValue; } }
 
         public byte LuminanceAward
         {
@@ -290,7 +290,7 @@ namespace ACE.Entity
 
         public uint? PaletteId
         {
-            get { return DataIdProperties.Find(x => x.PropertyId == (uint)PropertyDataId.PaletteBase)?.PropertyValue; }
+            get { return GetDataIdProperty(PropertyDataId.PaletteBase); }
             set { SetDataIdProperty(PropertyDataId.PaletteBase, value); }
         }
 
@@ -493,7 +493,7 @@ namespace ACE.Entity
         /// </summary>
         public uint PhysicsState
         {
-            get { return IntProperties.Find(x => x.PropertyId == (uint)PropertyInt.PhysicsState).PropertyValue; }
+            get { return GetIntProperty(PropertyInt.PhysicsState) ?? default(int); }
             set { SetIntProperty(PropertyInt.PhysicsState, value); }
         }
 
@@ -605,164 +605,77 @@ namespace ACE.Entity
             }
         }
 
-        public AceObjectPropertiesAttribute GetAttributeProperty(Ability ability)
+        public CreatureAbility GetAttributeProperty(Ability ability)
         {
-            var ret = AceObjectPropertiesAttributes.FirstOrDefault(x => x.AttributeId == (uint)ability);
+            CreatureAbility ret;
+            bool success = AceObjectPropertiesAttributes.TryGetValue(ability, out ret);
 
-            if (ret == null)
+            if (!success || ret == null)
             {
-                ret = new AceObjectPropertiesAttribute();
-                ret.AceObjectId = AceObjectId;
-                ret.AttributeId = (ushort)ability;
-                ret.AttributeBase = 0;
-                ret.AttributeRanks = 0;
-                ret.AttributeXpSpent = 0;
-                AceObjectPropertiesAttributes.Add(ret);
+                ret = new CreatureAbility(this, ability);
+                AceObjectPropertiesAttributes.Add(ability, ret);
             }
 
             return ret;
         }
 
-        public void SetAttributeProperty(AceObjectPropertiesAttribute attribute)
-        {
-            AceObjectPropertiesAttribute oldAttribute = GetAttributeProperty((Ability)attribute.AttributeId);
-            if (attribute != null)
+        private void SetProperty<K, V>(Dictionary<K, V> dict, K key, V value) {
+            if (dict.ContainsKey(key))
             {
-                if (oldAttribute != null)
-                {
-                    oldAttribute.AttributeBase = attribute.AttributeBase;
-                    oldAttribute.AttributeRanks = attribute.AttributeRanks;
-                    oldAttribute.AttributeXpSpent = attribute.AttributeXpSpent;
-                }
-                else
-                {
-                    AceObjectPropertiesAttributes.Add(attribute);
-                }
+                dict[key] = value;
             }
             else
             {
-                if (oldAttribute != null)
-                {
-                    AceObjectPropertiesAttributes.Remove(oldAttribute);
-                }
+                dict.Add(key, value);
             }
         }
 
-        public AceObjectPropertiesAttribute2nd GetAttribute2ndProperty(Ability ability)
+        public void SetAttributeProperty(Ability ability, CreatureAbility value)
         {
-            var ret = AceObjectPropertiesAttributes2nd.FirstOrDefault(x => x.Attribute2ndId == (uint)ability);
+            SetProperty(AceObjectPropertiesAttributes, ability, value);
+        }
 
-            if (ret == null)
+        public CreatureAbility GetAttribute2ndProperty(Ability ability)
+        {
+            CreatureAbility ret;
+            bool success = AceObjectPropertiesAttributes2nd.TryGetValue(ability, out ret);
+
+            if (!success || ret == null)
             {
-                ret = new AceObjectPropertiesAttribute2nd();
-                ret.AceObjectId = AceObjectId;
-                ret.Attribute2ndId = (ushort)ability;
-                ret.Attribute2ndValue = 0;
-                ret.Attribute2ndRanks = 0;
-                ret.Attribute2ndXpSpent = 0;
-                AceObjectPropertiesAttributes2nd.Add(ret);
+                ret = new CreatureAbility(this, ability);
+                AceObjectPropertiesAttributes2nd.Add(ability, ret);
             }
 
             return ret;
         }
 
-        public void SetAttribute2ndProperty(AceObjectPropertiesAttribute2nd attribute)
+        public void SetAttribute2ndProperty(Ability ability, CreatureAbility value)
         {
-            AceObjectPropertiesAttribute2nd oldAttribute = GetAttribute2ndProperty((Ability)attribute.Attribute2ndId);
-            if (attribute != null)
-            {
-                if (oldAttribute != null)
-                {
-                    oldAttribute.Attribute2ndValue = attribute.Attribute2ndValue;
-                    oldAttribute.Attribute2ndRanks = attribute.Attribute2ndRanks;
-                    oldAttribute.Attribute2ndXpSpent = attribute.Attribute2ndXpSpent;
-                }
-                else
-                {
-                    AceObjectPropertiesAttributes2nd.Add(attribute);
-                }
-            }
-            else
-            {
-                if (oldAttribute != null)
-                {
-                    AceObjectPropertiesAttributes2nd.Remove(oldAttribute);
-                }
-            }
+            SetProperty(AceObjectPropertiesAttributes2nd, ability, value);
         }
 
-        public AceObjectPropertiesSkill GetSkillProperty(Skill skill)
+        public CreatureSkill GetSkillProperty(Skill skill)
         {
-            var ret = AceObjectPropertiesSkills.FirstOrDefault(x => x.SkillId == (uint)skill);
+            CreatureSkill ret;
+            bool success = AceObjectPropertiesSkills.TryGetValue(skill, out ret);
 
-            if (ret == null)
+            if (!success || ret == null)
             {
-                ret = new AceObjectPropertiesSkill();
-                ret.AceObjectId = AceObjectId;
-                ret.SkillId = (ushort)skill;
-                ret.SkillPoints = 0;
-                ret.SkillStatus = (ushort)SkillStatus.Untrained;
-                ret.SkillXpSpent = 0;
-                AceObjectPropertiesSkills.Add(ret);
+                ret = new CreatureSkill(this, skill, SkillStatus.Untrained, 0, 0);
+                AceObjectPropertiesSkills.Add(skill, ret);
             }
 
             return ret;
         }
 
-        public void SetSkillProperty(AceObjectPropertiesSkill skill)
+        public void SetSkillProperty(Skill skill, CreatureSkill value)
         {
-            AceObjectPropertiesSkill oldSkill = GetSkillProperty((Skill)skill.SkillId);
-            if (skill != null)
-            {
-                if (oldSkill != null)
-                {
-                    oldSkill.SkillId = skill.SkillId;
-                    oldSkill.SkillPoints = skill.SkillPoints;
-                    oldSkill.SkillStatus = skill.SkillStatus;
-                    oldSkill.SkillXpSpent = skill.SkillXpSpent;
-                }
-                else
-                {
-                    AceObjectPropertiesSkills.Add(skill);
-                }
-            }
-            else
-            {
-                if (oldSkill != null)
-                {
-                    AceObjectPropertiesSkills.Remove(skill);
-                }
-            }
+            SetProperty(AceObjectPropertiesSkills, skill, value);
         }
 
-        public List<AceObjectPropertiesSkill> GetSkills()
+        public List<CreatureSkill> GetSkills()
         {
-            return AceObjectPropertiesSkills;
-        }
-
-        public void SetAceObjectPropertiesSkill(AceObjectPropertiesSkill skill)
-        {
-            AceObjectPropertiesSkill oldSkill = GetSkillProperty((Skill)skill.SkillId);
-            if (skill != null)
-            {
-                if (oldSkill != null)
-                {
-                    oldSkill.SkillPoints = skill.SkillPoints;
-                    oldSkill.SkillStatus = skill.SkillStatus;
-                    oldSkill.SkillXpSpent = skill.SkillXpSpent;
-                }
-                else
-                {
-                    AceObjectPropertiesSkills.Add(skill);
-                }
-            }
-            else
-            {
-                if (oldSkill != null)
-                {
-                    AceObjectPropertiesSkills.Remove(oldSkill);
-                }
-            }
+            return AceObjectPropertiesSkills.Values.ToList();
         }
 
         public uint? GetIntProperty(PropertyInt property)
@@ -929,64 +842,47 @@ namespace ACE.Entity
 
         public List<AceObjectPropertiesString> StringProperties { get; set; } = new List<AceObjectPropertiesString>();
 
-        public List<AceObjectPropertiesAttribute> AceObjectPropertiesAttributes { get; set; } = new List<AceObjectPropertiesAttribute>();
+        // public List<AceObjectPropertiesAttribute> AceObjectPropertiesAttributes { get; set; } = new List<AceObjectPropertiesAttribute>();
+        public Dictionary<Ability, CreatureAbility> AceObjectPropertiesAttributes { get; set; } = new Dictionary<Ability, CreatureAbility>();
 
         // ReSharper disable once InconsistentNaming
-        public List<AceObjectPropertiesAttribute2nd> AceObjectPropertiesAttributes2nd { get; set; } = new List<AceObjectPropertiesAttribute2nd>();
+        // public List<AceObjectPropertiesAttribute2nd> AceObjectPropertiesAttributes2nd { get; set; } = new List<AceObjectPropertiesAttribute2nd>();
+        // FIXME(ddevec): Once we merge into mainline -- replace this with a CreatureVital
+        public Dictionary<Ability, CreatureAbility> AceObjectPropertiesAttributes2nd { get; set; } = new Dictionary<Ability, CreatureAbility>();
 
-        public List<AceObjectPropertiesSkill> AceObjectPropertiesSkills { get; set; } = new List<AceObjectPropertiesSkill>();
+        // public List<AceObjectPropertiesSkill> AceObjectPropertiesSkills { get; set; } = new List<AceObjectPropertiesSkill>();
+        public Dictionary<Skill, CreatureSkill> AceObjectPropertiesSkills { get; set; } = new Dictionary<Skill, CreatureSkill>();
 
-        // public Dictionary<PositionType, Position> Positions { get; set; } = new Dictionary<PositionType, Position>();
-        public List<AceObjectPropertiesPosition> Positions { get; set; } = new List<AceObjectPropertiesPosition>();
+        public Dictionary<PositionType, Position> AceObjectPropertiesPositions { get; set; } = new Dictionary<PositionType, Position>();
+        // public List<AceObjectPropertiesPosition> Positions { get; set; } = new List<AceObjectPropertiesPosition>();
 
-        public AceObjectPropertiesPosition Destination
+        public Position Destination
         {
             get { return GetPosition(PositionType.Destination); }
             set { SetPosition(PositionType.Destination, value); }
         }
 
-        public AceObjectPropertiesPosition Location
+        public Position Location
         {
             get { return GetPosition(PositionType.Location); }
             set { SetPosition(PositionType.Location, value); }
         }
 
-        protected AceObjectPropertiesPosition GetPosition(PositionType positionType)
+        protected Position GetPosition(PositionType positionType)
         {
-            return Positions.FirstOrDefault(x => x.DbPositionType == (uint)positionType);
+            Position ret;
+            bool success = AceObjectPropertiesPositions.TryGetValue(positionType, out ret);
+
+            if (!success)
+            {
+                return null;
+            }
+            return ret;
         }
 
-        protected void SetPosition(PositionType positionType, AceObjectPropertiesPosition value)
+        protected void SetPosition(PositionType positionType, Position value)
         {
-            AceObjectPropertiesPosition oldPosition = Positions.Find(x => x.DbPositionType == (ushort)value.DbPositionType);
-            if (value != null)
-            {
-                if (oldPosition == null)
-                {
-                    oldPosition = (AceObjectPropertiesPosition)value.Clone();
-
-                    Positions.Add(oldPosition);
-                }
-                else
-                {
-                    oldPosition.PositionId = value.PositionId;
-                    oldPosition.Cell = value.Cell;
-                    oldPosition.PositionX = value.PositionX;
-                    oldPosition.PositionY = value.PositionY;
-                    oldPosition.PositionZ = value.PositionZ;
-                    oldPosition.RotationW = value.RotationW;
-                    oldPosition.RotationX = value.RotationX;
-                    oldPosition.RotationY = value.RotationY;
-                    oldPosition.RotationZ = value.RotationZ;
-                }
-            }
-            else
-            {
-                if (oldPosition != null)
-                {
-                    Positions.Remove(oldPosition);
-                }
-            }
+            SetProperty(AceObjectPropertiesPositions, positionType, value);
         }
 
         public object Clone()
@@ -1011,10 +907,10 @@ namespace ACE.Entity
             ret.DataIdProperties = CloneList(DataIdProperties);
             ret.InstanceIdProperties = CloneList(InstanceIdProperties);
             ret.StringProperties = CloneList(StringProperties);
-            ret.AceObjectPropertiesAttributes = CloneList(AceObjectPropertiesAttributes);
-            ret.AceObjectPropertiesAttributes2nd = CloneList(AceObjectPropertiesAttributes2nd);
-            ret.AceObjectPropertiesSkills = CloneList(AceObjectPropertiesSkills);
-            ret.Positions = CloneList(Positions);
+            ret.AceObjectPropertiesAttributes = CloneDict(AceObjectPropertiesAttributes);
+            ret.AceObjectPropertiesAttributes2nd = CloneDict(AceObjectPropertiesAttributes2nd);
+            ret.AceObjectPropertiesSkills = CloneDict(AceObjectPropertiesSkills);
+            ret.AceObjectPropertiesPositions = CloneDict(AceObjectPropertiesPositions);
 
             return ret;
         }
@@ -1022,6 +918,11 @@ namespace ACE.Entity
         private static List<T> CloneList<T>(IEnumerable<T> toClone) where T : ICloneable
         {
             return toClone.Select(x => (T)x.Clone()).ToList();
+        }
+
+        private static Dictionary<K,V> CloneDict<K,V>(Dictionary<K,V> toClone) where V : ICloneable
+        {
+            return toClone.ToDictionary(x => x.Key, x => (V)x.Value.Clone());
         }
     }
 }

--- a/Source/ACE.Entity/CreatureAbility.cs
+++ b/Source/ACE.Entity/CreatureAbility.cs
@@ -1,8 +1,9 @@
-﻿using ACE.Entity.Enum;
+﻿using System;
+using ACE.Entity.Enum;
 
 namespace ACE.Entity
 {
-    public class CreatureAbility
+    public class CreatureAbility : ICloneable
     {
         // because health/stam/mana values are determined from stats, we need a reference to the WeenieCreatureData
         // so we can calculate.  this could be refactored into a better pattern, but it will do for now.
@@ -87,6 +88,25 @@ namespace ACE.Entity
             Base = 10;
         }
 
+        public CreatureAbility(ICreatureStats stats, AceObjectPropertiesAttribute attrib)
+        {
+            this.creature = stats;
+            Ability = (Ability)attrib.AttributeId;
+            Ranks = attrib.AttributeRanks;
+            Base = attrib.AttributeBase;
+            ExperienceSpent = attrib.AttributeXpSpent;
+        }
+
+        public CreatureAbility(ICreatureStats stats, AceObjectPropertiesAttribute2nd vital)
+        {
+            this.creature = stats;
+            Ability = (Ability)vital.Attribute2ndId;
+            Ranks = vital.Attribute2ndRanks;
+            Current = vital.Attribute2ndValue;
+            ExperienceSpent = vital.Attribute2ndXpSpent;
+            Base = 0;
+        }
+
         public AceObjectPropertiesAttribute GetAttribute(uint objId)
         {
             var ret = new AceObjectPropertiesAttribute();
@@ -111,6 +131,11 @@ namespace ACE.Entity
             ret.Attribute2ndXpSpent = ExperienceSpent;
 
             return ret;
+        }
+
+        public object Clone()
+        {
+            return MemberwiseClone();
         }
     }
 }

--- a/Source/ACE.Entity/CreatureSkill.cs
+++ b/Source/ACE.Entity/CreatureSkill.cs
@@ -1,9 +1,10 @@
-﻿using ACE.Entity.Enum;
+﻿using System;
+using ACE.Entity.Enum;
 using ACE.Entity;
 
 namespace ACE.Entity
 {
-    public class CreatureSkill
+    public class CreatureSkill : ICloneable
     {
         // because skill values are determined from stats, we need a reference to the character
         // so we can calculate.  this could be refactored into a better pattern, but it will
@@ -52,6 +53,15 @@ namespace ACE.Entity
             ExperienceSpent = xpSpent;
         }
 
+        public CreatureSkill(ICreatureStats character, AceObjectPropertiesSkill skill)
+        {
+            this.character = character;
+            Skill = (Skill)skill.SkillId;
+            Status = (SkillStatus)skill.SkillStatus;
+            Ranks = skill.SkillPoints;
+            ExperienceSpent = skill.SkillXpSpent;
+        }
+
         public AceObjectPropertiesSkill GetAceObjectSkill(uint objId)
         {
             var ret = new AceObjectPropertiesSkill();
@@ -63,6 +73,11 @@ namespace ACE.Entity
             ret.SkillXpSpent = ExperienceSpent;
 
             return ret;
+        }
+
+        public object Clone()
+        {
+            return MemberwiseClone();
         }
     }
 }

--- a/Source/ACE/Entity/CollidableObject.cs
+++ b/Source/ACE/Entity/CollidableObject.cs
@@ -23,9 +23,10 @@ namespace ACE.Entity
         internal CollidableObject(AceObject aceO)
             : base((ObjectType)aceO.ItemType, new ObjectGuid(aceO.AceObjectId))
         {
+            // FIXME(ddevec): These should be inhereted from aceO, not copied from aceO
             Name = aceO.Name;
             DescriptionFlags = (ObjectDescriptionFlag)aceO.AceObjectDescriptionFlags;
-            Location = new Position(aceO.Location);
+            Location = aceO.Location;
             WeenieClassid = aceO.WeenieClassId;
             WeenieFlags = (WeenieHeaderFlag)aceO.WeenieHeaderFlags;
 

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -10,6 +10,16 @@ namespace ACE.Entity
 
         private readonly object inventoryMutex = new object();
 
+        /// <summary>
+        /// Load from template
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="guid"></param>
+        /// <param name="name"></param>
+        /// <param name="weenieClassId"></param>
+        /// <param name="descriptionFlag"></param>
+        /// <param name="weenieFlag"></param>
+        /// <param name="position"></param>
         public Container(ObjectType type, ObjectGuid guid, string name, ushort weenieClassId, ObjectDescriptionFlag descriptionFlag, WeenieHeaderFlag weenieFlag, Position position)
             : base(type, guid)
         {
@@ -19,6 +29,13 @@ namespace ACE.Entity
             Location = position;
             WeenieClassid = weenieClassId;
         }
+
+        /// <summary>
+        /// Load from saved object
+        /// </summary>
+        /// <param name="baseObject"></param>
+        public Container(AceObject baseObject)
+            : base(baseObject) { }
 
         // Inventory Management Functions
         public virtual void AddToInventory(WorldObject inventoryItem)

--- a/Source/ACE/Entity/Creature.cs
+++ b/Source/ACE/Entity/Creature.cs
@@ -99,6 +99,12 @@ namespace ACE.Entity
             SetAbilities(aceC.WeenieObject);
         }
 
+        public Creature(AceObject baseObject) : base(baseObject)
+        {
+            // FIXME(ddevec): Once physics data has been refactored this shouldn't be needed...
+            SetObjectData(baseObject);
+        }
+
         private void SetObjectData(AceObject aco)
         {
             PhysicsData.CurrentMotionState = new UniversalMotion(MotionStance.Standing);
@@ -108,18 +114,6 @@ namespace ACE.Entity
             PhysicsData.Petable = aco.PhysicsTableId;
             PhysicsData.ObjScale = aco.DefaultScale;
             PhysicsData.PhysicsState = (PhysicsState)aco.PhysicsState;
-
-            // game data min required flags;
-            Icon = aco.IconId;
-
-            ContainerCapacity = aco.ContainersCapacity;
-            ItemCapacity = aco.ItemsCapacity;
-            Usable = (Usable?)aco.ItemUseable;
-            // intersting finding: the radar color is influenced over the weenieClassId and NOT the blipcolor
-            // the blipcolor in DB is 0 whereas the enum suggests it should be 2
-            RadarColor = (RadarColor?)aco.BlipColor;
-            RadarBehavior = (RadarBehavior?)aco.Radar;
-            UseRadius = aco.UseRadius;
         }
 
         protected void SetAbilities(AceObject aco)

--- a/Source/ACE/Entity/Creature.cs
+++ b/Source/ACE/Entity/Creature.cs
@@ -13,27 +13,58 @@ namespace ACE.Entity
 {
     public class Creature : Container
     {
-        protected Dictionary<Enum.Ability, CreatureAbility> abilities = new Dictionary<Enum.Ability, CreatureAbility>();
+        public CreatureAbility Strength {
+            get { return AceObject.StrengthAbility; }
+            set { AceObject.StrengthAbility = value; }
+        }
 
-        public ReadOnlyDictionary<Enum.Ability, CreatureAbility> Abilities;
+        public CreatureAbility Endurance
+        {
+            get { return AceObject.EnduranceAbility; }
+            set { AceObject.EnduranceAbility = value; }
+        }
 
-        public CreatureAbility Strength { get; set; }
+        public CreatureAbility Coordination
+        {
+            get { return AceObject.CoordinationAbility; }
+            set { AceObject.CoordinationAbility = value; }
+        }
 
-        public CreatureAbility Endurance { get; set; }
+        public CreatureAbility Quickness
+        {
+            get { return AceObject.QuicknessAbility; }
+            set { AceObject.QuicknessAbility = value; }
+        }
 
-        public CreatureAbility Coordination { get; set; }
+        public CreatureAbility Focus
+        {
+            get { return AceObject.FocusAbility; }
+            set { AceObject.FocusAbility = value; }
+        }
 
-        public CreatureAbility Quickness { get; set; }
+        public CreatureAbility Self
+        {
+            get { return AceObject.SelfAbility; }
+            set { AceObject.SelfAbility = value; }
+        }
 
-        public CreatureAbility Focus { get; set; }
+        public CreatureAbility Health
+        {
+            get { return AceObject.Health; }
+            set { AceObject.Health = value; }
+        }
 
-        public CreatureAbility Self { get; set; }
+        public CreatureAbility Stamina
+        {
+            get { return AceObject.Stamina; }
+            set { AceObject.Stamina = value; }
+        }
 
-        public CreatureAbility Health { get; set; }
-
-        public CreatureAbility Stamina { get; set; }
-
-        public CreatureAbility Mana { get; set; }
+        public CreatureAbility Mana
+        {
+            get { return AceObject.Mana; }
+            set { AceObject.Mana = value; }
+        }
 
         /// <summary>
         /// This will be false when creature is dead and waits for respawn
@@ -93,46 +124,16 @@ namespace ACE.Entity
 
         protected void SetAbilities(AceObject aco)
         {
-            Strength = new CreatureAbility(aco, Enum.Ability.Strength);
-            Endurance = new CreatureAbility(aco, Enum.Ability.Endurance);
-            Coordination = new CreatureAbility(aco, Enum.Ability.Coordination);
-            Quickness = new CreatureAbility(aco, Enum.Ability.Quickness);
-            Focus = new CreatureAbility(aco, Enum.Ability.Focus);
-            Self = new CreatureAbility(aco, Enum.Ability.Self);
-
-            Health = new CreatureAbility(aco, Enum.Ability.Health);
-            Stamina = new CreatureAbility(aco, Enum.Ability.Stamina);
-            Mana = new CreatureAbility(aco, Enum.Ability.Mana);
-
-            Strength.Base = aco.Strength;
-            Endurance.Base = aco.Endurance;
-            Coordination.Base = aco.Coordination;
-            Quickness.Base = aco.Quickness;
-            Focus.Base = aco.Focus;
-            Self.Base = aco.Self;
-
             // TODO: determine if this is necessary
             // recalculate the base value as the abilities end/will have an influence on those
             // Health.Base = aco.Health - Health.UnbuffedValue;
             // Stamina.Base = aco.Stamina - Stamina.UnbuffedValue;
             // Mana.Base = aco.Mana - Mana.UnbuffedValue;
 
+            // FIXME(ddevec): Should we always start w/ max's? Probably not...
             Health.Current = Health.MaxValue;
             Stamina.Current = Stamina.MaxValue;
             Mana.Current = Mana.MaxValue;
-
-            abilities.Add(Enum.Ability.Strength, Strength);
-            abilities.Add(Enum.Ability.Endurance, Endurance);
-            abilities.Add(Enum.Ability.Coordination, Coordination);
-            abilities.Add(Enum.Ability.Quickness, Quickness);
-            abilities.Add(Enum.Ability.Focus, Focus);
-            abilities.Add(Enum.Ability.Self, Self);
-
-            abilities.Add(Enum.Ability.Health, Health);
-            abilities.Add(Enum.Ability.Stamina, Stamina);
-            abilities.Add(Enum.Ability.Mana, Mana);
-
-            Abilities = new ReadOnlyDictionary<Enum.Ability, CreatureAbility>(abilities);
 
             IsAlive = true;
         }

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -91,7 +91,8 @@ namespace ACE.Entity
         public DebugObject(AceObject aceO)
             : this(new ObjectGuid(aceO.AceObjectId), aceO)
         {
-            Location = new Position(aceO.Location);
+            // FIXME(ddevec): These should be inhereted from aceO, not copied
+            Location = aceO.Location;
             Debug.Assert(aceO.Location != null, "Trying to create DebugObject with null location");
             WeenieClassid = aceO.WeenieClassId;
             GameDataType = aceO.ItemType;

--- a/Source/ACE/Entity/Door.cs
+++ b/Source/ACE/Entity/Door.cs
@@ -21,8 +21,9 @@ namespace ACE.Entity
         {
             Name = aceO.Name;
 
+            // FIXME(ddevec): These should be inhereted from aceO, not copied?
             DescriptionFlags = (ObjectDescriptionFlag)aceO.AceObjectDescriptionFlags;
-            Location = new Position(aceO.Location);
+            Location = aceO.Location;
             WeenieClassid = aceO.WeenieClassId;
             WeenieFlags = (WeenieHeaderFlag)aceO.WeenieHeaderFlags;
 

--- a/Source/ACE/Entity/Lifestone.cs
+++ b/Source/ACE/Entity/Lifestone.cs
@@ -17,9 +17,10 @@ namespace ACE.Entity
         public Lifestone(AceObject aceO)
             : base((ObjectType)aceO.ItemType, new ObjectGuid(aceO.AceObjectId))
         {
+            // FIXME(ddevec): These should be inhereted frome aceO not copied...
             Name = aceO.Name;
             DescriptionFlags = (ObjectDescriptionFlag)aceO.AceObjectDescriptionFlags;
-            Location = new Position(aceO.Location);
+            Location = aceO.Location;
             WeenieClassid = aceO.WeenieClassId;
             WeenieFlags = (WeenieHeaderFlag)aceO.WeenieHeaderFlags;
 

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -74,7 +74,10 @@ namespace ACE.Entity
 
         private AceCharacter Character { get { return AceObject as AceCharacter; } }
 
-        private Dictionary<Skill, CreatureSkill> skills = new Dictionary<Skill, CreatureSkill>();
+        private Dictionary<Skill, CreatureSkill> Skills
+        {
+            get { return AceObject.AceObjectPropertiesSkills; }
+        }
 
         private readonly object clientObjectMutex = new object();
 
@@ -93,7 +96,10 @@ namespace ACE.Entity
         // dictionary for delaying further actions for an objectID
         private readonly Dictionary<uint, double> delayedActions = new Dictionary<uint, double>();
 
-        public Dictionary<PositionType, Position> Positions { get; set; } = new Dictionary<PositionType, Position>();
+        public Dictionary<PositionType, Position> Positions
+        {
+            get { return AceObject.AceObjectPropertiesPositions; }
+        }
 
         public Position PositionSanctuary {
             get
@@ -247,13 +253,7 @@ namespace ACE.Entity
                 //    character.IsAdvocate= true;
             }
 
-            Location = new Position(character.Location);
-
-            foreach (AceObjectPropertiesSkill skill in AceObject.GetSkills())
-            {
-                Skill skillId = (Skill)skill.SkillId;
-                skills[skillId] = new CreatureSkill(AceObject, skillId, (SkillStatus)skill.SkillStatus, skill.SkillPoints, skill.SkillXpSpent);
-            }
+            Location = character.Location;
 
             SetAbilities(character);
 
@@ -308,29 +308,6 @@ namespace ACE.Entity
             // TODO: Fix this hack - not sure where but weenieclassid is getting set to 0 has to be 1 for players
             // this is crap and needs to be fixed.
             obj.WeenieClassId = 1;
-
-            // Copy in any data Character doesn't reflect...
-            // Bad stuff -- fix
-            // Attributes
-            obj.SetAttributeProperty(Strength.GetAttribute(Character.AceObjectId));
-            obj.SetAttributeProperty(Coordination.GetAttribute(Character.AceObjectId));
-            obj.SetAttributeProperty(Endurance.GetAttribute(Character.AceObjectId));
-            obj.SetAttributeProperty(Quickness.GetAttribute(Character.AceObjectId));
-            obj.SetAttributeProperty(Focus.GetAttribute(Character.AceObjectId));
-            obj.SetAttributeProperty(Self.GetAttribute(Character.AceObjectId));
-            // Vitals
-            obj.SetAttribute2ndProperty(Health.GetVital(Character.AceObjectId));
-            obj.SetAttribute2ndProperty(Stamina.GetVital(Character.AceObjectId));
-            obj.SetAttribute2ndProperty(Mana.GetVital(Character.AceObjectId));
-
-            // Skillz
-            foreach (var skill in skills.Values)
-            {
-                obj.SetSkillProperty(skill.GetAceObjectSkill(Character.AceObjectId));
-            }
-
-            // Positions -- These are curently maintained internally...
-            obj.Positions = Positions.Select(x => x.Value.GetAceObjectPosition(Guid, x.Key)).ToList();
 
             return obj;
         }
@@ -528,7 +505,15 @@ namespace ACE.Entity
 
         public void SpendXp(Enum.Ability ability, uint amount)
         {
-            CreatureAbility creatureAbility = Abilities[ability];
+            CreatureAbility creatureAbility;
+            bool success = AceObject.AceObjectPropertiesAttributes.TryGetValue(ability, out creatureAbility);
+            if (!success)
+            {
+                success = AceObject.AceObjectPropertiesAttributes2nd.TryGetValue(ability, out creatureAbility);
+                // Invalid ability
+                log.Error("Invalid ability passed to Player.SpendXp");
+                return;
+            }
             uint baseValue = creatureAbility.Base;
             uint result = SpendAbilityXp(creatureAbility, amount);
             bool isSecondary = (ability == Enum.Ability.Health || ability == Enum.Ability.Stamina || ability == Enum.Ability.Mana);
@@ -700,7 +685,7 @@ namespace ACE.Entity
         public void SpendXp(Skill skill, uint amount)
         {
             uint baseValue = 0;
-            CreatureSkill creatureSkill = skills[skill];
+            CreatureSkill creatureSkill = Skills[skill];
             uint result = SpendSkillXp(creatureSkill, amount);
 
             uint ranks = creatureSkill.Ranks;

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -500,8 +500,11 @@ namespace ACE.Entity
             {
                 success = AceObject.AceObjectPropertiesAttributes2nd.TryGetValue(ability, out creatureAbility);
                 // Invalid ability
-                log.Error("Invalid ability passed to Player.SpendXp");
-                return;
+                if (!success)
+                {
+                    log.Error("Invalid ability passed to Player.SpendXp");
+                    return;
+                }
             }
             uint baseValue = creatureAbility.Base;
             uint result = SpendAbilityXp(creatureAbility, amount);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -184,25 +184,14 @@ namespace ACE.Entity
             // This is the default send upon log in and the most common.   Anything with a velocity will need to add that flag.
             PositionFlag |= UpdatePositionFlag.ZeroQx | UpdatePositionFlag.ZeroQy | UpdatePositionFlag.Contact | UpdatePositionFlag.Placement;
 
-            Name = session.CharacterRequested.Name;
-            Icon = 0x1036;
-            WeenieClassid = 1; // Human
-            GameDataType = (uint)ObjectType.Creature;
-            ItemCapacity = 102;
-            Burden = 0;
-            this.Spell = 0;
-            // this.CurrentMotionState = new UniversalMotion(MotionStance.Standing);
-            ContainerCapacity = 7;
-            RadarBehavior = Network.Enum.RadarBehavior.ShowAlways;
-            RadarColor = Network.Enum.RadarColor.White;
-            Usable = Network.Enum.Usable.UsableObjectSelf;
-
+            // FIXME(ddevec): Once physics data is refactored this shouldn't be needed
             SetPhysicsState(PhysicsState.IgnoreCollision | PhysicsState.Gravity | PhysicsState.Hidden | PhysicsState.EdgeSlide, false);
             PhysicsData.PhysicsDescriptionFlag = PhysicsDescriptionFlag.CSetup | PhysicsDescriptionFlag.MTable | PhysicsDescriptionFlag.Stable | PhysicsDescriptionFlag.Petable | PhysicsDescriptionFlag.Position | PhysicsDescriptionFlag.Movement;
 
             // apply defaults.  "Load" should be overwriting these with values specific to the character
             // TODO: Load from database should be loading player data - including inventroy and positions
             PhysicsData.CurrentMotionState = new UniversalMotion(MotionStance.Standing);
+
             PhysicsData.MTableResourceId = 0x09000001u;
             PhysicsData.Stable = 0x20000001u;
             PhysicsData.Petable = 0x34000004u;

--- a/Source/ACE/Entity/Portal.cs
+++ b/Source/ACE/Entity/Portal.cs
@@ -109,8 +109,9 @@ namespace ACE.Entity
         public Portal(AceObject aceO)
             : base(aceO)
         {
+            // FIXME(ddevec): Should be inhereted from aceO, not extend it...
             if (aceO.Destination != null)
-                Destination = new Position(aceO.Destination);
+                Destination = aceO.Destination;
         }
 
         public uint MinimumLevel

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -43,14 +43,18 @@ namespace ACE.Entity
 
         public virtual Position Location
         {
-            get { return PhysicsData.Position; }
+            get { return AceObject.Location; }
             protected set
             {
-                if (PhysicsData.Position != null)
-                    LastUpdatedTicks = WorldManager.PortalYearTicks;
-
+                /*
                 log.Debug($"{Name} moved to {PhysicsData.Position}");
 
+                PhysicsData.Position = value;
+                */
+                if (AceObject.Location != null)
+                    LastUpdatedTicks = WorldManager.PortalYearTicks;
+                AceObject.Location = value;
+                // FIXME(ddevec): When PhysicsData is factored out this can be deleted
                 PhysicsData.Position = value;
             }
         }

--- a/Source/ACE/Network/GameEvent/Events/GameEventPlayerDescription.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventPlayerDescription.cs
@@ -286,11 +286,11 @@ namespace ACE.Network.GameEvent.Events
 
                 foreach (var skill in skills)
                 {
-                    Writer.Write((uint)skill.SkillId); // skill id
-                    Writer.Write((ushort)skill.SkillPoints); // points raised
+                    Writer.Write((uint)skill.Skill); // skill id
+                    Writer.Write((ushort)skill.Ranks); // points raised
                     Writer.Write((ushort)0);
-                    Writer.Write((uint)skill.SkillStatus); // skill state
-                    Writer.Write((uint)skill.SkillXpSpent); // xp spent on this skill
+                    Writer.Write((uint)skill.Status); // skill state
+                    Writer.Write((uint)skill.ExperienceSpent); // xp spent on this skill
                     Writer.Write(0u); // current bonus points applied (buffs) - not implemented
                     Writer.Write(0u); // task difficulty
                     Writer.Write(0d);

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -121,6 +121,11 @@ namespace ACE.Network.Handlers
             CharGen cg = CharGen.ReadFromDat();
             AceCharacter character = new AceCharacter(DatabaseManager.Shard.GetNextCharacterId());
 
+            // FIXME(ddevec): These should go in AceCharacter constructor, but the Network enum is not available there
+            character.Radar = (byte)Network.Enum.RadarBehavior.ShowAlways;
+            character.BlipColor = (byte)Network.Enum.RadarColor.White;
+            character.ItemUseable = (uint)Network.Enum.Usable.UsableObjectSelf;
+
             reader.Skip(4);   /* Unknown constant (1) */
             character.Heritage = reader.ReadUInt32();
             character.Gender = reader.ReadUInt32();

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -212,21 +212,21 @@ namespace ACE.Network.Handlers
 
             // stats
             // TODO - Validate this is equal to 330 (Total Attribute Credits)
-            character.StrengthAbility.AttributeBase = (ushort)reader.ReadUInt32();
-            character.EnduranceAbility.AttributeBase = (ushort)reader.ReadUInt32();
-            character.CoordinationAbility.AttributeBase = (ushort)reader.ReadUInt32();
-            character.QuicknessAbility.AttributeBase = (ushort)reader.ReadUInt32();
-            character.FocusAbility.AttributeBase = (ushort)reader.ReadUInt32();
-            character.SelfAbility.AttributeBase = (ushort)reader.ReadUInt32();
+            character.StrengthAbility.Base = (ushort)reader.ReadUInt32();
+            character.EnduranceAbility.Base = (ushort)reader.ReadUInt32();
+            character.CoordinationAbility.Base = (ushort)reader.ReadUInt32();
+            character.QuicknessAbility.Base = (ushort)reader.ReadUInt32();
+            character.FocusAbility.Base = (ushort)reader.ReadUInt32();
+            character.SelfAbility.Base = (ushort)reader.ReadUInt32();
 
             // data we don't care about
             uint characterSlot = reader.ReadUInt32();
             uint classId = reader.ReadUInt32();
 
             // characters start with max vitals
-            character.Health.Attribute2ndValue = AbilityExtensions.GetFormula(Entity.Enum.Ability.Health).CalcBase(character);
-            character.Stamina.Attribute2ndValue = AbilityExtensions.GetFormula(Entity.Enum.Ability.Stamina).CalcBase(character);
-            character.Mana.Attribute2ndValue = AbilityExtensions.GetFormula(Entity.Enum.Ability.Mana).CalcBase(character);
+            character.Health.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Health).CalcBase(character);
+            character.Stamina.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Stamina).CalcBase(character);
+            character.Mana.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Mana).CalcBase(character);
 
             character.TotalSkillCredits = 52;
             character.AvailableSkillCredits = 52;
@@ -325,7 +325,7 @@ namespace ACE.Network.Handlers
 
         public static void CharacterCreateSetDefaultCharacterPositions(AceCharacter character)
         {
-            character.Location = CharacterPositionExtensions.StartingPosition().GetAceObjectPosition(character.AceObjectId, PositionType.Location);
+            character.Location = CharacterPositionExtensions.StartingPosition();
         }
 
         private static void SendCharacterCreateResponse(Session session, CharacterGenerationVerificationResponse response, ObjectGuid guid = default(ObjectGuid), string charName = "")

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # ACEmulator Change Log
 
+### 2017-06-15
+[ddevec]
+* Refactor of AceObject
+* Player/Creature/WorldObject persistent attirbutes now forward to AceObject
+* Fixed Attribute2nd initailization error in the process.
+
 ### 2017-06-14
 
 [ddevec]


### PR DESCRIPTION
Clean-up of backing state in game.  Primary focuses:

- Make persistent state of in-game objects to be backed by the AceObject
- Remove unneeded database fields from active state
- Stop in-game objects from redundantly writing to their AceObject.

Also fixes:
- Attribute2nd (vitals -- health/stam/mana) initializing incorrectly.

Still needs to be done:
- ORM interface cleanup.