### PR TITLE
Fix: Incorrect data type when changing a bigint property that has previously been set

### DIFF
--- a/Source/ACE.Entity/AceObject.cs
+++ b/Source/ACE.Entity/AceObject.cs
@@ -780,7 +780,7 @@ namespace ACE.Entity
                 }
                 else
                 {
-                    listItem.PropertyValue = (uint)value;
+                    listItem.PropertyValue = (ulong)value;
                 }
             }
             else

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # ACEmulator Change Log
 
 ### 2017-06-26
+[fantoms]
+* Changed from `uint` too `ulong` in the `bigint` properties, when a field has already been set.
+
 [Jyrus]
 * Add protection to the SpawnPortal method, so any old ushort cannot be used for the weenieclassID that it is expecting
 


### PR DESCRIPTION
* Changed from uint to ulong, to match the bigint/int64 data types.

This fix allows characters to once again level up correctly, along with allowing other properties to work.