### PR TITLE
Shutdown Controls

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -40,6 +40,13 @@ namespace ACE.Common
         public ConfigAccountDefaults Accounts { get; set; }
 
         public string DatFilesDirectory { get; set; }
+
+        /// <summary>
+        /// The ammount of seconds to wait before turning off the server. Default value is 60 (for 1 minute).
+        /// </summary>
+        [System.ComponentModel.DefaultValue(60)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public uint ShutdownInterval { get; set; }
     }
 
     public struct ConfigMySqlDatabase

--- a/Source/ACE/ACE.cs
+++ b/Source/ACE/ACE.cs
@@ -23,6 +23,7 @@ namespace ACE
             Console.Title = @"ACEmulator";
 
             ConfigManager.Initialize();
+            ServerManager.Initialize();
             DatabaseManager.Initialize();
             DbManager.Initialize();
             AssetManager.Initialize();

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Managers\DbManager.cs" />
     <Compile Include="Managers\GuidManager.cs" />
     <Compile Include="Managers\LandblockManager.cs" />
+    <Compile Include="Managers\ServerManager.cs" />
     <Compile Include="Network\ChatPacket.cs" />
     <Compile Include="Network\ClientMessage.cs" />
     <Compile Include="Network\ClientPacket.cs" />
@@ -378,7 +379,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>copy "$(ProjectDir)config.json" "$(TargetDir)config.json"</PreBuildEvent>
+    <PreBuildEvent>copy "$(ProjectDir)Config.json" "$(TargetDir)Config.json"</PreBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\StyleCop.MSBuild.5.0.0-beta01\build\StyleCop.MSBuild.targets" />
 </Project>

--- a/Source/ACE/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE/Command/Handlers/AdminCommands.cs
@@ -1471,5 +1471,111 @@ namespace ACE.Command.Handlers
 
             // TODO: output
         }
