### PR TITLE
Re-Added a debug command to list all players connected to the server.

### DIFF
--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -634,5 +634,30 @@ namespace ACE.Command.Handlers
                 session.Network.EnqueueSend(errorMessage);
             }
         }
+
+        /// <summary>
+        /// Debug command to print out all of the active players connected too the server.
+        /// </summary>
+        [CommandHandler("listplayers", AccessLevel.Developer, CommandHandlerFlag.None, 0,
+            "Displays all of the active players connected too the serve.",
+            "@players")]
+        public static void HandleListPlayers(Session session, params string[] parameters)
+        {
+            uint playerCounter = 0;
+            // Build a string message containing all available characters and send as a System Chat message
+            string message = "";
+            foreach (Session playerSession in WorldManager.GetAll(false))
+            {
+                message += $"{playerSession.Player.Name} : {(uint)playerSession.Id}\n";
+                playerCounter++;
+            }
+            message += $"Total connected Players: {playerCounter}\n";
+            if (session != null)
+            {
+                var listPlayersMessage = new GameMessageSystemChat(message, ChatMessageType.Broadcast);
+                session.Network.EnqueueSend(listPlayersMessage);
+            } else
+                Console.WriteLine(message);
+        }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # ACEmulator Change Log
 
 ### 2017-06-17
+[fantoms]
+* Added the debug command `listplayers`, that will list all players currently connected too the server.
+
 [Ripley]
 * Made changes to WorldBase and ShardBase scripts to correct issues with landblocks and POIs. 
 * Changed CachedWordObject to CachedWorldObject.


### PR DESCRIPTION
This code was lost during the object-overhaul switchover, from the PR #346 and was altered slightly to allow use from within the server console.

* Added a Helpful debug command for testing who is connected too your server.
* Can now be used from the console.