### PR TITLE
Added minimum UseRadius for Doors

### DIFF
--- a/Source/ACE/Entity/Door.cs
+++ b/Source/ACE/Entity/Door.cs
@@ -59,6 +59,9 @@ namespace ACE.Entity
 
             movementOpen.ForwardCommand = (ushort)MotionCommand.On;
             movementClosed.ForwardCommand = (ushort)MotionCommand.Off;
+
+            if (UseRadius < 2)
+                UseRadius = 2;
         }
 
         private bool IsOpen

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2017-09-20
+[Ripley]
+* Added a minimum UseRadius to Doors. This prevents the radius being so small as to require you to be inside the door to open/close it.
+
 ### 2017-09-18
 [Mogwai]
 * Starter clothing done.  other stuff WIP.


### PR DESCRIPTION
Added a minimum UseRadius to Doors. This prevents the radius being so small as to require you to be inside the door to open/close it.