### PR TITLE
Have Landblocks load all terrain, building, and generic obstacle data during start up and store it for use in the physics engine.

### DIFF
--- a/Source/ACE.DatLoader/Entity/Frame.cs
+++ b/Source/ACE.DatLoader/Entity/Frame.cs
@@ -11,6 +11,16 @@ namespace ACE.DatLoader.Entity
         public Vector3 Origin { get; private set; }
         public Quaternion Orientation { get; private set; }
 
+        public Frame()
+        {
+        }
+
+        public Frame(ACE.Entity.Position position)
+        {
+            Origin = new Vector3(position.PositionX, position.PositionY, position.PositionZ);
+            Orientation = new Quaternion(position.RotationX, position.RotationY, position.RotationZ, position.RotationW);
+        }
+
         public void Unpack(BinaryReader reader)
         {
             Origin = reader.ReadVector3();

--- a/Source/ACE.DatLoader/Entity/SWVertex.cs
+++ b/Source/ACE.DatLoader/Entity/SWVertex.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 
 namespace ACE.DatLoader.Entity
 {
@@ -31,6 +32,11 @@ namespace ACE.DatLoader.Entity
             NormalZ = reader.ReadSingle();
 
             UVs.Unpack(reader, numUVs);
+        }
+
+        public Vector3 ToVector()
+        {
+            return new Vector3(X, Y, Z);
         }
     }
 }

