### PR TITLE
EquipMask Enum Fix

### DIFF
--- a/Source/ACE.Entity/Enum/EquipMask.cs
+++ b/Source/ACE.Entity/Enum/EquipMask.cs
@@ -41,7 +41,7 @@ namespace ACE.Entity.Enum
         SigilTwo            = 0x20000000,
         SigilThree          = 0x40000000,
         Clothing            = 0x80000000 | HeadWear | ChestWear | AbdomenWear | UpperArmWear | LowerArmWear | HandWear | UpperLegWear | LowerLegWear | FootWear,
-        Armor               = ChestArmor | AbdomenArmor | UpperArmArmor | LowerArmArmor | UpperLegArmor | LowerLegWear | FootWear,
+        Armor               = ChestArmor | AbdomenArmor | UpperArmArmor | LowerArmArmor | UpperLegArmor | LowerLegArmor | FootWear,
         Jewelry             = NeckWear | WristWearLeft | WristWearRight | FingerWearLeft | FingerWearRight | TrinketOne | Cloak | SigilOne | SigilTwo | SigilThree,
         WristWear           = WristWearLeft | WristWearRight,
         FingerWear          = FingerWearLeft | FingerWearRight,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # ACEmulator Change Log
 ### 2017-10-24
+[OptimShi]
+* Fixed bug with Equipment Mask enum that was causing Greaves/Lower Leg Armor not to appear on character
+
 [Mogwai]
 * API Host Updates for consistency and messaging.
 


### PR DESCRIPTION
Fixed bug with EquipMask enum that was causing Greaves/Lower Leg Armor not to appear on character