### PR TITLE
Reducing threading in core & simplifying coding model

### DIFF
--- a/Source/ACE.Entity/Enum/CombatMode.cs
+++ b/Source/ACE.Entity/Enum/CombatMode.cs
@@ -3,7 +3,7 @@
 namespace ACE.Entity.Enum
 {
     [Flags]
-    public enum CombatMode
+    public enum CombatMode : int
     {
         Undef       = 0x00,
         NonCombat   = 0x01,

--- a/Source/ACE/Entity/Book.cs
+++ b/Source/ACE/Entity/Book.cs
@@ -17,28 +17,21 @@ namespace ACE.Entity
         }
 
         // Called by the Landblock for books that are WorldObjects (some notes pinned to the ground, statues, pedestals and tips in training academy, etc
-        public override void HandleActionOnUse(ObjectGuid playerId)
+        public override void ActOnUse(ObjectGuid playerId)
         {
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            if (player == null)
             {
-                Player player = wo as Player;
-                if (player == null)
-                {
-                    return;
-                }
+                return;
+            }
 
-                // Make sure player is within the use radius of the item.
-                if (!player.IsWithinUseRadiusOf(this))
-                    player.DoMoveTo(this);
-                else
-                {
-                    BookUseHandler(player.Session);
-                }
-            });
-
-            // Run on the player
-            chain.EnqueueChain();
+            // Make sure player is within the use radius of the item.
+            if (!player.IsWithinUseRadiusOf(this))
+                player.DoMoveTo(this);
+            else
+            {
+                BookUseHandler(player.Session);
+            }
         }
 
         // Called when the items is in a player's inventory

--- a/Source/ACE/Entity/Cow.cs
+++ b/Source/ACE/Entity/Cow.cs
@@ -43,45 +43,33 @@ namespace ACE.Entity
             set;
         }
 
-        public override void HandleActionOnUse(ObjectGuid playerId)
+        public override void ActOnUse(ObjectGuid playerId)
         {
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            if (player == null)
             {
-                Player player = wo as Player;
-                if (player == null)
+                return;
+            }
+
+            ////if (playerDistanceTo >= 2500)
+            ////{
+            ////    var sendTooFarMsg = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_0037);
+            ////    player.Session.Network.EnqueueSend(sendTooFarMsg, sendUseDoneEvent);
+            ////    return;
+            ////}
+
+            if (!player.IsWithinUseRadiusOf(this))
+                player.DoMoveTo(this);
+            else
+            {
+                if (AllowedActivator == null)
                 {
-                    return;
+                    Activate(playerId);
                 }
 
-                ////if (playerDistanceTo >= 2500)
-                ////{
-                ////    var sendTooFarMsg = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_0037);
-                ////    player.Session.Network.EnqueueSend(sendTooFarMsg, sendUseDoneEvent);
-                ////    return;
-                ////}
-
-                if (!player.IsWithinUseRadiusOf(this))
-                    player.DoMoveTo(this);
-                else
-                {
-                    ActionChain useObjectChain = new ActionChain();
-
-                    useObjectChain.AddAction(this, () =>
-                    {
-                        if (AllowedActivator == null)
-                        {
-                            Activate(playerId);
-                        }
-
-                        var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                        player.Session.Network.EnqueueSend(sendUseDoneEvent);
-                    });
-
-                    useObjectChain.EnqueueChain();
-                }
-            });
-            chain.EnqueueChain();
+                var sendUseDoneEvent = new GameEventUseDone(player.Session);
+                player.Session.Network.EnqueueSend(sendUseDoneEvent);
+            }
         }
 
         private void Activate(ObjectGuid activator = new ObjectGuid())

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -537,6 +537,24 @@ namespace ACE.Entity
                     sound,
                     volume));
         }
+        
+        /// <summary>
+        /// Convenience wrapper to EnqueueBroadcast to broadcast local chat.
+        /// </summary>
+        /// <param name="wo"></param>
+        /// <param name="message"></param>
+        public void EnqueueBroadcastSystemChat(WorldObject wo, string message, ChatMessageType type)
+        {
+            // wo must exist on us
+            if (wo.CurrentLandblock != this)
+            {
+                log.Error("ERROR: Broadcasting chat from object not on our landblock");
+            }
+
+            GameMessageSystemChat chatMsg = new GameMessageSystemChat(message, type);
+
+            EnqueueBroadcast(wo.Location, MaxObjectRange, chatMsg);
+        }
 
         /// <summary>
         /// Convenience wrapper to EnqueueBroadcast to broadcast local chat.

