### PR TITLE
Quick fix for proper GUID assignment on objects from Generators

### DIFF
--- a/Source/ACE/Factories/GeneratorFactory.cs
+++ b/Source/ACE/Factories/GeneratorFactory.cs
@@ -115,15 +115,16 @@ namespace ACE.Factories
                 // else spawn the objects directly from this generator
                 else
                 {
-                    WorldObject wo = WorldObjectFactory.CreateWorldObject((uint)generator.ActivationCreateClass);
+                    // TODO: Re-evaluate guid assignment here, is it a bad thing items and creatures are in the same pool? Probably.
+                    WorldObject wo = WorldObjectFactory.CreateNewWorldObject((uint)generator.ActivationCreateClass);
 
                     if (wo != null)
                     {
                         wo.Location = pos;
-                        if (wo.WeenieType == WeenieType.Creature || wo.WeenieType == WeenieType.Cow)
-                            wo.Guid = GuidManager.NewNonStaticGuid();
-                        else
-                            wo.Guid = GuidManager.NewItemGuid();
+                        // if (wo.WeenieType == WeenieType.Creature || wo.WeenieType == WeenieType.Cow)
+                        //    wo.Guid = GuidManager.NewNonStaticGuid();
+                        // else
+                        //    wo.Guid = GuidManager.NewItemGuid();
                         wo.GeneratorId = generator.AceObjectId;
 
                         results.Add(wo);

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2017-09-03
+[Ripley]
+* Changed GeneratorFactory to use WorldObjectFactory.CreateNewWorldObject insted of CreateWorldObject for now.
+
 ### 2017-09-01
 [OptimShi]
 * Added Region (0x13...) parsing from the client_portal.dat


### PR DESCRIPTION
This fixes a crash bug associated with picking up objects generated by generators. GUID change wasn't propagating to properties.