### PR TITLE
Retreat!   Fix for peace mode from unarmed

### DIFF
--- a/Database/Updates/World/10-03-2017-updateintprop46.sql
+++ b/Database/Updates/World/10-03-2017-updateintprop46.sql
@@ -1,0 +1,238 @@
+# Clear out the old - none existed on 46 before this script
+# Since I am not using the primary key, I need to turn safe deletes off to clear these out.
+SET SQL_SAFE_UPDATES = 0;
+DELETE
+FROM
+   ace_world.ace_object_properties_int
+WHERE intPropertyId = 46;
+SET SQL_SAFE_UPDATES = 1;
+
+#ID the UA items
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('8000003c', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE (
+      weenieclassdescription LIKE '%Katar%'
+      OR weenieclassdescription LIKE '%Cestus%'
+      OR weenieclassdescription LIKE '%Knuckles%'
+      OR weenieclassdescription LIKE '%Claw%'
+      OR weenieclassdescription LIKE '%Nekode%'
+      OR weenieclassdescription LIKE '%Fist%'
+      OR weenieclassdescription LIKE '%Korua%'
+      OR weenieclassdescription LIKE '%Matihao%'
+      OR weenieclassdescription LIKE '%SteelButterfly%'
+      OR weenieclassdescription LIKE '%CrescentMoons%'
+      OR weenieclassdescription LIKE '%Gauraloi%'
+      OR weenieclassdescription LIKE '%Skulpuncher%'
+      OR weenieclassdescription LIKE '%Needletooth%'
+      OR weenieclassdescription LIKE '%Handwraps%'
+      OR weenieClassDescription LIKE '%Basalt%'
+   )
+   AND wc.itemtype = 1
+   AND aopi.propertyValue NOT IN (3, 4, 5)
+ORDER BY weenieClassid;
+
+# ID the two handed weapons sword stance
+INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+ SELECT
+    weenieClassId
+   , 46
+   , CONV('80000044', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE wc.itemType = 1
+   AND aopi.propertyValue = 5
+   AND weenieclassdescription NOT LIKE '%mace%' AND weenieclassdescription NOT LIKE '%Tetsubo'
+ORDER BY wc.weenieClassId;
+
+# ID the two handed weapons staff stance
+INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+ SELECT
+    weenieClassId
+   , 46
+   , CONV('80000044', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE wc.itemType = 1
+   AND aopi.propertyValue = 5
+   AND weenieclassdescription LIKE '%mace%' OR weenieclassdescription LIKE '%Tetsubo'
+ORDER BY wc.weenieClassId;
+
+#ID the crossbows
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('80000041', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE (
+      weenieclassdescription LIKE '%crossbow%'
+      OR weenieclassdescription LIKE '%Arbalest%'
+      OR weenieclassdescription LIKE '%IronBull%'
+      OR weenieclassdescription LIKE '%FeatheredRazor%'
+      OR weenieclassdescription LIKE '%AudetaungasKalindanoftheMountains%'
+      OR weenieclassdescription LIKE '%Kalindan%'
+      OR weenieclassdescription LIKE '%Palauloi%'
+      OR weenieclassdescription LIKE '%VortexThorn%'
+      OR weenieclassdescription LIKE '%ZefirsBreath%'
+   )
+   AND itemtype = 256
+   AND aopi.propertyValue NOT IN (3, 4, 5)
+ORDER BY weenieClassid;
+
+#ID the Atlatl
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('80000138', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE (
+      weenieclassdescription LIKE '%atlatl%'
+      OR weenieClassDescription LIKE '%DartFlinger%'
+      OR weenieClassDescription LIKE '%CrimsonBraceofPain%'
+      OR weenieClassDescription LIKE '%Eyeslayer%'
+   )
+   AND itemtype = 256
+   AND aopi.propertyValue NOT IN (3, 4, 5)
+ORDER BY weenieClassid;
+
+#ID Thrown
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('80000047', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 51
+WHERE (
+      weenieclassdescription LIKE '%throwing%'
+      OR weenieClassDescription LIKE '%phial%'
+      OR weenieClassDescription LIKE '%spike%'
+      OR weenieClassDescription LIKE '%pumpkin%'
+      OR weenieClassDescription LIKE '%lantern%'
+      OR weenieClassDescription LIKE '%skull%'
+      OR weenieClassDescription LIKE '%slingshot%'
+      OR weenieClassDescription LIKE '%lumpof%'
+      OR weenieClassDescription LIKE '%hatchet%'
+      OR weenieClassDescription LIKE '%Javelin%'
+      OR weenieClassDescription LIKE '%Ball%'
+      OR weenieClassDescription LIKE '%brace%'
+      OR weenieClassDescription LIKE '%shard%'
+      OR weenieClassDescription LIKE '%coconut%'
+      OR weenieClassDescription LIKE '%rock%'
+      OR weenieClassDescription LIKE '%axe%'
+      OR weenieClassDescription = 'bowl'
+      OR weenieClassDescription LIKE '%chalice%'
+      OR weenieClassDescription LIKE '%bouquet%'
+      OR weenieClassDescription LIKE '%discus%'
+      OR weenieClassDescription LIKE '%flagon%'
+      OR weenieClassDescription LIKE '%cup%'
+      OR weenieClassDescription LIKE '%granade%'
+      OR weenieClassDescription LIKE '%goblet%'
+      OR weenieClassDescription LIKE '%boulder%'
+      OR weenieClassDescription LIKE '%tankard%'
+      OR weenieClassDescription LIKE '%ewer%'
+      OR weenieClassDescription LIKE '%plate%'
+      OR weenieClassDescription LIKE '%djar%'
+      OR weenieClassDescription LIKE '%mug%'
+      OR weenieClassDescription LIKE '%nannerpie%'
+   )
+   AND itemtype = 256
+   AND aopi.propertyValue NOT IN (3, 4, 5)
+ORDER BY weenieClassid;
+
+#By process of elimination this is the bows.
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('8000003f', 16, 10)
+FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 46
+   LEFT OUTER JOIN ace_object_properties_int aopi2
+      ON wc.aceObjectId = aopi2.aceObjectId
+      AND aopi2.intPropertyId = 51
+WHERE wc.itemType = 256
+   AND aopi.aceObjectId IS NULL
+   AND aopi2.propertyValue NOT IN (3, 4, 5)
+ORDER BY wc.weenieClassId;
+
+#By process of elimination this is the melee weapons.
+ INSERT INTO ace_world.ace_object_properties_int (
+   aceObjectId
+   , intPropertyId
+   , propertyValue
+)
+SELECT
+   weenieClassId
+   , 46
+   , CONV('8000003e', 16, 10)
+   FROM
+   vw_ace_weenie_class wc
+   LEFT OUTER JOIN ace_object_properties_int aopi
+      ON wc.aceObjectId = aopi.aceObjectId
+      AND aopi.intPropertyId = 46
+LEFT OUTER JOIN ace_object_properties_int aopi2
+      ON wc.aceObjectId = aopi2.aceObjectId
+      AND aopi2.intPropertyId = 51      
+WHERE wc.itemType = 1
+   AND aopi.aceObjectId IS NULL  
+   AND aopi2.propertyValue NOT IN (3, 4, 5) 
+ORDER BY wc.weenieClassId;
+

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -5,27 +5,18 @@
         // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
         // http://ac.yotesfan.com/ace_object/not_used_enums.php
         // source: @OptimShi
-
         // description attributes are used by the weenie editor for a cleaner display name
 
-        [ServerOnly]
         Undef                            = 0,
         Stuck                            = 1,
         Open                             = 2,
         Locked                           = 3,
-        [ServerOnly]
         RotProof                         = 4,
-        [ServerOnly]
         AllegianceUpdateRequest          = 5,
-        [ServerOnly]
         AiUsesMana                       = 6,
-        [ServerOnly]
         AiUseHumanMagicAnimations        = 7,
-        [ServerOnly]
         AllowGive                        = 8,
-        [ServerOnly]
         CurrentlyAttacking               = 9,
-        [ServerOnly]
         AttackerAi                       = 10,
         IgnoreCollisions                 = 11,
         ReportCollisions                 = 12,
@@ -36,205 +27,115 @@
         Inelastic                        = 17,
         Visibility                       = 18,
         Attackable                       = 19,
-        [ServerOnly]
         SafeSpellComponents              = 20,
-        [ServerOnly]
         AdvocateState                    = 21,
         Inscribable                      = 22,
-        [ServerOnly]
         DestroyOnSell                    = 23,
         UiHidden                         = 24,
         IgnoreHouseBarriers              = 25,
         HiddenAdmin                      = 26,
-        [ServerOnly]
         PkWounder                        = 27,
         PkKiller                         = 28,
-        [ServerOnly]
         NoCorpse                         = 29,
-        [ServerOnly]
         UnderLifestoneProtection         = 30,
-        [ServerOnly]
         ItemManaUpdatePending            = 31,
         GeneratorStatus                  = 32,
-        [ServerOnly]
         ResetMessagePending              = 33,
-        [ServerOnly]
         DefaultOpen                      = 34,
-        [ServerOnly]
         DefaultLocked                    = 35,
-        [ServerOnly]
         DefaultOn                        = 36,
-        [ServerOnly]
         OpenForBusiness                  = 37,
-        [ServerOnly]
         IsFrozen                         = 38,
-        [ServerOnly]
         DealMagicalItems                 = 39,
-        [ServerOnly]
         LogoffImDead                     = 40,
         ReportCollisionsAsEnvironment    = 41,
         AllowEdgeSlide                   = 42,
-        [ServerOnly]
         AdvocateQuest                    = 43,
-        [ServerOnly]
         IsAdmin                          = 44,
-        [ServerOnly]
         IsArch                           = 45,
-        [ServerOnly]
         IsSentinel                       = 46,
-        [ServerOnly]
         IsAdvocate                       = 47,
-        [ServerOnly]
         CurrentlyPoweringUp              = 48,
-        [ServerOnly]
         GeneratorEnteredWorld            = 49,
-        [ServerOnly]
         NeverFailCasting                 = 50,
         VendorService                    = 51,
-        [ServerOnly]
         AiImmobile                       = 52,
-        [ServerOnly]
         DamagedByCollisions              = 53,
-        [ServerOnly]
         IsDynamic                        = 54,
-        [ServerOnly]
         IsHot                            = 55,
-        [ServerOnly]
         IsAffecting                      = 56,
-        [ServerOnly]
         AffectsAis                       = 57,
-        [ServerOnly]
         SpellQueueActive                 = 58,
-        [ServerOnly]
         GeneratorDisabled                = 59,
-        [ServerOnly]
         IsAcceptingTells                 = 60,
-        [ServerOnly]
         LoggingChannel                   = 61,
-        [ServerOnly]
         OpensAnyLock                     = 62,
         UnlimitedUse                     = 63,
-        [ServerOnly]
         GeneratedTreasureItem            = 64,
-        [ServerOnly]
         IgnoreMagicResist                = 65,
-        [ServerOnly]
         IgnoreMagicArmor                 = 66,
-        [ServerOnly]
         AiAllowTrade                     = 67,
-        [ServerOnly]
         SpellComponentsRequired          = 68,
         IsSellable                       = 69,
-        [ServerOnly]
         IgnoreShieldsBySkill             = 70,
         NoDraw                           = 71,
-        [ServerOnly]
         ActivationUntargeted             = 72,
-        [ServerOnly]
         HouseHasGottenPriorityBootPos    = 73,
-        [ServerOnly]
         GeneratorAutomaticDestruction    = 74,
-        [ServerOnly]
         HouseHooksVisible                = 75,
-        [ServerOnly]
         HouseRequiresMonarch             = 76,
-        [ServerOnly]
         HouseHooksEnabled                = 77,
-        [ServerOnly]
         HouseNotifiedHudOfHookCount      = 78,
-        [ServerOnly]
         AiAcceptEverything               = 79,
-        [ServerOnly]
         IgnorePortalRestrictions         = 80,
         RequiresBackpackSlot             = 81,
-        [ServerOnly]
         DontTurnOrMoveWhenGiving         = 82,
-        [ServerOnly]
         NpcLooksLikeObject               = 83,
-        [ServerOnly]
         IgnoreCloIcons                   = 84,
         AppraisalHasAllowedWielder       = 85,
-        [ServerOnly]
         ChestRegenOnClose                = 86,
-        [ServerOnly]
         LogoffInMinigame                 = 87,
-        [ServerOnly]
         PortalShowDestination            = 88,
-        [ServerOnly]
         PortalIgnoresPkAttackTimer       = 89,
-        [ServerOnly]
         NpcInteractsSilently             = 90,
         Retained                         = 91,
-        [ServerOnly]
         IgnoreAuthor                     = 92,
-        [ServerOnly]
         Limbo                            = 93,
         AppraisalHasAllowedActivator     = 94,
-        [ServerOnly]
         ExistedBeforeAllegianceXpChanges = 95,
-        [ServerOnly]
         IsDeaf                           = 96,
-        [ServerOnly]
         IsPsr                            = 97,
-        [ServerOnly]
         Invincible                       = 98,
         Ivoryable                        = 99,
         Dyable                           = 100,
-        [ServerOnly]
         CanGenerateRare                  = 101,
-        [ServerOnly]
         CorpseGeneratedRare              = 102,
-        [ServerOnly]
         NonProjectileMagicImmune         = 103,
-        [ServerOnly]
         ActdReceivedItems                = 104,
-        [ServerOnly]
         Unknown105                       = 105,
-        [ServerOnly]
         FirstEnterWorldDone              = 106,
-        [ServerOnly]
         RecallsDisabled                  = 107,
         RareUsesTimer                    = 108,
-        [ServerOnly]
         ActdPreorderReceivedItems        = 109,
-        [ServerOnly]
         Afk                              = 110,
-        [ServerOnly]
         IsGagged                         = 111,
-        [ServerOnly]
         ProcSpellSelfTargeted            = 112,
-        [ServerOnly]
         IsAllegianceGagged               = 113,
-        [ServerOnly]
         EquipmentSetTriggerPiece         = 114,
-        [ServerOnly]
         Uninscribe                       = 115,
         WieldOnUse                       = 116,
-        [ServerOnly]
         ChestClearedWhenClosed           = 117,
-        [ServerOnly]
         NeverAttack                      = 118,
-        [ServerOnly]
         SuppressGenerateEffect           = 119,
-        [ServerOnly]
         TreasureCorpse                   = 120,
-        [ServerOnly]
         EquipmentSetAddLevel             = 121,
-        [ServerOnly]
         BarberActive                     = 122,
-        [ServerOnly]
         TopLayerPriority                 = 123,
-        [ServerOnly]
         NoHeldItemShown                  = 124,
-        [ServerOnly]
         LoginAtLifestone                 = 125,
-        [ServerOnly]
         OlthoiPk                         = 126,
-        [ServerOnly]
         Account15Days                    = 127,
-        [ServerOnly]
         HadNoVitae                       = 128,
-        [ServerOnly]
         NoOlthoiTalk                     = 129,
         AutowieldLeft                    = 130,
         [ServerOnly]

--- a/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
@@ -5,17 +5,13 @@
         // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
         // http://ac.yotesfan.com/ace_object/not_used_enums.php
         // source: @OptimShi
-
         // description attributes are used by the weenie editor for a cleaner display name
 
-        [ServerOnly]
         Undef                      = 0,
         Setup                      = 1,
         MotionTable                = 2,
         SoundTable                 = 3,
-        [ServerOnly]
         CombatTable                = 4,
-        [ServerOnly]
         QualityFilter              = 5,
         PaletteBase                = 6,
         ClothingBase               = 7,
@@ -23,94 +19,55 @@
         EyesTexture                = 9,
         NoseTexture                = 10,
         MouthTexture               = 11,
-        [ServerOnly]
         DefaultEyesTexture         = 12,
-        [ServerOnly]
         DefaultNoseTexture         = 13,
-        [ServerOnly]
         DefaultMouthTexture        = 14,
         HairPalette                = 15,
         EyesPalette                = 16,
         SkinPalette                = 17,
-        [ServerOnly]
         HeadObject                 = 18,
-        [ServerOnly]
         ActivationAnimation        = 19,
-        [ServerOnly]
         InitMotion                 = 20,
-        [ServerOnly]
         ActivationSound            = 21,
         PhysicsEffectTable         = 22,
-        [ServerOnly]
         UseSound                   = 23,
-        [ServerOnly]
         UseTargetAnimation         = 24,
-        [ServerOnly]
         UseTargetSuccessAnimation  = 25,
-        [ServerOnly]
         UseTargetFailureAnimation  = 26,
         UseUserAnimation           = 27,
         Spell                      = 28,
-        [ServerOnly]
         SpellComponent             = 29,
         PhysicsScript              = 30,
-        [ServerOnly]
         LinkedPortalOne            = 31,
-        [ServerOnly]
         WieldedTreasureType        = 32,
-        [ServerOnly]
         UnknownGuessedname         = 33,
-        [ServerOnly]
         UnknownGuessedname2        = 34,
-        [ServerOnly]
         DeathTreasureType          = 35,
-        [ServerOnly]
         MutateFilter               = 36,
-        [ServerOnly]
         ItemSkillLimit             = 37,
-        [ServerOnly]
         UseCreateItem              = 38,
-        [ServerOnly]
         DeathSpell                 = 39,
-        [ServerOnly]
         VendorsClassId             = 40,
         ItemSpecializedOnly        = 41,
-        [ServerOnly]
         HouseId                    = 42,
-        [ServerOnly]
         AccountHouseId             = 43,
-        [ServerOnly]
         RestrictionEffect          = 44,
-        [ServerOnly]
         CreationMutationFilter     = 45,
-        [ServerOnly]
         TsysMutationFilter         = 46,
-        [ServerOnly]
         LastPortal                 = 47,
-        [ServerOnly]
         LinkedPortalTwo            = 48,
-        [ServerOnly]
         OriginalPortal             = 49,
         IconOverlay                = 50,
-        [ServerOnly]
         IconOverlaySecondary       = 51,
         IconUnderlay               = 52,
-        [ServerOnly]
         AugmentationMutationFilter = 53,
-        [ServerOnly]
         AugmentationEffect         = 54,
         ProcSpell                  = 55,
-        [ServerOnly]
         AugmentationCreateItem     = 56,
-        [ServerOnly]
         AlternateCurrency          = 57,
-        [ServerOnly]
         BlueSurgeSpell             = 58,
-        [ServerOnly]
         YellowSurgeSpell           = 59,
-        [ServerOnly]
         RedSurgeSpell              = 60,
-        [ServerOnly]
         OlthoiDeathTreasureType    = 61,
         [ServerOnly]
         HairTexture                = 9001,

--- a/Source/ACE.Entity/Enum/Properties/PropertyDouble.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDouble.cs
@@ -5,33 +5,20 @@
         // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
         // http://ac.yotesfan.com/ace_object/not_used_enums.php
         // source: @OptimShi
-
         // description attributes are used by the weenie editor for a cleaner display name
 
-        [ServerOnly]
         Undef                          = 0,
-        [ServerOnly]
         HeartbeatInterval              = 1,
-        [ServerOnly]
         HeartbeatTimestamp             = 2,
-        [ServerOnly]
         HealthRate                     = 3,
-        [ServerOnly]
         StaminaRate                    = 4,
         ManaRate                       = 5,
-        [ServerOnly]
         HealthUponResurrection         = 6,
-        [ServerOnly]
         StaminaUponResurrection        = 7,
-        [ServerOnly]
         ManaUponResurrection           = 8,
-        [ServerOnly]
         StartTime                      = 9,
-        [ServerOnly]
         StopTime                       = 10,
-        [ServerOnly]
         ResetInterval                  = 11,
-        [ServerOnly]
         Shade                          = 12,
         ArmorModVsSlash                = 13,
         ArmorModVsPierce               = 14,
@@ -40,285 +27,160 @@
         ArmorModVsFire                 = 17,
         ArmorModVsAcid                 = 18,
         ArmorModVsElectric             = 19,
-        [ServerOnly]
         CombatSpeed                    = 20,
         WeaponLength                   = 21,
         DamageVariance                 = 22,
-        [ServerOnly]
         CurrentPowerMod                = 23,
-        [ServerOnly]
         AccuracyMod                    = 24,
-        [ServerOnly]
         StrengthMod                    = 25,
         MaximumVelocity                = 26,
-        [ServerOnly]
         RotationSpeed                  = 27,
-        [ServerOnly]
         MotionTimestamp                = 28,
         WeaponDefense                  = 29,
-        [ServerOnly]
         WimpyLevel                     = 30,
-        [ServerOnly]
         VisualAwarenessRange           = 31,
-        [ServerOnly]
         AuralAwarenessRange            = 32,
-        [ServerOnly]
         PerceptionLevel                = 33,
-        [ServerOnly]
         PowerupTime                    = 34,
-        [ServerOnly]
         MaxChargeDistance              = 35,
-        [ServerOnly]
         ChargeSpeed                    = 36,
-        [ServerOnly]
         BuyPrice                       = 37,
-        [ServerOnly]
         SellPrice                      = 38,
         DefaultScale                   = 39,
-        [ServerOnly]
         LockpickMod                    = 40,
         RegenerationInterval           = 41,
-        [ServerOnly]
         RegenerationTimestamp          = 42,
-        [ServerOnly]
         GeneratorRadius                = 43,
-        [ServerOnly]
         TimeToRot                      = 44,
-        [ServerOnly]
         DeathTimestamp                 = 45,
-        [ServerOnly]
         PkTimestamp                    = 46,
-        [ServerOnly]
         VictimTimestamp                = 47,
-        [ServerOnly]
         LoginTimestamp                 = 48,
-        [ServerOnly]
         CreationTimestamp              = 49,
-        [ServerOnly]
         MinimumTimeSincePk             = 50,
-        [ServerOnly]
         DeprecatedHousekeepingPriority = 51,
-        [ServerOnly]
         AbuseLoggingTimestamp          = 52,
-        [ServerOnly]
         LastPortalTeleportTimestamp    = 53,
         UseRadius                      = 54,
-        [ServerOnly]
         HomeRadius                     = 55,
-        [ServerOnly]
         ReleasedTimestamp              = 56,
-        [ServerOnly]
         MinHomeRadius                  = 57,
-        [ServerOnly]
         Facing                         = 58,
-        [ServerOnly]
         ResetTimestamp                 = 59,
-        [ServerOnly]
         LogoffTimestamp                = 60,
-        [ServerOnly]
         EconRecoveryInterval           = 61,
         WeaponOffense                  = 62,
         DamageMod                      = 63,
-        [ServerOnly]
         ResistSlash                    = 64,
-        [ServerOnly]
         ResistPierce                   = 65,
-        [ServerOnly]
         ResistBludgeon                 = 66,
-        [ServerOnly]
         ResistFire                     = 67,
-        [ServerOnly]
         ResistCold                     = 68,
-        [ServerOnly]
         ResistAcid                     = 69,
-        [ServerOnly]
         ResistElectric                 = 70,
-        [ServerOnly]
         ResistHealthBoost              = 71,
-        [ServerOnly]
         ResistStaminaDrain             = 72,
-        [ServerOnly]
         ResistStaminaBoost             = 73,
-        [ServerOnly]
         ResistManaDrain                = 74,
-        [ServerOnly]
         ResistManaBoost                = 75,
         Translucency                   = 76,
         PhysicsScriptIntensity         = 77,
         Friction                       = 78,
         Elasticity                     = 79,
-        [ServerOnly]
         AiUseMagicDelay                = 80,
-        [ServerOnly]
         ItemMinSpellcraftMod           = 81,
-        [ServerOnly]
         ItemMaxSpellcraftMod           = 82,
-        [ServerOnly]
         ItemRankProbability            = 83,
-        [ServerOnly]
         Shade2                         = 84,
-        [ServerOnly]
         Shade3                         = 85,
-        [ServerOnly]
         Shade4                         = 86,
         ItemEfficiency                 = 87,
-        [ServerOnly]
         ItemManaUpdateTimestamp        = 88,
-        [ServerOnly]
         SpellGestureSpeedMod           = 89,
-        [ServerOnly]
         SpellStanceSpeedMod            = 90,
-        [ServerOnly]
         AllegianceAppraisalTimestamp   = 91,
-        [ServerOnly]
         PowerLevel                     = 92,
-        [ServerOnly]
         AccuracyLevel                  = 93,
-        [ServerOnly]
         AttackAngle                    = 94,
-        [ServerOnly]
         AttackTimestamp                = 95,
-        [ServerOnly]
         CheckpointTimestamp            = 96,
-        [ServerOnly]
         SoldTimestamp                  = 97,
-        [ServerOnly]
         UseTimestamp                   = 98,
-        [ServerOnly]
         UseLockTimestamp               = 99,
         HealkitMod                     = 100,
-        [ServerOnly]
         FrozenTimestamp                = 101,
-        [ServerOnly]
         HealthRateMod                  = 102,
-        [ServerOnly]
         AllegianceSwearTimestamp       = 103,
-        [ServerOnly]
         ObviousRadarRange              = 104,
-        [ServerOnly]
         HotspotCycleTime               = 105,
-        [ServerOnly]
         HotspotCycleTimeVariance       = 106,
-        [ServerOnly]
         SpamTimestamp                  = 107,
-        [ServerOnly]
         SpamRate                       = 108,
-        [ServerOnly]
         BondWieldedTreasure            = 109,
-        [ServerOnly]
         BulkMod                        = 110,
-        [ServerOnly]
         SizeMod                        = 111,
-        [ServerOnly]
         GagTimestamp                   = 112,
-        [ServerOnly]
         GeneratorUpdateTimestamp       = 113,
-        [ServerOnly]
         DeathSpamTimestamp             = 114,
-        [ServerOnly]
         DeathSpamRate                  = 115,
-        [ServerOnly]
         WildAttackProbability          = 116,
-        [ServerOnly]
         FocusedProbability             = 117,
-        [ServerOnly]
         CrashAndTurnProbability        = 118,
-        [ServerOnly]
         CrashAndTurnRadius             = 119,
-        [ServerOnly]
         CrashAndTurnBias               = 120,
-        [ServerOnly]
         GeneratorInitialDelay          = 121,
-        [ServerOnly]
         AiAcquireHealth                = 122,
-        [ServerOnly]
         AiAcquireStamina               = 123,
-        [ServerOnly]
         AiAcquireMana                  = 124,
         /// <summary>
         /// this had a default of "1" - leaving comment to investigate potential options for defaulting these things (125)
         /// </summary>
-        [ServerOnly]
         ResistHealthDrain              = 125,
-        [ServerOnly]
         LifestoneProtectionTimestamp   = 126,
-        [ServerOnly]
         AiCounteractEnchantment        = 127,
-        [ServerOnly]
         AiDispelEnchantment            = 128,
-        [ServerOnly]
         TradeTimestamp                 = 129,
-        [ServerOnly]
         AiTargetedDetectionRadius      = 130,
-        [ServerOnly]
         EmotePriority                  = 131,
-        [ServerOnly]
         LastTeleportStartTimestamp     = 132,
-        [ServerOnly]
         EventSpamTimestamp             = 133,
-        [ServerOnly]
         EventSpamRate                  = 134,
-        [ServerOnly]
         InventoryOffset                = 135,
         CriticalMultiplier             = 136,
         ManaStoneDestroyChance         = 137,
-        [ServerOnly]
         SlayerDamageBonus              = 138,
-        [ServerOnly]
         AllegianceInfoSpamTimestamp    = 139,
-        [ServerOnly]
         AllegianceInfoSpamRate         = 140,
-        [ServerOnly]
         NextSpellcastTimestamp         = 141,
-        [ServerOnly]
         AppraisalRequestedTimestamp    = 142,
-        [ServerOnly]
         AppraisalHeartbeatDueTimestamp = 143,
         ManaConversionMod              = 144,
-        [ServerOnly]
         LastPkAttackTimestamp          = 145,
-        [ServerOnly]
         FellowshipUpdateTimestamp      = 146,
         CriticalFrequency              = 147,
-        [ServerOnly]
         LimboStartTimestamp            = 148,
         WeaponMissileDefense           = 149,
         WeaponMagicDefense             = 150,
-        [ServerOnly]
         IgnoreShield                   = 151,
         ElementalDamageMod             = 152,
-        [ServerOnly]
         StartMissileAttackTimestamp    = 153,
-        [ServerOnly]
         LastRareUsedTimestamp          = 154,
         IgnoreArmor                    = 155,
-        [ServerOnly]
         ProcSpellRate                  = 156,
         ResistanceModifier             = 157,
-        [ServerOnly]
         AllegianceGagTimestamp         = 158,
         AbsorbMagicDamage              = 159,
-        [ServerOnly]
         CachedMaxAbsorbMagicDamage     = 160,
-        [ServerOnly]
         GagDuration                    = 161,
-        [ServerOnly]
         AllegianceGagDuration          = 162,
-        [ServerOnly]
         GlobalXpMod                    = 163,
-        [ServerOnly]
         HealingModifier                = 164,
         ArmorModVsNether               = 165,
-        [ServerOnly]
         ResistNether                   = 166,
         CooldownDuration               = 167,
-        [ServerOnly]
         WeaponAuraOffense              = 168,
-        [ServerOnly]
         WeaponAuraDefense              = 169,
-        [ServerOnly]
         WeaponAuraElemental            = 170,
-        [ServerOnly]
         WeaponAuraManaConv             = 171
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -5,73 +5,50 @@
         // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
         // http://ac.yotesfan.com/ace_object/not_used_enums.php
         // source: @OptimShi
-
         // description attributes are used by the weenie editor for a cleaner display name
 
-        [ServerOnly]
         Undef                                    = 0,
         ItemType                                 = 1,
         CreatureType                             = 2,
-        [ServerOnly]
         PaletteTemplate                          = 3,
         ClothingPriority                         = 4,
         EncumbranceVal                           = 5, // ENCUMB_VAL_INT,
         ItemsCapacity                            = 6,
         ContainersCapacity                       = 7,
-        [ServerOnly]
         Mass                                     = 8,
         ValidLocations                           = 9, // LOCATIONS_INT
         CurrentWieldedLocation                   = 10,
         MaxStackSize                             = 11,
         StackSize                                = 12,
-        [ServerOnly]
         StackUnitEncumbrance                     = 13,
-        [ServerOnly]
         StackUnitMass                            = 14,
-        [ServerOnly]
         StackUnitValue                           = 15,
         ItemUseable                              = 16,
         RareId                                   = 17,
         UiEffects                                = 18,
         Value                                    = 19,
-        [ServerOnly]
         CoinValue                                = 20,
-        [ServerOnly]
         TotalExperience                          = 21,
-        [ServerOnly]
         AvailableCharacter                       = 22,
-        [ServerOnly]
         TotalSkillCredits                        = 23,
-        [ServerOnly]
         AvailableSkillCredits                    = 24,
         Level                                    = 25,
         AccountRequirements                      = 26,
-        [ServerOnly]
         ArmorType                                = 27,
         ArmorLevel                               = 28,
-        [ServerOnly]
         AllegianceCpPool                         = 29,
         AllegianceRank                           = 30,
-        [ServerOnly]
         ChannelsAllowed                          = 31,
-        [ServerOnly]
         ChannelsActive                           = 32,
         Bonded                                   = 33,
-        [ServerOnly]
         MonarchsRank                             = 34,
-        [ServerOnly]
         AllegianceFollowers                      = 35,
         ResistMagic                              = 36,
-        [ServerOnly]
         ResistItemAppraisal                      = 37,
         ResistLockpick                           = 38,
-        [ServerOnly]
         DeprecatedResistRepair                   = 39,
-        [ServerOnly]
         CombatMode                               = 40,
-        [ServerOnly]
         CurrentAttackHeight                      = 41,
-        [ServerOnly]
         CombatCollisions                         = 42,
         NumDeaths                                = 43,
         Damage                                   = 44,
@@ -84,72 +61,40 @@
         CombatUse                                = 51,
         ParentLocation                           = 52,
         PlacementPosition                        = 53,
-        [ServerOnly]
         WeaponEncumbrance                        = 54,
-        [ServerOnly]
         WeaponMass                               = 55,
-        [ServerOnly]
         ShieldValue                              = 56,
-        [ServerOnly]
         ShieldEncumbrance                        = 57,
-        [ServerOnly]
         MissileInventoryLocation                 = 58,
-        [ServerOnly]
         FullDamageType                           = 59,
-        [ServerOnly]
         WeaponRange                              = 60,
-        [ServerOnly]
         AttackersSkill                           = 61,
-        [ServerOnly]
         DefendersSkill                           = 62,
-        [ServerOnly]
         AttackersSkillValue                      = 63,
-        [ServerOnly]
         AttackersClass                           = 64,
-        [ServerOnly]
         Placement                                = 65,
-        [ServerOnly]
         CheckpointStatus                         = 66,
-        [ServerOnly]
         Tolerance                                = 67,
-        [ServerOnly]
         TargetingTactic                          = 68,
-        [ServerOnly]
         CombatTactic                             = 69,
-        [ServerOnly]
         HomesickTargetingTactic                  = 70,
-        [ServerOnly]
         NumFollowFailures                        = 71,
-        [ServerOnly]
         FriendType                               = 72,
-        [ServerOnly]
         FoeType                                  = 73,
-        [ServerOnly]
         MerchandiseItemTypes                     = 74,
-        [ServerOnly]
         MerchandiseMinValue                      = 75,
-        [ServerOnly]
         MerchandiseMaxValue                      = 76,
-        [ServerOnly]
         NumItemsSold                             = 77,
-        [ServerOnly]
         NumItemsBought                           = 78,
-        [ServerOnly]
         MoneyIncome                              = 79,
-        [ServerOnly]
         MoneyOutflow                             = 80,
         MaxGeneratedObjects                      = 81,
-        [ServerOnly]
         InitGeneratedObjects                     = 82,
-        [ServerOnly]
         ActivationResponse                       = 83,
-        [ServerOnly]
         OriginalValue                            = 84,
-        [ServerOnly]
         NumMoveFailures                          = 85,
         MinLevel                                 = 86,
         MaxLevel                                 = 87,
-        [ServerOnly]
         LockpickMod                              = 88,
         BoosterEnum                              = 89,
         BoostValue                               = 90,
@@ -158,19 +103,13 @@
         PhysicsState                             = 93,
         TargetType                               = 94,
         RadarBlipColor                           = 95,
-        [ServerOnly]
         EncumbranceCapacity                      = 96,
-        [ServerOnly]
         LoginTimestamp                           = 97,
         CreationTimestamp                        = 98,
-        [ServerOnly]
         PkLevelModifier                          = 99,
         GeneratorType                            = 100,
-        [ServerOnly]
         AiAllowedCombatStyle                     = 101,
-        [ServerOnly]
         LogoffTimestamp                          = 102,
-        [ServerOnly]
         GeneratorDestructionType                 = 103,
         ActivationCreateClass                    = 104,
         ItemWorkmanship                          = 105,
@@ -180,106 +119,63 @@
         ItemDifficulty                           = 109,
         ItemAllegianceRankLimit                  = 110,
         PortalBitmask                            = 111,
-        [ServerOnly]
         AdvocateLevel                            = 112,
         Gender                                   = 113,
         Attuned                                  = 114,
         ItemSkillLevelLimit                      = 115,
-        [ServerOnly]
         GateLogic                                = 116,
         ItemManaCost                             = 117,
-        [ServerOnly]
         Logoff                                   = 118,
-        [ServerOnly]
         Active                                   = 119,
-        [ServerOnly]
         AttackHeight                             = 120,
-        [ServerOnly]
         NumAttackFailures                        = 121,
-        [ServerOnly]
         AiCpThreshold                            = 122,
-        [ServerOnly]
         AiAdvancementStrategy                    = 123,
-        [ServerOnly]
         Version                                  = 124,
         Age                                      = 125,
-        [ServerOnly]
         VendorHappyMean                          = 126,
-        [ServerOnly]
         VendorHappyVariance                      = 127,
-        [ServerOnly]
         CloakStatus                              = 128,
-        [ServerOnly]
         VitaeCpPool                              = 129,
-        [ServerOnly]
         NumServicesSold                          = 130,
         MaterialType                             = 131,
-        [ServerOnly]
         NumAllegianceBreaks                      = 132,
         ShowableOnRadar                          = 133,
         PlayerKillerStatus                       = 134,
-        [ServerOnly]
         VendorHappyMaxItems                      = 135,
-        [ServerOnly]
         ScorePageNum                             = 136,
-        [ServerOnly]
         ScoreConfigNum                           = 137,
-        [ServerOnly]
         ScoreNumScores                           = 138,
-        [ServerOnly]
         DeathLevel                               = 139,
-        [ServerOnly]
         AiOptions                                = 140,
-        [ServerOnly]
         OpenToEveryone                           = 141,
         GeneratorTimeType                        = 142,
-        [ServerOnly]
         GeneratorStartTime                       = 143,
-        [ServerOnly]
         GeneratorEndTime                         = 144,
-        [ServerOnly]
         GeneratorEndDestructionType              = 145,
-        [ServerOnly]
         XpOverride                               = 146,
-        [ServerOnly]
         NumCrashAndTurns                         = 147,
-        [ServerOnly]
         ComponentWarningThreshold                = 148,
-        [ServerOnly]
         HouseStatus                              = 149,
-        [ServerOnly]
         HookPlacement                            = 150,
         HookType                                 = 151,
         HookItemType                             = 152,
-        [ServerOnly]
         AiPpThreshold                            = 153,
-        [ServerOnly]
         GeneratorVersion                         = 154,
-        [ServerOnly]
         HouseType                                = 155,
-        [ServerOnly]
         PickupEmoteOffset                        = 156,
-        [ServerOnly]
         WeenieIteration                          = 157,
         WieldRequirements                        = 158,
         WieldSkilltype                           = 159,
         WieldDifficulty                          = 160,
-        [ServerOnly]
         HouseMaxHooksUsable                      = 161,
-        [ServerOnly]
         HouseCurrentHooksUsable                  = 162,
-        [ServerOnly]
         AllegianceMinLevel                       = 163,
-        [ServerOnly]
         AllegianceMaxLevel                       = 164,
-        [ServerOnly]
         HouseRelinkHookCount                     = 165,
         SlayerCreatureType                       = 166,
-        [ServerOnly]
         ConfirmationInProgress                   = 167,
-        [ServerOnly]
         ConfirmationTypeInProgress               = 168,
-        [ServerOnly]
         TsysMutationData                         = 169,
         NumItemsInMaterial                       = 170,
         NumTimesTinkered                         = 171,
@@ -291,172 +187,95 @@
         GemCount                                 = 177,
         GemType                                  = 178,
         ImbuedEffect                             = 179,
-        [ServerOnly]
         AttackersRawSkillValue                   = 180,
         ChessRank                                = 181,
-        [ServerOnly]
         ChessTotalGames                          = 182,
-        [ServerOnly]
         ChessGamesWon                            = 183,
-        [ServerOnly]
         ChessGamesLost                           = 184,
-        [ServerOnly]
         TypeOfAlteration                         = 185,
-        [ServerOnly]
         SkillToBeAltered                         = 186,
-        [ServerOnly]
         SkillAlterationCount                     = 187,
         HeritageGroup                            = 188,
-        [ServerOnly]
         TransferFromAttribute                    = 189,
-        [ServerOnly]
         TransferToAttribute                      = 190,
-        [ServerOnly]
         AttributeTransferCount                   = 191,
         FakeFishingSkill                         = 192,
         NumKeys                                  = 193,
-        [ServerOnly]
         DeathTimestamp                           = 194,
-        [ServerOnly]
         PkTimestamp                              = 195,
-        [ServerOnly]
         VictimTimestamp                          = 196,
-        [ServerOnly]
         HookGroup                                = 197,
-        [ServerOnly]
         AllegianceSwearTimestamp                 = 198,
-        [ServerOnly]
         HousePurchaseTimestamp                   = 199,
-        [ServerOnly]
         RedirectableEquippedArmorCount           = 200,
-        [ServerOnly]
         MeleedefenseImbuedEffectTypeCache        = 201,
-        [ServerOnly]
         MissileDefenseImbuedEffectTypeCache      = 202,
-        [ServerOnly]
         MagicDefenseImbuedEffectTypeCache        = 203,
         ElementalDamageBonus                     = 204,
-        [ServerOnly]
         ImbueAttempts                            = 205,
-        [ServerOnly]
         ImbueSuccesses                           = 206,
-        [ServerOnly]
         CreatureKills                            = 207,
-        [ServerOnly]
         PlayerKillsPk                            = 208,
-        [ServerOnly]
         PlayerKillsPkl                           = 209,
-        [ServerOnly]
         RaresTierOne                             = 210,
-        [ServerOnly]
         RaresTierTwo                             = 211,
-        [ServerOnly]
         RaresTierThree                           = 212,
-        [ServerOnly]
         RaresTierFour                            = 213,
-        [ServerOnly]
         RaresTierFive                            = 214,
-        [ServerOnly]
         AugmentationStat                         = 215,
-        [ServerOnly]
         AugmentationFamilyStat                   = 216,
-        [ServerOnly]
         AugmentationInnateFamily                 = 217,
-        [ServerOnly]
         AugmentationInnateStrength               = 218,
-        [ServerOnly]
         AugmentationInnateEndurance              = 219,
-        [ServerOnly]
         AugmentationInnateCoordination           = 220,
-        [ServerOnly]
         AugmentationInnateQuickness              = 221,
-        [ServerOnly]
         AugmentationInnateFocus                  = 222,
-        [ServerOnly]
         AugmentationInnateSelf                   = 223,
-        [ServerOnly]
         AugmentationSpecializeSalvaging          = 224,
-        [ServerOnly]
         AugmentationSpecializeItemTinkering      = 225,
-        [ServerOnly]
         AugmentationSpecializeArmorTinkering     = 226,
-        [ServerOnly]
         AugmentationSpecializeMagicItemTinkering = 227,
-        [ServerOnly]
         AugmentationSpecializeWeaponTinkering    = 228,
-        [ServerOnly]
         AugmentationExtraPackSlot                = 229,
-        [ServerOnly]
         AugmentationIncreasedCarryingCapacity    = 230,
-        [ServerOnly]
         AugmentationLessDeathItemLoss            = 231,
-        [ServerOnly]
         AugmentationSpellsRemainPastDeath        = 232,
-        [ServerOnly]
         AugmentationCriticalDefense              = 233,
-        [ServerOnly]
         AugmentationBonusXp                      = 234,
-        [ServerOnly]
         AugmentationBonusSalvage                 = 235,
-        [ServerOnly]
         AugmentationBonusImbueChance             = 236,
-        [ServerOnly]
         AugmentationFasterRegen                  = 237,
-        [ServerOnly]
         AugmentationIncreasedSpellDuration       = 238,
-        [ServerOnly]
         AugmentationResistanceFamily             = 239,
-        [ServerOnly]
         AugmentationResistanceSlash              = 240,
-        [ServerOnly]
         AugmentationResistancePierce             = 241,
-        [ServerOnly]
         AugmentationResistanceBlunt              = 242,
-        [ServerOnly]
         AugmentationResistanceAcid               = 243,
-        [ServerOnly]
         AugmentationResistanceFire               = 244,
-        [ServerOnly]
         AugmentationResistanceFrost              = 245,
-        [ServerOnly]
         AugmentationResistanceLightning          = 246,
-        [ServerOnly]
         RaresTierOneLogin                        = 247,
-        [ServerOnly]
         RaresTierTwoLogin                        = 248,
-        [ServerOnly]
         RaresTierThreeLogin                      = 249,
-        [ServerOnly]
         RaresTierFourLogin                       = 250,
-        [ServerOnly]
         RaresTierFiveLogin                       = 251,
-        [ServerOnly]
         RaresLoginTimestamp                      = 252,
-        [ServerOnly]
         RaresTierSix                             = 253,
-        [ServerOnly]
         RaresTierSeven                           = 254,
-        [ServerOnly]
         RaresTierSixLogin                        = 255,
-        [ServerOnly]
         RaresTierSevenLogin                      = 256,
         ItemAttributeLimit                       = 257,
         ItemAttributeLevelLimit                  = 258,
-        [ServerOnly]
         ItemAttribute2ndLimit                    = 259,
-        [ServerOnly]
         ItemAttribute2ndLevelLimit               = 260,
         CharacterTitleId                         = 261,
         NumCharacterTitles                       = 262,
         ResistanceModifierType                   = 263,
-        [ServerOnly]
         FreeTinkersBitfield                      = 264,
         EquipmentSetId                           = 265,
-        [ServerOnly]
         PetClass                                 = 266,
         Lifespan                                 = 267,
         RemainingLifespan                        = 268,
-        [ServerOnly]
         UseCreateQuantity                        = 269,
         WieldRequirements2                       = 270,
         WieldSkilltype2                          = 271,
@@ -470,43 +289,26 @@
         Unique                                   = 279,
         SharedCooldown                           = 280,
         Faction1Bits                             = 281,
-        [ServerOnly]
         Faction2Bits                             = 282,
-        [ServerOnly]
         Faction3Bits                             = 283,
-        [ServerOnly]
         Hatred1Bits                              = 284,
-        [ServerOnly]
         Hatred2Bits                              = 285,
-        [ServerOnly]
         Hatred3Bits                              = 286,
         SocietyRankCelhan                        = 287,
         SocietyRankEldweb                        = 288,
         SocietyRankRadblo                        = 289,
-        [ServerOnly]
         HearLocalSignals                         = 290,
-        [ServerOnly]
         HearLocalSignalsRadius                   = 291,
         Cleaving                                 = 292,
-        [ServerOnly]
         AugmentationSpecializeGearcraft          = 293,
-        [ServerOnly]
         AugmentationInfusedCreatureMagic         = 294,
-        [ServerOnly]
         AugmentationInfusedItemMagic             = 295,
-        [ServerOnly]
         AugmentationInfusedLifeMagic             = 296,
-        [ServerOnly]
         AugmentationInfusedWarMagic              = 297,
-        [ServerOnly]
         AugmentationCriticalExpertise            = 298,
-        [ServerOnly]
         AugmentationCriticalPower                = 299,
-        [ServerOnly]
         AugmentationSkilledMelee                 = 300,
-        [ServerOnly]
         AugmentationSkilledMissile               = 301,
-        [ServerOnly]
         AugmentationSkilledMagic                 = 302,
         ImbuedEffect2                            = 303,
         ImbuedEffect3                            = 304,
@@ -514,112 +316,65 @@
         ImbuedEffect5                            = 306,
         DamageRating                             = 307,
         DamageResistRating                       = 308,
-        [ServerOnly]
         AugmentationDamageBonus                  = 309,
-        [ServerOnly]
         AugmentationDamageReduction              = 310,
-        [ServerOnly]
         ImbueStackingBits                        = 311,
-        [ServerOnly]
         HealOverTime                             = 312,
         CritRating                               = 313,
         CritDamageRating                         = 314,
         CritResistRating                         = 315,
         CritDamageResistRating                   = 316,
-        [ServerOnly]
         HealingResistRating                      = 317,
-        [ServerOnly]
         DamageOverTime                           = 318,
         ItemMaxLevel                             = 319,
         ItemXpStyle                              = 320,
-        [ServerOnly]
         EquipmentSetExtra                        = 321,
-        [ServerOnly]
         AetheriaBitfield                         = 322,
-        [ServerOnly]
         HealingBoostRating                       = 323,
         HeritageSpecificArmor                    = 324,
-        [ServerOnly]
         AlternateRacialSkills                    = 325,
         /// <summary>
         /// why was this defaulted to 1?  leaving comment
         /// </summary>
-        [ServerOnly]
         AugmentationJackOfAllTrades              = 326,
-        [ServerOnly]
         AugmentationResistanceNether             = 327,
-        [ServerOnly]
         AugmentationInfusedVoidMagic             = 328,
-        [ServerOnly]
         WeaknessRating                           = 329,
-        [ServerOnly]
         NetherOverTime                           = 330,
-        [ServerOnly]
         NetherResistRating                       = 331,
-        [ServerOnly]
         LuminanceAward                           = 332,
-        [ServerOnly]
         LumAugDamageRating                       = 333,
-        [ServerOnly]
         LumAugDamageReductionRating              = 334,
-        [ServerOnly]
         LumAugCritDamageRating                   = 335,
-        [ServerOnly]
         LumAugCritReductionRating                = 336,
-        [ServerOnly]
         LumAugSurgeEffectRating                  = 337,
-        [ServerOnly]
         LumAugSurgeChanceRating                  = 338,
-        [ServerOnly]
         LumAugItemManaUsage                      = 339,
-        [ServerOnly]
         LumAugItemManaGain                       = 340,
-        [ServerOnly]
         LumAugVitality                           = 341,
-        [ServerOnly]
         LumAugHealingRating                      = 342,
-        [ServerOnly]
         LumAugSkilledCraft                       = 343,
-        [ServerOnly]
         LumAugSkilledSpec                        = 344,
-        [ServerOnly]
         LumAugNoDestroyCraft                     = 345,
-        [ServerOnly]
         RestrictInteraction                      = 346,
-        [ServerOnly]
         OlthoiLootTimestamp                      = 347,
-        [ServerOnly]
         OlthoiLootStep                           = 348,
-        [ServerOnly]
         UseCreatesContractId                     = 349,
-        [ServerOnly]
         DotResistRating                          = 350,
         LifeResistRating                         = 351,
         CloakWeaveProc                           = 352,
         WeaponType                               = 353,
-        [ServerOnly]
         MeleeMastery                             = 354,
-        [ServerOnly]
         RangedMastery                            = 355,
-        [ServerOnly]
         SneakAttackRating                        = 356,
-        [ServerOnly]
         RecklessnessRating                       = 357,
-        [ServerOnly]
         DeceptionRating                          = 358,
-        [ServerOnly]
         CombatPetRange                           = 359,
-        [ServerOnly]
         WeaponAuraDamage                         = 360,
-        [ServerOnly]
         WeaponAuraSpeed                          = 361,
-        [ServerOnly]
         SummoningMastery                         = 362,
-        [ServerOnly]
         HeartbeatLifespan                        = 363,
-        [ServerOnly]
         UseLevelRequirement                      = 364,
-        [ServerOnly]
         LumAugAllSkills                          = 365,
         UseRequiresSkill                         = 366,
         UseRequiresSkillLevel                    = 367,
@@ -659,7 +414,9 @@
         CharacterOptions2                        = 9004,
         [ServerOnly]
         LootTier                                 = 9005,
+        [ServerOnly]
         GeneratorProbability                     = 9006,
+        [ServerOnly]
         WeenieType                               = 9007
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
@@ -3,24 +3,17 @@
     // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
     // http://ac.yotesfan.com/ace_object/not_used_enums.php
     // source: @OptimShi
-
     // description attributes are used by the weenie editor for a cleaner display name
     public enum PropertyInt64 : ushort
     {
-        [ServerOnly]
         Undef               = 0,
-        [ServerOnly]
         TotalExperience     = 1,
-        [ServerOnly]
         AvailableExperience = 2,
         AugmentationCost    = 3,
         ItemTotalXp         = 4,
         ItemBaseXp          = 5,
-        [ServerOnly]
         AvailableLuminance  = 6,
-        [ServerOnly]
         MaximumLuminance    = 7,
-        [ServerOnly]
         InteractionReqs     = 8,
         [ServerOnly]
         DeleteTime          = 9001

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-
 namespace ACE.Entity.Enum.Properties
 {
     public enum PropertyString : ushort
@@ -7,98 +6,62 @@ namespace ACE.Entity.Enum.Properties
         // properties marked as ServerOnly are properties we never saw in PCAPs, from here:
         // http://ac.yotesfan.com/ace_object/not_used_enums.php
         // source: @OptimShi
-
         // description attributes are used by the weenie editor for a cleaner display name
-
-        [ServerOnly]
         Undef                           = 0,
         Name                            = 1,
         /// <summary>
         /// default "Adventurer"
         /// </summary>
-        [ServerOnly]
         Title                           = 2,
-        [ServerOnly]
         Sex                             = 3,
-        [ServerOnly]
         HeritageGroup                   = 4,
         Template                        = 5,
-        [ServerOnly]
         AttackersName                   = 6,
         Inscription                     = 7,
         [Description("Scribe Name")]
         ScribeName                      = 8,
-        [ServerOnly]
         VendorsName                     = 9,
-        [ServerOnly]
         Fellowship                      = 10,
-        [ServerOnly]
         MonarchsName                    = 11,
-        [ServerOnly]
         LockCode                        = 12,
-        [ServerOnly]
         KeyCode                         = 13,
         Use                             = 14,
         ShortDesc                       = 15,
         LongDesc                        = 16,
         ActivationTalk                  = 17,
-        [ServerOnly]
         UseMessage                      = 18,
-        [ServerOnly]
         ItemHeritageGroupRestriction    = 19,
         PluralName                      = 20,
         MonarchsTitle                   = 21,
-        [ServerOnly]
         ActivationFailure               = 22,
-        [ServerOnly]
         ScribeAccount                   = 23,
-        [ServerOnly]
         TownName                        = 24,
         CraftsmanName                   = 25,
-        [ServerOnly]
         UsePkServerError                = 26,
-        [ServerOnly]
         ScoreCachedText                 = 27,
-        [ServerOnly]
         ScoreDefaultEntryFormat         = 28,
-        [ServerOnly]
         ScoreFirstEntryFormat           = 29,
-        [ServerOnly]
         ScoreLastEntryFormat            = 30,
-        [ServerOnly]
         ScoreOnlyEntryFormat            = 31,
-        [ServerOnly]
         ScoreNoEntry                    = 32,
-        [ServerOnly]
         Quest                           = 33,
-        [ServerOnly]
         GeneratorEvent                  = 34,
         PatronsTitle                    = 35,
         HouseOwnerName                  = 36,
-        [ServerOnly]
         QuestRestriction                = 37,
         AppraisalPortalDestination      = 38,
         TinkerName                      = 39,
         ImbuerName                      = 40,
-        [ServerOnly]
         HouseOwnerAccount               = 41,
-        [ServerOnly]
         DisplayName                     = 42,
         DateOfBirth                     = 43,
-        [ServerOnly]
         ThirdPartyApi                   = 44,
-        [ServerOnly]
         KillQuest                       = 45,
-        [ServerOnly]
         Afk                             = 46,
         AllegianceName                  = 47,
-        [ServerOnly]
         AugmentationAddQuest            = 48,
-        [ServerOnly]
         KillQuest2                      = 49,
-        [ServerOnly]
         KillQuest3                      = 50,
-        [ServerOnly]
         UseSendsSignal                  = 51,
         GearPlatingName                 = 52
         // values over 9000 are ones that we have added and should not be sent to the client

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # ACEmulator Change Log
 
+### 2017-10-03
+[Og II]
+* Added update script to modify defaultCombatStance ace_object_properties_int to match change with @OptimShi changes of 10/02
+* Rolled back [ServerOnly] attribute on enums.   I left the mechanism in place and tagged all over 9000 as such.   Our method for determining
+* this is not correct.   We can add these back when we fully understand which are truly not needed by the client.
+
+
+
 ### 2017-10-02
 [OptimShi]
 * Changed MotionCommand and MotionState enums to full uint instead of short and adjusted the movement serializing functions to work with these changes.


### PR DESCRIPTION
"These engines are the fastest in any tanks in the European Theater of Operations, forwards or backwards. You see, man, we like to feel we can get out of trouble, quicker than we got into it."   Oddball - Kelly's Heroes.

### 2017-10-03
[Og II]
* Added update script to modify defaultCombatStance ace_object_properties_int to match change with @OptimShi changes of 10/02
* Rolled back [ServerOnly] attribute on enums.   I left the mechanism in place and tagged all over 9000 as such.   Our method for determining which of these are server only  this is not correct.   We can add these back when we fully understand which are truly not needed by the client.
![image](https://user-images.githubusercontent.com/25460553/31134257-32520b08-a827-11e7-84ae-353e346e262c.png)
