### PR TITLE
1000th Commit to ACE! Morph command for Admins/Liveops

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -365,6 +365,7 @@ namespace ACE.Database
                 .Include(r => r.BiotaPropertiesInt)
                 .Include(r => r.BiotaPropertiesInt64)
                 .Include(r => r.BiotaPropertiesString)
+                .Include(r => r.BiotaPropertiesSpellBook)
                 .FirstOrDefault(r => r.Id == id);
 
             if (biota == null)
@@ -419,10 +420,10 @@ namespace ACE.Database
             // Player only
             //biota.BiotaPropertiesSpellBar = context.BiotaPropertiesSpellBar.Where(r => r.ObjectId == biota.Id).ToList();
 
-            if (isCreature)
-            {
-                biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
-            }
+            //if (isCreature)
+            //{
+            //    biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
+            //}
 
             biota.BiotaPropertiesTextureMap = context.BiotaPropertiesTextureMap.Where(r => r.ObjectId == biota.Id).ToList();
 

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -16,6 +16,9 @@ using ACE.Server.Network;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
+using System.Linq;
+using System.Collections.ObjectModel;
+using ACE.Database.Models.Shard;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -1355,12 +1358,111 @@ namespace ACE.Server.Command.Handlers
         }
 
         // morph
-        [CommandHandler("morph", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
+        [CommandHandler("morph", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Morphs your bodily form into that of the specified creature. Be careful with this one!",
+            "[wcid or weenie class name]")]
         public static void HandleMorph(Session session, params string[] parameters)
         {
             // @morph - Morphs your bodily form into that of the specified creature. Be careful with this one!
 
-            // TODO: output
+            string weenieClassDescription = parameters[0];
+            bool wcid = uint.TryParse(weenieClassDescription, out uint weenieClassId);
+            if (wcid)
+            {
+                if (weenieClassId < 1 && weenieClassId > WEENIE_MAX)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"Not a valid weenie id - must be a number between 1 - {WEENIE_MAX}", ChatMessageType.Broadcast));
+                    return;
+                }
+            }
+
+            Weenie weenie;
+            if (wcid)
+                weenie = DatabaseManager.World.GetCachedWeenie(weenieClassId);
+            else
+                weenie = DatabaseManager.World.GetCachedWeenie(weenieClassDescription);
+
+            if (weenie == null)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Weenie {weenieClassDescription} not found in database, unable to morph.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (weenie.Type != (int)WeenieType.Creature || weenie.Type != (int)WeenieType.Cow
+                || weenie.Type != (int)WeenieType.Admin || weenie.Type != (int)WeenieType.Sentinel || weenie.Type != (int)WeenieType.Vendor
+                || weenie.Type != (int)WeenieType.Pet || weenie.Type != (int)WeenieType.CombatPet)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Weenie {weenie.GetProperty(PropertyString.Name)} ({weenieClassDescription}) is of WeenieType.{Enum.GetName(typeof(WeenieType), weenie.Type)} ({weenie.Type}), unable to morph because that is not allowed.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Morphing you into {weenie.GetProperty(PropertyString.Name)} ({weenieClassDescription})... You will be logged out.", ChatMessageType.Broadcast));
+
+            var guid = GuidManager.NewPlayerGuid();
+
+            weenie.Type = (int)session.Player.WeenieType;
+
+            var player = new Player(weenie, guid, session);
+            player.Location = session.Player.Location;
+
+            player.CharacterOptions1Mapping = session.Player.CharacterOptions1Mapping;
+            player.CharacterOptions2Mapping = session.Player.CharacterOptions2Mapping;
+
+            //var wearables = weenie.GetCreateList((sbyte)DestinationType.Wield);
+            var wearables = weenie.WeeniePropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Wield).ToList();
+            foreach(var wearable in wearables)
+            {
+                var weenieOfWearable = DatabaseManager.World.GetCachedWeenie(wearable.WeenieClassId);
+
+                if (weenieOfWearable == null)
+                    continue;
+
+                var worldObject = WorldObjectFactory.CreateNewWorldObject(weenieOfWearable);
+
+                if (worldObject == null)
+                    continue;
+
+                if (wearable.Palette > 0)
+                    worldObject.PaletteTemplate = wearable.Palette;
+                if (wearable.Shade > 0)
+                    worldObject.Shade = wearable.Shade;
+                player.TryEquipObject(worldObject, worldObject.GetProperty(PropertyInt.ValidLocations) ?? 0);
+            }
+
+            var containables = weenie.WeeniePropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Contain || x.DestinationType == (int)DestinationType.Shop
+            || x.DestinationType == (int)DestinationType.Treasure || x.DestinationType == (int)DestinationType.ContainTreasure || x.DestinationType == (int)DestinationType.ShopTreasure).ToList();
+            foreach (var containable in containables)
+            {
+                var weenieOfWearable = DatabaseManager.World.GetCachedWeenie(containable.WeenieClassId);
+
+                if (weenieOfWearable == null)
+                    continue;
+
+                var worldObject = WorldObjectFactory.CreateNewWorldObject(weenieOfWearable);
+
+                if (worldObject == null)
+                    continue;
+
+                if (containable.Palette > 0)
+                    worldObject.PaletteTemplate = containable.Palette;
+                if (containable.Shade > 0)
+                    worldObject.Shade = containable.Shade;
+                player.TryAddToInventory(worldObject, out Container _);
+            }
+
+            var possessions = player.GetAllPossessions();
+            var possessedBiotas = new Collection<Biota>();
+            foreach (var possession in possessions)
+                possessedBiotas.Add(possession.Biota);
+
+            DatabaseManager.Shard.AddBiota(player.Biota, null);
+
+            DatabaseManager.Shard.AddBiotas(possessedBiotas, null);
+
+            session.Character.BiotaId = player.Guid.Full;
+            DatabaseManager.Shard.SaveCharacter(session.Character, null);
+
+            session.LogOffPlayer();
         }
 
         // qst

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1409,7 +1409,7 @@ namespace ACE.Server.Command.Handlers
             player.CharacterOptions2Mapping = session.Player.CharacterOptions2Mapping;
 
             //var wearables = weenie.GetCreateList((sbyte)DestinationType.Wield);