--- a/Source/ACE/Entity/Landblock.cs
+++ b/Source/ACE/Entity/Landblock.cs
@@ -331,7 +331,8 @@ namespace ACE.Entity
         }
 
         /// <summary>
-        /// main game loop
+        /// Every game-loop iteration work.  Ideally this wouldn't exist, but we haven't finished
+        /// fully transitioning landblocks to an event-based system.
         /// </summary>
         public void UseTime(double tickTime)
         {
@@ -716,7 +717,7 @@ namespace ACE.Entity
             return null;
         }
 
-        private WorldObject GetObject(ObjectGuid guid)
+        public WorldObject GetObject(ObjectGuid guid)
         {
             Landblock lb = GetOwner(guid);
             if (lb == null)
@@ -751,6 +752,7 @@ namespace ACE.Entity
             return worldObjects.ContainsKey(guid) ? worldObjects[guid].WeenieType : 0;
         }
 
+        /*
         public void ChainOnObject(ActionChain chain, ObjectGuid woGuid, Action<WorldObject> action)
         {
             WorldObject wo = GetObject(woGuid);
@@ -761,6 +763,7 @@ namespace ACE.Entity
 
             chain.AddAction(wo, () => action(wo));
         }
+        */
 
         /// <summary>
         /// Intended for when moving an item directly to a player's container (which is not visible to the landblock)
@@ -812,6 +815,7 @@ namespace ACE.Entity
 
             RemoveWorldObjectInternal(woGuid, false);
             wo.ContainerId = container.Guid.Full;
+
             // We are coming off the world we need to be ready to save.
             wo.Location = null;
             wo.InitializeAceObjectForSave();

--- a/Source/ACE/Entity/Lifestone.cs
+++ b/Source/ACE/Entity/Lifestone.cs
@@ -15,49 +15,44 @@ namespace ACE.Entity
         {
         }
 
-        public override void HandleActionOnUse(ObjectGuid playerId)
+        public override void ActOnUse(ObjectGuid playerId)
         {
             // All data on a lifestone is constant -- therefore we just run in context of player
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            string serverMessage = null;
+            // validate within use range, taking into account the radius of the model itself, as well
+            SetupModel csetup = SetupModel.ReadFromDat(SetupTableId.Value);
+            float radiusSquared = (UseRadius.Value + csetup.Radius) * (UseRadius.Value + csetup.Radius);
+
+            // Run this animation...
+            // Player Enqueue:
+            var motionSanctuary = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Sanctuary));
+
+            var animationEvent = new GameMessageUpdateMotion(player.Guid,
+                                                             player.Sequences.GetCurrentSequence(Network.Sequence.SequenceType.ObjectInstance),
+                                                             player.Sequences, motionSanctuary);
+
+            // This event was present for a pcap in the training dungeon.. Why? The sound comes with animationEvent...
+            var soundEvent = new GameMessageSound(Guid, Sound.LifestoneOn, 1);
+
+            if (player.Location.SquaredDistanceTo(Location) >= radiusSquared)
             {
-                Player player = wo as Player;
-                string serverMessage = null;
-                // validate within use range, taking into account the radius of the model itself, as well
-                SetupModel csetup = SetupModel.ReadFromDat(SetupTableId.Value);
-                float radiusSquared = (UseRadius.Value + csetup.Radius) * (UseRadius.Value + csetup.Radius);
+                serverMessage = "You wandered too far to attune with the Lifestone!";
+            }
+            else
+            {
+                player.SetCharacterPosition(PositionType.Sanctuary, player.Location);
 
-                // Run this animation...
-                // Player Enqueue:
-                var motionSanctuary = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Sanctuary));
+                // create the outbound server message
+                serverMessage = "You have attuned your spirit to this Lifestone. You will resurrect here after you die.";
+                player.HandleActionMotion(motionSanctuary);
+                player.Session.Network.EnqueueSend(soundEvent);
+            }
 
