### PR TITLE
Update Player.cs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -284,7 +284,11 @@ namespace ACE.Server.WorldObjects
             else
             {
                 // examine item on land block
-                CurrentLandblock.GetObject(examinationId).Examine(Session);
+                wo = CurrentLandblock.GetObject(examinationId);
+                if(wo != null)
+                {
+                    CurrentLandblock.GetObject(examinationId).Examine(Session);
+                }
             }
 
             RequestedAppraisalTarget = examinationId.Full;


### PR DESCRIPTION
NullPointerException avoided.. If you  examine a monster as you kill it, the server would crash the second it died.