### PR TITLE
Fix race in SpawnPortal when using ActionQueue and assign unique Id's to each Portal object

### DIFF
--- a/Source/ACE/Factories/SpecialPortalObjectFactory.cs
+++ b/Source/ACE/Factories/SpecialPortalObjectFactory.cs
@@ -28,6 +28,8 @@ namespace ACE.Factories
         {
             AceObject aceO = DatabaseManager.World.GetAceObjectByWeenie((ushort)weenieClassId);
 
+            aceO.AceObjectId = CommonObjectFactory.DynamicObjectId;
+
             aceO.AceObjectPropertiesPositions.Add(PositionType.Location, newPosition);
 
             WorldObject portal = new Portal(aceO);
@@ -37,7 +39,7 @@ namespace ACE.Factories
             // Create portal decay
             ActionChain despawnChain = new ActionChain();
             despawnChain.AddDelaySeconds(despawnTime);
-            despawnChain.AddAction(portal.CurrentLandblock, () => LandblockManager.RemoveObject(portal));
+            despawnChain.AddAction(portal, () => portal.CurrentLandblock.RemoveWorldObject(portal.Guid, false));
             despawnChain.EnqueueChain();
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ### 2017-06-26
 [Jyrus]
 * Add protection to the SpawnPortal method, so any old ushort cannot be used for the weenieclassID that it is expecting
+* Use CommonObjectFactory.DynamicObjectId to assign a unique AceObjectId to each spawn
+* Set the portal object as the IActor and the portal.CurrentLandblock.RemoveWorldObject(portal.Guid, false) as the action to perform
+* Reduce the decay timer to 15 seconds
 
 ### 2017-06-25
 [OptimShi]


### PR DESCRIPTION
Someone other than me should check this PR in practice to see if it really is working, and that it isn't just a fluke that it works for me, before it is merged.  Should be able to summon multiple portals and they all should individually disappear in 15 seconds.