-                var animationEvent = new GameMessageUpdateMotion(player.Guid,
-                                                                 player.Sequences.GetCurrentSequence(Network.Sequence.SequenceType.ObjectInstance),
-                                                                 player.Sequences, motionSanctuary);
-
-                // This event was present for a pcap in the training dungeon.. Why? The sound comes with animationEvent...
-                var soundEvent = new GameMessageSound(Guid, Sound.LifestoneOn, 1);
-
-                if (player.Location.SquaredDistanceTo(Location) >= radiusSquared)
-                {
-                    serverMessage = "You wandered too far to attune with the Lifestone!";
-                }
-                else
-                {
-                    player.SetCharacterPosition(PositionType.Sanctuary, player.Location);
-
-                    // create the outbound server message
-                    serverMessage = "You have attuned your spirit to this Lifestone. You will resurrect here after you die.";
-                    player.HandleActionMotion(motionSanctuary);
-                    player.Session.Network.EnqueueSend(soundEvent);
-                }
-
-                var lifestoneBindMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.Magic);
-                // always send useDone event
-                var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                player.Session.Network.EnqueueSend(lifestoneBindMessage, sendUseDoneEvent);
-            });
-            chain.EnqueueChain();
+            var lifestoneBindMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.Magic);
+            // always send useDone event
+            var sendUseDoneEvent = new GameEventUseDone(player.Session);
+            player.Session.Network.EnqueueSend(lifestoneBindMessage, sendUseDoneEvent);
         }
     }
 }

--- a/Source/ACE/Entity/Portal.cs
+++ b/Source/ACE/Entity/Portal.cs
@@ -167,173 +167,161 @@ namespace ACE.Entity
         {
             string serverMessage;
 
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            if (player == null)
             {
-                Player player = wo as Player;
-                if (player == null)
-                {
-                    return;
-                }
-                if (Destination != null)
-                {
+                return;
+            }
+            if (Destination != null)
+            {
 #if DEBUG
-                    serverMessage = "Checking requirements for " + this.Name;
-                    var usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                serverMessage = "Checking requirements for " + this.Name;
+                var usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                player.Session.Network.EnqueueSend(usePortalMessage);
+#endif
+                // Check player level -- requires remote query to player (ugh)...
+                if ((player.Level >= MinimumLevel) && ((player.Level <= MaximumLevel) || (MaximumLevel == 0)))
+                {
+                    Position portalDest = Destination;
+                    switch (WeenieClassId)
+                    {
+                        /// <summary>
+                        /// Setup correct racial portal destination for the Central Courtyard in the Training Academy
+                        /// </summary>
+                        case (ushort)SpecialPortalWCID.CentralCourtyard:
+                            {
+                                uint playerLandblockId = player.Location.LandblockId.Raw;
+                                switch (playerLandblockId)
+                                {
+                                    case (uint)SpecialPortalLandblockID.ShoushiCCLaunch:    // Shoushi
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiCCLanding);
+                                            break;
+                                        }
+                                    case (uint)SpecialPortalLandblockID.YaraqCCLaunch:    // Yaraq
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqCCLanding);
+                                            break;
+                                        }
+                                    case (uint)SpecialPortalLandblockID.SanamarCCLaunch:    // Sanamar
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarCCLanding);
+                                            break;
+                                        }
+                                    default:            // Holtburg
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgCCLanding);
+                                            break;
+                                        }
+                                }
+
+                                portalDest.PositionX = Destination.PositionX;
+                                portalDest.PositionY = Destination.PositionY;
+                                portalDest.PositionZ = Destination.PositionZ;
+                                portalDest.RotationX = Destination.RotationX;
+                                portalDest.RotationY = Destination.RotationY;
+                                portalDest.RotationZ = Destination.RotationZ;
+                                portalDest.RotationW = Destination.RotationW;
+                                break;
+                            }
+                        /// <summary>
+                        /// Setup correct racial portal destination for the Outer Courtyard in the Training Academy
+                        /// </summary>
+                        case (ushort)SpecialPortalWCID.OuterCourtyard:
+                            {
+                                uint playerLandblockId = player.Location.LandblockId.Raw;
+                                switch (playerLandblockId)
+                                {
+                                    case (uint)SpecialPortalLandblockID.ShoushiOCLaunch:    // Shoushi
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiOCLanding);
+                                            break;
+                                        }
+                                    case (uint)SpecialPortalLandblockID.YaraqOCLaunch:    // Yaraq
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqOCLanding);
+                                            break;
+                                        }
+                                    case (uint)SpecialPortalLandblockID.SanamarOCLaunch:    // Sanamar
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarOCLanding);
+                                            break;
+                                        }
+                                    default:            // Holtburg
+                                        {
+                                            portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgOCLanding);
+                                            break;
+                                        }
+                                }
+
+                                portalDest.PositionX = Destination.PositionX;
+                                portalDest.PositionY = Destination.PositionY;
+                                portalDest.PositionZ = Destination.PositionZ;
+                                portalDest.RotationX = Destination.RotationX;
+                                portalDest.RotationY = Destination.RotationY;
+                                portalDest.RotationZ = Destination.RotationZ;
+                                portalDest.RotationW = Destination.RotationW;
+                                break;
+                            }
+                        /// <summary>
+                        /// All other portals don't need adjustments.
+                        /// </summary>
+                        default:
+                            {
+                                break;
+                            }
+                    }
+
+#if DEBUG
+                    serverMessage = "Portal sending player to destination";
+                    usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
                     player.Session.Network.EnqueueSend(usePortalMessage);
 #endif
