### PR TITLE
Enable MinMax Portal level enforcement

### DIFF
--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -151,13 +151,13 @@ namespace ACE.Server.WorldObjects
         private int? MaxLevel
         {
             get => Biota.GetProperty(PropertyInt.MaxLevel);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.MinLevel); else SetProperty(PropertyInt.MinLevel, value.Value); }
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.MaxLevel); else SetProperty(PropertyInt.MaxLevel, value.Value); }
         }
 
         private int? PortalBitmask
         {
             get => Biota.GetProperty(PropertyInt.PortalBitmask);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.MinLevel); else SetProperty(PropertyInt.MinLevel, value.Value); }
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.PortalBitmask); else SetProperty(PropertyInt.PortalBitmask, value.Value); }
         }
 
         public int SocietyId => 0;

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -127,9 +127,9 @@ namespace ACE.Server.WorldObjects
             SetProperty(PropertyBool.Stuck, true);
             SetProperty(PropertyBool.Attackable, true);
 
-            MinLevel = Biota.GetProperty(PropertyInt.MinLevel) ?? 0;
-            MaxLevel = Biota.GetProperty(PropertyInt.MaxLevel) ?? 0;
-            PortalBitmask = Biota.GetProperty(PropertyInt.PortalBitmask) ?? 0;
+            MinLevel = MinLevel ?? 0;
+            MaxLevel = MaxLevel ?? 0;
+            PortalBitmask = PortalBitmask ?? 0;
         }
 
         public string AppraisalPortalDestination
@@ -142,22 +142,22 @@ namespace ACE.Server.WorldObjects
             get;
         }
 
-        public int MinLevel
+        private int? MinLevel
         {
-            get;
-            set;
+            get => Biota.GetProperty(PropertyInt.MinLevel);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.MinLevel); else SetProperty(PropertyInt.MinLevel, value.Value); }
         }
 
-        public int MaxLevel
+        private int? MaxLevel
         {
-            get;
-            set;
+            get => Biota.GetProperty(PropertyInt.MaxLevel);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.MinLevel); else SetProperty(PropertyInt.MinLevel, value.Value); }
         }
 
-        public int PortalBitmask
+        private int? PortalBitmask
         {
-            get;
-            set;
+            get => Biota.GetProperty(PropertyInt.PortalBitmask);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.MinLevel); else SetProperty(PropertyInt.MinLevel, value.Value); }
         }
 
         public int SocietyId => 0;

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -126,6 +126,10 @@ namespace ACE.Server.WorldObjects
 
             SetProperty(PropertyBool.Stuck, true);
             SetProperty(PropertyBool.Attackable, true);
+
+            MinLevel = Biota.GetProperty(PropertyInt.MinLevel) ?? 0;
+            MaxLevel = Biota.GetProperty(PropertyInt.MaxLevel) ?? 0;
+            PortalBitmask = Biota.GetProperty(PropertyInt.PortalBitmask) ?? 0;
         }
 
         public string AppraisalPortalDestination
@@ -138,14 +142,22 @@ namespace ACE.Server.WorldObjects
             get;
         }
 
-        public int MinimumLevel
+        public int MinLevel
         {
             get;
+            set;
         }
 
-        public int MaximumLevel
+        public int MaxLevel
         {
             get;
+            set;
+        }
+
+        public int PortalBitmask
+        {
+            get;
+            set;
         }
 
         public int SocietyId => 0;
@@ -179,7 +191,7 @@ namespace ACE.Server.WorldObjects
                 player.Session.Network.EnqueueSend(usePortalMessage);
 #endif
                 // Check player level -- requires remote query to player (ugh)...
-                if ((player.Level >= MinimumLevel) && ((player.Level <= MaximumLevel) || (MaximumLevel == 0)))
+                if ((player.Level >= MinLevel) && ((player.Level <= MaxLevel) || (MaxLevel == 0)))
                 {
                     Position portalDest = Destination;
                     switch (WeenieClassId)
@@ -276,7 +288,7 @@ namespace ACE.Server.WorldObjects
                     if (IsRecallable)
                         player.SetCharacterPosition(PositionType.LastPortal, portalDest);
                 }
-                else if ((player.Level > MaximumLevel) && (MaximumLevel != 0))
+                else if ((player.Level > MaxLevel) && (MaxLevel != 0))
                 {
                     // You are too powerful to interact with that portal!
                     var failedUsePortalMessage = new GameEventDisplayStatusMessage(player.Session, StatusMessageType1.YouAreTooPowerfulToUsePortal);


### PR DESCRIPTION
Changes the variables used for Portal level enforcement to those that are set in the database and retrieves and sets their values on Portal creation.