### PR TITLE
Portals update

### DIFF
--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -757,6 +757,11 @@ namespace ACE.Entity
             return lb.worldObjects[guid].Location;
         }
 
+        public WeenieType GetWeenieType(ObjectGuid guid)
+        {
+            return worldObjects.ContainsKey(guid) ? worldObjects[guid].WeenieType : 0;
+        }
+
         public void ChainOnObject(ActionChain chain, ObjectGuid woGuid, Action<WorldObject> action)
         {
             WorldObject wo = GetObject(woGuid);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -2752,8 +2752,16 @@ namespace ACE.Entity
                     return;
                 }
 
-                OnAutonomousMove(CurrentLandblock.GetPosition(target),
-                                         Sequences, MovementTypes.MoveToObject, target);
+                if (CurrentLandblock.GetWeenieType(target) == WeenieType.Portal)
+                {
+                    OnAutonomousMove(CurrentLandblock.GetPosition(target),
+                                            Sequences, MovementTypes.MoveToPosition, target);
+                }
+                else
+                {
+                    OnAutonomousMove(CurrentLandblock.GetPosition(target),
+                                            Sequences, MovementTypes.MoveToObject, target);
+                }
             });
 
             // poll for arrival every .1 seconds

--- a/Source/ACE/Entity/Portal.cs
+++ b/Source/ACE/Entity/Portal.cs
@@ -325,6 +325,7 @@ namespace ACE.Entity
                     player.DoMoveTo(this);
                 else
                 {
+                    // TODO: to be removed once physics collisions are implemented
                     HandleActionOnCollide(playerId);
                     // always send useDone event
                     var sendUseDoneEvent = new GameEventUseDone(player.Session);

--- a/Source/ACE/Entity/Portal.cs
+++ b/Source/ACE/Entity/Portal.cs
@@ -165,15 +165,7 @@ namespace ACE.Entity
 
         public override void HandleActionOnCollide(ObjectGuid playerId)
         {
-            HandleActionOnUse(playerId);
-        }
-
-        public override void HandleActionOnUse(ObjectGuid playerId)
-        {
             string serverMessage;
-
-            // validate within use range :: set to a fixed value as static Portals are normally OnCollide usage
-            var rangeCheck = 5.0f;
 
             ActionChain chain = new ActionChain();
             CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
@@ -183,152 +175,157 @@ namespace ACE.Entity
                 {
                     return;
                 }
-                // Can check location by guid
-                // NOTE: Must use CurrentLandblock.GetPosition() for the portal's position...
-                if (CurrentLandblock.GetPosition(Guid).SquaredDistanceTo(player.Location) < rangeCheck)
+                if (Destination != null)
                 {
-                    if (Destination != null)
-                    {
 #if DEBUG
-                        serverMessage = "Checking requirements for " + this.Name;
-                        var usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                    serverMessage = "Checking requirements for " + this.Name;
+                    var usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                    player.Session.Network.EnqueueSend(usePortalMessage);
+#endif
+                    // Check player level -- requires remote query to player (ugh)...
+                    if ((player.Level >= MinimumLevel) && ((player.Level <= MaximumLevel) || (MaximumLevel == 0)))
+                    {
+                        Position portalDest = Destination;
+                        switch (WeenieClassId)
+                        {
+                            /// <summary>
+                            /// Setup correct racial portal destination for the Central Courtyard in the Training Academy
+                            /// </summary>
+                            case (ushort)SpecialPortalWCID.CentralCourtyard:
+                                {
+                                    uint playerLandblockId = player.Location.LandblockId.Raw;
+                                    switch (playerLandblockId)
+                                    {
+                                        case (uint)SpecialPortalLandblockID.ShoushiCCLaunch:    // Shoushi
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiCCLanding);
+                                                break;
+                                            }
+                                        case (uint)SpecialPortalLandblockID.YaraqCCLaunch:    // Yaraq
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqCCLanding);
+                                                break;
+                                            }
+                                        case (uint)SpecialPortalLandblockID.SanamarCCLaunch:    // Sanamar
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarCCLanding);
+                                                break;
+                                            }
+                                        default:            // Holtburg
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgCCLanding);
+                                                break;
+                                            }
+                                    }
+
+                                    portalDest.PositionX = Destination.PositionX;
+                                    portalDest.PositionY = Destination.PositionY;
+                                    portalDest.PositionZ = Destination.PositionZ;
+                                    portalDest.RotationX = Destination.RotationX;
+                                    portalDest.RotationY = Destination.RotationY;
+                                    portalDest.RotationZ = Destination.RotationZ;
+                                    portalDest.RotationW = Destination.RotationW;
+                                    break;
+                                }
+                            /// <summary>
+                            /// Setup correct racial portal destination for the Outer Courtyard in the Training Academy
+                            /// </summary>
+                            case (ushort)SpecialPortalWCID.OuterCourtyard:
+                                {
+                                    uint playerLandblockId = player.Location.LandblockId.Raw;
+                                    switch (playerLandblockId)
+                                    {
+                                        case (uint)SpecialPortalLandblockID.ShoushiOCLaunch:    // Shoushi
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiOCLanding);
+                                                break;
+                                            }
+                                        case (uint)SpecialPortalLandblockID.YaraqOCLaunch:    // Yaraq
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqOCLanding);
+                                                break;
+                                            }
+                                        case (uint)SpecialPortalLandblockID.SanamarOCLaunch:    // Sanamar
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarOCLanding);
+                                                break;
+                                            }
+                                        default:            // Holtburg
+                                            {
+                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgOCLanding);
+                                                break;
+                                            }
+                                    }
+
+                                    portalDest.PositionX = Destination.PositionX;
+                                    portalDest.PositionY = Destination.PositionY;
+                                    portalDest.PositionZ = Destination.PositionZ;
+                                    portalDest.RotationX = Destination.RotationX;
+                                    portalDest.RotationY = Destination.RotationY;
+                                    portalDest.RotationZ = Destination.RotationZ;
+                                    portalDest.RotationW = Destination.RotationW;
+                                    break;
+                                }
+                            /// <summary>
+                            /// All other portals don't need adjustments.
+                            /// </summary>
+                            default:
+                                {
+                                    break;
+                                }
+                        }
+
+#if DEBUG
+                        serverMessage = "Portal sending player to destination";
+                        usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
                         player.Session.Network.EnqueueSend(usePortalMessage);
 #endif
