### PR TITLE
Fix non-critical typo in hex constant.

### DIFF
--- a/Source/ACE/Network/PacketHeader.cs
+++ b/Source/ACE/Network/PacketHeader.cs
@@ -50,7 +50,7 @@ namespace ACE.Network
         {
             uint checksum = 0;
             uint original = Checksum;
-            Checksum = 0x0BADD70DD;
+            Checksum = 0xBADD70DD;
             byte[] rawHeader = GetRaw();
             checksum = Hash32.Calculate(rawHeader, rawHeader.Length);
             Checksum = original;


### PR DESCRIPTION
Not important, just a little thing I noticed a while back,
Considering how C# handles constants, I don't think this could become an issue (even in the case system endian was reversed). Just a style issue, at most.