-                    // Check player level -- requires remote query to player (ugh)...
-                    if ((player.Level >= MinimumLevel) && ((player.Level <= MaximumLevel) || (MaximumLevel == 0)))
-                    {
-                        Position portalDest = Destination;
-                        switch (WeenieClassId)
-                        {
-                            /// <summary>
-                            /// Setup correct racial portal destination for the Central Courtyard in the Training Academy
-                            /// </summary>
-                            case (ushort)SpecialPortalWCID.CentralCourtyard:
-                                {
-                                    uint playerLandblockId = player.Location.LandblockId.Raw;
-                                    switch (playerLandblockId)
-                                    {
-                                        case (uint)SpecialPortalLandblockID.ShoushiCCLaunch:    // Shoushi
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiCCLanding);
-                                                break;
-                                            }
-                                        case (uint)SpecialPortalLandblockID.YaraqCCLaunch:    // Yaraq
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqCCLanding);
-                                                break;
-                                            }
-                                        case (uint)SpecialPortalLandblockID.SanamarCCLaunch:    // Sanamar
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarCCLanding);
-                                                break;
-                                            }
-                                        default:            // Holtburg
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgCCLanding);
-                                                break;
-                                            }
-                                    }
-
-                                    portalDest.PositionX = Destination.PositionX;
-                                    portalDest.PositionY = Destination.PositionY;
-                                    portalDest.PositionZ = Destination.PositionZ;
-                                    portalDest.RotationX = Destination.RotationX;
-                                    portalDest.RotationY = Destination.RotationY;
-                                    portalDest.RotationZ = Destination.RotationZ;
-                                    portalDest.RotationW = Destination.RotationW;
-                                    break;
-                                }
-                            /// <summary>
-                            /// Setup correct racial portal destination for the Outer Courtyard in the Training Academy
-                            /// </summary>
-                            case (ushort)SpecialPortalWCID.OuterCourtyard:
-                                {
-                                    uint playerLandblockId = player.Location.LandblockId.Raw;
-                                    switch (playerLandblockId)
-                                    {
-                                        case (uint)SpecialPortalLandblockID.ShoushiOCLaunch:    // Shoushi
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.ShoushiOCLanding);
-                                                break;
-                                            }
-                                        case (uint)SpecialPortalLandblockID.YaraqOCLaunch:    // Yaraq
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.YaraqOCLanding);
-                                                break;
-                                            }
-                                        case (uint)SpecialPortalLandblockID.SanamarOCLaunch:    // Sanamar
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.SanamarOCLanding);
-                                                break;
-                                            }
-                                        default:            // Holtburg
-                                            {
-                                                portalDest.LandblockId = new LandblockId((uint)SpecialPortalLandblockID.HoltburgOCLanding);
-                                                break;
-                                            }
-                                    }
-
-                                    portalDest.PositionX = Destination.PositionX;
-                                    portalDest.PositionY = Destination.PositionY;
-                                    portalDest.PositionZ = Destination.PositionZ;
-                                    portalDest.RotationX = Destination.RotationX;
-                                    portalDest.RotationY = Destination.RotationY;
-                                    portalDest.RotationZ = Destination.RotationZ;
-                                    portalDest.RotationW = Destination.RotationW;
-                                    break;
-                                }
-                            /// <summary>
-                            /// All other portals don't need adjustments.
-                            /// </summary>
-                            default:
-                                {
-                                    break;
-                                }
-                        }
-
-#if DEBUG
-                        serverMessage = "Portal sending player to destination";
-                        usePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
-                        player.Session.Network.EnqueueSend(usePortalMessage);
-#endif
-                        player.Session.Player.Teleport(portalDest);
-                        // If the portal just used is able to be recalled to,
-                        // save the destination coordinates to the LastPortal character position save table
-                        if (IsRecallable)
-                            player.SetCharacterPosition(PositionType.LastPortal, portalDest);
-                    }
-                    else if ((player.Level > MaximumLevel) && (MaximumLevel != 0))
-                    {
-                        // You are too powerful to interact with that portal!
-                        var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AC);
-                        player.Session.Network.EnqueueSend(failedUsePortalMessage);
-                    }
-                    else
-                    {
-                        // You are not powerful enough to interact with that portal!
-                        var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AB);
-                        player.Session.Network.EnqueueSend(failedUsePortalMessage);
-                    }
+                    player.Session.Player.Teleport(portalDest);
+                    // If the portal just used is able to be recalled to,
+                    // save the destination coordinates to the LastPortal character position save table
+                    if (IsRecallable)
+                        player.SetCharacterPosition(PositionType.LastPortal, portalDest);
                 }