-                        // Check player level -- requires remote query to player (ugh)...
-                        if ((player.Level >= MinimumLevel) && ((player.Level <= MaximumLevel) || (MaximumLevel == 0)))
-                        {
-                            Position portalDest = Destination;
-                            switch (WeenieClassId)
-                            {
-                                /// <summary>
-                                /// Setup correct racial portal destination for the Central Courtyard in the Training Academy
-                                /// </summary>
-                                case (ushort)SpecialPortalWCID.CentralCourtyard:
-                                    {
-                                        uint playerLandblockId = player.Location.LandblockId.Raw;
-                                        switch (playerLandblockId)
-                                        {
-                                            case (uint)SpecialPortalLandblockID.ShoushiCCLaunch:    // Shoushi
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiCCLanding);
-                                                    break;
-                                                }
-                                            case (uint)SpecialPortalLandblockID.YaraqCCLaunch:    // Yaraq
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqCCLanding);
-                                                    break;
-                                                }
-                                            case (uint)SpecialPortalLandblockID.SanamarCCLaunch:    // Sanamar
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarCCLanding);
-                                                    break;
-                                                }
-                                            default:            // Holtburg
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgCCLanding);
-                                                    break;
-                                                }
-                                        }
-
-                                        portalDest.PositionX = Destination.PositionX;
-                                        portalDest.PositionY = Destination.PositionY;
-                                        portalDest.PositionZ = Destination.PositionZ;
-                                        portalDest.RotationX = Destination.RotationX;
-                                        portalDest.RotationY = Destination.RotationY;
-                                        portalDest.RotationZ = Destination.RotationZ;
-                                        portalDest.RotationW = Destination.RotationW;
-                                        break;
-                                    }
-                                /// <summary>
-                                /// Setup correct racial portal destination for the Outer Courtyard in the Training Academy
-                                /// </summary>
-                                case (ushort)SpecialPortalWCID.OuterCourtyard:
-                                    {
-                                        uint playerLandblockId = player.Location.LandblockId.Raw;
-                                        switch (playerLandblockId)
-                                        {
-                                            case (uint)SpecialPortalLandblockID.ShoushiOCLaunch:    // Shoushi
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiOCLanding);
-                                                    break;
-                                                }
-                                            case (uint)SpecialPortalLandblockID.YaraqOCLaunch:    // Yaraq
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqOCLanding);
-                                                    break;
-                                                }
-                                            case (uint)SpecialPortalLandblockID.SanamarOCLaunch:    // Sanamar
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarOCLanding);
-                                                    break;
-                                                }
-                                            default:            // Holtburg
-                                                {
-                                                    portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgOCLanding);
-                                                    break;
-                                                }
-                                        }
-
-                                        portalDest.PositionX = Destination.PositionX;
-                                        portalDest.PositionY = Destination.PositionY;
-                                        portalDest.PositionZ = Destination.PositionZ;
-                                        portalDest.RotationX = Destination.RotationX;
-                                        portalDest.RotationY = Destination.RotationY;
-                                        portalDest.RotationZ = Destination.RotationZ;
-                                        portalDest.RotationW = Destination.RotationW;
-                                        break;
-                                    }
-                                /// <summary>
-                                /// All other portals don't need adjustments.
-                                /// </summary>
-                                default:
-                                    {
-                                        break;
-                                    }
-                            }
-
-#if DEBUG 
-                            serverMessage = "Portal sending player to destination";
-                            usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
-                            player.Session.Network.EnqueueSend(usePortalMessage);
-#endif
-                            player.Session.Player.Teleport(portalDest);
-                            // If the portal just used is able to be recalled to,
-                            // save the destination coordinates to the LastPortal character position save table
-                            if (IsRecallable)
-                                player.SetCharacterPosition(PositionType.LastPortal, portalDest);
-                            // always send useDone event
-                            var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                            player.Session.Network.EnqueueSend(sendUseDoneEvent);
-                        }
-                        else if ((player.Level > MaximumLevel) && (MaximumLevel != 0))
-                        {
-                            // You are too powerful to interact with that portal!
-                            var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AC);
-                            // always send useDone event
-                            var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                            player.Session.Network.EnqueueSend(failedUsePortalMessage, sendUseDoneEvent);
-                        }
-                        else
-                        {
-                            // You are not powerful enough to interact with that portal!
-                            var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AB);
-                            // always send useDone event
-                            var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                            player.Session.Network.EnqueueSend(failedUsePortalMessage, sendUseDoneEvent);
-                        }
+                        player.Session.Player.Teleport(portalDest);
+                        // If the portal just used is able to be recalled to,
+                        // save the destination coordinates to the LastPortal character position save table
+                        if (IsRecallable)
+                            player.SetCharacterPosition(PositionType.LastPortal, portalDest);
+                    }
+                    else if ((player.Level > MaximumLevel) && (MaximumLevel != 0))
+                    {
+                        // You are too powerful to interact with that portal!
+                        var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AC);
+                        player.Session.Network.EnqueueSend(failedUsePortalMessage);
                     }
                     else
                     {
-                        serverMessage = "Portal destination for portal ID " + this.WeenieClassId + " not yet implemented!";
-                        var failedUsePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
-                        // always send useDone event
-                        var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                        player.Session.Network.EnqueueSend(failedUsePortalMessage, sendUseDoneEvent);
+                        // You are not powerful enough to interact with that portal!
+                        var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AB);
+                        player.Session.Network.EnqueueSend(failedUsePortalMessage);
                     }
                 }
                 else
                 {
+                    serverMessage = "Portal destination for portal ID " + this.WeenieClassId + " not yet implemented!";
+                    var failedUsePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                    player.Session.Network.EnqueueSend(failedUsePortalMessage);
+                }
+            });
+            // Run on the player
+            chain.EnqueueChain();
+        }
+
+        public override void HandleActionOnUse(ObjectGuid playerId)
+        {
+            ActionChain chain = new ActionChain();
+            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            {
+                Player player = wo as Player;
+                if (player == null)
+                {
+                    return;
+                }
+
+                if (!player.IsWithinUseRadiusOf(this))
+                    player.DoMoveTo(this);
+                else
+                {
+                    HandleActionOnCollide(playerId);
                     // always send useDone event
                     var sendUseDoneEvent = new GameEventUseDone(player.Session);
                     player.Session.Network.EnqueueSend(sendUseDoneEvent);

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2017-10-04
+[Jyrus]
+* Moved handling of the Portals into the HandleOnCollide method and implemented MoveTo for OnUse for Portals.  Currently, OnUse also queues up portaling
+	via a direct call to Portal.HandleOnCollide, which can be removed when collision is implemented.
+
 ### 2017-10-03
 [OptimShi]
 * Added method to get animation timings out of MotionTable and updated several instances where we were faking it previously.


### PR DESCRIPTION
Moved handling of Portals into the HandleOnCollide method and implemented MoveTo for OnUse for Portals.  Currently, OnUse also queues up portaling via a direct call to Portal.HandleOnCollide, which can be removed when collision is implemented.