### PR TITLE
Fix IsAttuned method

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -489,7 +489,7 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
 
-            int attunedProperty = (int)item.GetProperty(PropertyInt.Attuned);
+            int attunedProperty = (item.GetProperty(PropertyInt.Attuned) ?? 0);
             if (attunedProperty == 1)
             {
                 isAttuned = true;


### PR DESCRIPTION
As caught by Derrick, a null check was missing vs the Attuned property itself.  However, the fist null check should remain, as there is a possibility that GetInventoryItem() might return a null, which would need to be handled in a manner to avoid a null pointer exception.