-                else
+                else if ((player.Level > MaximumLevel) && (MaximumLevel != 0))
                 {
-                    serverMessage = "Portal destination for portal ID " + this.WeenieClassId + " not yet implemented!";
-                    var failedUsePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                    // You are too powerful to interact with that portal!
+                    var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AC);
                     player.Session.Network.EnqueueSend(failedUsePortalMessage);
                 }
-            });
-            // Run on the player
-            chain.EnqueueChain();
-        }
-
-        public override void HandleActionOnUse(ObjectGuid playerId)
-        {
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
-            {
-                Player player = wo as Player;
-                if (player == null)
-                {
-                    return;
-                }
-
-                if (!player.IsWithinUseRadiusOf(this))
-                    player.DoMoveTo(this);
                 else
                 {
-                    // TODO: to be removed once physics collisions are implemented
-                    HandleActionOnCollide(playerId);
-                    // always send useDone event
-                    var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                    player.Session.Network.EnqueueSend(sendUseDoneEvent);
+                    // You are not powerful enough to interact with that portal!
+                    var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.Enum_04AB);
+                    player.Session.Network.EnqueueSend(failedUsePortalMessage);
                 }
-            });
-            // Run on the player
-            chain.EnqueueChain();
+            }
+            else
+            {
+                serverMessage = "Portal destination for portal ID " + this.WeenieClassId + " not yet implemented!";
+                var failedUsePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
+                player.Session.Network.EnqueueSend(failedUsePortalMessage);
+            }
+        }
+
+        public override void ActOnUse(ObjectGuid playerId)
+        {
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            if (player == null)
+            {
+                return;
+            }
+
+            if (!player.IsWithinUseRadiusOf(this))
+                player.DoMoveTo(this);
+            else
+            {
+                // TODO: to be removed once physics collisions are implemented
+                HandleActionOnCollide(playerId);
+                // always send useDone event
+                var sendUseDoneEvent = new GameEventUseDone(player.Session);
+                player.Session.Network.EnqueueSend(sendUseDoneEvent);
+            }
         }
     }
 }

--- a/Source/ACE/Entity/Vendor.cs
+++ b/Source/ACE/Entity/Vendor.cs
@@ -53,30 +53,21 @@ namespace ACE.Entity
         /// Fired when Client clicks on the Vendor World Object
         /// </summary>
         /// <param name="playerId"></param>
-        public override void HandleActionOnUse(ObjectGuid playerId)
+        public override void ActOnUse(ObjectGuid playerId)
         {
-            ActionChain chain = new ActionChain();
-            CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+            Player player = CurrentLandblock.GetObject(playerId) as Player;
+            if (player == null)
             {
-                Player player = wo as Player;
-                if (player == null)
-                {
-                    return;
-                }
+                return;
+            }
 
-                if (!player.IsWithinUseRadiusOf(this))
-                    player.DoMoveTo(this);
-                else
-                {
-                    chain.AddAction(this, () =>
-                    {
-                        LoadInventory();
-                        ApproachVendor(player);
-                    });
-                }
-            });
-
-            chain.EnqueueChain();
+            if (!player.IsWithinUseRadiusOf(this))
+                player.DoMoveTo(this);
+            else
+            {
+                LoadInventory();
+                ApproachVendor(player);
+            }
         }
 
         /// <summary>
