### PR TITLE
Minor tweak to QueryItemMana

### DIFF
--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -923,7 +923,6 @@ namespace ACE.Entity
 
         public void HandleActionQueryItemMana(ObjectGuid queryId)
         {
-            // TODO: Why does the client send a QueryItemMana action with a queryid of 0
             if (queryId.Full == 0)
             {
                 // Do nothing if the queryID is 0

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -1906,6 +1906,9 @@ namespace ACE.Entity
                 success = 1;
             }
 
+            if (success == 0) // according to retail PCAPs, if success = 0, mana = 0.
+                manaPercentage = 0;
+
             var updateMana = new GameEventQueryItemManaResponse(examiner, Guid.Full, manaPercentage, success);
             examiner.Network.EnqueueSend(updateMana);
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,19 @@
 # ACEmulator Change Log
-### 2017-24-2017
+
+### 2017-07-25
+[Ripley]
+* Minor change to QueryItemMana based on PCAPs.
+
+### 2017-07-24
+[Lidefeath]
+* Added GameAction and GameEvent for querying an items Mana.
+
 [Og II]
 * Refactored debug command learn spell.
 * Made spells persist to the database.
 * Added abilty to delete spell from spell book and send that persistantly to the database on character save.
 * TODO: Put in the abilty to use scrolls to learn spells.
 
-### 2017-07-24
-[Lidefeath]
-* Added GameAction and GameEvent for querying an items Mana.
-
-### 2017-07-24
 [Ripley]
 * Added Bools used by ObjectDescriptionFlag and PhysicsState.
 * Added WeenieType to PropertyInt Enum for future use.


### PR DESCRIPTION
`// TODO: Why does the client send a QueryItemMana action with a queryid of 0`

Looks like the client did this all the time, no reason seems apparent in retail pcaps, so killing this out for now