--- a/Source/ACE.Server/Entity/LandblockMesh.cs
+++ b/Source/ACE.Server/Entity/LandblockMesh.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
+using ACE.Entity;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// The polygonal landblock mesh
+    /// </summary>
+    public class LandblockMesh: Mesh
+    {
+        public LandblockId LandblockId;
+
+        /// <summary>
+        /// The heights of the landblock cell vertices
+        /// </summary>
+        public float[,] VertexHeights;
+
+        /// <summary>
+        /// A landblock has this many cells squared
+        /// </summary>
+        public static readonly int CellDim = 8;
+
+        /// <summary>
+        /// A landblock is this unit size squared
+        /// </summary>
+        public static readonly int LandblockSize = 192;
+
+        /// <summary>
+        /// A landblock cell is this unit size squared
+        /// </summary>
+        public static readonly int CellSize = LandblockSize / CellDim;
+
+        /// <summary>
+        /// A landblock has this many vertices squared
+        /// </summary>
+        public static readonly int VertexDim = CellDim + 1;
+
+        /// <summary>
+        /// LandHeightTable mapping non-linear heights
+        /// </summary>
+        public static RegionDesc RegionDesc;
+
+        /// <summary>
+        /// Static constructor
+        /// </summary>
+        static LandblockMesh()
+        {
+            // load the region file from portal.dat
+            RegionDesc = DatManager.PortalDat.ReadFromDat<RegionDesc>(0x13000000);
+        }
+
+        /// <summary>
+        /// Constructs a new mesh for a landblock
+        /// </summary>
+        public LandblockMesh(LandblockId id)
+        {
+            LandblockId = id;
+
+            BuildVertices();
+            BuildTriangles();
+        }
+
+        /// <summary>
+        /// Builds the vertices for the landblock cells
+        /// </summary>
+        public void BuildVertices()
+        {
+            VertexHeights = GetVertexHeights();
+            LoadVertices(VertexHeights);
+        }
+
+        /// <summary>
+        /// Reads the heights for each vertex in the landblock cells
+        /// </summary>
+        /// <param name="cellLandblock">A landblock from the cell database</param>
+        /// <returns>The vertex heights for the landblock cells</returns>
+        public float[,] GetVertexHeights()
+        {
+            // The vertex heights in the cell database are stored in bytes,
+            // which map to offsets in the land height table from the region file in the portal database.
+
+            var cellLandblock = DatManager.CellDat.ReadFromDat<CellLandblock>(LandblockId.Raw | 0xFFFF);
+
+            var heights = new float[VertexDim, VertexDim];
+
+            for (int x = 0; x < VertexDim; x++)
+            {
+                for (int y = 0; y < VertexDim; y++)
+                {
+                    heights[x, y] = RegionDesc.LandDefs.LandHeightTable[cellLandblock.Height[x * VertexDim + y]];
+                }
+            }
+            return heights;
+        }
+
+        /// <summary>
+        /// Loads the vertices for a landblock mesh
+        /// </summary>
+        /// <param name="height">The height of each vertex in the landblock cells</param>
+        public void LoadVertices(float[,] height)
+        {
+            var xSize = height.GetLength(0);
+            var ySize = height.GetLength(1);
+
+            Vertices = new List<Vector3>(xSize * ySize);
+
+            for (int x = 0; x < xSize; x++)
+            {
+                for (int y = 0; y < ySize; y++)
+                {
+                    Vertices.Add(new Vector3(x * CellSize, y * CellSize, height[x, y]));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates the triangles from the mesh vertices
+        /// </summary>
+        /// <returns>The list of triangles generated for the landblock mesh</returns>
+        public void BuildTriangles()
+        {
+            Triangles = new List<Triangle>();
+
+            for (int x = 0; x < CellDim; x++)
+            {
+                for (int y = 0; y < CellDim; y++)
+                {
+                    int lowerLeft = x + y * VertexDim;
+                    int lowerRight = (x + 1) + y * VertexDim;
+                    int topLeft = x + (y + 1) * VertexDim;
+                    int topRight = (x + 1) + (y + 1) * VertexDim;
+
+                    // determine where to draw the split line
+                    if (GetSplitDir(LandblockId, x, y))
+                    {
+                        // clockwise winding order
+                        Triangles.Add(new Triangle(topLeft, lowerRight, lowerLeft));
+                        Triangles.Add(new Triangle(topLeft, topRight, lowerRight));
+                    }
+                    else
+                    {
+                        Triangles.Add(new Triangle(topRight, lowerRight, lowerLeft));
+                        Triangles.Add(new Triangle(topRight, lowerLeft, topLeft));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines the split line direction
+        /// for a cell triangulation
+        /// </summary>
+        /// <param name="id">A reference to the landblock ID</param>
+        /// <param name="cellX">The horizontal cell position within the landblock</param>
+        /// <param name="cellY">The vertical cell position within the landblock</param>
+        /// <returns>TRUE if NW-SE split, FALSE if NE-SW split</returns>
+        public bool GetSplitDir(LandblockId id, int cellX, int cellY)
+        {
+            // get the global tile offsets
+            var x = (id.LandblockX * 8) + cellX;
+            var y = (id.LandblockY * 8) + cellY;
+
+            // Thanks to https://github.com/deregtd/AC2D for this bit
+            var dw = x * y * 0x0CCAC033 - x * 0x421BE3BD + y * 0x6C1AC587 - 0x519B8F25;
+            return (dw & 0x80000000) == 0;
+        }
+
+        /// <summary>
+        /// Returns the shared line between 2 triangles
+        /// </summary>
+        public Line2 GetSplitter(List<Triangle> triangles)
+        {
+            if (triangles[0].Indices[1] == triangles[1].Indices[2])
+                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[1]]);
+            else
+                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[2]]);
+        }
+
+        /// <summary>
+        /// Returns the triangle containing a pair of x,y coordinates
+        /// </summary>
+        public Triangle GetTriangle(Vector2 point)
+        {
+            // find the cell which contains these coordinates
+            Vector2 cellOffset = GetCell(point);
+
+            // get the triangles for this cell
+            var cellTriangles = GetCellTriangles(cellOffset);
+
+            // return the triangle containing this point
+            if (cellTriangles[0].Contains(point, Vertices))
+                return cellTriangles[0];
+            else
+                return cellTriangles[1];
+        }
+
+        /// <summary>
+        /// Given a pair of 2D coordinates within a landblock,
+        /// Returns the cell that contains these coordinates
+        /// </summary>
+        /// <param name="point">The 2D coordinates within the landblock</param>
+        /// <returns>The cell that contains these coordinates</returns>
+        public static Vector2 GetCell(Vector2 point)
+        {
+            return new Vector2(
+                (float)Math.Floor(point.X / LandblockMesh.CellSize),
+                (float)Math.Floor(point.Y / LandblockMesh.CellSize)
+            );
+        }
+
+        /// <summary>
+        /// Returns the 2 triangles for a cell
+        /// </summary>
+        public List<Triangle> GetCellTriangles(Vector2 cellOffset)
+        {
+            var offset = (int)((cellOffset.Y * CellDim + cellOffset.X) * 2);
+            // TODO: ensure within bounds
+            return new List<Triangle>() { Triangles[offset], Triangles[offset + 1] };
+        }
+
+        /// <summary>
+        /// Returns the z height coordinate for a 2D position within a landblock
+        /// </summary>
+        public float GetZ(Vector2 point)
+        {
+            // find the triangle that contains this point
+            var triangle = GetTriangle(point);
+
+            // calculate the z coordinate at x,y
+            // for the plane defined by this triangle
+            return triangle.GetZ(Vertices, point);
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Mesh.cs
+++ b/Source/ACE.Server/Entity/Mesh.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System.Numerics;
-using ACE.Entity;
 
 namespace ACE.Server.Entity
 {
     /// <summary>
     /// A 3D mesh of vertices and triangles
+    /// Used for collision detection and physics simulation
     /// </summary>
     public class Mesh
     {
@@ -18,139 +18,5 @@ namespace ACE.Server.Entity
         /// The list of triangles comprising the mesh
         /// </summary>
         public List<Triangle> Triangles;
-
-        /// <summary>
-        /// This is only set for landblock meshes
-        /// </summary>
-        public LandblockId LandblockId;
-
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        public Mesh()
-        {
-        }
-
-        /// <summary>
-        /// Constructs a new mesh for landblock
-        /// </summary>
-        public Mesh(LandblockId id)
-        {
-            LandblockId = id;
-        }
-
-        /// <summary>
-        /// Loads the vertices for a landblock mesh
-        /// </summary>
-        /// <param name="height">The height of each vertex in the landblock cells</param>
-        public void LoadVertices(float[,] height)
-        {
-            var xSize = height.GetLength(0);
-            var ySize = height.GetLength(1);
-
-            Vertices = new List<Vector3>(xSize * ySize);
-
-            for (int x = 0; x < xSize; x++)
-            {
-                for (int y = 0; y < ySize; y++)
-                {
-                    Vertices.Add(new Vector3(x * Landblock.CellSize, y * Landblock.CellSize, height[x, y]));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Generates the triangles from the mesh vertices
-        /// </summary>
-        /// <param name="id">The landblock to generate triangles for</param>
-        public void BuildTriangles(LandblockId id)
-        {
-            var cellDim = Landblock.CellDim;
-            var vertexDim = Landblock.VertexDim;
-
-            Triangles = new List<Triangle>();
-
-            for (int x = 0; x < cellDim; x++)
-            {
-                for (int y = 0; y < cellDim; y++)
-                {
-                    int lowerLeft = x + y * vertexDim;
-                    int lowerRight = (x + 1) + y * vertexDim;
-                    int topLeft = x + (y + 1) * vertexDim;
-                    int topRight = (x + 1) + (y + 1) * vertexDim;
-
-                    // determine where to draw the split line
-                    if (GetSplitDir(id, x, y))
-                    {
-                        // clockwise winding order
-                        Triangles.Add(new Triangle(topLeft, lowerRight, lowerLeft));
-                        Triangles.Add(new Triangle(topLeft, topRight, lowerRight));
-                    }
-                    else
-                    {
-                        Triangles.Add(new Triangle(topRight, lowerRight, lowerLeft));
-                        Triangles.Add(new Triangle(topRight, lowerLeft, topLeft));
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Determines the split line direction
-        /// for a cell triangulation
-        /// </summary>
-        /// <param name="id">A reference to the landblock ID</param>
-        /// <param name="cellX">The horizontal cell position within the landblock</param>
-        /// <param name="cellY">The vertical cell position within the landblock</param>
-        /// <returns>TRUE if NW-SE split, FALSE if NE-SW split</returns>
-        public bool GetSplitDir(LandblockId id, int cellX, int cellY)
-        {
-            // get the global tile offsets
-            var x = (id.LandblockX * 8) + cellX;
-            var y = (id.LandblockY * 8) + cellY;
-
-            // Thanks to https://github.com/deregtd/AC2D for this bit
-            var dw = x * y * 0x0CCAC033 - x * 0x421BE3BD + y * 0x6C1AC587 - 0x519B8F25;
-            return (dw & 0x80000000) == 0;
-        }
-
-        /// <summary>
-        /// Returns the shared line between 2 triangles
-        /// </summary>
-        public Line2 GetSplitter(List<Triangle> triangles)
-        {
-            if (triangles[0].Indices[1] == triangles[1].Indices[2])
-                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[1]]);
-            else
-                return new Line2(Vertices[triangles[0].Indices[0]], Vertices[triangles[0].Indices[2]]);
-        }
-
-        /// <summary>
-        /// Returns the triangle containing a pair of x,y coordinates
-        /// </summary>
-        public Triangle GetTriangle(Vector2 point)
-        {
-            // find the cell which contains these coordinates
-            Vector2 cellOffset = Landblock.GetCell(point);
-
-            // get the triangles for this cell
-            var cellTriangles = GetCellTriangles(cellOffset);
-
-            // return the triangle containing this point
-            if (cellTriangles[0].Contains(point, Vertices))
-                return cellTriangles[0];
-            else
-                return cellTriangles[1];
-        }
-
-        /// <summary>
-        /// Returns the 2 triangles for a cell
-        /// </summary>
-        public List<Triangle> GetCellTriangles(Vector2 cellOffset)
-        {
-            var offset = (int)((cellOffset.Y * Landblock.CellDim + cellOffset.X) * 2);
-            // TODO: ensure within bounds
-            return new List<Triangle>() { Triangles[offset], Triangles[offset + 1] };
-        }
     }
 }

--- a/Source/ACE.Server/Entity/ModelMesh.cs
+++ b/Source/ACE.Server/Entity/ModelMesh.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using ACE.DatLoader.Entity;
+
+namespace ACE.Server.Entity
+{
+    public enum ModelMeshType
+    {
+        Building,
+        LandObject,
+        Scenery,
+        Weenie
+    };
+
+    /// <summary>
+    /// An instanced static mesh
+    /// </summary>
+    public class ModelMesh: Mesh
+    {
+        /// <summary>
+        /// The static mesh
+        /// </summary>
+        public StaticMesh StaticMesh;
+
+        /// <summary>
+        /// The position and orientation
+        /// </summary>
+        public Frame Frame;
+
+        /// <summary>
+        /// The list of polygons comprising the mesh
+        /// </summary>
+        public List<Polygon> Polygons;
+
+        /// <summary>
+        /// Constructs a static mesh instance from a model and frame
+        /// </summary>
+        public ModelMesh(uint modelId, Frame frame)
+        {
+            GetMesh(modelId);
+            Frame = frame;
+            BuildPolygons();
+        }
+
+        /// <summary>
+        /// Constructs a new model mesh for a static land object
+        /// </summary>
+        public ModelMesh(Stab stab)
+        {
+            GetMesh(stab.Id);
+            Frame = stab.Frame;
+            BuildPolygons();
+        }
+
+        /// <summary>
+        /// Constructs a new model mesh for a building
+        /// </summary>
+        public ModelMesh(BuildInfo buildInfo)
+        {
+            GetMesh(buildInfo.ModelId);
+            Frame = buildInfo.Frame;
+            BuildPolygons();
+        }
+
+        /// <summary>
+        /// Returns a pointer to the static mesh
+        /// </summary>
+        public void GetMesh(uint modelId)
+        {
+            StaticMesh = StaticMeshCache.GetMesh(modelId);
+        }
+
+        /// <summary>
+        /// Builds the polygons for this model mesh
+        /// into world space
+        /// </summary>
+        public void BuildPolygons()
+        {
+            Polygons = new List<Polygon>();
+
+            foreach (var polygon in StaticMesh.Polygons)
+            {
+                Polygons.Add(new Polygon(polygon, Frame));
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/ModelPolygon.cs
+++ b/Source/ACE.Server/Entity/ModelPolygon.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using ACE.DatLoader.Entity;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Represents a polygon in local model space
+    /// </summary>
+    public class ModelPolygon
+    {
+        /// <summary>
+        /// The list of vertices
+        /// </summary>
+        public List<SWVertex> Vertices;
+
+        /// <summary>
+        /// The polygon in AC data formats
+        /// </summary>
+        public DatLoader.Entity.Polygon Polygon;
+
+        /// <summary>
+        /// Constructs a new polygon
+        /// </summary>
+        public ModelPolygon(DatLoader.Entity.Polygon polygon, CVertexArray vertexArray)            
+        {
+            Polygon = polygon;
+            LoadVertices(vertexArray);
+        }
+
+        /// <summary>
+        /// Loads the vertices for a polygon
+        /// </summary>
+        public void LoadVertices(CVertexArray vertexArray)
+        {
+            Vertices = new List<SWVertex>();
+
+            foreach (var id in Polygon.VertexIds)
+                Vertices.Add(vertexArray.Vertices[(ushort)id]);
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Polygon.cs
+++ b/Source/ACE.Server/Entity/Polygon.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Numerics;
+using ACE.DatLoader.Entity;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// A polygon in world space
+    /// </summary>
+    public class Polygon
+    {
+        public List<Vector3> Vertices;
+
+        public Polygon(ModelPolygon _poly, Frame frame)
+        {
+            Vertices = new List<Vector3>();
+
+            // transform the vertices
+            // from local object to world space
+            foreach (var vertex in _poly.Vertices)
+            {
+                // move to position within the landblock
+                var translate = Matrix4x4.CreateTranslation(frame.Origin);
+
+                // rotate
+                var rotate = Matrix4x4.CreateFromQuaternion(frame.Orientation);
+
+                Vertices.Add(Vector3.Transform(vertex.ToVector(), rotate * translate));
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/StaticMesh.cs
+++ b/Source/ACE.Server/Entity/StaticMesh.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// A static mesh contains all data that is common
+    /// to each instance with this model id
+    /// </summary>
+    public class StaticMesh
+    {
+        /// <summary>
+        /// The unique model identifier
+        /// </summary>
+        public uint ModelId;
+
+        /// <summary>
+        /// A multi-part model
+        /// </summary>
+        public SetupModel SetupModel;
+
+        /// <summary>
+        /// The individual model parts
+        /// </summary>
+        public List<GfxObj> GfxObjs;
+
+        /// <summary>
+        /// The list of polygons for this model
+        /// </summary>
+        public List<ModelPolygon> Polygons;
+
+        /// <summary>
+        /// Constructs a new static mesh from a model id
+        /// </summary>
+        public StaticMesh(uint modelId)
+        {
+            ModelId = modelId;
+
+            var modelType = modelId >> 24;
+
+            if (modelType == 0x01)
+            {
+                LoadModelPart(modelId);
+            }
+            else if (modelType == 0x02)
+            {
+                SetupModel = DatManager.PortalDat.ReadFromDat<SetupModel>(modelId);
+                foreach (var part in SetupModel.Parts)
+                    LoadModelPart(part);
+            }
+        }
+
+        /// <summary>
+        /// Loads an individual piece of a model
+        /// </summary>
+        public void LoadModelPart(uint modelId)
+        {
+            if (GfxObjs == null) GfxObjs = new List<GfxObj>();
+            if (Polygons == null) Polygons = new List<ModelPolygon>();
+
+            var gfxObj = DatManager.PortalDat.ReadFromDat<GfxObj>(modelId);
+            GfxObjs.Add(gfxObj);
+
+            foreach (var poly in gfxObj.Polygons.Values)
+            {
+                Polygons.Add(new ModelPolygon(poly, gfxObj.VertexArray));
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/StaticMeshCache.cs
+++ b/Source/ACE.Server/Entity/StaticMeshCache.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Maintains a single copy of each static mesh
+    /// </summary>
+    public class StaticMeshCache
+    {
+        /// <summary>
+        /// The static mesh cache
+        /// </summary>
+        public static Dictionary<uint, StaticMesh> Meshes;
+
+        /// <summary>
+        /// Static constructor
+        /// </summary>
+        static StaticMeshCache()
+        {
+            Meshes = new Dictionary<uint, StaticMesh>();
+        }
+
+        /// <summary>
+        /// Returns true if mesh is already cached
+        /// </summary>
+        /// <param name="id">The model id</param>
+        public static bool Contains(uint id)
+        {
+            return Meshes.ContainsKey(id);
+        }
+
+        /// <summary>
+        /// Adds a static mesh to the cache
+        /// </summary>
+        public static void Add(uint id, StaticMesh mesh)
+        {
+            Meshes.Add(id, mesh);
+        }
+
+        /// <summary>
+        /// Performs a cache lookup,
+        /// adds a new static mesh if not found
+        /// </summary>
+        /// <param name="id">The model id to fetch the static mesh for</param>
+        public static StaticMesh GetMesh(uint id)
+        {
+            StaticMesh mesh = null;
+            Meshes.TryGetValue(id, out mesh);
+            if (mesh == null)
+            {
+                mesh = new StaticMesh(id);
+                Add(id, mesh);
+            }
+            return mesh;
+        }
+
+        // TODO: different caching strategies
+        // besides global cache
+    }
+}


### PR DESCRIPTION
This PR is for loading the landblock objects / obstacles, buildings, and landblock weenies stored in the database

A lot of the code from the last PR in Landblock.cs and Mesh.cs has been moved to a new LandblockMesh.cs class. Mesh.cs is now a base class for both the triangle-based landblock meshes, and the new ModelMesh.cs. Model meshes are polygonal based, and have most of their data stored in a StaticMesh object, which points to a global cache for efficiency.

https://www.youtube.com/watch?v=X4c7VHJ6DHE