+
+        /// <summary>
+        /// Cancels an in-progress shutdown event.
+        /// </summary>
+        [CommandHandler("cancel-shutdown", AccessLevel.Admin, CommandHandlerFlag.None, 0,
+            "Stops an active server shutdown.",
+            "@cancel-shutdown")]
+        public static void HandleCancelShutdown(Session session, params string[] parameters)
+        {
+            ServerManager.CancelShutdown();
+        }
+
+        /// <summary>
+        /// Increase or decrease the server shutdown interval in seconds
+        /// </summary>
+        [CommandHandler("set-shutdown-interval", AccessLevel.Admin, CommandHandlerFlag.None, 1,
+            "Changes the delay before the server will shutdown.",
+            "@set-shutdown-interval < 0-99999 >")]
+        public static void HandleSetShutdownInterval(Session session, params string[] parameters)
+        {
+            if (parameters?.Length > 0)
+            {
+                uint newShutdownInterval = 0;
+                // delay server shutdown for up to x minutes
+                // limit to uint length 65535
+                string parseInt = parameters[0].Length > 5 ? parameters[0].Substring(0, 5) : parameters[0];
+                if (uint.TryParse(parseInt, out newShutdownInterval))
+                {
+                    // newShutdownInterval is represented as a time element
+                    if (newShutdownInterval > uint.MaxValue) newShutdownInterval = uint.MaxValue;
+
+                    // set the interval
+                    ServerManager.SetShutdownInterval(Convert.ToUInt32(newShutdownInterval));
+
+                    // message the admin
+                    ChatPacket.SendServerMessage(session, $"Shutdown Interval (seconds to shutdown server) has been set to {ServerManager.ShutdownInterval}.", ChatMessageType.Broadcast);
+                    return;
+                }
+            }
+            ChatPacket.SendServerMessage(session, "Usage: /change-shutdown-interval <00000>", ChatMessageType.Broadcast);
+        }
+
+        /// <summary>
+        /// Immediately begins the shutdown process by setting the shutdown interval to 0 before executing the shutdown method
+        /// </summary>
+        [CommandHandler("stop-now", AccessLevel.Admin, CommandHandlerFlag.None, -1,
+            "Shuts the server down, immediately!",
+            "\nThis command will attempt to safely logoff all players, before shutting down the server.")]
+        public static void ShutdownServerNow(Session session, params string[] parameters)
+        {
+            ServerManager.SetShutdownInterval(0);
+            ShutdownServer(session, parameters);
+        }
+
+        /// <summary>
+        /// Function to shutdown the server from console or in-game.
+        /// </summary>
+        [CommandHandler("shutdown", AccessLevel.Admin, CommandHandlerFlag.None, 0,
+            "Begins the server shutdown process. Optionally displays a shutdown message, if a string is passed.",
+            "< Optional Shutdown Message >\n"+
+            "\tUse @cancel-shutdown too abort an active shutdown!\n" +
+            "\tSet the shutdown delay with @set-shutdown-interval < 0-99999 >")]
+        public static void ShutdownServer(Session session, params string[] parameters)
+        {
+            // inform the world that a shutdown is about to take place
+            string shutdownInitiator = (session == null ? "Server" : session.Player.Name.ToString());
+            string shutdownText = "";
+            string adminShutdownText = "";
+            TimeSpan timeTillShutdown = TimeSpan.FromSeconds(ServerManager.ShutdownInterval);
+            string timeRemaining = (timeTillShutdown.TotalSeconds > 120 ? $"The server will go down in {(int)timeTillShutdown.TotalMinutes} minutes." 
+                : $"The server will go down in {timeTillShutdown.TotalSeconds} seconds.");
+
+            // add admin shutdown text
+            if (parameters?.Length > 0)
+            {
+                foreach (var word in parameters)
+                {
+                    if (adminShutdownText.Length > 0)
+                        adminShutdownText += " " + (string)word;
+                    else
+                        adminShutdownText += (string)word;
+                }
+            }
+
+            shutdownText += $"{shutdownInitiator} initiated a complete server shutdown @ {DateTime.UtcNow} UTC";
+
+            // output to console (log in the future)
+            Console.WriteLine(shutdownText);
+            Console.WriteLine(timeRemaining);
+
+            if (adminShutdownText.Length > 0)
+                Console.WriteLine("Admin message: " + adminShutdownText);
+
+            // send a message to each player that the server will go down in x interval
+            foreach (var player in WorldManager.GetAll())
+            {
+                // send server shutdown message and time remaining till shutdown
+                player.Network.EnqueueSend(new GameMessageSystemChat(shutdownText + "\n" + timeRemaining, ChatMessageType.Broadcast));
+
+                if (adminShutdownText.Length > 0)
+                    player.Network.EnqueueSend(new GameMessageSystemChat($"Message from {shutdownInitiator}: {adminShutdownText}", ChatMessageType.Broadcast));
+
+            }
+            ServerManager.BeginShutdown();
+        }
     }
 }
+

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -11,7 +11,8 @@
             "OverrideCharacterPermissions": true,
             "DefaultAccessLevel": 0
         },
