### PR TITLE
Basic support for Animation Broadcasts

### DIFF
--- a/Source/ACE/Entity/MovementData.cs
+++ b/Source/ACE/Entity/MovementData.cs
@@ -2,10 +2,14 @@
 using ACE.Network.Enum;
 using System.IO;
 
+using log4net;
+
 namespace ACE.Entity
 {
     public class MovementData
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public MovementStateFlag MovementStateFlag { get; private set; } = 0;
 
         private ushort currentStyle = 0;
@@ -106,25 +110,130 @@ namespace ACE.Entity
             }
         }
 
+        /// <summary>
+        /// This guy is nasty!  The movement commands input by the client are not ACCEPTED by the client!
+        /// Only forward and right motions are accepted -- any left or reverse motions are not!
+        /// To fix, we need to use negative speeds with right motions when the client requests a left motion.
+        /// FIXME: Need to dig through client to figure out how to calculate value passed to client based on run
+        /// </summary>
+        /// <param name="holdKey"></param>
+        /// <returns></returns>
+        public MovementData ConvertToClientAccepted(uint holdKey, CreatureSkill run)
+        {
+            MovementData md = new MovementData();
+            // FIXME(ddevec): -- This is hacky!  I mostly reverse engineered it from old network logs
+            //   WARNING: this is ugly stuffs -- 
+            //      I'm basically just converting based on analyzing packet stuffs, no idea where the magic #'s come from
+            if (holdKey != 0 && holdKey != 2)
+            {
+                log.WarnFormat("Unexpected hold key: {0}", holdKey.ToString("X"));
+            }
+
+            if ((MovementStateFlag & MovementStateFlag.CurrentStyle) != 0) {
+                md.CurrentStyle = CurrentStyle;
+            }
+
+            float baseTurnSpeed = 1;
+            float baseSidestepSpeed = 1;
+            float baseSpeed = 1;
+            if (holdKey == 2)
+            {
+                // THis is just a random number that looks close to what the game expects
+                baseSpeed = 1.66f;
+                baseTurnSpeed = 1.5f;
+                baseSidestepSpeed = 1.5f;
+            }
+
+            if (ForwardCommand != 0)
+            {
+                if (ForwardCommand == (ushort)MotionCommand.WalkForward)
+                {
+                    if (holdKey == 2)
+                    {
+                        md.ForwardCommand = (ushort)MotionCommand.RunForward;
+                    }
+                    else
+                    {
+                        md.ForwardCommand = (ushort)MotionCommand.WalkForward;
+                    }
+                    md.ForwardSpeed = baseSpeed;
+                }
+                else if (ForwardCommand == (ushort)MotionCommand.WalkBackwards)
+                {
+                    md.ForwardCommand = (ushort)MotionCommand.WalkForward;
+                    md.ForwardSpeed = -1 * baseSpeed;
+                }
+                // Emote -- some are put here, others are sent externally -- ugh
+                //   This relates to if you can move (e.g. sidestep) while emoting -- some you can some you cant
+                else
+                {
+                    md.ForwardCommand = ForwardCommand;
+                }
+            }
+
+            if (SideStepCommand != 0)
+            {
+                if (SideStepCommand == (ushort)MotionCommand.SideStepRight)
+                {
+                    md.SideStepCommand = (ushort)MotionCommand.SideStepRight;
+                    md.SideStepSpeed = baseSidestepSpeed;
+                }
+                else if (SideStepCommand == (ushort)MotionCommand.SideStepLeft)
+                {
+                    md.SideStepCommand = (ushort)MotionCommand.SideStepRight;
+                    md.SideStepSpeed = -1 * baseSidestepSpeed;
+                }
+                // Unknown turn command?
+                else
+                {
+                    log.WarnFormat("Unexpected SideStep command: {0}", SideStepCommand.ToString("X"));
+                }
+            }
+
+            if (TurnCommand != 0)
+            {
+                if (TurnCommand == (ushort)MotionCommand.TurnRight)
+                {
+                    md.TurnCommand = (ushort)MotionCommand.TurnRight;
+                    md.TurnSpeed = baseTurnSpeed;
+                }
+                else if (TurnCommand == (ushort)MotionCommand.TurnLeft)
+                {
+                    md.TurnCommand = (ushort)MotionCommand.TurnRight;
+                    md.TurnSpeed = -1 * baseTurnSpeed;
+                }
+                // Unknown turn command?
+                else
+                {
+                    log.WarnFormat("Unexpected turn command: {0}", TurnCommand.ToString("X"));
+                }
+            }
+
+            return md;
+        }
+
         public void Serialize(BinaryWriter writer)
         {
             if ((this.MovementStateFlag & MovementStateFlag.CurrentStyle) != 0)
-                writer.Write((uint)this.CurrentStyle);
+                writer.Write((ushort)this.CurrentStyle);
 
             if ((this.MovementStateFlag & MovementStateFlag.ForwardCommand) != 0)
-                writer.Write((uint)this.ForwardCommand);
+                // writer.Write((uint)this.ForwardCommand);
+                writer.Write((ushort)this.ForwardCommand);
+
+            if ((this.MovementStateFlag & MovementStateFlag.SideStepCommand) != 0)
+                // writer.Write((uint)this.SideStepCommand);
+                writer.Write((ushort)this.SideStepCommand);
+
+            if ((this.MovementStateFlag & MovementStateFlag.TurnCommand) != 0)
+                // writer.Write((uint)this.TurnCommand);
+                writer.Write((ushort)this.TurnCommand);
 
             if ((this.MovementStateFlag & MovementStateFlag.ForwardSpeed) != 0)
                 writer.Write((float)this.ForwardSpeed);
 
-            if ((this.MovementStateFlag & MovementStateFlag.SideStepCommand) != 0)
-                writer.Write((uint)this.SideStepCommand);
-
             if ((this.MovementStateFlag & MovementStateFlag.SideStepSpeed) != 0)
                 writer.Write((float)this.SideStepSpeed);
-
-            if ((this.MovementStateFlag & MovementStateFlag.TurnCommand) != 0)
-                writer.Write((uint)this.TurnCommand);
 
             if ((this.MovementStateFlag & MovementStateFlag.TurnSpeed) != 0)
                 writer.Write((float)this.TurnSpeed);

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,16 @@
 # ACEmulator Change Log
 
+### 2017-06-29
+[ddevec]
+* Added basic support for motion broadcasting.
+
 ### 2017-06-28
 [Jyrus]
 * Implement Auto close timer for Doors
 
 ### 2017-06-28
 [Og II]
-Update readme with db minimum required versions.
+* Update readme with db minimum required versions.
 
 [Og II]
 * Completed work on flattening PhysicsData and ModelData


### PR DESCRIPTION
Basic support for animation broadcasts.  

- A client may now observe running/sidestepping/other animations/motion for another player
- FIXME: All animation speed data is just made-up.  Some of it appears correct, but I need to dig the formulas out of the client.
- FIXME/TODO: Some animations are broadcast multiple times (e.g. waving).  This is because we're receiving multiple requests form the client (possibly a networking error).  I should dedupe this, but I don't have animation timing information to do this.
