### PR TITLE
Make NPCs in database wield items also in database

### DIFF
--- a/Source/ACE.Entity/AceObject.cs
+++ b/Source/ACE.Entity/AceObject.cs
@@ -481,6 +481,18 @@ namespace ACE.Entity
             set { SetIntProperty(PropertyInt.CurrentWieldedLocation, value); }
         }
 
+        public uint? Parent
+        {
+            get { return GetInstanceIdProperty(PropertyInstanceId.Wielder); }
+            set { SetInstanceIdProperty(PropertyInstanceId.Wielder, value); }
+        }
+
+        public uint? ParentLocation
+        {
+            get { return GetIntProperty(PropertyInt.ParentLocation); }
+            set { SetIntProperty(PropertyInt.ParentLocation, value); }
+        }
+
         public float? DefaultScale
         {
             get { return (float?)GetDoubleProperty(PropertyDouble.DefaultScale); }

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -34,8 +34,6 @@ namespace ACE.Entity
             PhysicsData.DefaultScript = baseAceObject.DefaultScript;
             PhysicsData.DefaultScriptIntensity = (float?)baseAceObject.PhysicsScriptIntensity;
             PhysicsData.Elasticity = baseAceObject.Elasticity;
-            // PhysicsData.EquipperPhysicsDescriptionFlag = (EquipMask?)baseAceObject.CurrentWieldedLocation; // what is going on here?
-            // PhysicsData.EquipperPhysicsDescriptionFlag = baseAceObject.ParentLocation;
             PhysicsData.Parent = baseAceObject.Parent;
             PhysicsData.ParentLocation = baseAceObject.ParentLocation;
             PhysicsData.Friction = baseAceObject.Friction;

--- a/Source/ACE/Entity/DebugObject.cs
+++ b/Source/ACE/Entity/DebugObject.cs
@@ -34,7 +34,10 @@ namespace ACE.Entity
             PhysicsData.DefaultScript = baseAceObject.DefaultScript;
             PhysicsData.DefaultScriptIntensity = (float?)baseAceObject.PhysicsScriptIntensity;
             PhysicsData.Elasticity = baseAceObject.Elasticity;
-            PhysicsData.EquipperPhysicsDescriptionFlag = (EquipMask?)baseAceObject.CurrentWieldedLocation;
+            // PhysicsData.EquipperPhysicsDescriptionFlag = (EquipMask?)baseAceObject.CurrentWieldedLocation; // what is going on here?
+            // PhysicsData.EquipperPhysicsDescriptionFlag = baseAceObject.ParentLocation;
+            PhysicsData.Parent = baseAceObject.Parent;
+            PhysicsData.ParentLocation = baseAceObject.ParentLocation;
             PhysicsData.Friction = baseAceObject.Friction;
             if (baseAceObject.CurrentMotionState == "0" || baseAceObject.CurrentMotionState == null)
                 PhysicsData.CurrentMotionState = null;
@@ -60,6 +63,7 @@ namespace ACE.Entity
             MaxStackSize = baseAceObject.MaxStackSize;
             Wielder = baseAceObject.WielderId;
             ContainerId = baseAceObject.ContainerId;
+            CurrentWieldedLocation = (EquipMask?)baseAceObject.CurrentWieldedLocation;
 
             // TODO: this needs to be pulled in from pcap data. Missing - Name Plural never set need to address
 

--- a/Source/ACE/Entity/PhysicsData.cs
+++ b/Source/ACE/Entity/PhysicsData.cs
@@ -32,7 +32,6 @@ namespace ACE.Entity
         public uint ItemsEquipedCount;
         public uint? Parent;
         public uint? ParentLocation;
-        // public EquipMask? EquipperPhysicsDescriptionFlag;
         private readonly List<EquippedItem> children = new List<EquippedItem>();
 
         public float? ObjScale;
@@ -77,7 +76,7 @@ namespace ACE.Entity
             if ((AnimationFrame != null) && (AnimationFrame != 0))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.AnimationFrame;
 
-            if (Position != null) // && (wo.Wielder == null) && (wo.ContainerId == null))
+            if (Position != null)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Position;
 
             // NOTE: While we fill with 0 the flag still has to reflect that we are not really making this entry for the client.
@@ -131,36 +130,6 @@ namespace ACE.Entity
         // todo: return bytes of data for network write ? ?
         public void Serialize(WorldObject wo, BinaryWriter writer)
         {
-            // TODO: Remove this really ugly hack - POC on how equipted items (weapons and shields maybe other things)
-            // We do not have a way to save or load this data yet.   I am looking for Rand the humter in holtburg
-            // I am adding his spear as a child item.
-            ////if (wo.Guid.Full == 0xDBB12C7E)
-            ////{
-            ////    // this is implementation for children mapping to equipMask is  wrong.
-            ////    // Just made an interesting discovery.PhysicsData.Children is never greater than 2 in any of the 4 million create objects.
-            ////    // Maybe everyone knew this but It looks like that is only used for items that can be selected when wielded.weapon caster
-            ////    // or shield in either hand.that is represented as id (the item you are wielding) and a location_id
-            ////    // we currently have that mapped to equipedmask but that is not correct.There are only 2 values I can find 1 or 3.
-            ////    // 1 seems to be your weapon or caster while 3 is shield.I don't see any enums that map to that.
-            ////    var item = new EquippedItem(0xDBAC8105, EquipMask.MeleeWeapon);
-            ////    wo.PhysicsData.children.Add(item);
-            ////    ItemsEquipedCount = (uint)wo.PhysicsData.children.Count;
-            ////}
-
-            // Here I am looking for the spear and making Rand the parent.
-            // There is a squence here that we will need to figure out.   You only see this if you login, then log out
-            // and log back in.   I THINK we need have the landblock create an times that have a weilder_Id - I am not sure
-            // but either the spear must exist and have the holder assigned as it's parent or the holder has to exist first not sure
-            // which but there is some sequence.
-            // TODO: Remove this really ugly hack - POC on how equipted items (weapons and shields maybe other things)
-
-            ////if (wo.Guid.Full == 0xDBAC8105)
-            ////{
-            ////    // wo.ValidLocations = EquipMask.BraceletRight;
-            ////    // wo.CurrentWieldedLocation = EquipMask.BraceletRight;
-            ////    wo.PhysicsData.Parent = 0xDBB12C7E;
-            ////}
-
             PhysicsDescriptionFlag = SetPhysicsDescriptionFlag(wo);
 
             writer.Write((uint)PhysicsDescriptionFlag);
@@ -219,11 +188,8 @@ namespace ACE.Entity
                 writer.Write(ItemsEquipedCount);
                 foreach (var child in children)
                 {
-                    // TODO : need to figure out the location (second value) to write - it is not the mask 1 is in left hand 3 look to be in right?
-                    // maybe some sort of slot enum?   We can probably find it in the client.
                     writer.Write(child.Guid);
-                    // writer.Write((uint)child.EquipMask);  - this is not right.
-                    writer.Write(1u);
+                    writer.Write(1u); // This is going to be child.ParentLocation when we get to it
                 }
             }
 

--- a/Source/ACE/Entity/PhysicsData.cs
+++ b/Source/ACE/Entity/PhysicsData.cs
@@ -30,8 +30,9 @@ namespace ACE.Entity
 
         // these are all related
         public uint ItemsEquipedCount;
-        public uint Parent;
-        public EquipMask? EquipperPhysicsDescriptionFlag;
+        public uint? Parent;
+        public uint? ParentLocation;
+        // public EquipMask? EquipperPhysicsDescriptionFlag;
         private readonly List<EquippedItem> children = new List<EquippedItem>();
 
         public float? ObjScale;
@@ -76,7 +77,7 @@ namespace ACE.Entity
             if ((AnimationFrame != null) && (AnimationFrame != 0))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.AnimationFrame;
 
-            if ((Position != null) && (wo.Wielder == null) && (wo.ContainerId == null))
+            if (Position != null) // && (wo.Wielder == null) && (wo.ContainerId == null))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Position;
 
             // NOTE: While we fill with 0 the flag still has to reflect that we are not really making this entry for the client.
@@ -95,7 +96,7 @@ namespace ACE.Entity
             if (ItemsEquipedCount != 0)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Children;
 
-            if (Parent != 0)
+            if (Parent != null)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Parent;
 
             if ((ObjScale != null) && (Math.Abs((float)ObjScale) >= 0.001))
@@ -133,18 +134,18 @@ namespace ACE.Entity
             // TODO: Remove this really ugly hack - POC on how equipted items (weapons and shields maybe other things)
             // We do not have a way to save or load this data yet.   I am looking for Rand the humter in holtburg
             // I am adding his spear as a child item.
-            if (wo.Guid.Full == 0xDBB12C7E)
-            {
-                // this is implementation for children mapping to equipMask is  wrong.
-                // Just made an interesting discovery.PhysicsData.Children is never greater than 2 in any of the 4 million create objects.
-                // Maybe everyone knew this but It looks like that is only used for items that can be selected when wielded.weapon caster
-                // or shield in either hand.that is represented as id (the item you are wielding) and a location_id
-                // we currently have that mapped to equipedmask but that is not correct.There are only 2 values I can find 1 or 3.
-                // 1 seems to be your weapon or caster while 3 is shield.I don't see any enums that map to that.
-                var item = new EquippedItem(0xDBAC8105, EquipMask.MeleeWeapon);
-                wo.PhysicsData.children.Add(item);
-                ItemsEquipedCount = (uint)wo.PhysicsData.children.Count;
-            }
+            ////if (wo.Guid.Full == 0xDBB12C7E)
+            ////{
+            ////    // this is implementation for children mapping to equipMask is  wrong.
+            ////    // Just made an interesting discovery.PhysicsData.Children is never greater than 2 in any of the 4 million create objects.
+            ////    // Maybe everyone knew this but It looks like that is only used for items that can be selected when wielded.weapon caster
+            ////    // or shield in either hand.that is represented as id (the item you are wielding) and a location_id
+            ////    // we currently have that mapped to equipedmask but that is not correct.There are only 2 values I can find 1 or 3.
+            ////    // 1 seems to be your weapon or caster while 3 is shield.I don't see any enums that map to that.
+            ////    var item = new EquippedItem(0xDBAC8105, EquipMask.MeleeWeapon);
+            ////    wo.PhysicsData.children.Add(item);
+            ////    ItemsEquipedCount = (uint)wo.PhysicsData.children.Count;
+            ////}
 
             // Here I am looking for the spear and making Rand the parent.
             // There is a squence here that we will need to figure out.   You only see this if you login, then log out
@@ -153,12 +154,12 @@ namespace ACE.Entity
             // which but there is some sequence.
             // TODO: Remove this really ugly hack - POC on how equipted items (weapons and shields maybe other things)
 
-            if (wo.Guid.Full == 0xDBAC8105)
-            {
-                wo.ValidLocations = EquipMask.BraceletRight;
-                wo.CurrentWieldedLocation = EquipMask.BraceletRight;
-                wo.PhysicsData.Parent = 0xDBB12C7E;
-            }
+            ////if (wo.Guid.Full == 0xDBAC8105)
+            ////{
+            ////    // wo.ValidLocations = EquipMask.BraceletRight;
+            ////    // wo.CurrentWieldedLocation = EquipMask.BraceletRight;
+            ////    wo.PhysicsData.Parent = 0xDBB12C7E;
+            ////}
 
             PhysicsDescriptionFlag = SetPhysicsDescriptionFlag(wo);
 
@@ -209,8 +210,8 @@ namespace ACE.Entity
 
             if ((PhysicsDescriptionFlag & PhysicsDescriptionFlag.Parent) != 0)
             {
-                writer.Write(Parent);
-                writer.Write((uint)EquipperPhysicsDescriptionFlag);
+                writer.Write((uint)Parent);
+                writer.Write((uint)ParentLocation);
             }
 
             if ((PhysicsDescriptionFlag & PhysicsDescriptionFlag.Children) != 0)

--- a/Source/ACE/Entity/UsableObject.cs
+++ b/Source/ACE/Entity/UsableObject.cs
@@ -39,7 +39,6 @@ namespace ACE.Entity
             PhysicsData.DefaultScript = baseAceObject.DefaultScript;
             PhysicsData.DefaultScriptIntensity = baseAceObject.PhysicsScriptIntensity;
             PhysicsData.Elasticity = baseAceObject.Elasticity;
-            PhysicsData.EquipperPhysicsDescriptionFlag = EquipMask.Wand;
             PhysicsData.Friction = baseAceObject.Friction;
             PhysicsData.MTableResourceId = baseAceObject.MotionTableId;
             PhysicsData.ObjScale = baseAceObject.DefaultScale;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2017-06-18
+[Ripley]
+* Made changes to AceObject, PhysicsData, DebugObject and UsableObject to make wielded items in database work better.
+* Note that PhysicsData.Children does not set properly yet but is seemingly not needed for the effect to work at least for static npcs/items.
+
 ### 2017-06-17
 [Ripley]
 * Made changes to WorldBase and ShardBase scripts to correct issues with landblocks and POIs. 


### PR DESCRIPTION
This code change corrects issues with AceObject, PhysicsData, DebugObject and UsableObject to make wielded items in database appear in world and attach mostly correct to their wielders. I say mostly correct as visually they look good, but all of the NPCs are static at this point and we're not setting the children flag on NPCs as well so there could be issues laying in wait for us when we get to movement for them which will require us to get that part working.

This works with data found in the last two ACE-World releases, no new export was required, although the latest release would be suggested as it fixes issues with landblock loading.