### PR TITLE
Fix TypeO in AuthApi.Host/Program.cs

### DIFF
--- a/Source/ACE.Api.Host/Startup.cs
+++ b/Source/ACE.Api.Host/Startup.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
 using ACE.Api.Common;
 using ACE.Common;
@@ -17,7 +13,7 @@ namespace ACE.Api.Host
             if(ConfigManager.Config.ApiServer != null && ConfigManager.Config.ApiServer.Url?.Length > 0)
             {
                 // Get the bind address and port from config:
-                var server = WebApp.Start<ACE.Api.Startup>(url: ConfigManager.Config.ApiServer.Url);
+                var server = WebApp.Start<Api.Startup>(url: ConfigManager.Config.ApiServer.Url);
                 Console.WriteLine($"ACE API listening at {ConfigManager.Config.ApiServer.Url}");
                 Console.ReadLine();
             } else {

--- a/Source/ACE.AuthApi.Host/Program.cs
+++ b/Source/ACE.AuthApi.Host/Program.cs
@@ -1,10 +1,5 @@
-﻿using ACE.Api;
-using Microsoft.Owin.Hosting;
+﻿using Microsoft.Owin.Hosting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ACE.Common;
 using ACE.Api.Common;
 
@@ -18,8 +13,8 @@ namespace ACE.AuthApi.Host
             if (ConfigManager.Config.AuthServer != null && ConfigManager.Config.AuthServer.Url?.Length > 0)
             {
                 // Get the bind address and port from config:
-                var server = WebApp.Start<ACE.Api.Startup>(url: ConfigManager.Config.AuthServer.Url);
-                Console.WriteLine($"ACE API listening at {ConfigManager.Config.AuthServer.Url}");
+                var server = WebApp.Start<Startup>(url: ConfigManager.Config.AuthServer.Url);
+                Console.WriteLine($"ACE Auth API listening at {ConfigManager.Config.AuthServer.Url}");
                 Console.ReadLine();
             }
             else

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 # ACEmulator Change Log
-### 2017-20-23
+### 2017-10-23
 [Jyrus]
 * Fix a typeo in ACE.AuthApi.Host, as it was attempting to start the API host in place of the AuthAPI host
 
-### 2017-20-22
+### 2017-10-22
 [fantoms]
 * Changed build output path for Api.Host and AuthApi.Host projects, in an attempt to share the server config for debug and build.
 * Added simple service configuration function to Api.Common, to load the initial config for Api host apps.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # ACEmulator Change Log
+### 2017-20-23
+[Jyrus]
+* Fix a typeo in ACE.AuthApi.Host, as it was attempting to start the API host in place of the AuthAPI host
 
 ### 2017-20-22
 [fantoms]


### PR DESCRIPTION
* Fix a typeo in ACE.AuthApi.Host, as it was attempting to start the API host in place of the AuthAPI host;
should be "var server = WebApp.Start<Startup>(url: ConfigManager.Config.AuthServer.Url);", not "var server = WebApp.Start<ACE.Api.Startup>(url: ConfigManager.Config.AuthServer.Url);"

Credit to Slushnas