### PR TITLE
Fixed several movement related bugs

### DIFF
--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -217,6 +217,11 @@ namespace ACE.Entity
             return new Actions.ActionChain(this, () => AddWorldObjectInternal(wo));
         }
 
+        public void AddWorldObjectForPhysics(WorldObject wo)
+        {
+            AddWorldObjectInternal(wo);
+        }
+
         private void AddWorldObjectInternal(WorldObject wo)
         {
             Log($"adding {wo.Guid.Full.ToString("X")}");
@@ -260,6 +265,11 @@ namespace ACE.Entity
             return null;
         }
 
+        /// <summary>
+        /// Should only be called by physics/relocation engines -- not from player
+        /// </summary>
+        /// <param name="objectId"></param>
+        /// <param name="adjacencyMove"></param>
         public void RemoveWorldObjectForPhysics(ObjectGuid objectId, bool adjacencyMove)
         {
             RemoveWorldObjectInternal(objectId, adjacencyMove);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1251,12 +1251,11 @@ namespace ACE.Entity
 
             teleportChain.AddAction(this, () => TeleportInternal(newPosition));
 
-            teleportChain.AddDelaySeconds(10);
-            // Use ForceUpdate b/c it overrides physics motions
+            teleportChain.AddDelaySeconds(3);
+            // Once back in world we can start listening to the game's request for positions
             teleportChain.AddAction(this, () => 
             {
                 InWorld = true;
-                ForceUpdatePosition(newPosition);
             });
 
             return teleportChain;

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -754,6 +754,12 @@ namespace ACE.Entity
             RequestedLocation = newPosition;
         }
 
+        public void ClearRequestedPositions()
+        {
+            ForcedLocation = null;
+            RequestedLocation = null;
+        }
+
         /// <summary>
         /// Alerts clients of change in position
         /// </summary>

--- a/Source/ACE/Managers/LandblockManager.cs
+++ b/Source/ACE/Managers/LandblockManager.cs
@@ -73,12 +73,19 @@ namespace ACE.Managers
         }
 
         /// <summary>
-        /// Relocates an object to the appropriate landblock
+        /// Relocates an object to the appropriate landblock -- Should only be called from physics/worldmanager -- not player!
         /// </summary>
-        public static void RelocateObject(WorldObject worldObject)
+        public static void RelocateObjectForPhysics(WorldObject worldObject)
         {
-            var block = GetLandblock(worldObject.Location.LandblockId, true);
-            block.AddWorldObject(worldObject);
+            var oldBlock = worldObject.CurrentLandblock;
+            var newBlock = GetLandblock(worldObject.Location.LandblockId, true);
+            // Remove from the old landblock -- force
+            if (oldBlock != null)
+            {
+                oldBlock.RemoveWorldObjectForPhysics(worldObject.Guid, true);
+            }
+            // Add to the new landblock
+            newBlock.AddWorldObjectForPhysics(worldObject);
         }
 
         /// <summary>

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -229,15 +229,16 @@ namespace ACE.Managers
                 IEnumerable<WorldObject> movedObjects = FakePhysics(PortalYearTicks);
 
                 // Do any pre-calculated landblock transfers --
-                Parallel.ForEach(movedObjects, wo =>
+                foreach (WorldObject wo in movedObjects)
                 {
                     // If it was picked up, or moved
                     // NOTE: The object's Location can now be null, if a player logs out, or an item is picked up
                     if (wo.Location != null && wo.Location.LandblockId != wo.CurrentLandblock.Id)
                     {
-                        LandblockManager.RelocateObject(wo);
+                        // NOTE: We are moving the objects on behalf of the physics 
+                        LandblockManager.RelocateObjectForPhysics(wo);
                     }
-                });
+                }
 
                 // FIXME(ddevec): This O(n^2) tracking loop is a remenant of the old structure -- we should probably come up with a more efficient tracking scheme
                 Parallel.ForEach(movedObjects, mo =>
@@ -331,6 +332,8 @@ namespace ACE.Managers
                     {
                         wo.PhysicsUpdatePosition(newPosition);
                     }
+
+                    wo.ClearRequestedPositions();
                 }
             });
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # ACEmulator Change Log
 
+### 2017-06-23
+[ddevec]
+* Fix to teleport freezing characters in place (Wasn't clearing requested location)
+* Fix to occasional crash when moving long distances (Wasn't properly handling landblock transferring)
+* Fix to glitch in movement when exiting teleport (was setting position when I shouldn't have been)
+
 ### 2017-06-21
 [ddevec]
 * Fix logoff crash in core/landblock restrucutre due to nulliing a location then


### PR DESCRIPTION
Bugs fixed:

- Player sticks when coming out of teleport (wasn't clearing requested positions properly from physics)
- Game sometimes crashes when transferring landblocks (Wasn't clearing player from old landblock properly)
- "glitch" in motion shortly after teleporting (was setting position after teleporting improperly).