### PR TITLE
Re-Added Configuration for Maximum Allowed Sessions

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -10,6 +10,16 @@ namespace ACE.Common
         public string Host { get; set; }
 
         public uint Port { get; set; }
+
+        /// <summary>
+        /// Increasing this setting will allow more Accounts to connect with this server.
+        /// </summary>
+        /// <remarks>
+        /// WARNING: Must be greater then 0 to allow users to connect.
+        /// </remarks>
+        [System.ComponentModel.DefaultValue(128)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public uint MaximumAllowedSessions { get; set; }
     }
 
     public struct ConfigAccountDefaults

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -4,7 +4,8 @@
         "Welcome": "Welcome to this ACE server!\nFor more information visit http://www.acemulator.org.",
         "Network": {
             "Host": "0.0.0.0",
-            "Port": 9000
+            "Port": 9000,
+            "MaximumAllowedSessions" : 128
         },
         "Accounts": {
             "OverrideCharacterPermissions": true,

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -20,7 +20,7 @@ namespace ACE.Managers
 
         // Hard coded server Id, this will need to change if we move to multi-process or multi-server model
         public const ushort ServerId = 0xB;
-        private static Session[] sessionMap = new Session[128]; // TODO Placeholder, should be config MaxSessions
+        private static Session[] sessionMap = new Session[ConfigManager.Config.Server.Network.MaximumAllowedSessions];
         private static readonly List<Session> sessions = new List<Session>();
         private static readonly ReaderWriterLockSlim sessionLock = new ReaderWriterLockSlim();
 
@@ -37,6 +37,7 @@ namespace ACE.Managers
             var thread = new Thread(UpdateWorld);
             thread.Start();
             log.DebugFormat("ServerTime initialized to {0}", WorldStartFromTime.ToString());
+            log.DebugFormat($"Current maximum allowed sessions: {ConfigManager.Config.Server.Network.MaximumAllowedSessions}");
         }
 
         public static void ProcessPacket(ClientPacket packet, IPEndPoint endPoint)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # ACEmulator Change Log
 
 ### 2017-06-17
+[fantoms]
+* Created a `DefaultValue` attribute for `MaximumAllowedSessions` of 128.
+* Added `MaximumAllowedSessions` to the `ConfigManager` and the `Config.json.example` file.
+* Began using the variable in the `WorldManager.cs` server initalization step, allowing usersr to configure the max allowed sessions.
+
 [Ripley]
 * Made changes to WorldBase and ShardBase scripts to correct issues with landblocks and POIs. 
 * Changed CachedWordObject to CachedWorldObject.


### PR DESCRIPTION
* Added a Config Setting and Max Allowed Sessions code, to allow configuration of the total concurrent connections.

This code was lost during the object-overhaul change: PR #345 -

* Changed the configuration sections to allow for the "MaxSessions" setting.
* There is a default value of 128.
* Check the Config.json.example for help.