-            var wearables = weenie.WeeniePropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Wield).ToList();
+            var wearables = weenie.WeeniePropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Wield || x.DestinationType == (int)DestinationType.WieldTreasure).ToList();
             foreach(var wearable in wearables)
             {
                 var weenieOfWearable = DatabaseManager.World.GetCachedWeenie(wearable.WeenieClassId);

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1388,9 +1388,9 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
-            if (weenie.Type != (int)WeenieType.Creature || weenie.Type != (int)WeenieType.Cow
-                || weenie.Type != (int)WeenieType.Admin || weenie.Type != (int)WeenieType.Sentinel || weenie.Type != (int)WeenieType.Vendor
-                || weenie.Type != (int)WeenieType.Pet || weenie.Type != (int)WeenieType.CombatPet)
+            if (weenie.Type != (int)WeenieType.Creature && weenie.Type != (int)WeenieType.Cow
+                && weenie.Type != (int)WeenieType.Admin && weenie.Type != (int)WeenieType.Sentinel && weenie.Type != (int)WeenieType.Vendor
+                && weenie.Type != (int)WeenieType.Pet && weenie.Type != (int)WeenieType.CombatPet)
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Weenie {weenie.GetProperty(PropertyString.Name)} ({weenieClassDescription}) is of WeenieType.{Enum.GetName(typeof(WeenieType), weenie.Type)} ({weenie.Type}), unable to morph because that is not allowed.", ChatMessageType.Broadcast));
                 return;

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -15,6 +15,7 @@ using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Database.Models.Shard;
+using System.Linq;
 
 namespace ACE.Server.Network
 {
@@ -289,6 +290,8 @@ namespace ACE.Server.Network
 
             DatabaseManager.Shard.GetCharacters(Id, ((List<Character> result) =>
             {
+                result = result.OrderByDescending(o => o.LastLoginTimestamp).ToList();
+
                 UpdateCachedCharacters(result);
                 Network.EnqueueSend(new GameMessageCharacterList(result, this));
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # ACEmulator Change Log
 
+### 2018-03-10
+[Ripley]
+* Adding /morph command for admins.
+  - The command was used to facilitate live ops by developers to play out story elements such as Martine wreaking havoc upon the lands.
+  - For some samples, you can try `martinelo`, `baelzharon`, `asheronlo`, `ayanbaqurdrunkenscholar`, `rabbitwhite`, `monoguapaul`, or even `golemmegamagma`.
+  - Protip: If you do morph into a golem, press the b key ;)
+
 ### 2018-03-07
 [Ripley]
 * Fixed Skills and Vital calculations when spending xp and potential sequence errors.


### PR DESCRIPTION
* Adding /morph command for admins.
  - The command was used to facilitate live ops by developers to play out story elements such as Martine wreaking havoc upon the lands.
  - For some samples, you can try `martinelo`, `baelzharon`, `asheronlo`, `ayanbaqurdrunkenscholar`, `rabbitwhite`, `monougapaul`, or even `golemmegamagma`.
  - Protip: If you do morph into a golem, press the b key ;)

The command usage is: `/morph [wcid or weenieClassName here]`
If successful, you will be logged out and when you enter the game again you'll be that creature