### PR TITLE
Fixes to raising attributes

### DIFF
--- a/Source/ACE.Entity/AbilityFormulaAttribute.cs
+++ b/Source/ACE.Entity/AbilityFormulaAttribute.cs
@@ -56,7 +56,7 @@ namespace ACE.Entity
                 sum += stats.Strength;
             }
 
-            return (sum * AbilityMultiplier) / Divisor;
+            return (uint) Math.Ceiling((double)(sum * AbilityMultiplier) / Divisor);
         }
     }
 }

--- a/Source/ACE.Entity/CreatureVital.cs
+++ b/Source/ACE.Entity/CreatureVital.cs
@@ -55,7 +55,7 @@ namespace ACE.Entity
             get
             {
                 // TODO: buffs?  not sure where they will go
-                // TODO: check if this can be replaced this with Ability.GetFormula().CalcBase(creature)
+                // TODO: check if this can be replaced with Ability.GetFormula().CalcBase(creature)
                 var formula = this.Ability.GetFormula();
 
                 uint derivationTotal = 0;

--- a/Source/ACE.Entity/CreatureVital.cs
+++ b/Source/ACE.Entity/CreatureVital.cs
@@ -55,6 +55,7 @@ namespace ACE.Entity
             get
             {
                 // TODO: buffs?  not sure where they will go
+                // TODO: check if this can be replaced this with Ability.GetFormula().CalcBase(creature)
                 var formula = this.Ability.GetFormula();
 
                 uint derivationTotal = 0;
@@ -72,7 +73,7 @@ namespace ACE.Entity
                     derivationTotal += wil * this.creature.Self;
 
                     derivationTotal *= formula.AbilityMultiplier;
-                    abilityTotal = derivationTotal / formula.Divisor;
+                    abilityTotal = (uint)Math.Ceiling((double)derivationTotal / (double)formula.Divisor);
                 }
 
                 abilityTotal += this.Ranks + this.Base;
@@ -152,7 +153,6 @@ namespace ACE.Entity
             this.creature = creature;
             this.RegenRate = regenRate;
             Ability = ability;
-            this.Base = Ability.GetFormula().CalcBase(creature);
         }
 
         public CreatureVital(ICreatureStats creature, AceObjectPropertiesAttribute2nd props) 
@@ -160,7 +160,6 @@ namespace ACE.Entity
             this._backer = props;
             this.creature = creature;
             this.RegenRate = Ability.GetRegenRate();
-            this.Base = Ability.GetFormula().CalcBase(creature);
         }
 
         public AceObjectPropertiesAttribute2nd GetVital()

