### PR TITLE
Updated GameEventMagicUpdateEnchantment to write the info correctly. …

### DIFF
--- a/Source/ACE/Entity/Gem.cs
+++ b/Source/ACE/Entity/Gem.cs
@@ -4,6 +4,7 @@ using ACE.Entity.Actions;
 using ACE.Entity.Enum;
 using ACE.Network;
 using ACE.Network.GameEvent.Events;
+using ACE.Network.GameMessages.Messages;
 
 namespace ACE.Entity
 {
@@ -38,7 +39,42 @@ namespace ACE.Entity
         /// <param name="session">Pass the session variable so we will have access to player and the correct sequences</param>
         public override void OnUse(Session session)
         {
-            if (UseCreateContractId == null) return;
+            if (UseCreateContractId == null)
+                if (UseCreateContractId == null)
+                 {
+                SpellTable spellTable = SpellTable.ReadFromDat();
+                                if (!spellTable.Spells.ContainsKey((uint)SpellDID))
+                                    {
+                                       return;
+                                    }
+                SpellBase spell = spellTable.Spells[(uint)SpellDID];
+                string castMessage = "The gem casts " + spell.Name + " on you";
+                    ////These if statements are to catch spells with an apostrophe in the dat file which throws off the client in reading it from the dat.
+                    if (spell.MetaSpellId == 3810)
+                    {
+                        castMessage = "The gem casts Asheron's Benediction on you";
+                    }
+                    if (spell.MetaSpellId == 3811)
+                    {
+                        castMessage = "The gem casts Blackmoor's Favor on you";
+                    }
+                    if (spell.MetaSpellId == 3953)
+                    {
+                        castMessage = "The gem casts Carraida's Benediction on you";
+                    }
+                    if (spell.MetaSpellId == 4024)
+                    {
+                        castMessage = "The gem casts Asheron's Lesser Benediction on you";
+                    }
+                 castMessage += "."; // If not refreshing/surpassing/less than active spell, which I will check for in the very near future when I get the active enchantment list implemented.
+                 session.Network.EnqueueSend(new GameMessageSystemChat(castMessage, ChatMessageType.Magic));
+                session.Player.PlayParticleEffect((PlayScript)spell.TargetEffect, session.Player.Guid);
+                const ushort layer = 1; // FIXME: This will be tracked soon, once a list is made to track active enchantments
+                session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(session, session.Player, spell, layer, 1, (uint)0x2009010)); ////The values that are hardcoded are not directly available from spell table, but will be available soon.
+                ////session.Player.HandleActionRemoveItemFromInventory(Guid.Full, (uint)ContainerId, 1); This is commented out to aid in testing. Will be uncommented later.
+                session.Player.SendUseDoneEvent();
+                return;
+                }
             ContractTracker contractTracker = new ContractTracker((uint)UseCreateContractId, session.Player.Guid.Full)
             {
                 Stage = 0,
@@ -95,7 +131,7 @@ namespace ACE.Entity
                     DegradeModifier = 0,
                     DegradeLimit = -666
             };
-                session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(session, spellBase, layer, spellCategory, CooldownId.Value, (uint)EnchantmentTypeFlags.Cooldown));
+                session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(session, session.Player, spellBase, layer, CooldownId.Value, (uint)EnchantmentTypeFlags.Cooldown));
 
                 // Ok this was not known to us, so we used the contract - now remove it from inventory.
                 // HandleActionRemoveItemFromInventory is has it's own action chain.

--- a/Source/ACE/Network/GameEvent/Events/GameEventMagicUpdateEnchantment.cs
+++ b/Source/ACE/Network/GameEvent/Events/GameEventMagicUpdateEnchantment.cs
@@ -1,31 +1,31 @@
-﻿using ACE.DatLoader.Entity;
+using ACE.DatLoader.Entity;
+using ACE.Entity;
 
 namespace ACE.Network.GameEvent.Events
 {
     public class GameEventMagicUpdateEnchantment : GameEventMessage
     {
-        public GameEventMagicUpdateEnchantment(Session session, SpellBase spellBase, uint layer, uint spellCategory, int cooldownId, uint enchantmentTypeFlag)
+        public GameEventMagicUpdateEnchantment(Session session, WorldObject target, SpellBase spellBase, uint layer, int cooldownId, uint enchantmentTypeFlag)
             : base(GameEventType.MagicUpdateEnchantment, GameMessageGroup.Group09, session)
         {
             const double startTime = 0;
             const double lastTimeDegraded = 0;
-            const uint key = 0;
-            const float val = 0;
-            const uint spellSetId = 0;
-            uint spellId = layer | spellCategory | (uint)cooldownId; // spellId is made up of these 3 components
-            Writer.Write(spellId);
-            Writer.Write(layer | spellCategory); // packed spell category
+            ////val is something that is currently not available directly from the spell tables. I am working on fixing this for the SpellManager that is being worked on.
+            const float val = 35;
+            const ushort spellSetId = 0;
+            Writer.Write((ushort)spellBase.MetaSpellId);
+            Writer.Write((ushort)layer);
+            Writer.Write((ushort)spellBase.Category);
+            Writer.Write(spellSetId);
             Writer.Write(spellBase.Power);
             Writer.Write(startTime); // FIXME: this needs to be passed it.
             Writer.Write(spellBase.Duration);
-            Writer.Write(session.Player.Guid.Full);
+            Writer.Write(target.Guid.Full);
             Writer.Write(spellBase.DegradeModifier);
             Writer.Write(spellBase.DegradeLimit);
-            Writer.Write(lastTimeDegraded);
-            Writer.Write(enchantmentTypeFlag);
-
-            // FIXME: These next 2 may be depreciated need more research.
-            Writer.Write(key);
+            Writer.Write(lastTimeDegraded);////This needs timer updates to work correctly
+            Writer.Write(enchantmentTypeFlag);////This is something that needs to be worked on. There is currently no way to get correct flags based on the spell table itself. They are in the logs though and we could eventually add this to the spell table.
+            Writer.Write(spellBase.Category);
             Writer.Write(val);
             Writer.Write(spellSetId);
 


### PR DESCRIPTION
* Updated GameEventMagicUpdateEnchantment to write the info correctly. This now matches retail. Also added session and target so that it will be flexible when applying spells from casting to self and other, not just for gems (per Morosity's review).
Added Gem OnUse functionality. Gems now cast spells on you when used and values are updated in client.