### PR TITLE
Fixed logoff crashing bug

### DIFF
--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -609,7 +609,6 @@ namespace ACE.Command.Handlers
             session.Network.EnqueueSend(positionMessage);
         }
 
-        // FIXME(ddevec): Reintroduce once spelltables are merged back in
         /*
         /// <summary>
         /// Debug command to test the ObjDescEvent message. 

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -78,16 +78,13 @@ namespace ACE.Command.Handlers
             "Recalls the last portal used.")]
         public static void HandleDebugPortalRecall(Session session, params string[] parameters)
         {
-            if (session.Player.LastPortal != null)
-            {
-                session.Player.Teleport(session.Player.LastPortal);
-            }
-            else
+            session.Player.HandleActionTeleToPosition(PositionType.LastPortal, () =>
+            // On error
             {
                 // You are too powerful to interact with that portal!
                 var portalRecallMessage = new GameEventDisplayStatusMessage(session, StatusMessageType1.Enum_04A3);
                 session.Network.EnqueueSend(portalRecallMessage);
-            }
+            });
         }
 
         // grantxp ulong

--- a/Source/ACE/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE/Command/Handlers/DebugCommands.cs
@@ -651,6 +651,7 @@ namespace ACE.Command.Handlers
                 ChatPacket.SendServerMessage(session, "Please enter a value greater than 0x10000000 and less than 0x1000086C", ChatMessageType.Broadcast);
             }
         }
+        */
 
         /// <summary>
         /// Debug command to learn a spell.
@@ -693,7 +694,6 @@ namespace ACE.Command.Handlers
                 session.Network.EnqueueSend(errorMessage);
             }
         }
-        */
 
         /// <summary>
         /// Debug command to print out all of the active players connected too the server.

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -9,8 +9,6 @@ namespace ACE.Entity
     {
         private readonly Dictionary<ObjectGuid, WorldObject> inventory = new Dictionary<ObjectGuid, WorldObject>();
 
-        private readonly object inventoryMutex = new object();
-
         public Container(ObjectType type, ObjectGuid guid, string name, ushort weenieClassId, ObjectDescriptionFlag descriptionFlag, WeenieHeaderFlag weenieFlag, Position position)
             : base(type, guid)
         {
@@ -76,12 +74,9 @@ namespace ACE.Entity
         public ushort UpdateBurden()
         {
             ushort calculatedBurden = 0;
-            lock (inventoryMutex)
+            foreach (KeyValuePair<ObjectGuid, WorldObject> entry in inventory)
             {
-                foreach (KeyValuePair<ObjectGuid, WorldObject> entry in inventory)
-                {
-                    calculatedBurden += entry.Value.Burden ?? 0;
-                }
+                calculatedBurden += entry.Value.Burden ?? 0;
             }
             return calculatedBurden;
         }

--- a/Source/ACE/Entity/Creature.cs
+++ b/Source/ACE/Entity/Creature.cs
@@ -150,6 +150,11 @@ namespace ACE.Entity
             return onKillChain;
         }
 
+        virtual protected float GetCorpseSpawnTime()
+        {
+            return 60;
+        }
+
         public ActionChain GetCreateCorpseChain()
         {
             ActionChain createCorpseChain = new ActionChain(this, () =>
@@ -164,14 +169,14 @@ namespace ACE.Entity
                 // Corpses stay on the ground for 5 * player level but minimum 1 hour
                 // corpse.DespawnTime = Math.Max((int)session.Player.PropertiesInt[Enum.Properties.PropertyInt.Level] * 5, 360) + WorldManager.PortalYearTicks; // as in live
                 // corpse.DespawnTime = 20 + WorldManager.PortalYearTicks; // only for testing
-                float despawnTime = 10;
+                float despawnTime = GetCorpseSpawnTime();
 
                 // Create corpse
                 CurrentLandblock.AddWorldObject(corpse);
                 // Create corpse decay
                 ActionChain despawnChain = new ActionChain();
                 despawnChain.AddDelaySeconds(despawnTime);
-                despawnChain.AddAction(CurrentLandblock, () => CurrentLandblock.RemoveWorldObject(corpse.Guid, false));
+                despawnChain.AddAction(CurrentLandblock, () => corpse.CurrentLandblock.RemoveWorldObject(corpse.Guid, false));
                 despawnChain.EnqueueChain();
             });
 
@@ -200,18 +205,8 @@ namespace ACE.Entity
             // If the object is a creature, Remove it from from Landblock
             if (!isDerivedPlayer)
             {
-                /*
-                QueuedGameAction removeCreature = new QueuedGameAction(this.Guid.Full, this, true, true, GameActionType.ObjectDelete);
-                session.Player.AddToActionQueue(removeCreature);
-                */
                 CurrentLandblock.RemoveWorldObject(Guid, false);
             }
-
-            // Add Corpse in that location via the ActionQueue to honor the motion delays
-            /*
-            QueuedGameAction addCorpse = new QueuedGameAction(this.Guid.Full, corpse, true, GameActionType.ObjectCreate);
-            session.Player.AddToActionQueue(addCorpse);
-            */
         }
 
         /// <summary>

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -98,10 +98,14 @@ namespace ACE.Entity
             get { return AceObject.AceObjectPropertiesPositions; }
         }
 