--- a/Source/ACE.Entity/Enum/Ability.cs
+++ b/Source/ACE.Entity/Enum/Ability.cs
@@ -7,8 +7,8 @@ namespace ACE.Entity.Enum
     {
         None            = 0,
         Strength        = 1,
-        Coordination    = 2,
-        Endurance       = 4,
+        Endurance       = 2,
+        Coordination    = 4,        
         Quickness       = 8,
         Focus           = 16,
         Self            = 32,

--- a/Source/ACE.Entity/Enum/Properties/PropertyAttribute.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyAttribute.cs
@@ -1,12 +1,13 @@
 ﻿namespace ACE.Entity.Enum.Properties
 {
+    // The order of quickness and coordination corresponds to the client
     public enum PropertyAttribute : ushort
     {
         Undef = 0,
         Strength = 1,
-        Coordination = 2,
-        Endurance = 3,
-        Quickness = 4,
+        Endurance = 2,
+        Quickness = 3,
+        Coordination = 4,
         Focus = 5,
         Self = 6,
         Health = 7,

--- a/Source/ACE.Entity/ICreatureXpSpendableStat.cs
+++ b/Source/ACE.Entity/ICreatureXpSpendableStat.cs
@@ -15,6 +15,8 @@ namespace ACE.Entity
 
         uint MaxValue { get; }
 
+        uint UnbuffedValue { get; }
+
         uint Base { get; }
 
         Ability Ability { get; }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -516,8 +516,8 @@ namespace ACE.Entity
             }
             uint baseValue = creatureStat.Base;
             uint result = SpendAbilityXp(creatureStat, amount);
-            uint ranks = creatureAbility.Ranks;
-            uint newValue = creatureAbility.UnbuffedValue;
+            uint ranks = creatureStat.Ranks;
+            uint newValue = creatureStat.UnbuffedValue;
             string messageText = "";
             if (result > 0u)
             {
@@ -528,7 +528,7 @@ namespace ACE.Entity
                 }
                 else
                 {
-                    abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, creatureAbility.Current);
+                    abilityUpdate = new GameMessagePrivateUpdateVital(Session, ability, ranks, baseValue, result, creatureStat.Current);
                 }
 
                 // checks if max rank is achieved and plays fireworks w/ special text
@@ -576,7 +576,6 @@ namespace ACE.Entity
         private uint SpendAbilityXp(ICreatureXpSpendableStat ability, uint amount)
         {
             uint result = 0;
-            bool addToCurrentValue = false;
             ExperienceExpenditureChart chart;
             XpTable xpTable = XpTable.ReadFromDat();
             switch (ability.Ability)
@@ -585,7 +584,6 @@ namespace ACE.Entity
                 case Enum.Ability.Stamina:
                 case Enum.Ability.Mana:
                     chart = xpTable.VitalXpChart;
-                    addToCurrentValue = true;
                     break;
                 default:
                     chart = xpTable.AbilityXpChart;
@@ -628,13 +626,8 @@ namespace ACE.Entity
 
             if (rankUps > 0)
             {
-                // FIXME(ddevec): This needs to be done for vitals only? Someone verify --
+                // FIXME(ddevec):
                 //      Really AddRank() should probably be a method of CreatureAbility/CreatureVital
-                CreatureVital vital = ability as CreatureVital;
-                if (vital != null)
-                {
-                    vital.Current += addToCurrentValue ? rankUps : 0u;
-                }
                 ability.Ranks += rankUps;
                 ability.ExperienceSpent += amount;
                 this.Character.SpendXp(amount);

--- a/Source/ACE/Network/GameAction/Actions/GameActionRaiseAbility.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionRaiseAbility.cs
@@ -1,5 +1,4 @@
-﻿using ACE.Entity.Enum;
-using ACE.Network.Enum;
+﻿using ACE.Entity.Enum.Properties;
 
 namespace ACE.Network.GameAction.Actions
 {
@@ -9,28 +8,28 @@ namespace ACE.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             Entity.Enum.Ability ability = Entity.Enum.Ability.None;
-            var networkAbility = (Ability)message.Payload.ReadUInt32();
+            var networkAbility = (PropertyAttribute)message.Payload.ReadUInt32();
             switch (networkAbility)
             {
-                case Ability.Strength:
+                case PropertyAttribute.Strength:
                     ability = Entity.Enum.Ability.Strength;
                     break;
-                case Ability.Endurance:
+                case PropertyAttribute.Endurance:
                     ability = Entity.Enum.Ability.Endurance;
                     break;
-                case Ability.Coordination:
+                case PropertyAttribute.Coordination:
                     ability = Entity.Enum.Ability.Coordination;
                     break;
-                case Ability.Quickness:
+                case PropertyAttribute.Quickness:
                     ability = Entity.Enum.Ability.Quickness;
                     break;
-                case Ability.Focus:
+                case PropertyAttribute.Focus:
                     ability = Entity.Enum.Ability.Focus;
                     break;
-                case Ability.Self:
+                case PropertyAttribute.Self:
                     ability = Entity.Enum.Ability.Self;
                     break;
-                case Ability.None:
+                case PropertyAttribute.Undef:
                     return;
             }
             var xpSpent = message.Payload.ReadUInt32();

--- a/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateAbility.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessagePrivateUpdateAbility.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using ACE.Network.Enum;
-using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 
 namespace ACE.Network.GameMessages.Messages
 {
@@ -11,27 +10,27 @@ namespace ACE.Network.GameMessages.Messages
         {
             // TODO We shouldn't be passing session. Insetad, we should pass the value after session.UpdateSkillSequence++.
 
-            Ability networkAbility;
+            PropertyAttribute networkAbility;
 
             switch (ability)
             {
                 case Entity.Enum.Ability.Strength:
-                    networkAbility = Ability.Strength;
+                    networkAbility = PropertyAttribute.Strength;
                     break;
                 case Entity.Enum.Ability.Endurance:
-                    networkAbility = Ability.Endurance;
+                    networkAbility = PropertyAttribute.Endurance;
                     break;
                 case Entity.Enum.Ability.Coordination:
-                    networkAbility = Ability.Coordination;
+                    networkAbility = PropertyAttribute.Coordination;
                     break;
                 case Entity.Enum.Ability.Quickness:
-                    networkAbility = Ability.Quickness;
+                    networkAbility = PropertyAttribute.Quickness;
                     break;
                 case Entity.Enum.Ability.Focus:
-                    networkAbility = Ability.Focus;
+                    networkAbility = PropertyAttribute.Focus;
                     break;
                 case Entity.Enum.Ability.Self:
-                    networkAbility = Ability.Self;
+                    networkAbility = PropertyAttribute.Self;
                     break;
                 default:
                     throw new ArgumentException("invalid ability specified");

--- a/Source/ACE/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE/Network/Handlers/CharacterHandler.cs
@@ -253,9 +253,9 @@ namespace ACE.Network.Handlers
             uint classId = reader.ReadUInt32();
 
             // characters start with max vitals
-            character.Health.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Health).CalcBase(character);
-            character.Stamina.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Stamina).CalcBase(character);
-            character.Mana.Current = AbilityExtensions.GetFormula(Entity.Enum.Ability.Mana).CalcBase(character);
+            character.Health.Current = character.Health.MaxValue;
+            character.Stamina.Current = character.Stamina.MaxValue;
+            character.Mana.Current = character.Mana.MaxValue;
 
             // set initial skill credit amount. 52 for all but "OlthoiAcid", which have 68
             character.AvailableSkillCredits = cg.HeritageGroups[(int)character.Heritage].SkillCredits;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # ACEmulator Change Log
 
+### 2017-07-20
+[Lidefeath]
+* Fix raising primary and secondary attributes.
+* Aligned the enums PropertyAttribute.Quickness and PropertyAttribute.Coordination with the client.
+* Due to this alignment old chars will have wrong coord and quick, so make new characters.
+* I didn't touch the trigger of VitalTicks yet, so vital ticking is only enabled during Player.Load().
+
 ### 2017-07-17
 [Ripley]
 * More field changes.


### PR DESCRIPTION
Primary and secondary attributes can be raised correctly with xp again. Existing characters will have coord and quick exchanged as the enums for those abilities in the server are now aligned with the client.
Vital ticking wasn't touched yet, so it only starts during Player.Load