@@ -227,7 +218,7 @@ namespace ACE.Entity
             }
 
             // send transaction to player for further processing and.
-            player.HandleActionBuyFinalTransaction(this, uqlist, genlist, true, goldcost);
+            player.FinalizeBuyTransaction(this, uqlist, genlist, true, goldcost);
         }
 
         /// <summary>
@@ -280,7 +271,7 @@ namespace ACE.Entity
             }
 
             ApproachVendor(player);
-            player.HandleActionSellFinalTransaction(this, true, accepted, payout);
+            player.FinalizeSellTransaction(this, true, accepted, payout);
         }
 
         #endregion

--- a/Source/ACE/Entity/WorldObject.cs
+++ b/Source/ACE/Entity/WorldObject.cs
@@ -3007,29 +3007,24 @@ namespace ACE.Entity
                 Frozen = true;
         }
 
-        public virtual void HandleActionOnUse(ObjectGuid playerId)
+        public virtual void ActOnUse(ObjectGuid playerId)
         {
             // Do Nothing by default
             if (CurrentLandblock != null)
             {
-                ActionChain chain = new ActionChain();
-                CurrentLandblock.ChainOnObject(chain, playerId, (WorldObject wo) =>
+                Player player = CurrentLandblock.GetObject(playerId) as Player;
+                if (player == null)
                 {
-                    Player player = wo as Player;
-                    if (player == null)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
 #if DEBUG
-                    var errorMessage = new GameMessageSystemChat($"Default HandleActionOnUse reached, this object ({Name}) not programmed yet.", ChatMessageType.System);
-                    player.Session.Network.EnqueueSend(errorMessage);
+                var errorMessage = new GameMessageSystemChat($"Default HandleActionOnUse reached, this object ({Name}) not programmed yet.", ChatMessageType.System);
+                player.Session.Network.EnqueueSend(errorMessage);
 #endif
 
-                    var sendUseDoneEvent = new GameEventUseDone(player.Session);
-                    player.Session.Network.EnqueueSend(sendUseDoneEvent);
-                });
-                chain.EnqueueChain();
+                var sendUseDoneEvent = new GameEventUseDone(player.Session);
+                player.Session.Network.EnqueueSend(sendUseDoneEvent);
             }
         }
 

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -313,7 +313,7 @@ namespace ACE.Managers
                     });
                 });
 
-                // Process between landblock object motions sequentially -- for safety
+                // Process between landblock object motions sequentially
                 // Currently only used for picking items up off a landblock
                 MotionQueue.RunActions();
 
@@ -321,16 +321,13 @@ namespace ACE.Managers
                 //   This is responsible for updating all "actors" residing within the landblock. 
                 //   Objects and landblocks are "actors"
                 //   "actors" decide if they want to read/modify their own state (set desired velocity), move-to positions, move items, read vitals, etc
-                //   RULE: action functions CANNOT read/modify other objects 
-                //      -- unless they "own" the other object: e.g. in a container
-                //      -- action objects must send requests (actions) to other actor's action queues, and have them do modification
                 // N.B. -- Broadcasts are enqueued for sending at the end of the landblock's action time
                 // FIXME(ddevec): Goal is to eventually migrate to an "Act" function of the LandblockManager ActiveLandblocks
                 //    Inactive landblocks will be put on TimeoutManager queue for timeout killing
-                ActionQueue.RunActionsParallel();
+                ActionQueue.RunActions();
 
                 // Handles sending out all per-landblock broadcasts -- This may rework when we rework tracking -- tbd
-                BroadcastQueue.RunActionsParallel();
+                BroadcastQueue.RunActions();
 
                 // XXX(ddevec): Should this be its own step in world-update thread?
                 sessionLock.EnterReadLock();

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # ACEmulator Change Log
 
 ### 2017-11-03
+[ddevec]
+* Change core structure eliminating multi-threading between threads.  
+* Removed ChainOnObject() from landblock, make GetObject() public.
+* Simplified Action code to reflect for new threading model.
+
 [Ripley]
 * Fix AppVeyor issues.
 


### PR DESCRIPTION
Landblocks no longer act in parallel.  Any game-content updates done from a landblock need not worry about synchronizing with other landblocks, this should simplify the coding of the core game logic.

NOTE: The network packet parsing still happens in its own thread, so ActionChains are still required to move work from the network thread onto the landblock.

ActionChains are also still included for their uses delaying work (e.g. when waiting for an animation, or to reach a destination).