### PR TITLE
Have Landblocks load all scenery during start up and store it for use in the physics engine.

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -65,6 +65,7 @@ namespace ACE.Server.Entity
 
         public LandblockId Id { get; }
 
+        public CellLandblock CellLandblock;
         public LandblockInfo LandblockInfo;
 
         /// <summary>
@@ -75,6 +76,7 @@ namespace ACE.Server.Entity
         public List<ModelMesh> LandObjects;
         public List<ModelMesh> Buildings;
         public List<ModelMesh> WeenieMeshes;
+        public List<ModelMesh> Scenery;
 
         public Landblock(LandblockId id)
         {
@@ -123,12 +125,14 @@ namespace ACE.Server.Entity
         /// </summary>
         public void LoadMeshes(List<AceObject> objects)
         {
+            CellLandblock = DatManager.CellDat.ReadFromDat<CellLandblock>(Id.Raw | 0xFFFF);
             LandblockInfo = DatManager.CellDat.ReadFromDat<LandblockInfo>((uint)Id.Landblock << 16 | 0xFFFE);
 
             LandblockMesh = new LandblockMesh(Id);
             LoadLandObjects();
             LoadBuildings();
             LoadWeenies(objects);
+            LoadScenery();
         }
 
         /// <summary>
@@ -164,6 +168,14 @@ namespace ACE.Server.Entity
             foreach (var obj in objects)
                 WeenieMeshes.Add(new ModelMesh(obj.SetupDID.Value,
                     new DatLoader.Entity.Frame(obj.AceObjectPropertiesPositions.Values.LastOrDefault())));
+        }
+
+        /// <summary>
+        /// Loads the meshes for the scenery on the landblock
+        /// </summary>
+        public void LoadScenery()
+        {
+            Scenery = Entity.Scenery.Load(this);
         }
 
         public void SetAdjacency(Adjacency adjacency, Landblock landblock)

--- a/Source/ACE.Server/Entity/LandblockMesh.cs
+++ b/Source/ACE.Server/Entity/LandblockMesh.cs
@@ -76,7 +76,6 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Reads the heights for each vertex in the landblock cells
         /// </summary>
