### PR TITLE
Mergers and Inquisitions: Added stack-able merge REVIEW ONLY Work in progress

### DIFF
--- a/Database/Updates/World/10-14-2017-fix-weenie-mmd-20630.sql
+++ b/Database/Updates/World/10-14-2017-fix-weenie-mmd-20630.sql
@@ -1,0 +1,14 @@
+# Fix weenie correct burden for 1 mmd note
+UPDATE ace_object_properties_int
+SET propertyValue = 5
+WHERE intPropertyId = 5 AND aceObjectId = 20630;
+
+# Fix weenie correct value for 1 mmd note
+UPDATE ace_object_properties_int
+SET propertyValue = 250000
+WHERE intPropertyId = 19 AND aceObjectId = 20630;
+
+# Fix weenie correct stacksize for 1 mmd note
+UPDATE ace_object_properties_int
+SET propertyValue = 1
+WHERE intPropertyId = 12 AND aceObjectId = 20630;

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Network\GameAction\Actions\GameActionQueryItemMana.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionMagicRemoveSpellId.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionSellItems.cs" />
+    <Compile Include="Network\GameAction\Actions\GameActionStackableMerge.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionSoulEmote.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionStackableSplitToContainer.cs" />
     <Compile Include="Network\GameAction\Actions\GameActionChannelIndex.cs" />

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -12,6 +12,7 @@ using ACE.Database;
 
 namespace ACE.Entity
 {
+
     public class Container : WorldObject
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -201,6 +202,7 @@ namespace ACE.Entity
             Burden -= inv[itemGuid].Burden;
             log.Debug($"Remove {inv[itemGuid].Name} in inventory, removing {inv[itemGuid].Burden}, current Burden = {Burden}");
 
+            // TODO: research, should this only be done for pyreal and trade notes?   Does the value of your items add to the container value?   I am not sure.
             Value -= inv[itemGuid].Value;
 
             inv.Remove(itemGuid);
@@ -236,6 +238,95 @@ namespace ACE.Entity
         }
 
         /// <summary>
