### PR TITLE
Limit Portal Spam from multiple collisions

### DIFF
--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -186,6 +186,11 @@ namespace ACE.Server.WorldObjects
             if (player == null)
                 return;
 
+            if (player.Teleporting)
+                return;
+
+            player.Teleporting = true;
+
             if (Destination != null)
             {
 #if DEBUG
@@ -296,12 +301,14 @@ namespace ACE.Server.WorldObjects
                     // You are too powerful to interact with that portal!
                     var failedUsePortalMessage = new GameEventWeenieError(player.Session, WeenieError.YouAreTooPowerfulToUsePortal);
                     player.Session.Network.EnqueueSend(failedUsePortalMessage);
+                    player.Teleporting = false;
                 }
                 else
                 {
                     // You are not powerful enough to interact with that portal!
                     var failedUsePortalMessage = new GameEventWeenieError(player.Session, WeenieError.YouAreNotPowerfulEnoughToUsePortal);
                     player.Session.Network.EnqueueSend(failedUsePortalMessage);
+                    player.Teleporting = false;
                 }
             }
             else
@@ -309,6 +316,7 @@ namespace ACE.Server.WorldObjects
                 serverMessage = "Portal destination for portal ID " + this.WeenieClassId + " not yet implemented!";
                 var failedUsePortalMessage = new GameMessageSystemChat(serverMessage, ChatMessageType.System);
                 player.Session.Network.EnqueueSend(failedUsePortalMessage);
+                player.Teleporting = false;
             }
         }
 


### PR DESCRIPTION
- Use the Player.Teleporting flag to prevent Portal.HandleActionOnCollide() from doing any actions multiple times because of repeated collisions