### PR TITLE
DDDInterrogation uses 32 bit quantities, not 64 bit.

### DIFF
--- a/Source/ACE/Network/GameMessages/Messages/GameMessageDDDInterrogation.cs
+++ b/Source/ACE/Network/GameMessages/Messages/GameMessageDDDInterrogation.cs
@@ -7,12 +7,12 @@ namespace ACE.Network.GameMessages.Messages
         public GameMessageDDDInterrogation()
             : base(GameMessageOpcode.DDD_Interrogation, GameMessageGroup.DatabaseQueue)
         {
-            Writer.Write(1ul);
-            Writer.Write(1ul);
-            Writer.Write(1ul);
-            Writer.Write(2ul);
-            Writer.Write(0ul);
-            Writer.Write(1ul);
+            Writer.Write(1u);
+            Writer.Write(1u);
+            Writer.Write(1u);
+            Writer.Write(2u);
+            Writer.Write(0u);
+            Writer.Write(1u);
         }
     }
 }


### PR DESCRIPTION
Though the client doesn't seem to mind.