### PR TITLE
Network fixes with inital Ack delay

### DIFF
--- a/Source/ACE/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE/Network/Handlers/AuthenticationHandler.cs
@@ -10,6 +10,7 @@ using ACE.Network.GameMessages.Messages;
 using ACE.Network.Packets;
 using System.Collections.Generic;
 using System.Linq;
+using log4net;
 
 namespace ACE.Network.Handlers
 {
@@ -19,6 +20,8 @@ namespace ACE.Network.Handlers
         /// Seconds until an authentication request will timeout/expire.
         /// </summary>
         public const int DefaultAuthTimeout = 15;
+
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         public static async void HandleLoginRequest(ClientPacket packet, Session session)
         {
@@ -37,6 +40,7 @@ namespace ACE.Network.Handlers
 
         private static void AccountSelectCallback(Account account, Session session)
         {
+            log.DebugFormat("ConnectRequest TS: {0}", session.Network.ConnectionData.ServerTime);
             var connectRequest = new PacketOutboundConnectRequest(session.Network.ConnectionData.ServerTime, 0, session.Network.ClientId, ISAAC.ServerSeed, ISAAC.ClientSeed);
 
             session.Network.EnqueueSend(connectRequest);

--- a/Source/ACE/Network/NetworkSession.cs
+++ b/Source/ACE/Network/NetworkSession.cs
@@ -34,11 +34,18 @@ namespace ACE.Network
         private ConcurrentDictionary<uint, MessageBuffer> partialFragments = new ConcurrentDictionary<uint, MessageBuffer>();
         private ConcurrentDictionary<uint, ClientMessage> outOfOrderFragments = new ConcurrentDictionary<uint, ClientMessage>();
 
-        private DateTime nextResync = DateTime.UtcNow;
-        private DateTime nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
         private DateTime nextSend = DateTime.UtcNow;
-        private bool sendAck = true;
+
+        // Resync will be started after ConnectResponse, and should immediately be sent then, so no delay here.
+        // Fun fact: even though we send the server time in the ConnectRequest, client doesn't seem to use it?  Therefore we must TimeSync early so client doesn't see a skew when we send it later.
         private bool sendResync = false;
+        private DateTime nextResync = DateTime.UtcNow;
+
+        // Ack should be sent after a 2 second delay, so start enabled with the delay.
+        // Sending this too early seems to cause issues with clients disconnecting.
+        private bool sendAck = true;
+        private DateTime nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
+        
         private uint lastReceivedPacketSequence = 1;
         private uint lastReceivedFragmentSequence = 0;
 
@@ -243,7 +250,7 @@ namespace ACE.Network
             }
 
             // This should be set on the second packet to the server from the client.
-            // This comletes the three-way handshake.
+            // This completes the three-way handshake.
             if (packet.Header.HasFlag(PacketHeaderFlags.ConnectResponse))
             {
                 sendResync = true;

--- a/Source/ACE/Network/NetworkSession.cs
+++ b/Source/ACE/Network/NetworkSession.cs
@@ -34,10 +34,10 @@ namespace ACE.Network
         private ConcurrentDictionary<uint, MessageBuffer> partialFragments = new ConcurrentDictionary<uint, MessageBuffer>();
         private ConcurrentDictionary<uint, ClientMessage> outOfOrderFragments = new ConcurrentDictionary<uint, ClientMessage>();
 
-        private DateTime nextResync = DateTime.UtcNow;
-        private DateTime nextAck = DateTime.UtcNow;
+        private DateTime nextResync = DateTime.UtcNow.AddMilliseconds(timeBetweenTimeSync);
+        private DateTime nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
         private DateTime nextSend = DateTime.UtcNow;
-        private bool sendAck = true;
+        private bool sendAck = false;
         private bool sendResync = false;
         private uint lastReceivedPacketSequence = 1;
         private uint lastReceivedFragmentSequence = 0;
@@ -115,6 +115,7 @@ namespace ACE.Network
             {
                 if (sendResync && !currentBundle.TimeSync && DateTime.UtcNow > nextResync)
                 {
+                    log.DebugFormat("[{0}] Setting to send TimeSync packet", session.Account);
                     currentBundle.TimeSync = true;
                     currentBundle.EncryptedChecksum = true;
                     nextResync = DateTime.UtcNow.AddMilliseconds(timeBetweenTimeSync);
@@ -122,6 +123,7 @@ namespace ACE.Network
 
                 if (sendAck && !currentBundle.SendAck && DateTime.UtcNow > nextAck)
                 {
+                    log.DebugFormat("[{0}] Setting to send ACK packet", session.Account);
                     currentBundle.SendAck = true;
                     nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
                 }

--- a/Source/ACE/Network/NetworkSession.cs
+++ b/Source/ACE/Network/NetworkSession.cs
@@ -34,10 +34,10 @@ namespace ACE.Network
         private ConcurrentDictionary<uint, MessageBuffer> partialFragments = new ConcurrentDictionary<uint, MessageBuffer>();
         private ConcurrentDictionary<uint, ClientMessage> outOfOrderFragments = new ConcurrentDictionary<uint, ClientMessage>();
 
-        private DateTime nextResync = DateTime.UtcNow.AddMilliseconds(timeBetweenTimeSync);
+        private DateTime nextResync = DateTime.UtcNow;
         private DateTime nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
         private DateTime nextSend = DateTime.UtcNow;
-        private bool sendAck = false;
+        private bool sendAck = true;
         private bool sendResync = false;
         private uint lastReceivedPacketSequence = 1;
         private uint lastReceivedFragmentSequence = 0;
@@ -218,6 +218,7 @@ namespace ACE.Network
 
             if (packet.Header.HasFlag(PacketHeaderFlags.TimeSynch))
             {
+                log.DebugFormat("[{0}] Incoming TimeSync TS: {1}", session.Account, packet.HeaderOptional.TimeSynch);
                 // Do something with this...
                 // Based on network traces these are not 1:1.  Server seems to send them every 20 seconds per port.
                 // Client seems to send them alternatingly every 2 or 4 seconds per port.
@@ -496,6 +497,7 @@ namespace ACE.Network
                     if (bundle.TimeSync) // 0x1000000
                     {
                         packetHeader.Flags |= PacketHeaderFlags.TimeSynch;
+                        log.DebugFormat("[{0}] Outgoing TimeSync TS: {1}", session.Account, ConnectionData.ServerTime);
                         packet.BodyWriter.Write(ConnectionData.ServerTime);
                     }
 

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -234,10 +234,6 @@ namespace ACE.Network
         {
             if (!CheckState(packet))
             {
-                // server treats all packets sent during the first 30 seconds as invalid packets due to server crash, this will move clients to the disconnect screen
-                if (DateTime.UtcNow < WorldManager.WorldStartTime.AddSeconds(30d))
-                    SendCharacterError(CharacterError.ServerCrash);
-
                 return;
             }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # ACEmulator Change Log
-
 ### 2017-07-28
+[Zegeger]
+* Tweaked the ACK timer to help improve network reliability
+
 [Og II]
 * Spent 5 or 6 hours tracking down an align bug in create object - Universial Motion section.   Damn it Jim, I am a high level programmer not a down in the bits and bytes weenie.... :)
 


### PR DESCRIPTION
Set Ack delay initially to be 2 seconds.  Having the acks sent too early seems to impact connection reliability.