### PR TITLE
Fix Weenie Instance Position data load into AceObject

### DIFF
--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -173,6 +173,9 @@ namespace ACE.Database
                 // Create a new AceObject from Weenie.
                 AceObject ao = GetObject(instance.WeenieClassId);
 
+                // Set the object's current location for this instance.
+                ao.Location = new Position(instance.LandblockRaw, instance.PositionX, instance.PositionY, instance.PositionZ, instance.RotationX, instance.RotationY, instance.RotationZ, instance.RotationW);
+
                 // Use the guid recorded by the PCAP.
                 // This step could eventually be removed if we want to let the GuidManager handle assigning guids for static objects, ignoring the recorded guids.
                 string cmsClone = ao.CurrentMotionState; // Make a copy of the CurrentMotionState for cloning

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 # ACEmulator Change Log
-### 2017-10-30
-[Mogwai]
-* implemented updating of weenies in ace-world necessary for crowd-sourced content creation
-* added database unit tests to AppVeyor build
+
+### 2017-11-02
+[Ripley]
+* Fix Landblock loading of weenie instance position data.
 
 ### 2017-11-01
 [Ripley]
@@ -14,6 +14,11 @@
 * Todo/Fixme: Combat Stances don't work properly due to GetInventoryItem issue.
 * Cleaned up StyleCop issues.
 * Updated README with ACE-World requirement.
+
+### 2017-10-30
+[Mogwai]
+* implemented updating of weenies in ace-world necessary for crowd-sourced content creation
+* added database unit tests to AppVeyor build
 
 ### 2017-10-27
 [OptimShi]


### PR DESCRIPTION
Forgot to recall the instance current location data and put it in AceObject.Location so that objects appear where they are supposed to.