### PR TITLE
Update readme with minimum required database versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Build status: [![Windows CI](https://ci.appveyor.com/api/projects/status/qyueypl
 ## Getting Started
 
 * Install MySQL (MariaDB is preferred, but either will work) MySQL minimum required version 5.7.17+ - MariaDB minimum required version 10.2+
+https://mariadb.org/download/
 * Create three databases named `ace_auth`, `ace_shard`, and `ace_world`.
 * Load AuthenticationBase.sql, ShardBase.sql, and WorldBase.sql for their respective databases. 
 * Load all incremental SQL updates in the Database\Updates sub directories.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build status: [![Windows CI](https://ci.appveyor.com/api/projects/status/qyueypl
 
 ## Getting Started
 
-* Install MySQL (MariaDB is preferred, but either will work).
+* Install MySQL (MariaDB is preferred, but either will work) MySQL minimum required version 5.7.17+ - MariaDB minimum required version 10.2+
 * Create three databases named `ace_auth`, `ace_shard`, and `ace_world`.
 * Load AuthenticationBase.sql, ShardBase.sql, and WorldBase.sql for their respective databases. 
 * Load all incremental SQL updates in the Database\Updates sub directories.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 # ACEmulator Change Log
 
 ### 2017-06-28
+
+[Og II]
+Update readme with db minimum required versions.
+
 [Og II]
 * Completed work on flattening PhysicsData and ModelData
 * Did work to align names of properties on aceObject and WorldObject using unabbreviated names used by the client.


### PR DESCRIPTION
We have had some contributors as well as people trying to install have issues.   Our computed columns require a newer version of mysql or mariadb.   Updated to reflect that.   