### PR TITLE
Gem OnUse and UpdateEnchantment

### DIFF
--- a/Source/ACE/Entity/Gem.cs
+++ b/Source/ACE/Entity/Gem.cs
@@ -4,7 +4,7 @@ using ACE.Entity.Actions;
 using ACE.Entity.Enum;
 using ACE.Network;
 using ACE.Network.GameEvent.Events;
-using ACE.Network.GameMessage.Messages;
+using ACE.Network.GameMessages.Messages;
 
 namespace ACE.Entity
 {

--- a/Source/ACE/Network/GameEvent/Events/GameEventMagicUpdateEnchantment.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventMagicUpdateEnchantment.cs
@@ -1,34 +1,32 @@
-﻿using ACE.DatLoader.Entity;
+using ACE.DatLoader.Entity;
 
 namespace ACE.Network.GameEvent.Events
 {
     public class GameEventMagicUpdateEnchantment : GameEventMessage
     {
-        public GameEventMagicUpdateEnchantment(Session session, SpellBase spellBase, uint layer, uint spellCategory, int cooldownId, uint enchantmentTypeFlag)
+        public GameEventMagicUpdateEnchantment(Session session, SpellBase spellBase, uint layer, int cooldownId, uint enchantmentTypeFlag)
             : base(GameEventType.MagicUpdateEnchantment, GameMessageGroup.Group09, session)
         {
             const double startTime = 0;
             const double lastTimeDegraded = 0;
-            const uint key = 0;
-            const float val = 0;
-            const uint spellSetId = 0;
-            uint spellId = layer | spellCategory | (uint)cooldownId; // spellId is made up of these 3 components
-            Writer.Write(spellId);
-            Writer.Write(layer | spellCategory); // packed spell category
+            ////val is something that is currently not available directly from the spell tables. I am working on fixing this for the SpellManager that is being worked on.
+            const float val = 35;
+            const ushort spellSetId = 0;
+            Writer.Write((ushort)spellBase.MetaSpellId);
+            Writer.Write((ushort)layer);
+            Writer.Write((ushort)spellBase.Category);
+            Writer.Write(spellSetId);
             Writer.Write(spellBase.Power);
             Writer.Write(startTime); // FIXME: this needs to be passed it.
             Writer.Write(spellBase.Duration);
             Writer.Write(session.Player.Guid.Full);
             Writer.Write(spellBase.DegradeModifier);
             Writer.Write(spellBase.DegradeLimit);
-            Writer.Write(lastTimeDegraded);
-            Writer.Write(enchantmentTypeFlag);
-
-            // FIXME: These next 2 may be depreciated need more research.
-            Writer.Write(key);
+            Writer.Write(lastTimeDegraded);////This needs timer updates to work correctly
+            Writer.Write(enchantmentTypeFlag);////This is something that needs to be worked on. There is currently no way to get correct flags based on the spell table itself. They are in the logs though and we could eventually add this to the spell table.
+            Writer.Write(spellBase.Category);
             Writer.Write(val);
             Writer.Write(spellSetId);
-
             Writer.Align();
         }
     }


### PR DESCRIPTION
Reworked GameEventMagicUpdateEnchantment. The way it was currently trying to pack spell data was garbling things up and the packet no longer matched a retail packet. Once I rewrote it, it now matches retail and also shows all spells in use in the active spell tab in the top left corner, with time remaining(client side).  This will be implemented server side soon.

To demonstrate this, I implemented non contract OnUse for gems. You can use Blackmoor's Favor, or the two gems that are available for sale at the gem shop in Holtburg.