-        "DatFilesDirectory": "c:\\ACE\\"
+      "DatFilesDirectory": "c:\\ACE\\",
+      "ShutdownInterval":  "60"
     },
     "MySql": {
         "Authentication": {

--- a/Source/ACE/Managers/ServerManager.cs
+++ b/Source/ACE/Managers/ServerManager.cs
@@ -1,0 +1,120 @@
+﻿using ACE.Common;
+using log4net;
+using System;
+using System.Threading;
+
+namespace ACE.Managers
+{
+    /// <summary>
+    /// Servermanager handles unloading the server application properly.
+    /// </summary>
+    /// <remarks>
+    ///   Possibly useful for:
+    ///     1. Monitor for errors and performance issues in LandblockManager, GuidManager, WorldManager,
+    ///         DatabaseManager, or AssetManager
+    ///   Known issue:
+    ///     1. No method to verify that everything unloaded properly.
+    /// </remarks>
+    public static class ServerManager
+    {
+        /// <summary>
+        /// Indicates advanced warning if the applcation will unload.
+        /// </summary>
+        public static bool ShutdownInitiated { get; private set; }
+
+        /// <summary>
+        /// The amount of seconds that the server will wait before unloading the application.
+        /// </summary>
+        public static uint ShutdownInterval { get; private set; }
+
+        /// <summary>
+        /// Sets the Shutdown Interval in Seconds
+        /// </summary>
+        /// <param name="interval">postive value representing seconds</param>
+        public static void SetShutdownInterval(uint interval)
+        {
+            log.Warn($"Server shutdown interval reset: {interval}");
+            ShutdownInterval = interval;
+        }
+
+        public static void Initialize()
+        {
+            // Loads the configuration for ShutdownInterval from the settings file.
+            ShutdownInterval = ConfigManager.Config.Server.ShutdownInterval;
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Starts the shutdown wait thread.
+        /// </summary>
+        public static void BeginShutdown()
+        {
+            ShutdownInitiated = true;
+            var shutdownThread = new Thread(ShutdownServer);
+            shutdownThread.Start();
+        }
+
+        /// <summary>
+        /// Calling this function will always cancel an in-progress shutdown (application unload). This will also
+        /// stop the shutdown wait thread and alert users that the server will stay in operation.
+        /// </summary>
+        public static void CancelShutdown()
+        {
+            ShutdownInitiated = false;
+        }
+
+        /// <summary>
+        /// Threaded task created when performing a server shutdown
+        /// </summary>
+        private static void ShutdownServer()
+        {
+            DateTime shutdownTime = DateTime.UtcNow.AddSeconds(ShutdownInterval);
+
+            // wait for shutdown interval to expire
+            while (shutdownTime != DateTime.MinValue && shutdownTime >= DateTime.UtcNow)
+            {
+                // this allows the server shutdown to be canceled
+                if (!ShutdownInitiated)
+                {
+                    // reset shutdown details
+                    string shutdownText = $"The server has canceled the shutdown procedure @ {DateTime.UtcNow} UTC";
+                    log.Warn(shutdownText);
+                    // special text
+                    foreach (var player in WorldManager.GetAll())
+                    {
+                        player.WorldBroadcast(shutdownText);
+                    }
+                    // break function
+                    return;
+                }
+            }
+
+            // logout each player
+            foreach (var player in WorldManager.GetAll(false))
+            {
+                player.LogOffPlayer();
+            }
+
+            // wait 6 seconds for log-off
+            Thread.Sleep(6000);
+
+            // TODO: Make sure that the landblocks unloads properly.
+
+            // TODO: Make sure that the databasemanager unloads properly.
+
+            // disabled thread update loop and halt application
+            WorldManager.StopWorld();
+            // wait for world to end
+            while (WorldManager.WorldActive)
+            {
+                // no nothing
+            }
+
+            // write exit to console/log
+            log.Warn($"Exiting at {DateTime.UtcNow}");
+            // system exit
+            Environment.Exit(Environment.ExitCode);
+        }
+    }
+}

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -27,7 +27,8 @@ namespace ACE.Managers
         private static readonly List<Session> sessions = new List<Session>();
         private static readonly ReaderWriterLockSlim sessionLock = new ReaderWriterLockSlim();
 
-        private static bool pendingWorldStop;
+        private static volatile bool pendingWorldStop;
+        public static bool WorldActive { get; private set; }
 
         public static DateTime WorldStartTime { get; } = DateTime.UtcNow;
 
@@ -111,6 +112,10 @@ namespace ACE.Managers
             return session;
         }
 
+        /// <summary>
+        /// Removes a player or worldobject from the active world.
+        /// </summary>
+        /// <param name="session"></param>
         public static void RemoveSession(Session session)
         {
             sessionLock.EnterWriteLock();
@@ -186,6 +191,11 @@ namespace ACE.Managers
             }
         }
 
+        /// <summary>
+        /// Returns a list of all players currently online
+        /// </summary>
+        /// <param name="isOnlineRequired">false returns all players (offline or online)</param>
+        /// <returns>List<> of all online players on the server</returns>
         public static List<Session> GetAll(bool isOnlineRequired = true)
         {
             sessionLock.EnterReadLock();
@@ -202,11 +212,14 @@ namespace ACE.Managers
             }
         }
 
