### PR TITLE
For Review Only: Added simple network session timeouts

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -20,6 +20,13 @@ namespace ACE.Common
         [System.ComponentModel.DefaultValue(128)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public uint MaximumAllowedSessions { get; set; }
+
+        /// <summary>
+        /// The amount of seconds until an active session will be declared dead/inactive. Default value is 60 (for 1 minute).
+        /// </summary>
+        [System.ComponentModel.DefaultValue(60)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public uint DefaultSessionTimeout { get; set; }
     }
 
     public struct ConfigAccountDefaults

--- a/Source/ACE.Database/CachingWorldDatabase.cs
+++ b/Source/ACE.Database/CachingWorldDatabase.cs
@@ -22,7 +22,6 @@ namespace ACE.Database
         /// </summary>
         private ConcurrentDictionary<uint, AceObject> _weenieCache = new ConcurrentDictionary<uint, AceObject>();
         
-
         public CachingWorldDatabase(IWorldDatabase wrappedDatabase)
         {
             _wrappedDatabase = wrappedDatabase;

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -5,7 +5,8 @@
         "Network": {
             "Host": "0.0.0.0",
             "Port": 9000,
-            "MaximumAllowedSessions" : 128
+            "MaximumAllowedSessions" : 128,
+            "DefaultSessionTimeout" : 60
         },
         "Accounts": {
             "OverrideCharacterPermissions": true,

--- a/Source/ACE/Network/Enum/SessionState.cs
+++ b/Source/ACE/Network/Enum/SessionState.cs
@@ -5,7 +5,7 @@
         AuthLoginRequest,
         AuthConnectResponse,
         AuthConnected,
-
-        WorldConnected
+        WorldConnected,
+        NetworkTimeout
     }
 }

--- a/Source/ACE/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE/Network/Handlers/AuthenticationHandler.cs
@@ -13,6 +13,11 @@ namespace ACE.Network.Handlers
 {
     public static class AuthenticationHandler
     {
+        /// <summary>
+        /// Seconds until an authentication request will timeout/expire.
+        /// </summary>
+        public const int DefaultAuthTimeout = 15;
+
         public static async void HandleLoginRequest(ClientPacket packet, Session session)
         {
             PacketInboundLoginRequest loginRequest = new PacketInboundLoginRequest(packet);

--- a/Source/ACE/Network/NetworkSession.cs
+++ b/Source/ACE/Network/NetworkSession.cs
@@ -12,6 +12,7 @@ using ACE.Network.Handlers;
 using ACE.Network.Managers;
 
 using log4net;
+using ACE.Managers;
 
 namespace ACE.Network
 {
@@ -57,6 +58,11 @@ namespace ACE.Network
 
         public readonly SessionConnectionData ConnectionData = new SessionConnectionData();
 
+        /// <summary>
+        /// Stores the tick value for the when the session will timeout. If this value is in the past, the session is dead/inactive.
+        /// </summary>
+        public long TimeoutTick { get; set; }
+
         public ushort ClientId { get; }
         public ushort ServerId { get; }
 
@@ -65,6 +71,7 @@ namespace ACE.Network
             this.session = session;
             ClientId = clientId;
             ServerId = serverId;
+            TimeoutTick = DateTime.UtcNow.AddSeconds(WorldManager.DefaultSessionTimeout).Ticks;
         }
 
         /// <summary>
@@ -188,6 +195,9 @@ namespace ACE.Network
             {
                 log.WarnFormat("[{0}] Packet {1} has invalid checksum", session.Account, packet.Header.Sequence);
             }
+
+            // Set the next timeout tick to compare against in the WorldManager
+            session.Network.TimeoutTick = DateTime.UtcNow.AddSeconds(WorldManager.DefaultSessionTimeout).Ticks;
 
             // If we have an EchoRequest flag, we should flag to respond with an echo response on next send.
             if (packet.Header.HasFlag(PacketHeaderFlags.EchoRequest))

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -82,8 +82,8 @@ namespace ACE.Network
 
         public void Update(double lastTick, long currentTimeTick)
         {
-            // Check the  that the server sent a pac has stopped responding.
-            if (Network.TimeoutTick <= currentTimeTick)
+            // Checks if the session has stopped responding.
+            if (currentTimeTick >= Network.TimeoutTick)
             {
                 // Change the state to show that the Session has reached a timeout.
                 State = SessionState.NetworkTimeout;

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -80,8 +80,15 @@ namespace ACE.Network
             }
         }
 
-        public void Update(double lastTick)
+        public void Update(double lastTick, long currentTimeTick)
         {
+            // Check the  that the server sent a pac has stopped responding.
+            if (Network.TimeoutTick <= currentTimeTick)
+            {
+                // Change the state to show that the Session has reached a timeout.
+                State = SessionState.NetworkTimeout;
+            }
+
             Network.Update(lastTick);
 
             // FIXME(ddevec): Most of the following work can probably be integrated into the player's action queue, or an action queue strucutre

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # ACEmulator Change Log
 
 ### 2017-06-27
+[fantoms]
+* Added `TimeoutTick` variable to network sessions, to store the tick value for next timeout.
+* Added functionality to `Session` that will increase the network Session timeout limit when a `successful` packet has been receieved.
+* Added a configuration variable called `DefaultSessionTimeout`, to control the session timeout value from outside of the code.
+* Added a session State enum called `NetworkTimeout`, for dead sessions.
+* Added functionality to `WorldManager.UpdateWorld`, that will disconnect active network sessions after they have reached a network timeout limit.
+
 [StackOverflow]
 * Added the following Landblock loading helper console commands.
 * loadLB (landblockid)  -- example "loadLB 0" - loads landblock 0.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 * Added a configuration variable called `DefaultSessionTimeout`, to control the session timeout value from outside of the code.
 * Added a session State enum called `NetworkTimeout`, for dead sessions.
 * Added functionality to `WorldManager.UpdateWorld`, that will disconnect active network sessions after they have reached a network timeout limit.
+* If a session connects and does not proceed to authenticate, the server will give a shorter network timeout that is set as a default in the Authentication Handler.
+* If a session advances through the authentication steps, it will be given the `DefaultSessionTimeout`.
 
 [StackOverflow]
 * Added the following Landblock loading helper console commands.


### PR DESCRIPTION
This is mostly for review, since @Zegeger has mentioned he created code to work with timeouts in issue #336, but I want to keep my server from crashing when 127 clients have connected, so I've implemented simple timeout testing code that is based on `ticks`.

In this code, sessions will timeout after 60 seconds of inactivity and be disconnected by the `WorldManager`.