-        public Position PositionSanctuary {
+        private Position PositionSanctuary {
             get
             {
-                return Positions[PositionType.Sanctuary];
+                if (Positions.ContainsKey(PositionType.Sanctuary))
+                {
+                    return Positions[PositionType.Sanctuary];
+                }
+                return null;
             }
             set
             {
@@ -109,10 +113,14 @@ namespace ACE.Entity
             }
         }
 
-        public Position PositionLastPortal {
+        private Position PositionLastPortal {
             get
             {
-                return Positions[PositionType.LastPortal];
+                if (Positions.ContainsKey(PositionType.LastPortal))
+                {
+                    return Positions[PositionType.LastPortal];
+                }
+                return null;
             }
             set
             {
@@ -123,11 +131,6 @@ namespace ACE.Entity
         public ReadOnlyDictionary<CharacterOption, bool> CharacterOptions
         {
             get { return Character.CharacterOptions; }
-        }
-
-        public Position LastPortal
-        {
-            get { return Positions[PositionType.LastPortal]; }
         }
 
         public ReadOnlyCollection<Friend> Friends
@@ -700,8 +703,40 @@ namespace ACE.Entity
         public override ActionChain GetOnKillChain(Session killerSession)
         {
             // First do on-kill
-            ActionChain onKillChain = base.GetOnKillChain(killerSession);
-            onKillChain.AddAction(this, () => OnKill(killerSession));
+            ActionChain onKillChain = new ActionChain(this, () => OnKill(killerSession));
+            onKillChain.AddChain(base.GetOnKillChain(killerSession));
+
+            // Send the teleport out
+            onKillChain.AddAction(this, () =>
+            {
+                // teleport to sanctuary or best location
+                Position newPosition = PositionSanctuary ?? PositionLastPortal ?? Location;
+
+                // Enqueue a teleport action, followed by Stand-up
+                // Queue the teleport to lifestone
+                ActionChain teleportChain = GetTeleportChain(newPosition);
+
+                teleportChain.AddAction(this, () =>
+                {
+                    // Regenerate/ressurect?
+                    UpdateVitalInternal(Health, 5);
+
+                    // Stand back up
+                    DoMotion(new UniversalMotion(MotionStance.Standing));
+
+                    // add a Corpse at the current location via the ActionQueue to honor the motion and teleport delays
+                    // QueuedGameAction addCorpse = new QueuedGameAction(this.Guid.Full, corpse, true, GameActionType.ObjectCreate);
+                    // AddToActionQueue(addCorpse);
+                    // If the player is outside of the landblock we just died in, then reboadcast the death for
+                    // the players at the lifestone.
+                    if (Positions.ContainsKey(PositionType.LastOutsideDeath) && Positions[PositionType.LastOutsideDeath].Cell != newPosition.Cell)
+                    {
+                        string currentDeathMessage = $"died to {killerSession.Player.Name}.";
+                        ActionBroadcastKill($"{Name} has {currentDeathMessage}", Guid, killerSession.Player.Guid);
+                    }
+                });
+                teleportChain.EnqueueChain();
+            });
 
             return onKillChain;
         }
@@ -747,47 +782,6 @@ namespace ACE.Entity
 
             // Broadcast the 019E: Player Killed GameMessage
             ActionBroadcastKill($"{Name} has {currentDeathMessage}", Guid, killerId);
-
-            /* ddevec -- handled by Creature::OnKill
-            // create corpse at location
-            var corpse = CorpseObjectFactory.CreateCorpse(this, this.Location);
-            corpse.Location.PositionY -= corpse.PhysicsData.ObjScale ?? 0;
-            corpse.Location.PositionZ -= (corpse.PhysicsData.ObjScale ?? 0) / 2;
-
-            // Corpses stay on the ground for 5 * player level but minimum 1 hour
-            // corpse.DespawnTime = Math.Max((int)session.Player.PropertiesInt[Enum.Properties.PropertyInt.Level] * 5, 360) + WorldManager.PortalYearTicks; // as in live
-            corpse.DespawnTime = 20 + WorldManager.PortalYearTicks; // only for testing
-
-            // Save character's last death position - for the time being, we will use any position
-            SetCharacterPosition(PositionType.LastOutsideDeath, Location);
-            */
-
-            // teleport to sanctuary or best location
-            Position newPosition = PositionSanctuary ?? PositionLastPortal ?? Location;
-
-            // Enqueue a teleport action, followed by Stand-up
-            // Queue the teleport to lifestone
-            ActionChain teleportChain = GetTeleportChain(newPosition);
-
-            teleportChain.AddAction(this, () =>
-            {
-                // Regenerate/ressurect?
-                UpdateVitalInternal(Health, 5);
-
-                // Stand back up
-                DoMotion(new UniversalMotion(MotionStance.Standing));
-
-                // add a Corpse at the current location via the ActionQueue to honor the motion and teleport delays
-                // QueuedGameAction addCorpse = new QueuedGameAction(this.Guid.Full, corpse, true, GameActionType.ObjectCreate);
-                // AddToActionQueue(addCorpse);
-                // If the player is outside of the landblock we just died in, then reboadcast the death for
-                // the players at the lifestone.
-                if (Positions.ContainsKey(PositionType.LastOutsideDeath) && Positions[PositionType.LastOutsideDeath].Cell != newPosition.Cell)
-                {
-                    ActionBroadcastKill($"{Name} has {currentDeathMessage}", Guid, killerId);
-                }
-            });
-            teleportChain.EnqueueChain();
         }
 
         public void HandleActionExamination(ObjectGuid examinationId)

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -232,7 +232,8 @@ namespace ACE.Managers
                 Parallel.ForEach(movedObjects, wo =>
                 {
                     // If it was picked up, or moved
-                    if (wo.Location.LandblockId != wo.CurrentLandblock.Id)
+                    // NOTE: The object's Location can now be null, if a player logs out, or an item is picked up
+                    if (wo.Location != null && wo.Location.LandblockId != wo.CurrentLandblock.Id)
                     {
                         LandblockManager.RelocateObject(wo);
                     }

--- a/Source/ACE/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -155,7 +155,7 @@ namespace ACE.Network.GameAction.Actions
             // TODO: Set other options from the packet
 
             // Save the options
-            session.Player.SaveCharacter();
+            session.Player.HandleActionSaveCharacter();
 
             return;
         }

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -5,6 +5,7 @@ using System.Net;
 using ACE.Common;
 using ACE.Database;
 using ACE.Entity;
+using ACE.Entity.Actions;
 using ACE.Entity.Enum;
 using ACE.Network.Enum;
 using ACE.Network.GameMessages.Messages;
@@ -130,7 +131,7 @@ namespace ACE.Network
         {
             if (this.Player != null)
             {
-                this.Player.SaveCharacter();
+                this.Player.HandleActionSaveCharacter();
             }
         }
 
@@ -182,7 +183,7 @@ namespace ACE.Network
             if (Player != null)
             {
                 SaveSession();
-                Player.Logout(true);
+                Player.HandleActionLogout(true);
             }
 
             WorldManager.RemoveSession(this);
@@ -190,8 +191,12 @@ namespace ACE.Network
 
         public void LogOffPlayer()
         {
-            SaveSession();
-            Player.Logout();
+            // First save, then logout
+            ActionChain logoutChain = new ActionChain();
+            logoutChain.AddChain(Player.GetSaveChain());
+            logoutChain.AddChain(Player.GetLogoutChain());
+            logoutChain.EnqueueChain();
+
             logOffRequestTime = DateTime.UtcNow;
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Minor fixups to player tracking
 * Forced character creation to wait for DbManager.SaveObject() to finish saving the character to avoid a race condition on character creation causing crashing
 * Changed DbManager functionality to more cleanly allow shutdown.
+* KNOWN BUG: On-death player often doesn't emerge from portal space
 
 ### 2017-06-20
 [StackOverflow]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,20 @@
 
 ### 2017-06-21
 [ddevec]
+* Fix logoff crash in core/landblock restrucutre due to nulliing a location then
+      moving an object
+
+### 2017-06-21
+[ddevec]
+* Major overhaul to core/landblock structure.  Details can be found: (https://github.com/ACEmulator/ACE/pull/398#partial-pull-merging)
+* Added actor/action interface
+* Restrucutred parallelism in WorldManager
+* Added broadcast system
+* Added plugins for what will hopefully one day be a physics system
+* Minor fixups to player tracking
+
+### 2017-06-21
+[ddevec]
 * Forced character creation to wait for DbManager.SaveObject() to finish saving the character to avoid a race condition on character creation causing crashing
 * Changed DbManager functionality to more cleanly allow shutdown.
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,18 +5,12 @@
 * Fix logoff crash in core/landblock restrucutre due to nulliing a location then
       moving an object
 * Also reintroduced learnspell       
-
-### 2017-06-21
-[ddevec]
 * Major overhaul to core/landblock structure.  Details can be found: (https://github.com/ACEmulator/ACE/pull/398#partial-pull-merging)
 * Added actor/action interface
 * Restrucutred parallelism in WorldManager
 * Added broadcast system
 * Added plugins for what will hopefully one day be a physics system
 * Minor fixups to player tracking
-
-### 2017-06-21
-[ddevec]
 * Forced character creation to wait for DbManager.SaveObject() to finish saving the character to avoid a race condition on character creation causing crashing
 * Changed DbManager functionality to more cleanly allow shutdown.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 [ddevec]
 * Fix logoff crash in core/landblock restrucutre due to nulliing a location then
       moving an object
+* Also reintroduced learnspell       
 
 ### 2017-06-21
 [ddevec]


### PR DESCRIPTION
My branch was causing a racy bug on logoff because I had not synchronized those operations with the server.  Those operations are now synchronized, as well as properly adding broadcasting for the logoff animation, and a timeout before the player is removed from world (while the logoff animation plays).

And uncommented learnspell (which now broadcasts the animation, so all can see you learn a spell).