### PR TITLE
Fix coin value and pickup of stack-able items from landblock

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -272,7 +272,6 @@ namespace ACE.Database
             return transaction.Commit().Result;
         }
 
-
         public void RemoveAllFriends(uint characterId)
         {
             throw new NotImplementedException();

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -361,8 +361,16 @@ namespace ACE.Entity
         {
             new ActionChain(this, () =>
             {
+                // is this something I already have? If not, it has to be a pickup - do the pickup and out.
+                if (!HasItem(mergeFromGuid))
+                {
+                    // This is a pickup into our main pack.
+                    session.Player.HandleActionPutItemInContainer(mergeFromGuid, session.Player.Guid);
+                }
+
                 WorldObject fromWo = GetInventoryItem(mergeFromGuid);
                 WorldObject toWo = GetInventoryItem(mergeToGuid);
+
                 if (fromWo == null || toWo == null) return;
 
                 // Check to see if we are trying to merge into a full stack. If so, nothing to do here.

--- a/Source/ACE/Entity/Container.cs
+++ b/Source/ACE/Entity/Container.cs
@@ -86,6 +86,9 @@ namespace ACE.Entity
                 WorldObject wo = WorldObjectFactory.CreateWorldObject(inventoryItem.Value);
                 InventoryObjects.Add(woGuid, wo);
 
+                if (wo.WeenieType == WeenieType.Coin)
+                    CoinValue += wo.Value ?? 0;
+
                 Burden += wo.Burden ?? 0;
                 log.Debug($"{aceObject.Name} is has {wo.Name} in inventory, adding {wo.Burden}, current Burden = {Burden}");
             }

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1275,17 +1275,17 @@ namespace ACE.Entity
                 {
                     HandleAddNewWorldObjectToInventory(wo);
                 }
-                UpdateCurrencyClientCalculations(WeenieType.Coin);
+                UpdateCurrencyClientCalculations();
             }).EnqueueChain();
             return true;
         }
 
         // todo re-think how this works..
-        private void UpdateCurrencyClientCalculations(WeenieType type)
+        private void UpdateCurrencyClientCalculations()
         {
             uint coins = 0;
             List<WorldObject> currency = new List<WorldObject>();
-            currency.AddRange(GetInventoryItemsOfTypeWeenieType(type));
+            currency.AddRange(GetInventoryItemsOfTypeWeenieType(WeenieType.Coin));
             foreach (WorldObject wo in currency)
             {
                 coins += wo.StackSize.Value;
@@ -1352,7 +1352,7 @@ namespace ACE.Entity
                     HandleAddNewWorldObjectToInventory(changeobj);
                 }
 
-                UpdateCurrencyClientCalculations(WeenieType.Coin);
+                UpdateCurrencyClientCalculations();
                 return true;
             }
             else
@@ -2441,7 +2441,7 @@ namespace ACE.Entity
             {
                 Burden += item.Burden ?? 0;
                 if (item.WeenieType == WeenieType.Coin)
-                    CoinValue += item.Value ?? 0;
+                    UpdateCurrencyClientCalculations();
             }
             Session.Network.EnqueueSend(
                 new GameMessagePutObjectInContainer(Session, container.Guid, item, placement),
@@ -2519,6 +2519,9 @@ namespace ACE.Entity
 
                     CurrentLandblock.EnqueueBroadcast(Location, MaxObjectTrackingRange,
                         msgPutObjectInContainer, msgAdjustOldStackSize, msgNewStack);
+
+                    if (stack.WeenieType == WeenieType.Coin)
+                        UpdateCurrencyClientCalculations();
                 });
             splitItemsChain.EnqueueChain();
         }
@@ -2689,7 +2692,7 @@ namespace ACE.Entity
 
                     if (item.WeenieType == WeenieType.Coin)
                     {
-                        CoinValue += item.Value ?? 0;
+                        UpdateCurrencyClientCalculations();
                     }
                 }
 
@@ -2699,6 +2702,7 @@ namespace ACE.Entity
                     foreach (var packItem in item.InventoryObjects)
                     {
                         Session.Network.EnqueueSend(new GameMessageCreateObject(packItem.Value));
+                        UpdateCurrencyClientCalculations();
                     }
                 }
 
@@ -3064,8 +3068,8 @@ namespace ACE.Entity
                 else
                 {
                     RemoveWorldObjectFromInventory(itemGuid);
-                    if (item.WeenieType == WeenieType.Coin)
-                        UpdateCurrencyClientCalculations(WeenieType.Coin);
+                    if (item.WeenieType == WeenieType.Coin || item.WeenieType == WeenieType.Container)
+                        UpdateCurrencyClientCalculations();
                 }
 
                 SetInventoryForWorld(item);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1275,20 +1275,21 @@ namespace ACE.Entity
                 {
                     HandleAddNewWorldObjectToInventory(wo);
                 }