+        /// This method handles the first part of the merge - split out for code reuse.  It calculates
+        /// the updated values for stack size, value and burden, creates the needed client messages
+        /// and sends them.   This must be called from within an action chain. Og II
+        /// </summary>
+        /// <param name="session">Session is used for sequence and target</param>
+        /// <param name="fromWo">World object of the item are we merging from</param>
+        /// <param name="toWo">World object of the item we are merging into</param>
+        /// <param name="amount">How many are we merging fromWo into the toWo</param>
+        public void UpdateToStack(Session session, WorldObject fromWo, WorldObject toWo, uint amount)
+        {
+            // unless we have a data issue, these are valid asserts Og II
+            Debug.Assert(toWo.Value != null, "toWo.Value != null");
+            Debug.Assert(fromWo.Value != null, "fromWo.Value != null");
+            Debug.Assert(toWo.StackSize != null, "toWo.StackSize != null");
+            Debug.Assert(fromWo.StackSize != null, "fromWo.StackSize != null");
+            Debug.Assert(toWo.Burden != null, "toWo.Burden != null");
+            Debug.Assert(fromWo.Burden != null, "fromWo.Burden != null");
+
+            uint newValue = (uint)(toWo.Value + ((fromWo.Value / fromWo.StackSize) * amount));
+            uint newBurden = (uint)(toWo.Burden + ((fromWo.Burden / fromWo.StackSize) * amount));
+
+            int oldStackSize = (int)toWo.StackSize;
+            toWo.StackSize += (ushort)amount;
+            toWo.Value = newValue;
+            toWo.Burden = (ushort)newBurden;
+
+            // Build the needed messages to the client.
+            GameMessagePrivateUpdatePropertyInt msgUpdateValue = new GameMessagePrivateUpdatePropertyInt(toWo.Sequences, PropertyInt.Value, newValue);
+            GameMessagePutObjectInContainer msgPutObjectInContainer = new GameMessagePutObjectInContainer(session, Guid, toWo, toWo.Placement ?? 0u);
+            Debug.Assert(toWo.StackSize != null, "toWo.StackSize != null");
+            GameMessageSetStackSize msgAdjustNewStackSize = new GameMessageSetStackSize(toWo.Sequences, toWo.Guid, (int)toWo.StackSize, oldStackSize);
+
+            CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange, msgUpdateValue, msgPutObjectInContainer, msgAdjustNewStackSize);
+        }
+
+        /// <summary>
+        /// This method handles the second part of the merge if we have not merged ALL of the fromWo into the toWo - split out for code reuse.  It calculates
+        /// the updated values for stack size, value and burden, creates the needed client messages
+        /// and sends them.   This must be called from within an action chain. Og II
+        /// </summary>
+        /// <param name="session">Session is used for sequence and target</param>
+        /// <param name="fromWo">World object of the item are we merging from</param>
+        /// <param name="amount">How many are we merging fromWo into the toWo</param>
+        public void UpdateFromStack(Session session, WorldObject fromWo,  uint amount)
+        {
+            // ok, there are some left, we need up update the stack size, value and burden of the fromWo
+            // unless we have a data issue, these are valid asserts Og II
+
+            Debug.Assert(fromWo.Value != null, "fromWo.Value != null");
+            Debug.Assert(fromWo.StackSize != null, "fromWo.StackSize != null");
+            Debug.Assert(fromWo.Burden != null, "fromWo.Burden != null");
+
+            uint newFromValue = (uint)(fromWo.Value + ((fromWo.Value / fromWo.StackSize) * -amount));
+            uint newFromBurden = (uint)(fromWo.Burden + ((fromWo.Burden / fromWo.StackSize) * -amount));
+
+            int oldFromStackSize = (int)fromWo.StackSize;
+            fromWo.StackSize -= (ushort)amount;
+            fromWo.Value = newFromValue;
+            fromWo.Burden = (ushort)newFromBurden;
+
+            // Build the needed messages to the client.
+            GameMessagePrivateUpdatePropertyInt msgUpdateValue = new GameMessagePrivateUpdatePropertyInt(fromWo.Sequences, PropertyInt.Value, newFromValue);
+            Debug.Assert(fromWo.StackSize != null, "fromWo.StackSize != null");
+            GameMessageSetStackSize msgAdjustNewStackSize = new GameMessageSetStackSize(fromWo.Sequences, fromWo.Guid, (int)fromWo.StackSize, oldFromStackSize);
+
+            CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange, msgUpdateValue, msgAdjustNewStackSize);
+        }
+
+        /// <summary>
+        /// This method will remove a worldobject if we have consumed all of the amount in the merge.
+        /// This checks inventory or wielded items (you could be pulling stackable ammo out of a wielded slot and into a stack in your pack
+        /// It then creates and sends the remove object message.   Lastly, if the wo has ever been saved to the db, we clean up after ourselves.
+        /// </summary>
+        /// <param name="session">Session is used for sequence and target</param>
+        /// <param name="fromWo">World object of the item are we merging from that needs to be destroyed.</param>
+        public void RemoveWorldObject(Session session, WorldObject fromWo)
+        {
+            if (HasItem(fromWo.Guid))
+                session.Player.RemoveFromInventory(InventoryObjects, fromWo.Guid);
+            else
+               session.Player.RemoveFromWieldedObjects(fromWo.Guid);
+            GameMessageRemoveObject msgRemoveFrom = new GameMessageRemoveObject(fromWo);
+            CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange, msgRemoveFrom);
+
+            if (fromWo.SnapShotOfAceObject().HasEverBeenSavedToDatabase)
+                DatabaseManager.Shard.DeleteObject(fromWo.SnapShotOfAceObject(), null);
+        }
+
+        /// <summary>
         /// This method processes the Stackable Merge Game Action (F7B1) Stackable Merge (0x0054)
         /// </summary>
         /// <param name="session">Session is used for sequence and target</param>
@@ -250,41 +341,28 @@ namespace ACE.Entity
                 WorldObject toWo = GetInventoryItem(mergeToGuid);
                 if (fromWo == null || toWo == null) return;
 
