### PR TITLE
Fix to asynchronous saving bug on character creation.

### DIFF
--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1056,20 +1056,6 @@ namespace ACE.Entity
         }
 
         /// <summary>
-        /// Saves options to the database.  Options include things like spell tabs, settings (F11), chat windows, etc.
-        /// </summary>
-        public void SaveOptions()
-        {
-            if (Character != null)
-            {
-                // DatabaseManager.Shard.SaveObject(GetSavableCharacter());
-                DbManager.SaveObject(GetSavableCharacter());
-            }
-
-            // TODO: Save other options as we implement them.
-        }
-
-        /// <summary>
         /// Set the currenly position of the character, to later save in the database.
         /// </summary>
         public void SetPhysicalCharacterPosition()

--- a/Source/ACE/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -155,7 +155,7 @@ namespace ACE.Network.GameAction.Actions
             // TODO: Set other options from the packet
 
             // Save the options
-            session.Player.SaveOptions();
+            session.Player.SaveCharacter();
 
             return;
         }

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -274,14 +274,14 @@ namespace ACE.Network.Handlers
             CharacterCreateSetDefaultCharacterOptions(character);
             CharacterCreateSetDefaultCharacterPositions(character);
 
-            // bool saveSuccess = await DatabaseManager.Shard.SaveObject(character);
-            DbManager.SaveObject(character);
+            // We must await here -- 
+            bool saveSuccess = await DbManager.SaveObject(character);
 
-            // if (!saveSuccess)
-            // {
-            //    SendCharacterCreateResponse(session, CharacterGenerationVerificationResponse.DatabaseDown);
-            //    return;
-            // }
+            if (!saveSuccess)
+            {
+               SendCharacterCreateResponse(session, CharacterGenerationVerificationResponse.DatabaseDown);
+               return;
+            }
             // DatabaseManager.Shard.SaveCharacterOptions(character);
             // DatabaseManager.Shard.InitCharacterPositions(character);
 

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -138,7 +138,6 @@ namespace ACE.Network
         {
             if (this.Player != null)
             {
-                this.Player.SaveOptions();
                 this.Player.SaveCharacter();
             }
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 # ACEmulator Change Log
+
+### 2017-06-21
+[ddevec]
+* Forced character creation to wait for DbManager.SaveObject() to finish saving the character to avoid a race condition on character creation causing crashing
+* Changed DbManager functionality to more cleanly allow shutdown.
+
 ### 2017-06-20
 [StackOverflow]
 * Moved Saving operations outside of primary game loop to prevent db operations from slowing down primary game loop.


### PR DESCRIPTION
There is a bug in one of our latest patches, in which asynchronous saving races with loading, causing the game to sometimes (frequently) crash on player creation.  This patch causes that function (run in session network handler, so can block) to wait for the initial character creation DB save to complete before attempting login/load.

Also fixes issue in prior code in which the asynchronous saving loop would not stop when server shutdown was requested.