-                UpdateCurrencyClientCalculations();
+                UpdateCurrencyClientCalculations(WeenieType.Coin);
             }).EnqueueChain();
             return true;
         }
 
         // todo re-think how this works..
-        private void UpdateCurrencyClientCalculations()
+        private void UpdateCurrencyClientCalculations(WeenieType type)
         {
             uint coins = 0;
             List<WorldObject> currency = new List<WorldObject>();
-            currency.AddRange(GetInventoryItemsOfTypeWeenieType(WeenieType.Coin));
+            currency.AddRange(GetInventoryItemsOfTypeWeenieType(type));
             foreach (WorldObject wo in currency)
             {
-                coins += wo.StackSize.Value;
+                if (wo.WeenieType == WeenieType.Coin )
+                    coins += wo.StackSize.Value;
             }
             // send packet to client letthing them know
             CoinValue = coins;
@@ -1352,7 +1353,7 @@ namespace ACE.Entity
                     HandleAddNewWorldObjectToInventory(changeobj);
                 }
 
-                UpdateCurrencyClientCalculations();
+                UpdateCurrencyClientCalculations(WeenieType.Coin);
                 return true;
             }
             else
@@ -2441,7 +2442,7 @@ namespace ACE.Entity
             {
                 Burden += item.Burden ?? 0;
                 if (item.WeenieType == WeenieType.Coin)
-                    UpdateCurrencyClientCalculations();
+                    UpdateCurrencyClientCalculations(WeenieType.Coin);
             }
             Session.Network.EnqueueSend(
                 new GameMessagePutObjectInContainer(Session, container.Guid, item, placement),
@@ -2521,7 +2522,7 @@ namespace ACE.Entity
                         msgPutObjectInContainer, msgAdjustOldStackSize, msgNewStack);
 
                     if (stack.WeenieType == WeenieType.Coin)
-                        UpdateCurrencyClientCalculations();
+                        UpdateCurrencyClientCalculations(WeenieType.Coin);
                 });
             splitItemsChain.EnqueueChain();
         }
@@ -2692,7 +2693,7 @@ namespace ACE.Entity
 
                     if (item.WeenieType == WeenieType.Coin)
                     {
-                        UpdateCurrencyClientCalculations();
+                        UpdateCurrencyClientCalculations(WeenieType.Coin);
                     }
                 }
 
@@ -2702,7 +2703,7 @@ namespace ACE.Entity
                     foreach (var packItem in item.InventoryObjects)
                     {
                         Session.Network.EnqueueSend(new GameMessageCreateObject(packItem.Value));
-                        UpdateCurrencyClientCalculations();
+                        UpdateCurrencyClientCalculations(WeenieType.Coin);
                     }
                 }
 
@@ -3069,7 +3070,7 @@ namespace ACE.Entity
                 {
                     RemoveWorldObjectFromInventory(itemGuid);
                     if (item.WeenieType == WeenieType.Coin || item.WeenieType == WeenieType.Container)
-                        UpdateCurrencyClientCalculations();
+                        UpdateCurrencyClientCalculations(WeenieType.Coin);
                 }
 
                 SetInventoryForWorld(item);

--- a/Source/ACE/Entity/Player.cs
+++ b/Source/ACE/Entity/Player.cs
@@ -1288,7 +1288,7 @@ namespace ACE.Entity
             currency.AddRange(GetInventoryItemsOfTypeWeenieType(type));
             foreach (WorldObject wo in currency)
             {
-                if (wo.WeenieType == WeenieType.Coin )
+                if (wo.WeenieType == WeenieType.Coin)
                     coins += wo.StackSize.Value;
             }
             // send packet to client letthing them know

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # ACEmulator Change Log
+### 2017-10-21
+[Jyrus]
+* Add the initial set of CoinValue in Container.cs to the value of contained Coins
+* Modified item move, drop, and pickup methods to account for pyreal changes using StackOverflow's UpdateCurrencyClientCalculations();
+
 ### 2017-10-20
 [Mogwai]
 * Authentication overhaul is done.  Please note there are significant changes to the Readme file.


### PR DESCRIPTION
* Add the initial set of CoinValue in Container.cs to the value of contained Coins
* Modified item move, drop, and pickup methods to account for Pyreal changes, using StackOverflow's UpdateCurrencyClientCalculations();