+                // Check to see if we are trying to merge into a full stack. If so, nothing to do here.
+                // Check this and see if I need to call UpdateToStack to clear the action with an amount of 0 Og II
+                if (toWo.MaxStackSize == toWo.StackSize)
+                    return;
+
                 Debug.Assert(toWo.StackSize != null, "toWo.StackSize != null");
                 if (toWo.MaxStackSize >= (ushort)(toWo.StackSize + amount))
                 {
-                    // unless we have a data issue, these are valid asserts Og II
-                    Debug.Assert(toWo.Value != null, "toWo.Value != null");
-                    Debug.Assert(fromWo.Value != null, "fromWo.Value != null");
-                    Debug.Assert(toWo.StackSize != null, "toWo.StackSize != null");
-                    Debug.Assert(fromWo.StackSize != null, "fromWo.StackSize != null");
-                    Debug.Assert(toWo.Burden != null, "toWo.Burden != null");
-                    Debug.Assert(fromWo.Burden != null, "fromWo.Burden != null");
-
-                    uint newValue = (uint)(toWo.Value + ((fromWo.Value / fromWo.StackSize) * amount));
-                    uint newBurden = (uint)(toWo.Burden + ((fromWo.Burden / fromWo.StackSize) * amount));
-
-                    int oldStackSize = (int)toWo.StackSize;
-                    toWo.StackSize += (ushort)amount;
-                    toWo.Value = newValue;
-                    toWo.Burden = (ushort)newBurden;
-
-                    // Build the needed messages to the client.
-                    GameMessagePrivateUpdatePropertyInt msgUpdateValue = new GameMessagePrivateUpdatePropertyInt(Sequences, PropertyInt.Value, newValue);
-                    GameMessagePutObjectInContainer msgPutObjectInContainer = new GameMessagePutObjectInContainer(session, Guid, toWo, toWo.Placement ?? 0u);
-                    Debug.Assert(toWo.StackSize != null, "toWo.StackSize != null");
-                    GameMessageSetStackSize msgAdjustNewStackSize = new GameMessageSetStackSize(toWo.Sequences, toWo.Guid, (int)toWo.StackSize, oldStackSize);
-
-                    CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange, msgUpdateValue, msgPutObjectInContainer, msgAdjustNewStackSize);
-
+                    UpdateToStack(session, fromWo, toWo, amount);
                     // Ok did we merge it all?   If so, let's destroy the from item.
                     if (fromWo.StackSize == amount)
-                    {
-                        session.Player.RemoveFromInventory(InventoryObjects, fromWo.Guid);
-                        GameMessageRemoveObject msgRemoveFrom = new GameMessageRemoveObject(fromWo);
-                        CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange, msgRemoveFrom);
-                        DatabaseManager.Shard.DeleteObject(fromWo.SnapShotOfAceObject(), null);
-                    }
+                        RemoveWorldObject(session, fromWo);
+                    else
+                        UpdateFromStack(session, fromWo, amount);
+                }
+                else
+                {
+                    // ok we have more than the max stack size on the to object, just add what we can and adjust both.
+                    Debug.Assert(toWo.MaxStackSize != null, "toWo.MaxStackSize != null");
+                    uint amtToFill = (uint)(toWo.MaxStackSize - toWo.StackSize);
+                    UpdateToStack(session, fromWo, toWo, amtToFill);
+                    UpdateFromStack(session, toWo, amtToFill);
                 }
             }).EnqueueChain();
         }

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -12,7 +12,6 @@ using ACE.Database;
 
 namespace ACE.Entity
 {
-
     public class Container : WorldObject
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -2763,10 +2763,11 @@ namespace ACE.Entity
                 else
                 {
                     ObjectGuid containerGuid = ObjectGuid.Invalid;
-                    WorldObject packItem;
+                    // Removed unused code Og II
                     var containers = InventoryObjects.Where(wo => wo.Value.WeenieType == WeenieType.Container).ToList();
                     foreach (var container in containers)
                     {
+                        WorldObject packItem;
                         if (container.Value.InventoryObjects.TryGetValue(itemGuid, out packItem))
                         {
                             containerGuid = container.Value.Guid;
@@ -2774,17 +2775,13 @@ namespace ACE.Entity
                         }
                     }
 
-                    Container pack;
-                    if (item != null && containerGuid != ObjectGuid.Invalid)
+                    if (containerGuid != ObjectGuid.Invalid)
                     {
-                        pack = (Container)GetInventoryItem(containerGuid);
-
                         RemoveFromInventory(InventoryObjects[containerGuid].InventoryObjects, itemGuid);
                     }
                     else
                     {
-                        if (item != null)
-                            RemoveFromInventory(InventoryObjects, itemGuid);
+                        RemoveFromInventory(InventoryObjects, itemGuid);
                     }
                 }
 
@@ -2817,6 +2814,7 @@ namespace ACE.Entity
                 new GameMessageUpdateInstanceId(itemGuid, clearContainer, PropertyInstanceId.Container));
 
                 // This is the sequence magic - adds back into 3d space seem to be treated like teleport.
+                Debug.Assert(item != null, "item != null");
                 item.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
                 item.Sequences.GetNextSequence(SequenceType.ObjectVector);
 
