### PR TITLE
For Review and possible merge: Fix portal requirements

### DIFF
--- a/Source/ACE.Database/CachingWorldDatabase.cs
+++ b/Source/ACE.Database/CachingWorldDatabase.cs
@@ -22,7 +22,6 @@ namespace ACE.Database
         /// </summary>
         private ConcurrentDictionary<uint, AceObject> _weenieCache = new ConcurrentDictionary<uint, AceObject>();
         
-
         public CachingWorldDatabase(IWorldDatabase wrappedDatabase)
         {
             _wrappedDatabase = wrappedDatabase;

--- a/Source/ACE/Entity/Portal.cs
+++ b/Source/ACE/Entity/Portal.cs
@@ -123,12 +123,18 @@ namespace ACE.Entity
 
         public uint MinimumLevel
         {
-            get { return AceObject.GetIntProperty(PropertyInt.MinLevel) ?? 0; }
+            get {
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                return weenie.GetIntProperty(PropertyInt.MinLevel) ?? 0;
+            }
         }
 
         public uint MaximumLevel
         {
-            get { return AceObject.GetIntProperty(PropertyInt.MaxLevel) ?? 0; }
+            get {
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                return weenie.GetIntProperty(PropertyInt.MaxLevel) ?? 0;
+            }
         }
 
         public uint SocietyId
@@ -138,23 +144,31 @@ namespace ACE.Entity
 
         public bool IsTieable
         {
-            get { return ((AceObject.GetIntProperty(PropertyInt.PortalBitmask) ?? 0) & (uint)PortalBitmask.NoRecall) == 0; }
+            get {
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                return ((AceObject.GetIntProperty(PropertyInt.PortalBitmask) ?? 0) & (uint)PortalBitmask.NoRecall) == 0;
+            }
             set
             {
-                uint current = AceObject.GetIntProperty(PropertyInt.PortalBitmask) ?? 0;
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                uint current = weenie.GetIntProperty(PropertyInt.PortalBitmask) ?? 0;
                 current = (value ? (current & ~(uint)PortalBitmask.NoRecall) : current | (uint)PortalBitmask.NoRecall);
-                AceObject.SetIntProperty(PropertyInt.PortalBitmask, current);
+                weenie.SetIntProperty(PropertyInt.PortalBitmask, current);
             }
         }
 
         public bool IsSummonable
         {
-            get { return ((AceObject.GetIntProperty(PropertyInt.PortalBitmask) ?? 0) & (uint)PortalBitmask.NoSummon) == 0; }
+            get {
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                return ((weenie.GetIntProperty(PropertyInt.PortalBitmask) ?? 0) & (uint)PortalBitmask.NoSummon) == 0;
+            }
             set
             {
-                uint current = AceObject.GetIntProperty(PropertyInt.PortalBitmask) ?? 0;
+                var weenie = Database.DatabaseManager.World.GetAceObjectByWeenie(AceObject.WeenieClassId);
+                uint current = weenie.GetIntProperty(PropertyInt.PortalBitmask) ?? 0;
                 current = (value ? (current & ~(uint)PortalBitmask.NoSummon) : current | (uint)PortalBitmask.NoSummon);
-                AceObject.SetIntProperty(PropertyInt.PortalBitmask, current);
+                weenie.SetIntProperty(PropertyInt.PortalBitmask, current);
             }
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2017-06-27
+[Jyrus]
+* Reactivated portal requirements by directing the lookups to the weenie entries in the IntProperty table, instead of the AceObject entries.
+* Fix StyleCop warning in CachingWorldDatabase.cs
+
 ### 2017-06-26
 [fantoms]
 * Changed from `uint` too `ulong` in the `bigint` properties, when a field has already been set.


### PR DESCRIPTION
The code works during my functional test, but I don't know if it was the correct way to fix it.  Also, there seems to be a slight delay when using a another portal, after having failed a different portal's activation requirements.  Example, with a character that is lower than 80, try to use the Eastwatch portal in the TN Annex.  Player gets denied because of being too low a level.  Next use the Danby's Output portal next to the Eastwatch one.  There is a slight delay before teleport.  Subsequent portals that don't block do not have a delay, until the next time the player doesn't pass the requirements of another portal.