### PR TITLE
Corpses had no value.

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -123,7 +123,7 @@ namespace ACE.Server.WorldObjects
                     }
                 }
             }
-
+            corpse.RemoveProperty(PropertyInt.Value);
             LandblockManager.AddObject(corpse);
         }
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -284,7 +284,11 @@ namespace ACE.Server.WorldObjects
             else
             {
                 // examine item on land block
-                CurrentLandblock.GetObject(examinationId).Examine(Session);
+                wo = CurrentLandblock.GetObject(examinationId);
+                if(wo != null)
+                {
+                    CurrentLandblock.GetObject(examinationId).Examine(Session);
+                }
             }
 
             RequestedAppraisalTarget = examinationId.Full;


### PR DESCRIPTION
Removed the value property from the corpse before it is added to the landblock. I don't know if this is an issue that most can see, but with loot, it is very noticeable.