### PR TITLE
Quick fix for Portals to become functional

### DIFF
--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -150,7 +150,11 @@ namespace ACE.Database
                 o.TextureOverrides = GetAceObjectTextureMaps(o.AceObjectId);
                 o.AnimationOverrides = GetAceObjectAnimations(o.AceObjectId);
                 o.PaletteOverrides = GetAceObjectPalettes(o.AceObjectId);
-                o.AceObjectPropertiesPositions = GetAceObjectPositions(o.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
+                // o.AceObjectPropertiesPositions = GetAceObjectPositions(o.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
+                // The following three lines is code drafted by Og II for the purpose of linking a weenie's position data to an instance's position data.
+                Dictionary<PositionType, Position> instancePositions = GetAceObjectPositions(o.AceObjectId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
+                Dictionary<PositionType, Position> weeniePositions = GetAceObjectPositions(o.WeenieClassId).ToDictionary(x => (PositionType)x.DbPositionType, x => new Position(x));
+                o.AceObjectPropertiesPositions = instancePositions.Union(instancePositions).Union(weeniePositions).ToDictionary(k => k.Key, v => v.Value); // not deduped ?
                 ret.Add(o);
             });
             return ret;

--- a/Source/ACE/Entity/CollidableObject.cs
+++ b/Source/ACE/Entity/CollidableObject.cs
@@ -66,6 +66,8 @@ namespace ACE.Entity
             TargetType = aceO.TargetTypeId;
             Usable = (Usable?)aceO.ItemUseable;
 
+            Type = (ObjectType)aceO.ItemType;
+
             aceO.AnimationOverrides.ForEach(ao => ModelData.AddModel(ao.Index, (ushort)ao.AnimationId));
             aceO.TextureOverrides.ForEach(to => ModelData.AddTexture(to.Index, (ushort)to.OldId, (ushort)to.NewId));
             aceO.PaletteOverrides.ForEach(po => ModelData.AddPalette(po.SubPaletteId, po.Offset, po.Length));

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # ACEmulator Change Log
 
+### 2017-06-23
+[Ripley]
+* Added code to set ObjectType stored in database on CollidableObjects
+* Added code provided by @ogmage78 to WorldDatabase to link position data of a weenie to its many instances.
+* The above change re-enables double click use of portals that have destination data in ACE-World. Happy portalling!
+
 ### 2017-06-21
 [ddevec]
 * Fix logoff crash in core/landblock restrucutre due to nulliing a location then


### PR DESCRIPTION
Code provided by @ogmage78 successfully re-enables portals to work again on double click provided they have PositionType.Destination data in the ACE-World database. Latest release of database includes all previously submitted portal destination data.

Also corrected ObjectType issue in CollidableObject. It was not being set from data stored in database leading to aberrant behavior in OnUse in game.