-        /// <param name="cellLandblock">A landblock from the cell database</param>
         /// <returns>The vertex heights for the landblock cells</returns>
         public float[,] GetVertexHeights()
         {
@@ -206,10 +205,16 @@ namespace ACE.Server.Entity
         /// <returns>The cell that contains these coordinates</returns>
         public static Vector2 GetCell(Vector2 point)
         {
-            return new Vector2(
-                (float)Math.Floor(point.X / LandblockMesh.CellSize),
-                (float)Math.Floor(point.Y / LandblockMesh.CellSize)
-            );
+            var cellX = (float)Math.Floor(point.X / CellSize);
+            var cellY = (float)Math.Floor(point.Y / CellSize);
+
+            if (cellX < 0) cellX = 0;
+            if (cellY < 0) cellY = 0;
+
+            if (cellX >= CellDim) cellX = CellDim - 1;
+            if (cellY >= CellDim) cellY = CellDim - 1;
+
+            return new Vector2(cellX, cellY);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Entity/Polygon.cs
+++ b/Source/ACE.Server/Entity/Polygon.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Numerics;
 using ACE.DatLoader.Entity;
 
@@ -11,23 +9,43 @@ namespace ACE.Server.Entity
     /// </summary>
     public class Polygon
     {
+        /// <summary>
+        /// The list of polygon vertices
+        /// transformed into world space
+        /// </summary>
         public List<Vector3> Vertices;
 
-        public Polygon(ModelPolygon _poly, Frame frame)
+        /// <summary>
+        /// Constructs a new polygon from a position, rotation, and scale
+        /// </summary>
+        public Polygon(ModelPolygon _poly, Vector3 position, Quaternion orientation, float scale = 1.0f)
+        {
+            BuildPolygon(_poly, position, orientation, scale);
+        }
+
+        /// <summary>
+        /// Constructs a new polygon from a frame and scale
+        /// </summary>
+        public Polygon(ModelPolygon _poly, Frame frame, float scale = 1.0f)
+        {
+            BuildPolygon(_poly, frame.Origin, frame.Orientation, scale);
+        }
+
+        /// <summary>
+        /// Transforms the model from local to world space
+        /// </summary>
+        public void BuildPolygon(ModelPolygon _poly, Vector3 position, Quaternion orientation, float scalar = 1.0f)
         {
             Vertices = new List<Vector3>();
+
+            // build the matrix transform
+            var transform = Matrix4x4.CreateScale(scalar) * Matrix4x4.CreateFromQuaternion(orientation) * Matrix4x4.CreateTranslation(position);
 
             // transform the vertices
             // from local object to world space
             foreach (var vertex in _poly.Vertices)
             {
-                // move to position within the landblock
-                var translate = Matrix4x4.CreateTranslation(frame.Origin);
-
-                // rotate
-                var rotate = Matrix4x4.CreateFromQuaternion(frame.Orientation);
-
-                Vertices.Add(Vector3.Transform(vertex.ToVector(), rotate * translate));
+                Vertices.Add(Vector3.Transform(vertex.ToVector(), transform));
             }
         }
     }

--- a/Source/ACE.Server/Entity/Scenery.cs
+++ b/Source/ACE.Server/Entity/Scenery.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.DatLoader;
+using ACE.DatLoader.Entity;
+using ACE.DatLoader.FileTypes;
+using ACE.Server.Physics;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Generates the scenery for a landblock
+    /// </summary>
+    public class Scenery
+    {
+        public static List<ModelMesh> Load(Landblock _landblock)
+        {
+            var landblock = _landblock.CellLandblock;
+
+            // get the landblock cell offsets
+            var blockX = (landblock.Id >> 24) * 8;
+            var blockY = (landblock.Id >> 16 & 0xFF) * 8;
+
+            var scenery = new List<ModelMesh>();
+
+            for (var i = 0; i < landblock.Terrain.Count; i++)
+            {
+                var terrain = landblock.Terrain[i];
+
+                var terrainType = terrain >> 2 & 0x1F;      // TerrainTypes table size = 32 (grass, desert, volcano, etc.)
+                var sceneType = terrain >> 11;              // SceneTypes table size = 89 total, 32 which can be indexed for each terrain type
+
+                var sceneInfo = (int)LandblockMesh.RegionDesc.TerrainInfo.TerrainTypes[terrainType].SceneTypes[sceneType];
+                var scenes = LandblockMesh.RegionDesc.SceneInfo.SceneTypes[sceneInfo].Scenes;
+                if (scenes.Count == 0) continue;
+
+                var cellX = i / LandblockMesh.VertexDim;
+                var cellY = i % LandblockMesh.VertexDim;
+
+                var globalCellX = (int)(cellX + blockX);
+                var globalCellY = (int)(cellY + blockY);
+
+                var cellMat = globalCellY * (712977289 * globalCellX + 1813693831) - 1109124029 * globalCellX + 2139937281;
+                var offset = cellMat * 2.3283064e-10;
+                var scene_idx = (int)Math.Abs(Math.Floor(scenes.Count * offset));
+                if (scene_idx >= scenes.Count) scene_idx = 0;
+
+                var sceneId = scenes[scene_idx];
+
+                var scene = DatManager.PortalDat.ReadFromDat<Scene>(sceneId);
+
+                var cellXMat = -1109124029 * globalCellX;
+                var cellYMat = 1813693831 * globalCellY;
+                cellMat = 1360117743 * globalCellX * globalCellY + 1888038839;
+
+                for (var j = 0; j < scene.Objects.Count; j++)
+                {
+                    var obj = scene.Objects[j];
+                    var noise = cellXMat + cellYMat - cellMat * 23399;
+
+                    if (Math.Abs(noise * 2.3283064e-10) < obj.Freq && obj.WeenieObj == 0)
+                    {
+                        var position = Displace(obj, globalCellX, globalCellY, j);
+
+                        // ensure within landblock range, and not near road
+                        var lx = cellX * LandblockMesh.CellSize + position.X;
+                        var ly = cellY * LandblockMesh.CellSize + position.Y;
+
+                        // TODO: ensure walkable slope
+                        if (lx < 0 || ly < 0 || lx > LandblockMesh.LandblockSize || ly > LandblockMesh.LandblockSize || OnRoad(obj, landblock, lx, ly)) continue;
+
+                        // load scenery
+                        var model = new ModelMesh(obj.ObjId, obj.BaseLoc);
+                        model.ObjectDesc = obj;
+                        model.Cell = new Vector2(cellX, cellY);
+                        model.Position = new Vector3(position.X, position.Y, GetZ(_landblock, model));
+                        model.Scale = ScaleObj(obj, globalCellX, globalCellY, j);
+                        model.BuildPolygons();
+                        model.BoundingBox = new BoundingBox(model);
+
+                        // collision detection
+                        if (Collision(_landblock.Buildings, model) || Collision(scenery, model))
+                            continue;
+
+                        scenery.Add(model);
+                    }
+                }
+            }
+            return scenery;
+        }
+
+        /// <summary>
+        /// Displaces a scenery object into a pseudo-randomized location
+        /// </summary>
+        /// <param name="obj">The object description</param>
+        /// <param name="ix">The global cell X-offset</param>
+        /// <param name="iy">The global cell Y-offset</param>
+        /// <param name="iq">The scene index of the object</param>
+        /// <returns>The new location of the object</returns>
+        public static Vector2 Displace(ObjectDesc obj, int ix, int iy, int iq)
+        {
+            float x;
+            float y;
+
+            var loc = obj.BaseLoc.Origin;
+
+            if (obj.DisplaceX <= 0)
+                x = loc.X;
+            else
+                x = (float)((1813693831 * iy - (iq + 45773) * (1360117743 * iy * ix + 1888038839) - 1109124029 * ix)
+                    * 2.3283064e-10 * obj.DisplaceX + loc.X);
+
+            if (obj.DisplaceY <= 0)
+                y = loc.Y;
+            else
+                y = (float)((1813693831 * iy - (iq + 72719) * (1360117743 * iy * ix + 1888038839) - 1109124029 * ix)
+                    * 2.3283064e-10 * obj.DisplaceY + loc.Y);
+
+            var quadrant = (1813693831 * iy - ix * (1870387557 * iy + 1109124029) - 402451965) * 2.3283064e-10;
+
+            if (quadrant >= 0.75) return new Vector2(y, -x);
+            if (quadrant >= 0.5)  return new Vector2(-x, -y);
+            if (quadrant >= 0.25) return new Vector2(-y, x);
+
+            return new Vector2(x, y);
+        }
+
+        /// <summary>
+        /// Returns the scale for a scenery object
+        /// </summary>
+        /// <param name="obj">The object decription</param>
+        /// <param name="x">The global cell X-offset</param>
+        /// <param name="y">The global cell Y-offset</param>
+        /// <param name="k">The scene index of the object</param>
+        public static float ScaleObj(ObjectDesc obj, int x, int y, int k)
+        {
+            var scale = 1.0f;
+
+            var minScale = obj.MinScale;
+            var maxScale = obj.MaxScale;
+
+            if (minScale == maxScale)
+                scale = maxScale;
+            else
+                scale = (float)(Math.Pow(maxScale / minScale,
+                    (1813693831 * y - (k + 32593) * (1360117743 * y * x + 1888038839) - 1109124029 * x) * 2.3283064e-10) * minScale);
+
+            return scale;
+        }
+
+        /// <summary>
+        /// Returns TRUE if x,y is located on a road cell
+        /// </summary>
+        public static bool OnRoad(ObjectDesc obj, CellLandblock landblock, float x, float y)
+        {
+            var cellX = (int)Math.Floor(x / LandblockMesh.CellSize);
+            var cellY = (int)Math.Floor(y / LandblockMesh.CellSize);
+            var terrain = landblock.Terrain[cellX * LandblockMesh.CellDim + cellY];     // ensure within bounds?
+            return (terrain & 0x3) != 0;    // TODO: more complicated check for within road range
+        }
+
+        /// <summary>
+        /// Returns TRUE is object intersects with any models
+        /// </summary>
+        public static bool Collision(List<ModelMesh> models, ModelMesh obj)
+        {
+            foreach (var model in models)
+                if (obj.BoundingBox.Intersect2D(model.BoundingBox))
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the landblock floor height for a scenery model
+        /// </summary>
+        public static float GetZ(Landblock landblock, ModelMesh modelMesh)
+        {
+            // get the landblock x/y position
+            var x = modelMesh.Cell.X * LandblockMesh.CellSize + modelMesh.Position.X;
+            var y = modelMesh.Cell.Y * LandblockMesh.CellSize + modelMesh.Position.Y;
+
+            return landblock.LandblockMesh.GetZ(new Vector2(x, y));
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/BoundingBox.cs
+++ b/Source/ACE.Server/Physics/BoundingBox.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Numerics;
+using ACE.Server.Entity;
+
+namespace ACE.Server.Physics
+{
+    /// <summary>
+    /// A bounding box for collision detection
+    /// </summary>
+    public class BoundingBox
+    {
+        /// <summary>
+        /// The model this bounding box encompasses
+        /// </summary>
+        public ModelMesh Model;
+
+        /// <summary>
+        /// The minimum values for each dimension
+        /// </summary>
+        public Vector3 Min;
+
+        /// <summary>
+        /// The maximum values for each dimension
+        /// </summary>
+        public Vector3 Max;
+
+        /// <summary>
+        /// The center of the bounding box
+        /// </summary>
+        public Vector3 Center;
+
+        /// <summary>
+        /// The size of the bounding box
+        /// </summary>
+        public Vector3 Size;
+
+        /// <summary>
+        /// Constructs a new bounding box
+        /// for a model
+        /// </summary>
+        public BoundingBox(ModelMesh model)
+        {
+            Model = model;
+            BuildBox(model);
+        }
+
+        /// <summary>
+        /// Builds a bounding box for a model
+        /// </summary>
+        public void BuildBox(ModelMesh model)
+        {
+            Min = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            Max = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+
+            // build the transformation matrix
+            var transform = GetTransform(model);
+
+            foreach (var gfxObj in model.StaticMesh.GfxObjs)
+            {
+                foreach (var v in gfxObj.VertexArray.Vertices.Values)
+                {
+                    var vertex = Vector3.Transform(new Vector3(v.X, v.Y, v.Z), transform);
+
+                    if (vertex.X < Min.X) Min.X = vertex.X;
+                    if (vertex.Y < Min.Y) Min.Y = vertex.Y;
+                    if (vertex.Z < Min.Z) Min.Z = vertex.Z;
+
+                    if (vertex.X > Max.X) Max.X = vertex.X;
+                    if (vertex.Y > Max.Y) Max.Y = vertex.Y;
+                    if (vertex.Z > Max.Z) Max.Z = vertex.Z;
+                }
+            }
+            CalcSize();
+        }
+
+        /// <summary>
+        /// Calculates the size and center properties
+        /// </summary>
+        public void CalcSize()
+        {
+            Size = new Vector3(Max.X - Min.X, Max.Y - Min.Y, Max.Z - Min.Z);
+            Center = new Vector3(Min.X + Size.X / 2, Min.Y + Size.Y / 2, Min.Z + Size.Z / 2);
+        }
+
+        /// <summary>
+        /// Builds the matrix transformation
+        /// </summary>
+        public Matrix4x4 GetTransform(ModelMesh model)
+        {
+            var scale = Matrix4x4.CreateScale(model.Scale);
+            var rotate = Matrix4x4.CreateFromQuaternion(new Quaternion(model.Frame.Orientation.X, model.Frame.Orientation.Y, model.Frame.Orientation.Z, model.Frame.Orientation.W));
+            var cellTranslate = Matrix4x4.CreateTranslation(new Vector3(model.Cell.X * LandblockMesh.CellSize, model.Cell.Y * LandblockMesh.CellSize, 0));
+            var cellTranslateInner = Matrix4x4.CreateTranslation(new Vector3(model.Position.X, model.Position.Y, model.Position.Z));
+
+            var transform = scale * rotate * cellTranslate * cellTranslateInner;
+
+            return transform;
+        }
+
+        /// <summary>
+        /// Returns TRUE if point is inside box
+        /// on the XY plane
+        /// </summary>
+        public bool Contains2D(Vector3 point)
+        {
+            return (point.X >= Min.X && point.X <= Max.X) &&
+                   (point.Y >= Min.Y && point.Y <= Max.Y);
+        }
+
+        /// <summary>
+        /// Returns TRUE if bounding boxes are touching
+        /// on the XY plane
+        /// </summary>
+        public bool Intersect2D(BoundingBox b)
+        {
+            return (Min.X <= b.Max.X && Max.X >= b.Min.X) &&
+                   (Min.Y <= b.Max.Y && Max.Y >= b.Min.Y);
+        }
+
+        /// <summary>
+        /// Returns TRUE if point is inside box
+        /// </summary>
+        public bool Contains(Vector3 point)
+        {
+            return (point.X >= Min.X && point.X <= Max.X) &&
+                   (point.Y >= Min.Y && point.Y <= Max.Y) &&
+                   (point.Z >= Min.Z && point.Z <= Max.Z);
+        }
+
+
+        /// <summary>
+        /// Returns TRUE if bounding boxes are touching
+        /// </summary>
+        public bool Intersect(BoundingBox b)
+        {
+            return (Min.X <= b.Max.X && Max.X >= b.Min.X) &&
+                   (Min.Y <= b.Max.Y && Max.Y >= b.Min.Y) &&
+                   (Min.Z <= b.Max.Z && Max.Z >= b.Min.Z);
+        }
+
+        /// <summary>
+        /// Returns 8 corner points of the bounding box
+        /// </summary>
+        public List<Vector3> GetCornerPoints()
+        {
+            // lower corner points
+            var lowerNW = new Vector3(Min.X, Min.Y, Max.Z);
+            var lowerNE = new Vector3(Max.X, Min.Y, Max.Z);
+            var lowerSW = new Vector3(Min.X, Min.Y, Min.Z);
+            var lowerSE = new Vector3(Max.X, Min.Y, Min.Z);
+
+            // upper corner points
+            var upperNW = new Vector3(Min.X, Max.Y, Max.Z);
+            var upperNE = new Vector3(Max.X, Max.Y, Max.Z);
+            var upperSW = new Vector3(Min.X, Max.Y, Min.Z);
+            var upperSE = new Vector3(Max.X, Max.Y, Min.Z);
+
+            return new List<Vector3>() { lowerNW, lowerNE, lowerSW, lowerSE, upperNW, upperNE, upperSW, upperSE };
+        }
+    }
+}


### PR DESCRIPTION
Here is the first attempt at the landscape scenery generation. It's performing the same calculations that the original client does to build the scenery objects, although it's still not matched up perfectly yet.

The scenery is defined on a per-cell basis, which gets mapped through the region file to the actual scenery data. Instead of placing individual shrubs and trees on each cell though, the game uses something akin to perlin noise generation to move scenery objects around the grid in a non-uniform way.

https://imgur.com/a/wyQRt

Todo:

- It appears there is more scenery generated than the original game, even though the functions should be matched up exactly with the client. I will need to investigate more to find out what could be causing any differences.

- Scenery items should not spawn on roads or anywhere near other objects. The collision detection is currently just using a basic bounding box, but in acclient this is performed by the physics engine.

- Scenery items should also not be placed on steep terrain that can't be traversed by the player. This should ideally be done by storing normals for each triangle in the landscape mesh, and performing the slope checks based on that.