### PR TITLE
Implement CellLandblock geometry cache.

### DIFF
--- a/Source/ACE.DatLoader/FileTypes/Wave.cs
+++ b/Source/ACE.DatLoader/FileTypes/Wave.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 
 namespace ACE.DatLoader.FileTypes
 {
@@ -14,14 +15,12 @@ namespace ACE.DatLoader.FileTypes
 
         public override void Unpack(BinaryReader reader)
         {
-            int headerSize  = reader.ReadInt32() - 2; // not sure why this is required, it just is.
-            int dataSize    = reader.ReadInt32();
+            int objectId   = reader.ReadInt32();
+            int headerSize = reader.ReadInt32();
+            int dataSize   = reader.ReadInt32();
 
-            Header  = reader.ReadBytes(headerSize);
-            Data    = reader.ReadBytes(dataSize);
-
-            // TODO: I don't know why, but the reader doesn't align properly with the length here
-            reader.BaseStream.Position = reader.BaseStream.Length;
+            Header = reader.ReadBytes(headerSize);
+            Data   = reader.ReadBytes(dataSize);
         }
 
         /// <summary>
@@ -29,7 +28,10 @@ namespace ACE.DatLoader.FileTypes
         /// </summary>
         public static void ExportWave(Wave wav, uint fileId, string directory)
         {
-            string filename = Path.Combine(directory, fileId.ToString("X8") + ".wav");
+            string ext = ".wav";
+            if (wav.Header[0] == 0x55) ext = ".mp3";
+
+            string filename = Path.Combine(directory, fileId.ToString("X8") + ext);
 
             // Good summary of the header for a WAV file and what all this means
             // http://www.topherlee.com/software/pcm-tut-wavformat.html
@@ -39,7 +41,7 @@ namespace ACE.DatLoader.FileTypes
 
             binaryWriter.Write(System.Text.Encoding.ASCII.GetBytes("RIFF"));
 
-            uint filesize = (uint)(wav.Header.Length + wav.Data.Length + 20); // 20 is added for all the extra we're adding for the WAV header format
+            uint filesize = (uint)(wav.Data.Length + 36); // 36 is added for all the extra we're adding for the WAV header format
             binaryWriter.Write(filesize);
 
             binaryWriter.Write(System.Text.Encoding.ASCII.GetBytes("WAVE"));
@@ -49,7 +51,13 @@ namespace ACE.DatLoader.FileTypes
 
             binaryWriter.Write((int)0x10); // 16 ... length of all the above
 
-            binaryWriter.Write(wav.Header);
+            // AC audio headers start at Format Type,
+            // and are usually 18 bytes, with some exceptions
+            // notably objectID A000393 which is 30 bytes
+
+            // WAV headers are always 16 bytes from Format Type to end of header,
+            // so this extra data is truncated here.
+            binaryWriter.Write(wav.Header.Take(16).ToArray());
 
             binaryWriter.Write(System.Text.Encoding.ASCII.GetBytes("data"));
             binaryWriter.Write((uint)wav.Data.Length);

--- a/Source/ACE.Server/Entity/Line2.cs
+++ b/Source/ACE.Server/Entity/Line2.cs
@@ -1,0 +1,149 @@
+using System.Numerics;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Represents a 2D line
+    /// </summary>
+    public class Line2
+    {
+        /// <summary>
+        /// The start point
+        /// </summary>
+        public Vector2 Start;
+
+        /// <summary>
+        /// The end point
+        /// </summary>
+        public Vector2 End;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Line2()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a line from 2 points
+        /// </summary>
+        public Line2(Vector2 start, Vector2 end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>
+        /// Constructs a line from 2 points
+        /// </summary>
+        public Line2(float startX, float startY, float endX, float endY)
+        {
+            Start = new Vector2(startX, startY);
+            End = new Vector2(endX, endY);
+        }
+
+        /// <summary>
+        /// Constructs a 2D line from 3D points, dropping the Z-component
+        /// </summary>
+        public Line2(Vector3 start, Vector3 end)
+        {
+            Start = new Vector2(start.X, start.Y);
+            End = new Vector2(end.X, end.Y);
+        }
+
+        /// <summary>
+        /// Returns the determinant of a line at point
+        /// </summary>
+        public static float Determinant(Line2 line, float x, float y)
+        {
+            return (line.End.X - line.Start.X) * (y - line.Start.Y) - (line.End.Y - line.Start.Y) * (x - line.Start.X);
+        }
+
+        public static float Determinant(Line2 line, Vector2 point)
+        {
+            return Determinant(line, point.X, point.Y);
+        }
+
+        public float Determinant(Vector2 point)
+        {
+            return Determinant(this, point);
+        }
+
+        /// <summary>
+        /// Returns TRUE if point resides on a line
+        /// </summary>
+        public static bool Collinear(Line2 line, Vector2 point)
+        {
+            return Determinant(line, point) == 0;
+        }
+
+        public static bool Collinear(Line2 line, float x, float y)
+        {
+            return Determinant(line, x, y) == 0;
+        }
+
+        public bool Collinear(float x, float y)
+        {
+            return Collinear(this, x, y);
+        }
+
+        public bool Collinear(Vector2 point)
+        {
+            return Collinear(this, point);
+        }
+
+        /// <summary>
+        /// Returns TRUE if point is on left side of line
+        /// </summary>
+        /// <remarks>
+        /// If we draw a horizontal line from left to right,
+        /// The left side is considered to be the top.
+        /// </remarks>
+        public static bool LeftSide(Line2 line, Vector2 point)
+        {
+            return Determinant(line, point) < 0;
+        }
+
+        public static bool LeftSide(Line2 line, float x, float y)
+        {
+            return Determinant(line, x, y) < 0;
+        }
+
+        public bool LeftSide(Vector2 point)
+        {
+            return LeftSide(this, point);
+        }
+
+        public bool LeftSide(float x, float y)
+        {
+            return LeftSide(this, x, y);
+        }
+
+        /// <summary>
+        /// Returns TRUE if point is on right side of line
+        /// </summary>
+        /// <remarks>
+        /// If we draw a horizontal line from left to right,
+        /// The right side is considered to be the bottom.
+        /// </remarks>
+        public static bool RightSide(Line2 line, Vector2 point)
+        {
+            return Determinant(line, point) > 0;
+        }
+
+        public static bool RightSide(Line2 line, float x, float y)
+        {
+            return Determinant(line, x, y) > 0;
+        }
+
+        public bool RightSide(Vector2 point)
+        {
+            return RightSide(this, point);
+        }
+
+        public bool RightSide(float x, float y)
+        {
+            return RightSide(this, x, y);
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Mesh.cs
+++ b/Source/ACE.Server/Entity/Mesh.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.Entity;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// A 3D mesh of vertices and triangles
+    /// </summary>
+    public class Mesh
+    {
+        /// <summary>
+        /// The list of vertices comprising the mesh
+        /// </summary>
+        public List<Vector3> Vertices;
+
+        /// <summary>
+        /// The list of triangles comprising the mesh
+        /// </summary>
+        public List<Triangle> Triangles;
+
+        /// <summary>
+        /// This is only set for landblock meshes
+        /// </summary>
+        public LandblockId LandblockId;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Mesh()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new mesh for landblock
+        /// </summary>
+        public Mesh(LandblockId id)
+        {
+            LandblockId = id;
+        }
+
+        /// <summary>
+        /// Loads the vertices for a landblock mesh
+        /// </summary>
+        /// <param name="height">The height of each vertex in the landblock cells</param>
+        public void LoadVertices(float[,] height)
+        {
+            var xSize = height.GetLength(0);
+            var ySize = height.GetLength(1);
+
+            Vertices = new List<Vector3>(xSize * ySize);
+
+            for (int x = 0; x < xSize; x++)
+            {
+                for (int y = 0; y < ySize; y++)
+                {
+                    Vertices.Add(new Vector3(x * Landblock.CellSize, y * Landblock.CellSize, height[x, y]));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates the triangles from the mesh vertices
+        /// </summary>
+        /// <param name="id">The landblock to generate triangles for</param>
+        public void BuildTriangles(LandblockId id)
+        {
+            var cellDim = Landblock.CellDim;
+            var vertexDim = Landblock.VertexDim;
+
+            Triangles = new List<Triangle>();
+
+            for (int x = 0; x < cellDim; x++)
+            {
+                for (int y = 0; y < cellDim; y++)
+                {
+                    int lowerLeft = x + y * vertexDim;
+                    int lowerRight = (x + 1) + y * vertexDim;
+                    int topLeft = x + (y + 1) * vertexDim;
+                    int topRight = (x + 1) + (y + 1) * vertexDim;
+
+                    // determine where to draw the split line
+                    if (GetSplitDir(id, x, y))
+                    {
+                        // clockwise winding order
+                        Triangles.Add(new Triangle(topLeft, lowerRight, lowerLeft));
+                        Triangles.Add(new Triangle(topLeft, topRight, lowerRight));
+                    }
+                    else
+                    {
+                        Triangles.Add(new Triangle(topRight, lowerRight, lowerLeft));
+                        Triangles.Add(new Triangle(topRight, lowerLeft, topLeft));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines the split line direction
+        /// for a cell triangulation
+        /// </summary>
+        /// <param name="id">A reference to the landblock ID</param>
+        /// <param name="cellX">The horizontal cell position within the landblock</param>
+        /// <param name="cellY">The vertical cell position within the landblock</param>
+        /// <returns>TRUE if NW-SE split, FALSE if NE-SW split</returns>
+        public bool GetSplitDir(LandblockId id, int cellX, int cellY)
+        {
+            // get the global tile offsets
+            var x = (id.LandblockX * 8) + cellX;
+            var y = (id.LandblockY * 8) + cellY;
+
+            // Thanks to https://github.com/deregtd/AC2D for this bit
+            var dw = x * y * 0x0CCAC033 - x * 0x421BE3BD + y * 0x6C1AC587 - 0x519B8F25;
+            return (dw & 0x80000000) == 0;
+        }
+
+        /// <summary>
+        /// Returns the shared line between 2 triangles
+        /// </summary>
+        public Line2 GetSplitter(List<Triangle> triangles)
+        {
+            if (triangles[0].Indices[1] == triangles[1].Indices[2])
+                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[1]]);
+            else
+                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[2]]);
+        }
+
+        /// <summary>
+        /// Returns the triangle containing a pair of x,y coordinates
+        /// </summary>
+        public Triangle GetTriangle(Vector2 point)
+        {
+            // find the cell which contains these coordinates
+            Vector2 cellOffset = Landblock.GetCell(point);
+
+            // get the triangles for this cell
+            var cellTriangles = GetCellTriangles(cellOffset);
+
+            // return the triangle containing this point
+            if (cellTriangles[0].Contains(point, Vertices))
+                return cellTriangles[0];
+            else
+                return cellTriangles[1];
+        }
+
+        /// <summary>
+        /// Returns the 2 triangles for a cell
+        /// </summary>
+        public List<Triangle> GetCellTriangles(Vector2 cellOffset)
+        {
+            var offset = (int)((cellOffset.Y * Landblock.CellDim + cellOffset.X) * 2);
+            // TODO: ensure within bounds
+            return new List<Triangle>() { Triangles[offset], Triangles[offset + 1] };
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Triangle.cs
+++ b/Source/ACE.Server/Entity/Triangle.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Represents a 3D triangle for meshes,
+    /// with some methods that operate in 2-space
+    /// </summary>
+    public class Triangle
+    {
+        /// <summary>
+        /// To avoid storing many redundant vertices,
+        /// only indices into the mesh vertices
+        /// </summary>
+        public int[] Indices;
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Triangle()
+        {
+            Indices = new int[3];
+        }
+
+        /// <summary>
+        /// Constructs a new triangle from 3 vertex indices
+        /// </summary>
+        public Triangle(int a, int b, int c)
+        {
+            Indices = new int[3] { a, b, c };
+        }
+
+        /// <summary>
+        /// Returns the vertices of the triangle
+        /// </summary>
+        public Vector3[] GetVertices(List<Vector3> vertices)
+        {
+            // TODO: out-of-bounds exception
+            return new Vector3[]
+            {
+                vertices[Indices[0]], vertices[Indices[1]], vertices[Indices[2]]
+            };
+        }
+
+        /// <summary>
+        /// Returns TRUE if point is contained within triangle
+        /// </summary>
+        public bool Contains(Vector2 point, List<Vector3> vertices)
+        {
+            var p1 = vertices[Indices[0]];
+            var p2 = vertices[Indices[1]];
+            var p3 = vertices[Indices[2]];
+
+            // TODO: further optimizations listed
+            // https://stackoverflow.com/questions/2049582/how-to-determine-if-a-point-is-in-a-2d-triangle
+            var area = Area(p1, p2, p3);
+
+            var s = 1.0f / (2 * area) * (p1.Y * p3.X - p1.X * p3.Y + (p3.Y - p1.Y) * point.X + (p1.X - p3.X) * point.Y);
+            if (s < 0) return false;
+
+            var t = 1.0f / (2 * area) * (p1.X * p2.Y - p1.Y * p2.X + (p1.Y - p2.Y) * point.X + (p2.X - p1.X) * point.Y);
+            if (t < 0 || 1 - s - t < 0) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the area of the 2D triangle
+        /// </summary>
+        public static float Area(Vector3 p1, Vector3 p2, Vector3 p3)
+        {
+            return 0.5f * (-p2.Y * p3.X + p1.Y * (-p2.X + p3.X) + p1.X * (p2.Y - p3.Y) + p2.X * p3.Y);
+        }
+
+        /// <summary>
+        /// Consider the triangle as a plane,
+        /// find the Z-coordinate for a 2D coordinate on the plane
+        /// </summary>
+        public float GetZ(List<Vector3> vertices, Vector2 point)
+        {
+            // Reference:
+            // https://social.msdn.microsoft.com/Forums/en-US/1b32dc40-f84d-4365-a677-b59e49d41eb0/how-to-calculate-a-point-on-a-plane-based-on-a-plane-from-3-points
+
+            Vector3 v1 = new Vector3();
+            Vector3 v2 = new Vector3();
+            Vector3 abc = new Vector3();
+
+            var p1 = vertices[Indices[0]];
+            var p2 = vertices[Indices[1]];
+            var p3 = vertices[Indices[2]];
+
+            v1.X = p1.X - p3.X;
+            v1.Y = p1.Y - p3.Y;
+            v1.Z = p1.Z - p3.Z;
+
+            v2.X = p2.X - p3.X;
+            v2.Y = p2.Y - p3.Y;
+            v2.Z = p2.Z - p3.Z;
+
+            abc.X = (v1.Y * v2.Z) - (v1.Z * v2.Y);
+            abc.Y = (v1.Z * v2.X) - (v1.X * v2.Z);
+            abc.Z = (v1.X * v2.Y) - (v1.Y * v2.X);
+
+            float d = (abc.X * p3.X) + (abc.Y * p3.Y) + (abc.Z * p3.Z);
+
+            float z = (d - (abc.X * point.X) - (abc.Y * point.Y)) / abc.Z;
+
+            return z;
+        }
+    }
+}


### PR DESCRIPTION
This pull request is for the 2 Trello tasks:

https://trello.com/c/4ErxP7lc/90-implement-celllandblock-geometry-cache
https://trello.com/c/TxnqEnBH/85-celllandblockgetz-needs-rework

I'm still learning my way around the ACE project, so it's possible this code is not integrated in the correct location yet...

A LoadMesh() method has been added to Landblock.cs, which uses the Region file to determine the correct heights for the vertices. It loads the landblock grid as a triangle mesh, using a snippet of code from AC2D to ensure the cells are split between the correct vertices. I have verified in a few different locations that these splitters are being generated correctly, but I have no automated way of ensuring 100% accuracy across the entire map yet.

The GetZ() method has been implemented in Landblock.cs, which returns the correct Z-height information for any X/Y position on the map.

There are no unit tests yet, but here is a video of the landblock grid mesh visualization:

https://youtu.be/5yTTcMY-1Pw

The video quality was unfortunately degraded when uploaded to Youtube, but in the right corner is a 'current landblock height' stat that is updated every time the camera moves. This shows the information returned by GetZ().

Since this mesh data is to eventually be consumed by other classes, it can be tailored to provide whatever public API would be most useful to these other classes. For now it just has some of the basics, but more can be added as needed.