@@ -2829,7 +2827,8 @@ namespace ACE.Entity
             });
 
                 chain.EnqueueChain();
-                Session.SaveSession();
+                // Removed SaveSession - this was causing items that were dropped to not be removed
+                // from inventory.   If this causes a problem with vendor, we need to fix vendor.  Og II
             });
 
             dropChain.EnqueueChain();
@@ -2950,7 +2949,7 @@ namespace ACE.Entity
             }).EnqueueChain();
     }
 
-    public void HandleActionApplySoundEffect(Sound sound)
+        public void HandleActionApplySoundEffect(Sound sound)
         {
             new ActionChain(this, () => PlaySound(sound, Guid)).EnqueueChain();
         }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -2108,7 +2108,7 @@ namespace ACE.Entity
         /// It does not add it to inventory as you could be unwielding to the ground or a chest. Og II
         /// </summary>
         /// <param name="itemGuid">Guid of the item to be unwielded.</param>
-        private void RemoveFromWieldedObjects(ObjectGuid itemGuid)
+        public void RemoveFromWieldedObjects(ObjectGuid itemGuid)
         {
             if (WieldedObjects.ContainsKey(itemGuid))
             {

--- a/Source/ACE/Network/GameAction/Actions/GameActionStackableMerge.cs
+++ b/Source/ACE/Network/GameAction/Actions/GameActionStackableMerge.cs
@@ -1,0 +1,21 @@
+﻿using ACE.Common.Extensions;
+using ACE.Entity;
+
+namespace ACE.Network.GameAction.Actions
+{
+    /// <summary>
+    /// This method processes the Game Action (F7B1) Inventory_StackableMerge (0x0054) and calls
+    /// the HandleActionStackableMerge method on the player object. Og II
+    /// </summary>
+    public static class GameActionStackableMerge
+    {
+        [GameAction(GameActionType.StackableMerge)]
+        public static void Handle(ClientMessage message, Session session)
+        {
+            uint mergeFromId = message.Payload.ReadUInt32();
+            uint mergeToId = message.Payload.ReadUInt32();
+            uint amount = message.Payload.ReadUInt32();
+            session.Player.HandleActionStackableMerge(session, new ObjectGuid(mergeFromId), new ObjectGuid(mergeToId), amount);
+        }
+    }
+}

--- a/Source/AppVeyor/MySqlInstall.bat
+++ b/Source/AppVeyor/MySqlInstall.bat
@@ -19,4 +19,5 @@ appveyor DownloadFile https://github.com/ACEmulator/ACE-World/releases/download/
 
 REM execute Update Scripts for World Database
 "C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\06-06-30-2017-generator-chains-testdata.sql
+"C:\Program Files\MySql\MySQL Server 5.7\bin\mysql.exe" -h localhost -u root -pPassword12! ace_world < database\updates\world\10-14-2017-fix-weenie-mmd-20630.sql
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2017-10-14
+[Og II]
+* Added processing for merge items.
+* Added script to update the burden, value and stack size of the weenie for MMD notes I used in testing.   20630 - value 250,000 burden 5 and stacksize 1
+
 ### 2017-10-13
 [Og II]
 * Added processing for item inscription. Implemented Set Inscription and Inscription Response messages. 


### PR DESCRIPTION
* Added processing for merge items.
* Added script to update the burden, value and stack size of the weenie for MMD notes I used in testing.   20630 - value 250,000 burden 5 and stack size 1
* Cleaned up code, fixed a bug with drop item.
* This is work in progress, I have more to do, I am putting this up now so we StackOverflow or Ripley can take a look at the issue with vendor

Test steps:

- run update script on your WORLD database to set the values correctly, they are wrong.

- "@ci 20630" do this twice.   You will now have 2 MMD notes in your main pack that are not stacked.

- You can inspect each, you will see bu of 5, value of 250,000

- Stack them - check bu and value

- Split them - check bu and value

- You can log in or out, drop the notes and all saves as it should.

I have not tested merging in side packs yet, I am not dealing with more that max stack size yet, I just wanted to get this up for review as there was some thrashing around vendor and this may break that fix.   We need to run down the root cause for the extra save that I removed and was added to make the vendor stuff work.
**UPDATE 10/14/2017**
I have implemented the rest of the logic to respect max stack size.   I have one outstanding bug to run down.

![z2v6ig](https://user-images.githubusercontent.com/25460553/31572978-c984ddb8-b077-11e7-8b7e-677df7c77518.jpg)
