### PR TITLE
Fix for AuthServer external access

### DIFF
--- a/Source/ACE.Api.Common/JwtManager.cs
+++ b/Source/ACE.Api.Common/JwtManager.cs
@@ -83,7 +83,7 @@ namespace ACE.Api.Common
                     new Claim("account_name", account.Name),
                     new Claim("account_guid", account.AccountGuid.ToString()),
                     new Claim("account_id", account.AccountId.ToString()),
-                    new Claim("issuing_server", ConfigManager.Config.AuthServer.Url)
+                    new Claim("issuing_server", ConfigManager.Config.AuthServer.PublicUrl)
                 }),
                 TokenIssuerName = AceIssuerName,
                 AppliesToAddress = AceAudience,

--- a/Source/ACE.Api/Controllers/ServerController.cs
+++ b/Source/ACE.Api/Controllers/ServerController.cs
@@ -25,7 +25,7 @@ namespace ACE.Api.Controllers
             info.Name = ConfigManager.Config.Server.WorldName;
             info.RequiresAuthentication = ConfigManager.Config.Server.SecureAuthentication;
             if (info.RequiresAuthentication)
-                info.LoginServer = ConfigManager.Config.AuthServer.Url;
+                info.LoginServer = ConfigManager.Config.AuthServer.PublicUrl;
 
             return Request.CreateResponse(HttpStatusCode.OK, info);
         }

--- a/Source/ACE.AuthApi.Host/Program.cs
+++ b/Source/ACE.AuthApi.Host/Program.cs
@@ -15,11 +15,11 @@ namespace ACE.AuthApi.Host
         public static void Main(string[] args)
         {
             ServiceConfig.LoadServiceConfig();
-            if (ConfigManager.Config.AuthServer != null && ConfigManager.Config.AuthServer.Url?.Length > 0)
+            if (ConfigManager.Config.AuthServer != null && ConfigManager.Config.AuthServer.ListenUrl?.Length > 0)
             {
                 // Get the bind address and port from config:
-                var server = WebApp.Start<ACE.Api.Startup>(url: ConfigManager.Config.AuthServer.Url);
-                Console.WriteLine($"ACE API listening at {ConfigManager.Config.AuthServer.Url}");
+                var server = WebApp.Start<ACE.AuthApi.Startup>(url: ConfigManager.Config.AuthServer.ListenUrl);
+                Console.WriteLine($"ACE Auth API listening at {ConfigManager.Config.AuthServer.ListenUrl}");
                 Console.ReadLine();
             }
             else

--- a/Source/ACE.Common/AuthServerConfiguration.cs
+++ b/Source/ACE.Common/AuthServerConfiguration.cs
@@ -9,10 +9,16 @@ namespace ACE.Common
     public class AuthServerConfiguration
     {
         /// <summary>
-        /// this is the url that is included in tickets coming from the auth server.  it should
-        /// be reachable by anyone connecting to your server.  if this says "localhost", only your
-        /// computer will be able to reach it.
+        /// This is the URL that the AuthServer will listen to requests on.
+        /// By default, http://*:8001 will listen on all addresses and would be best left unchanged.
         /// </summary>
-        public string Url { get; set; }
+        public string ListenUrl { get; set; }
+
+        /// <summary>
+        /// This is the URL that anyone connecting to your server for authorization uses.
+        /// Tickets issued by this AuthServer will point to this address.
+        /// If this address is not publically accessible on the internet, you're going to have a bad time.
+        /// </summary>
+        public string PublicUrl { get; set; }
     }
 }

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -24,7 +24,8 @@
     "Url": "http://+:8000"
   },
   "AuthServer": {
-    "Url": "http://+:8001"
+    "ListenUrl": "http://+:8001",
+    "PublicUrl": "http://localhost:8001",
   },
   "MySql": {
     "Authentication": {

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,19 @@
 # ACEmulator Change Log
 
-### 2017-20-22
+### 2017-10-24
+[Ripley]
+* @Slushnas found WebApp.Start error in ACE.AuthApi.Host: Changed ACE.Api.Startup to ACE.AuthApi.Startup to fix domain error.
+* AuthServer Changes:
+  - AuthServer needs a publicly accessible address to point connecting clients if you're trying to use the server outside of a localhost/internal lan only environment.
+  - The current defaults basically point everything to "http://+:8001" which fails to resolve. So the following changes have been made..
+  - Changed AuthServer.Url to AuthServer.ListenUrl
+  - Added AuthServer.PublicUrl
+  - Typically, you'll leave the AuthServer.ListenUrl to the default, but you'll want to change AuthServer.PublicUrl to either of the following: 
+    * The externally accessible address of the AuthServer so that clients from the internet can authenticate.
+    or
+    * localhost or the internal lan address so only those inside the local network/local machine can authenticate.
+
+### 2017-10-22
 [fantoms]
 * Changed build output path for Api.Host and AuthApi.Host projects, in an attempt to share the server config for debug and build.
 * Added simple service configuration function to Api.Common, to load the initial config for Api host apps.


### PR DESCRIPTION
* @Slushnas found WebApp.Start error in ACE.AuthApi.Host: Changed ACE.Api.Startup to ACE.AuthApi.Startup to fix domain error.
* AuthServer Changes:
  - AuthServer needs a publicly accessible address to point connecting clients if you're trying to use the server outside of a localhost/internal lan only environment.
  - The current defaults basically point everything to `http://+:8001` which fails to resolve. So the following changes have been made..
  - Changed AuthServer.Url to AuthServer.ListenUrl
  - Added AuthServer.PublicUrl
  - Typically, you'll leave the AuthServer.ListenUrl to the default, but you'll want to change AuthServer.PublicUrl to either of the following: 
    * The externally accessible address of the AuthServer so that clients from the internet can authenticate.

    OR

    * localhost or the internal lan address so only those inside the local network/local machine can authenticate.