### PR TITLE
Implemented StatMod World DB usage

### DIFF
--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -304,7 +304,7 @@ namespace ACE.Database
             {
                 var result = context.Spell
                     .AsNoTracking()
-                    .FirstOrDefault(r => r.Id == spellId);
+                    .FirstOrDefault(r => r.SpellId == spellId);
 
                 if (result != null)
                 {


### PR DESCRIPTION
All of the Boost type Life spells and the Transfer spells damage portion implemented using the data from the StatMod World DB entries; applying the Transfer spell's drain amount to caster and vital transfer spells still to be implemented.