+        /// <summary>
+        /// Function to begin ending the operations inside of an active world.
+        /// </summary>
         public static void StopWorld() { pendingWorldStop = true; }
 
         /// <summary>
         /// Manages updating all entities on the world.
-        ///  - Nerver-side command-line commands are handled in their own thread.
+        ///  - Server-side command-line commands are handled in their own thread.
         ///  - Network commands come from their own listener threads, and are queued in world objects
         ///  - This thread does the rest of the work!
         /// </summary>
@@ -214,7 +227,7 @@ namespace ACE.Managers
         {
             log.DebugFormat("Starting UpdateWorld thread");
             double lastTick = 0d;
-
+            WorldActive = true;
             var worldTickTimer = new Stopwatch();
             while (!pendingWorldStop)
             {
@@ -305,6 +318,8 @@ namespace ACE.Managers
                 lastTick = (double)worldTickTimer.ElapsedTicks / Stopwatch.Frequency;
                 PortalYearTicks += lastTick;
             }
+            // World has finished operations and concedes the thread to garbage collection
+            WorldActive = false;
         }
 
         private static IEnumerable<WorldObject> FakePhysics(double timeTick)

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -228,5 +228,14 @@ namespace ACE.Network
             // TODO: Hook in a player disconnect function and prevent the LogOffPlayer() function from firing after this diconnect has occurred.
             Network.EnqueueSend(new GameMessageBootAccount(this));
         }
+        /// <summary>
+        /// Sends a broadcast message to the player
+        /// </summary>
+        /// <param name="broadcastMessage"></param>
+        public void WorldBroadcast(string broadcastMessage)
+        {
+            var worldBroadcastMessage = new GameMessageSystemChat(broadcastMessage, ChatMessageType.Broadcast);
+            Network.EnqueueSend(worldBroadcastMessage);
+        }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # ACEmulator Change Log
 
+### 2017-06-22
+[fantoms]
+* Added `@set-shutdown-interval` command, to change the delay on the fly.
+* Added `@shutdown`, `@stop-now`, and `@cancel-shutdown` commands.
+* Added server shutdown command for admins - needed in consoles.
+* Added shutdown text, logoff, admin shutdown message.
+* Added `ShutdownInterval` to the `ConfigManager` Server Section, with a default of 60 seconds.
+* Added `ShutdownInterval` to the example config
+* Added some logging and moved the final exit too `ServerManager`.
+* Added a message broadcast through Session, to announce server broadcast messages from `WorldManager`.
+* Changed the case of the Config.json in the project build events, to match a Linux use case requirement for opening the Config file.
+
 ### 2017-06-21
 [ddevec]
 * Fix logoff crash in core/landblock restrucutre due to nulliing a location then


### PR DESCRIPTION
With these changes, there is now a way to stop the server after an interval has passed.

Stop the server after the interval set in the Config has Passed:
`@shutdown <shutdown text>`
Stop the Server immediately:
`@stop-now`
Cancel an in progress shutdown:
`@cancel-shutdown`
Change the seconds to wait until shutdown:
`@set-shutdown-interval <0-99999>`

There is also now a config change that adds an additional variable called `ShutdownInterval`. The goal of the variable is to tell the server how many seconds it will need to wait until shutdown. The maximum seconds allowed is 99999 and the default is 60.

This request has been worked on and tested since April, please let me know if you spot any issues. Previous iteration can be found here with additional concepts/scenarios: (https://github.com/LtRipley36706/ACE/pull/13). 

Here is an updated log:
- Added `@set-shutdown-interval` command, to change the delay on the fly.
- Added `@shutdown`, `@stop-now`, and `@cancel-shutdown` commands.
- Added server shutdown command for admins - needed in consoles.
- Added shutdown text, logoff, admin shutdown message.
- Added `ShutdownInterval` to the `ConfigManager` Server Section, with a default of 60 seconds.
- Added `ShutdownInterval` to the example config
- Added some logging and moved the final exit too `ServerManager`.
- Added a message broadcast through Session, to announce server broadcast messages from `WorldManager`.
- Changed the case of the Config.json in the project build events, to match a Linux use case requirement for opening the Config file.