### PR TITLE
Fix multifragment packetization logic

### DIFF
--- a/Source/ACE.Entity/Enum/Ability.cs
+++ b/Source/ACE.Entity/Enum/Ability.cs
@@ -37,7 +37,7 @@ namespace ACE.Entity.Enum
         // FIXME(ddevec): This will eventually be a formula...
         public static double GetRegenRate(this Ability ability)
         {
-            return ability.GetAttributeOfType<AbilityRegenAttribute>().Rate;
+            return 0;// ability.GetAttributeOfType<AbilityRegenAttribute>().Rate;
         }
     }
 }

--- a/Source/ACE.Entity/Enum/Ability.cs
+++ b/Source/ACE.Entity/Enum/Ability.cs
@@ -37,7 +37,7 @@ namespace ACE.Entity.Enum
         // FIXME(ddevec): This will eventually be a formula...
         public static double GetRegenRate(this Ability ability)
         {
-            return 0;// ability.GetAttributeOfType<AbilityRegenAttribute>().Rate;
+            return ability.GetAttributeOfType<AbilityRegenAttribute>().Rate;
         }
     }
 }

--- a/Source/ACE/Network/ClientPacket.cs
+++ b/Source/ACE/Network/ClientPacket.cs
@@ -10,10 +10,8 @@ namespace ACE.Network
         public BinaryReader Payload { get; }
         public PacketHeaderOptional HeaderOptional { get; private set; }
 
-        public ClientPacket(byte[] data, bool debug = false)
+        public ClientPacket(byte[] data)
         {
-            Direction = (debug ? PacketDirection.Server : PacketDirection.Client);
-
             using (var stream = new MemoryStream(data))
             {
                 using (var reader = new BinaryReader(stream))

--- a/Source/ACE/Network/Packet.cs
+++ b/Source/ACE/Network/Packet.cs
@@ -11,7 +11,6 @@ namespace ACE.Network
 
         public PacketHeader Header { get; protected set; }
         public MemoryStream Data { get; protected set; }
-        public PacketDirection Direction { get; protected set; } = PacketDirection.None;
         public List<PacketFragment> Fragments { get; } = new List<PacketFragment>();
     }
 }

--- a/Source/ACE/Network/PacketFragment.cs
+++ b/Source/ACE/Network/PacketFragment.cs
@@ -7,5 +7,13 @@
 
         public PacketFragmentHeader Header { get; protected set; }
         public byte[] Data { get; protected set; }
+
+        public int Length
+        {
+            get
+            {
+                return Data.Length + (int)PacketFragmentHeader.HeaderSize;
+            }
+        }
     }
 }

--- a/Source/ACE/Network/ServerPacket.cs
+++ b/Source/ACE/Network/ServerPacket.cs
@@ -10,8 +10,6 @@ namespace ACE.Network
     {
         public BinaryWriter BodyWriter { get; private set; }
 
-        private List<ServerPacketFragment> fragments = new List<ServerPacketFragment>();
-
         private uint issacXor = 0u;
         private bool issacXorSet = false;
         public uint IssacXor
@@ -37,11 +35,6 @@ namespace ACE.Network
             BodyWriter = new BinaryWriter(Data);
         }
 
-        public void AddFragment(ServerPacketFragment fragment)
-        {
-            fragments.Add(fragment);
-        }
-
         public byte[] GetPayload()
         {
             uint headerChecksum = 0u;
@@ -60,7 +53,7 @@ namespace ACE.Network
                         writer.Write(body);
                         bodyChecksum = Hash32.Calculate(body, body.Length);
                     }
-                    foreach (ServerPacketFragment fragment in fragments)
+                    foreach (ServerPacketFragment fragment in Fragments)
                     {
                         fragmentChecksum += fragment.GetPayload(writer);
                     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 # ACEmulator Change Log
 
+### 2017-08-16
+[Zegeger]
+* Rewrote packetizer code to fix incorrect multi-fragment messages (basically we shouldn't send optional headers when a single fragment fills the full packet)
+* In general this made the packetizer much cleaner and more organized
+* In the process I added support for premptive tail sending.  Essentially for multifragment packets, the last fragment will likely be much smaller then the full packet size, so it could fit in an earlier message among other fragments.  We see this can occur in production network traces (eg the last index arrives as the first fragment of the message). Previously we did not do this, but now we can.
+
 ### 2017-08-15
+[OptimShi]
 * Fixed book properties not cloning properly.
 
 ### 2017-08-11


### PR DESCRIPTION
* Rewrote packetizer code to fix incorrect multi-fragment messages (basically we shouldn't send optional headers when a single fragment fills the full packet)  
* In general this made the packetizer much cleaner and more organized  
* In the process I added support for preemptive tail sending.  Essentially for multifragment packets, the last fragment will likely be much smaller then the full packet size, so it could fit in an earlier message among other fragments.  We see this can occur in production network traces (eg the last index arrives as the first fragment of the message). Previously we did not do this, but now we can.  
