### PR TITLE
Added npcLooksLikeObject option in appraisal response

### DIFF
--- a/Source/ACE/Network/GameEvent/Events/GameEventIdentifyObjectResponse.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventIdentifyObjectResponse.cs
@@ -76,7 +76,7 @@ namespace ACE.Network.GameEvent.Events
             }
 
             var propertiesString = obj.PropertiesString.Where(x => x.PropertyId < 9000).ToList();
-
+/*
 #if DEBUG
             // TODO: This needs to come out - only in while we are testing.
             if (propertiesString.Find(x => x.PropertyId == (ushort)PropertyString.LongDesc)?.PropertyValue == null)
@@ -95,7 +95,7 @@ namespace ACE.Network.GameEvent.Events
                     propertiesString.Find(x => x.PropertyId == (ushort)PropertyString.LongDesc).PropertyValue += "\n\n" + DebugOutputString(type, obj);
             }
 #endif
-
+*/
             var propertiesSpellId = obj.PropertiesSpellId.ToList();
 
             if (propertiesSpellId.Count > 0)
@@ -144,7 +144,9 @@ namespace ACE.Network.GameEvent.Events
                 flags |= IdentifyResponseFlags.StringStatsTable;
             }
 
-            if (obj.ItemType == ItemType.Creature)
+            // if PropertyPool.NpcLooksLikeObject == true, do not treat as creature data
+            var npcLooksLikeObject = propertiesBool.FirstOrDefault(x => x.PropertyId == (uint)PropertyBool.NpcLooksLikeObject)?.PropertyValue;
+            if (obj.ItemType == ItemType.Creature && npcLooksLikeObject != true)
             {
                 flags |= IdentifyResponseFlags.CreatureProfile;
 #if DEBUG

--- a/Source/ACE/Network/GameEvent/Events/GameEventPlayerDescription.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventPlayerDescription.cs
@@ -52,15 +52,19 @@ namespace ACE.Network.GameEvent.Events
         [Flags]
         private enum DescriptionOptionFlag
         {
+            // PM_Packed_* in client
             None = 0x0000,
             Shortcut = 0x0001,
+            SquelchList = 0x0002,
+            MultiSpellLists = 0x0004,
             Component = 0x0008,
             SpellTab = 0x0010,
-            Unk20 = 0x0020,
+            SpellbookFilters = 0x0020,
             CharacterOption2 = 0x0040,
-            Unk100 = 0x0100,
+            TimeStampFormat = 0x0080, // This seems to not be used, and is set as a string property instead.
+            GenericQualitiesData = 0x0100,
             WindowLayout = 0x0200,
-            Unk400 = 0x0400,
+            SpellLists8 = 0x0400, 
         }
 
         public GameEventPlayerDescription(Session session)
@@ -348,14 +352,14 @@ namespace ACE.Network.GameEvent.Events
             {
             }*/
 
-            if ((optionFlags & DescriptionOptionFlag.Unk20) != 0)
+            if ((optionFlags & DescriptionOptionFlag.SpellbookFilters) != 0)
                 Writer.Write(0u);
 
             if ((optionFlags & DescriptionOptionFlag.CharacterOption2) != 0)
                 // Writer.Write(this.Session.Player.CharacterOptions.GetCharacterOptions2Flag());
                 Writer.Write(aceObj.CharacterOptions2Mapping);
 
-            /*if ((optionFlags & DescriptionOptionFlag.Unk100) != 0)
+            /*if ((optionFlags & DescriptionOptionFlag.GenericQualitiesData) != 0)
             {
             }*/
 
@@ -363,7 +367,7 @@ namespace ACE.Network.GameEvent.Events
             {
             }*/
 
-            /*if ((optionFlags & DescriptionOptionFlag.Unk400) != 0)
+            /*if ((optionFlags & DescriptionOptionFlag.SpellLists8) != 0)
             {
             }*/
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2017-07-16
+[OptimShi]
+* Added npcLooksLikeObject option in appraisal response 
+* Replaced some "unknown" bitfields with proper variable names in PlayerDescription.
+
 ### 2017-07-12
 [Ripley]
 * Moved most of the enums under ACE.Network to ACE.Entity.


### PR DESCRIPTION
* Added npcLooksLikeObject option in appraisal response (Note that no objects in ACE_World are currently set with this bool property)
* Replaced some "unknown" bitfields with proper variable names in PlayerDescription.