### PR TITLE
Magic :: Lesson 14 :: Items casting spells

### DIFF
--- a/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
@@ -203,7 +203,7 @@ namespace ACE.Server.Command.Handlers
                     var runEnchantment = new Enchantment(session.Player, spellID, 0, spell.StatModType, spell.StatModVal);
                     var msgRunEnchantment = new GameEventMagicUpdateEnchantment(session, runEnchantment);
                     session.Player.CurrentLandblock.EnqueueBroadcast(session.Player.Location, new GameMessageScript(session.Player.Guid, (PlayScript)spell.TargetEffect, 1f));
-                    session.Player.EnchantmentManager.Add(runEnchantment);
+                    session.Player.EnchantmentManager.Add(runEnchantment, false);
                     session.Network.EnqueueSend(new GameMessageSystemChat("Run forrest, run!", ChatMessageType.Broadcast), msgRunEnchantment);
                     break;
             }

--- a/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
@@ -200,7 +200,7 @@ namespace ACE.Server.Command.Handlers
                         session.Network.EnqueueSend(new GameMessageSystemChat("Run speed boost is currently INACTIVE", ChatMessageType.Broadcast));
                     break;
                 case "on":
-                    var runEnchantment = new Enchantment(session.Player, spellID, 0, spell.StatModType, spell.StatModVal);
+                    var runEnchantment = new Enchantment(session.Player, spellID, (double)spell.Duration, 0, spell.StatModType, spell.StatModVal);
                     var msgRunEnchantment = new GameEventMagicUpdateEnchantment(session, runEnchantment);
                     session.Player.CurrentLandblock.EnqueueBroadcast(session.Player.Location, new GameMessageScript(session.Player.Guid, (PlayScript)spell.TargetEffect, 1f));
                     session.Player.EnchantmentManager.Add(runEnchantment, false);

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -71,22 +71,7 @@ namespace ACE.Server.Managers
             // check for existing spell in this category
             var entry = GetCategory(enchantment.Spell.Category);
 
-            // Enchantment applied by an item
-            if (castByItem == true)
-            {
-                // if none, add new record
-                if (entry == null)
-                {
-                    entry = BuildEntry(enchantment.Spell.SpellId);
-                    entry.Duration = -1;
-                    entry.StartTime = 0;
-                    entry.LayerId = enchantment.Layer;
-                    var type = (EnchantmentTypeFlags)entry.StatModType;
-                    WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(entry);
-
-                    return StackType.Initial;
-                }
-
+/*
                 if (enchantment.Spell.Power > entry.PowerLevel)
                 {
                     // surpass existing spell
@@ -119,11 +104,11 @@ namespace ACE.Server.Managers
                 Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
                 return StackType.Surpassed;
             }
-
+            */
             // if none, add new record
             if (entry == null)
             {
-                entry = BuildEntry(enchantment.Spell.SpellId);
+                entry = BuildEntry(enchantment.Spell.SpellId, castByItem);
                 entry.LayerId = enchantment.Layer;
                 var type = (EnchantmentTypeFlags)entry.StatModType;
                 WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(entry);
@@ -136,13 +121,12 @@ namespace ACE.Server.Managers
                 // surpass existing spell
                 Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
                 Remove(entry, false);
-                entry = BuildEntry(enchantment.Spell.SpellId);
+                entry = BuildEntry(enchantment.Spell.SpellId, castByItem);
                 entry.LayerId = enchantment.Layer;
                 WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(entry);
                 return StackType.Surpass;
             }
 
-            // TODO: the refresh spell case may need some additional functionality to get working correctly
             if (enchantment.Spell.Power == entry.PowerLevel)
             {
                 if (entry.Duration != -1)
@@ -294,7 +278,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Builds an enchantment registry entry from a spell ID
         /// </summary>
-        public BiotaPropertiesEnchantmentRegistry BuildEntry(uint spellID)
+        public BiotaPropertiesEnchantmentRegistry BuildEntry(uint spellID, bool castByItem = false)
         {
             var spellBase = DatManager.PortalDat.SpellTable.Spells[spellID];
             var spell = DatabaseManager.World.GetCachedSpell(spellID);
@@ -308,7 +292,15 @@ namespace ACE.Server.Managers
             entry.SpellId = (int)spell.SpellId;
             entry.SpellCategory = (ushort)spell.Category;
             entry.PowerLevel = spell.Power;
-            entry.Duration = spell.Duration ?? 0.0;
+
+            if (castByItem)
+            {
+                entry.Duration = -1.0;
+                entry.StartTime = 0;
+            }
+            else
+                entry.Duration = spell.Duration ?? 0.0;
+
             entry.CasterObjectId = WorldObject.Guid.Full;   // only works for self?
             entry.DegradeModifier = spell.DegradeModifier ?? 0.0f;
             entry.DegradeLimit = spell.DegradeLimit ?? 0.0f;

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -100,6 +100,7 @@ namespace ACE.Server.Managers
                     return StackType.Surpass;
                 }
 
+                // TODO: the refresh spell case may need some additional functionality to get working correctly
                 if (enchantment.Spell.Power == entry.PowerLevel)
                 {
                     if (entry.Duration != -1)
@@ -141,6 +142,7 @@ namespace ACE.Server.Managers
                 return StackType.Surpass;
             }
 
+            // TODO: the refresh spell case may need some additional functionality to get working correctly
             if (enchantment.Spell.Power == entry.PowerLevel)
             {
                 if (entry.Duration != -1)

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventMagicDispelEnchantment.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventMagicDispelEnchantment.cs
@@ -1,0 +1,12 @@
+namespace ACE.Server.Network.GameEvent.Events
+{
+    public class GameEventMagicDispelEnchantment : GameEventMessage
+    {
+        public GameEventMagicDispelEnchantment(Session session, ushort spellID, ushort layer)
+            : base(GameEventType.MagicDispelEnchantment, GameMessageGroup.UIQueue, session)
+        {
+            Writer.Write(spellID);
+            Writer.Write(layer);
+        }
+    }
+}

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -21,33 +21,44 @@ namespace ACE.Server.Network.Structure
         public double Duration;
         public float? StatMod;
 
-        public Enchantment(WorldObject target, uint spellId, ushort layer, uint? enchantmentMask, float? statMod = null)
+        public Enchantment(WorldObject target, uint spellId, ushort layer, uint? enchantmentMask, float? statMod = null, bool castByItem = false)
         {
             Target = target;
             SpellBase = DatManager.PortalDat.SpellTable.Spells[spellId];
             Spell = DatabaseManager.World.GetCachedSpell(spellId);
             Layer = layer;
+            if (castByItem == true)
+                Duration = -1;
+            else
+                Duration = (double)Spell.Duration;
             EnchantmentMask = (EnchantmentMask)(enchantmentMask ?? 0);
             StatMod = statMod ?? Spell.StatModVal;
         }
 
-        public Enchantment(WorldObject target, SpellBase spellBase, ushort layer, uint? enchantmentMask, float? statMod = null)
+        public Enchantment(WorldObject target, SpellBase spellBase, ushort layer, uint? enchantmentMask, float? statMod = null, bool castByItem = false)
         {
             Target = target;
             SpellBase = spellBase;
             Layer = layer;
+            if (castByItem == true)
+                Duration = -1;
+            else
+                Duration = spellBase.Duration;
             EnchantmentMask = (EnchantmentMask)(enchantmentMask ?? 0);
             StatMod = statMod;
         }
 
-        public Enchantment(WorldObject target, BiotaPropertiesEnchantmentRegistry entry)
+        public Enchantment(WorldObject target, BiotaPropertiesEnchantmentRegistry entry, bool castByItem = false)
         {
             Target = target;
             SpellBase = DatManager.PortalDat.SpellTable.Spells[(uint)entry.SpellId];
             Spell = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
             Layer = entry.LayerId;
             StartTime = entry.StartTime;
-            Duration = entry.Duration;
+            if (castByItem == true)
+                Duration = -1;
+            else
+                Duration = entry.Duration;
             EnchantmentMask = (EnchantmentMask)entry.EnchantmentCategory;
             StatMod = entry.StatModValue;
         }

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -21,44 +21,35 @@ namespace ACE.Server.Network.Structure
         public double Duration;
         public float? StatMod;
 
-        public Enchantment(WorldObject target, uint spellId, ushort layer, uint? enchantmentMask, float? statMod = null, bool castByItem = false)
+        public Enchantment(WorldObject target, uint spellId, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
         {
             Target = target;
             SpellBase = DatManager.PortalDat.SpellTable.Spells[spellId];
             Spell = DatabaseManager.World.GetCachedSpell(spellId);
             Layer = layer;
-            if (castByItem == true)
-                Duration = -1;
-            else
-                Duration = (double)Spell.Duration;
+            Duration = duration;
             EnchantmentMask = (EnchantmentMask)(enchantmentMask ?? 0);
             StatMod = statMod ?? Spell.StatModVal;
         }
 
-        public Enchantment(WorldObject target, SpellBase spellBase, ushort layer, uint? enchantmentMask, float? statMod = null, bool castByItem = false)
+        public Enchantment(WorldObject target, SpellBase spellBase, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
         {
             Target = target;
             SpellBase = spellBase;
             Layer = layer;
-            if (castByItem == true)
-                Duration = -1;
-            else
-                Duration = spellBase.Duration;
+            Duration = duration;
             EnchantmentMask = (EnchantmentMask)(enchantmentMask ?? 0);
             StatMod = statMod;
         }
 
-        public Enchantment(WorldObject target, BiotaPropertiesEnchantmentRegistry entry, bool castByItem = false)
+        public Enchantment(WorldObject target, BiotaPropertiesEnchantmentRegistry entry)
         {
             Target = target;
             SpellBase = DatManager.PortalDat.SpellTable.Spells[(uint)entry.SpellId];
             Spell = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
             Layer = entry.LayerId;
             StartTime = entry.StartTime;
-            if (castByItem == true)
-                Duration = -1;
-            else
-                Duration = entry.Duration;
+            Duration = entry.Duration;
             EnchantmentMask = (EnchantmentMask)entry.EnchantmentCategory;
             StatMod = entry.StatModValue;
         }

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -18,6 +18,7 @@ namespace ACE.Server.Network.Structure
         public ushort Layer;
         public EnchantmentMask EnchantmentMask;
         public double StartTime;
+        public double Duration;
         public float? StatMod;
 
         public Enchantment(WorldObject target, uint spellId, ushort layer, uint? enchantmentMask, float? statMod = null)
@@ -46,6 +47,7 @@ namespace ACE.Server.Network.Structure
             Spell = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
             Layer = entry.LayerId;
             StartTime = entry.StartTime;
+            Duration = entry.Duration;
             EnchantmentMask = (EnchantmentMask)entry.EnchantmentCategory;
             StatMod = entry.StatModValue;
         }
@@ -78,7 +80,7 @@ namespace ACE.Server.Network.Structure
             writer.Write(HasSpellSetId);
             writer.Write(enchantment.SpellBase.Power);
             writer.Write(enchantment.StartTime);
-            writer.Write(enchantment.SpellBase.Duration);
+            writer.Write(enchantment.Duration);
             writer.Write(enchantment.Target.Guid.Full);
             writer.Write(enchantment.SpellBase.DegradeModifier);
             writer.Write(enchantment.SpellBase.DegradeLimit);

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -88,7 +88,7 @@ namespace ACE.Server.WorldObjects
                 player.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(player.Session, gem));
 
                 // add to enchantment registry
-                player.EnchantmentManager.Add(gem);
+                player.EnchantmentManager.Add(gem, false);
 
                 ////session.Player.HandleActionRemoveItemFromInventory(Guid.Full, (uint)ContainerId, 1); This is commented out to aid in testing. Will be uncommented later.
                 player.SendUseDoneEvent();

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -84,7 +84,7 @@ namespace ACE.Server.WorldObjects
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat(castMessage, ChatMessageType.Magic));
                 player.PlayParticleEffect((PlayScript)spellBase.TargetEffect, player.Guid);
                 const ushort layer = 1; // FIXME: This will be tracked soon, once a list is made to track active enchantments
-                var gem = new Enchantment(player, SpellDID.Value, layer, spell.Category);
+                var gem = new Enchantment(player, SpellDID.Value, (double)spell.Duration, layer, spell.Category);
                 player.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(player.Session, gem));
 
                 // add to enchantment registry
@@ -146,7 +146,7 @@ namespace ACE.Server.WorldObjects
                 //const uint spellCategory = 0x8000; // FIXME: Not sure where we get this from
                 var spellBase = new SpellBase(0, CooldownDuration.Value, 0, -666);
                 // cooldown not being used in network packet?
-                var gem = new Enchantment(player, spellBase, layer, /*CooldownId.Value,*/ (uint)EnchantmentTypeFlags.Cooldown);
+                var gem = new Enchantment(player, spellBase, spellBase.Duration, layer, /*CooldownId.Value,*/ (uint)EnchantmentTypeFlags.Cooldown);
                 player.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(player.Session, gem));
 
                 // Ok this was not known to us, so we used the contract - now remove it from inventory.

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -25,6 +25,9 @@ namespace ACE.Server.WorldObjects
         {
             var weapon = GetEquippedWeapon();
 
+            if (weapon == null)
+                return GetCreatureSkill(Skill.FinesseWeapons).Skill;    // Not sure what skill should be used for bare knuckle melee :: Change if incorrect
+
             // missile weapon
             if (weapon.CurrentWieldedLocation == EquipMask.MissileWeapon)
                 return GetCreatureSkill(Skill.MissileWeapons).Skill;
@@ -45,7 +48,15 @@ namespace ACE.Server.WorldObjects
 
         public AttackType GetAttackType()
         {
-            return GetEquippedWeapon().CurrentWieldedLocation == EquipMask.MeleeWeapon ? AttackType.Melee : AttackType.Missile;
+            AttackType attackType;
+            if (GetEquippedWeapon() == null)
+            {
+                attackType = AttackType.Melee;
+            }
+            else
+                attackType = GetEquippedWeapon().CurrentWieldedLocation == EquipMask.MeleeWeapon ? AttackType.Melee : AttackType.Missile;
+
+            return attackType;
         }
 
         public void DamageTarget(WorldObject target)

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -54,7 +54,7 @@ namespace ACE.Server.WorldObjects
             var spellID = (uint)Network.Enum.Spell.Vitae;
             var spellBase = DatManager.PortalDat.SpellTable.Spells[spellID];
             var spell = DatabaseManager.World.GetCachedSpell(spellID);
-            var vitaeEnchantment = new Enchantment(this, spellID, 0, spell.StatModType, vitae);
+            var vitaeEnchantment = new Enchantment(this, spellID, (double)spell.Duration, 0, spell.StatModType, vitae);
             var msgVitaeEnchantment = new GameEventMagicUpdateEnchantment(Session, vitaeEnchantment);
 
             var msgHealthUpdate = new GameMessagePrivateUpdateAttribute2ndLevel(this, Vital.Health, 0);

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -623,7 +623,7 @@ namespace ACE.Server.WorldObjects
                     if (item.Biota.BiotaPropertiesSpellBook != null)
                     {
                         // TODO: Once Item Current Mana is fixed for loot generated items, '|| item.ItemCurMana == null' can be removed
-                        if (item.ItemCurMana < 1 || item.ItemCurMana == null)
+                        if (item.ItemCurMana > 1 || item.ItemCurMana == null)
                         {
                             for (int i = 0; i < item.Biota.BiotaPropertiesSpellBook.Count; i++)
                             {

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Diagnostics;
 
 using ACE.DatLoader;
@@ -471,6 +472,15 @@ namespace ACE.Server.WorldObjects
                 // Was I equiped? If so, lets take care of that and unequip
                 if (item.WielderId != null)
                 {
+                    // If item has any spells, remove them from the registry on unequip
+                    if (item.Biota.BiotaPropertiesSpellBook != null)
+                    {
+                        for (int i = 0; i < item.Biota.BiotaPropertiesSpellBook.Count; i++)
+                        {
+                            RemoveItemSpell(item.Guid, (uint)item.Biota.BiotaPropertiesSpellBook.ElementAt(i).Spell);
+                        }
+                    }
+
                     UnwieldItemWithNetworking(container, item, placement);
                     return;
                 }
@@ -608,6 +618,18 @@ namespace ACE.Server.WorldObjects
                     {
                         log.Error("Player_Inventory HandleActionGetAndWieldItem TryEquipObject failed");
                         return;
+                    }
+
+                    if (item.Biota.BiotaPropertiesSpellBook != null)
+                    {
+                        // TODO: Once Item Current Mana is fixed for loot generated items, '|| item.ItemCurMana == null' can be removed
+                        if (item.ItemCurMana < 1 || item.ItemCurMana == null)
+                        {
+                            for (int i = 0; i < item.Biota.BiotaPropertiesSpellBook.Count; i++)
+                            {
+                                CreateItemSpell(item.Guid, (uint)item.Biota.BiotaPropertiesSpellBook.ElementAt(i).Spell);
+                            }
+                        }
                     }
 
                     if ((EquipMask)wieldLocation == EquipMask.MissileAmmo)

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -67,7 +67,7 @@ namespace ACE.Server.WorldObjects
             CreatureSkill missileDefense = player.GetCreatureSkill(Skill.MissileDefense);
             CreatureSkill magicDefense = player.GetCreatureSkill(Skill.MagicDefense);
 
-            if (item.ItemDifficulty >= arcaneLore.Current || item.ItemDifficulty == null)
+            if (arcaneLore.Current >= item.ItemDifficulty || item.ItemDifficulty == null)
             {
                 if (item.AppraisalItemSkill != 0 || item.AppraisalItemSkill != null)
                 {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1,8 +1,18 @@
+using System;
+
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.Motion;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Database;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
+using ACE.DatLoader.Entity;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.WorldObjects.Entity;
 
 namespace ACE.Server.WorldObjects
 {
@@ -37,6 +47,641 @@ namespace ACE.Server.WorldObjects
         public void HandleActionMagicCastUnTargetedSpell(uint spellId)
         {
             CreatePlayerSpell(spellId);
+        }
+
+        /// <summary>
+        /// Method used for handling items casting spells on the player equiping the item
+        /// </summary>
+        /// <param name="guidItem"></param>
+        /// <param name="spellId"></param>
+        public void CreateItemSpell(ObjectGuid guidItem, uint spellId)
+        {
+            Player player = CurrentLandblock.GetObject(Guid) as Player;
+            WorldObject item = player.GetWieldedItem(guidItem);
+
+            if (item == null)
+                return;
+
+            CreatureSkill arcaneLore = player.GetCreatureSkill(Skill.ArcaneLore);
+            CreatureSkill meleeDefense = player.GetCreatureSkill(Skill.MeleeDefense);
+            CreatureSkill missileDefense = player.GetCreatureSkill(Skill.MissileDefense);
+            CreatureSkill magicDefense = player.GetCreatureSkill(Skill.MagicDefense);
+
+            if (item.ItemDifficulty >= arcaneLore.Current || item.ItemDifficulty == null)
+            {
+                if (item.AppraisalItemSkill != 0 || item.AppraisalItemSkill != null)
+                {
+                    switch (item.AppraisalItemSkill)
+                    {
+                        case 6:
+                            if (meleeDefense.Current < item.ItemSkillLevelLimit)
+                                return;
+                            break;
+                        case 7:
+                            if (missileDefense.Current < item.ItemSkillLevelLimit)
+                                return;
+                            break;
+                        case 8:
+                            if (magicDefense.Current < item.ItemSkillLevelLimit)
+                                return;
+                            break;
+                    }
+                }
+
+                SpellTable spellTable = DatManager.PortalDat.SpellTable;
+                if (!spellTable.Spells.ContainsKey(spellId))
+                {
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicInvalidSpellType));
+                    return;
+                }
+
+                SpellBase spell = spellTable.Spells[spellId];
+
+                Database.Models.World.Spell spellStatMod = DatabaseManager.World.GetCachedSpell(spellId);
+                if (spellStatMod == null)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
+                    return;
+                }
+
+                float scale = SpellAttributes(player.Session.Account, spellId, out float castingDelay, out MotionCommand windUpMotion, out MotionCommand spellGesture);
+
+                switch (spell.School)
+                {
+                    case MagicSchool.CreatureEnchantment:
+                        if (IsSpellHarmful(spell))
+                            break;
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(player.Guid, (PlayScript)spell.TargetEffect, scale));
+                        CreatureMagic(player, spell, spellStatMod, true);
+                        break;
+                    case MagicSchool.LifeMagic:
+                        if (spell.MetaSpellType != SpellType.LifeProjectile)
+                        {
+                            if (IsSpellHarmful(spell))
+                                break;
+                        }
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(player.Guid, (PlayScript)spell.TargetEffect, scale));
+                        LifeMagic(player, spell, spellStatMod, out string message, true);
+                        if (message != null)
+                            player.Session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.Magic));
+                        break;
+                    case MagicSchool.ItemEnchantment:
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(item.Guid, (PlayScript)spell.TargetEffect, scale));
+                        ItemMagic(item, spell, spellStatMod, true);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Method for handling the removal of an item's spell from the Enchantment registry
+        /// </summary>
+        /// <param name="guidItem"></param>
+        /// <param name="spellId"></param>
+        public void RemoveItemSpell(ObjectGuid guidItem, uint spellId)
+        {
+            WorldObject item = GetWieldedItem(guidItem);
+
+            if (item == null)
+                return;
+
+            SpellTable spellTable = DatManager.PortalDat.SpellTable;
+            if (!spellTable.Spells.ContainsKey(spellId))
+            {
+                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
+                return;
+            }
+
+            SpellBase spell = spellTable.Spells[spellId];
+
+            // Retrieve enchantment
+            if (EnchantmentManager.HasSpell(spellId))
+                EnchantmentManager.Dispel(EnchantmentManager.GetSpell(spellId));
+        }
+
+        /// <summary>
+        /// Method used for handling player targeted spell casts
+        /// </summary>
+        public void CreatePlayerSpell(ObjectGuid guidTarget, uint spellId)
+        {
+            Player player = CurrentLandblock.GetObject(Guid) as Player;
+            WorldObject target = CurrentLandblock.GetObject(guidTarget);
+
+            SpellTable spellTable = DatManager.PortalDat.SpellTable;
+            if (!spellTable.Spells.ContainsKey(spellId))
+            {
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicInvalidSpellType));
+                return;
+            }
+
+            SpellBase spell = spellTable.Spells[spellId];
+
+            if (IsInvalidTarget(spell, target))
+            {
+                player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"{spell.Name} cannot be cast on {target.Name}."));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None));
+                return;
+            }
+
+            Database.Models.World.Spell spellStatMod = DatabaseManager.World.GetCachedSpell(spellId);
+            if (spellStatMod == null)
+            {
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicInvalidSpellType));
+                return;
+            }
+
+            if (player.IsBusy == true)
+            {
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YoureTooBusy));
+                return;
+            }
+            else
+                player.IsBusy = true;
+
+            uint targetEffect = spell.TargetEffect;
+
+            // Grab player's skill level in the spell's Magic School
+            var magicSkill = player.GetCreatureSkill(spell.School).Current;
+
+            if (target == null)
+                target = player.GetWieldedItem(guidTarget);
+            else
+            {
+                if (guidTarget != Guid)
+                {
+                    float distanceTo = Location.Distance2D(target.Location);
+
+                    if (distanceTo > spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod)
+                    {
+                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicTargetOutOfRange),
+                            new GameMessageSystemChat($"{target.Name} is out of range!", ChatMessageType.Magic));
+                        player.IsBusy = false;
+                        return;
+                    }
+                }
+            }
+
+            // Ensure that a harmful spell isn't being cast on a player target that doesn't have the same PK status
+            if (target.WeenieClassId == 1 && player.PlayerKillerStatus != ACE.Entity.Enum.PlayerKillerStatus.NPK)
+            {
+                bool isSpellHarmful = IsSpellHarmful(spell);
+                if (player.PlayerKillerStatus != target.PlayerKillerStatus && isSpellHarmful)
+                {
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.InvalidPkStatus));
+                    player.IsBusy = false;
+                    return;
+                }
+            }
+
+            float scale = SpellAttributes(player.Session.Account, spellId, out float castingDelay, out MotionCommand windUpMotion, out MotionCommand spellGesture);
+            var formula = SpellTable.GetSpellFormula(spellTable, spellId, player.Session.Account);
+
+            bool spellCastSuccess = false || ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill, (int)spell.Power)))
+                && (magicSkill >= (int)spell.Power - 50) && (magicSkill > 0));
+
+            // Calculating mana usage
+            #region
+            CreatureSkill mc = player.GetCreatureSkill(Skill.ManaConversion);
+            double z = mc.Current;
+            double baseManaPercent = 1;
+            if (z > spell.Power)
+            {
+                baseManaPercent = spell.Power / z;
+            }
+            double preCost;
+            uint manaUsed;
+            if ((int)Math.Floor(baseManaPercent) == 1)
+            {
+                preCost = spell.BaseMana;
+                manaUsed = (uint)preCost;
+            }
+            else
+            {
+                preCost = spell.BaseMana * baseManaPercent;
+                if (preCost < 1)
+                    preCost = 1;
+                manaUsed = (uint)Physics.Common.Random.RollDice(1, (int)preCost);
+            }
+            if (spell.MetaSpellType == SpellType.Transfer)
+            {
+                uint vitalChange, casterVitalChange;
+                vitalChange = (uint)(player.GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source) * spellStatMod.Proportion);
+                if (spellStatMod.TransferCap != 0)
+                {
+                    if (vitalChange > spellStatMod.TransferCap)
+                        vitalChange = (uint)spellStatMod.TransferCap;
+                }
+                casterVitalChange = (uint)(vitalChange * (1.0f - spellStatMod.LossPercent));
+                vitalChange = (uint)(casterVitalChange / (1.0f - spellStatMod.LossPercent));
+
+                if (spellStatMod.Source == (int)PropertyAttribute2nd.Mana && (vitalChange + 10 + manaUsed) > player.Mana.Current)
+                {
+                    ActionChain resourceCheckChain = new ActionChain();
+
+                    resourceCheckChain.AddAction(this, () =>
+                    {
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                    });
+
+                    resourceCheckChain.AddDelaySeconds(2.0f);
+                    resourceCheckChain.AddAction(this, () =>
+                    {
+                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
+                        player.IsBusy = false;
+                    });
+
+                    resourceCheckChain.EnqueueChain();
+
+                    return;
+                }
+                else if ((vitalChange + 10) > player.GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source))
+                {
+                    ActionChain resourceCheckChain = new ActionChain();
+
+                    resourceCheckChain.AddAction(this, () =>
+                    {
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                    });
+
+                    resourceCheckChain.AddDelaySeconds(2.0f);
+                    resourceCheckChain.AddAction(this, () => player.IsBusy = false);
+                    resourceCheckChain.EnqueueChain();
+
+                    return;
+                }
+            }
+            else if (manaUsed > player.Mana.Current)
+            {
+                ActionChain resourceCheckChain = new ActionChain();
+
+                resourceCheckChain.AddAction(this, () =>
+                {
+                    CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                });
+
+                resourceCheckChain.AddDelaySeconds(2.0f);
+                resourceCheckChain.AddAction(this, () =>
+                {
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
+                    player.IsBusy = false;
+                });
+
+                resourceCheckChain.EnqueueChain();
+
+                return;
+            }
+            else
+                player.Mana.Current = player.Mana.Current - manaUsed;
+            #endregion
+
+            ActionChain spellChain = new ActionChain();
+
+            uint fastCast = (spell.Bitfield >> 14) & 0x1u;
+            if (fastCast != 1)
+            {
+                spellChain.AddAction(this, () =>
+                {
+                    var motionWindUp = new UniversalMotion(MotionStance.Spellcasting);
+                    motionWindUp.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                    motionWindUp.MovementData.ForwardCommand = (uint)windUpMotion;
+                    motionWindUp.MovementData.ForwardSpeed = 2;
+                    DoMotion(motionWindUp);
+                });
+            }
+
+            spellChain.AddAction(this, () =>
+            {
+                CurrentLandblock.EnqueueBroadcast(Location, new GameMessageCreatureMessage(SpellComponentsTable.GetSpellWords(DatManager.PortalDat.SpellComponentsTable,
+                    formula), Name, Guid.Full, ChatMessageType.Magic));
+            });
+
+            spellChain.AddAction(this, () =>
+            {
+                var motionCastSpell = new UniversalMotion(MotionStance.Spellcasting);
+                motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
+                motionCastSpell.MovementData.ForwardSpeed = 2;
+                DoMotion(motionCastSpell);
+            });
+
+            if (fastCast == 1)
+            {
+                spellChain.AddDelaySeconds(castingDelay * 0.26f);
+            }
+            else
+                spellChain.AddDelaySeconds(castingDelay);
+
+            if (spellCastSuccess == false)
+                spellChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
+            else
+            {
+                spellChain.AddAction(this, () =>
+                {
+                    bool targetDeath;
+                    string message;
+
+                    switch (spell.School)
+                    {
+                        case MagicSchool.WarMagic:
+                            WarMagic(target, spell, spellStatMod);
+                            break;
+                        case MagicSchool.VoidMagic:
+                            VoidMagic(target, spell, spellStatMod);
+                            break;
+                        case MagicSchool.CreatureEnchantment:
+                            if (IsSpellHarmful(spell))
+                            {
+                                // Retrieve player's skill level in the Magic School
+                                var playerMagicSkill = player.GetCreatureSkill(spell.School).Current;
+
+                                // Retrieve target's Magic Defense Skill
+                                Creature creature = (Creature)target;
+                                var targetMagicDefenseSkill = creature.GetCreatureSkill(Skill.MagicDefense).Current;
+
+                                if (MagicDefenseCheck(playerMagicSkill, targetMagicDefenseSkill))
+                                {
+                                    CurrentLandblock.EnqueueBroadcastSound(player, Sound.ResistSpell);
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists {spell.Name}", ChatMessageType.Magic));
+                                    break;
+                                }
+                            }
+                            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                            CreatureMagic(target, spell, spellStatMod);
+                            break;
+                        case MagicSchool.LifeMagic:
+                            if (spell.MetaSpellType != SpellType.LifeProjectile)
+                            {
+                                if (IsSpellHarmful(spell))
+                                {
+                                    // Retrieve player's skill level in the Magic School
+                                    var playerMagicSkill = player.GetCreatureSkill(spell.School).Current;
+
+                                    // Retrieve target's Magic Defense Skill
+                                    Creature creature = (Creature)target;
+                                    var targetMagicDefenseSkill = creature.GetCreatureSkill(Skill.MagicDefense).Current;
+
+                                    if (MagicDefenseCheck(playerMagicSkill, targetMagicDefenseSkill))
+                                    {
+                                        CurrentLandblock.EnqueueBroadcastSound(player, Sound.ResistSpell);
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists {spell.Name}", ChatMessageType.Magic));
+                                        break;
+                                    }
+                                }
+                            }
+                            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                            targetDeath = LifeMagic(target, spell, spellStatMod, out message);
+                            if (message != null)
+                                player.Session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.Magic));
+                            if (targetDeath == true)
+                            {
+                                Creature creatureTarget = (Creature)target;
+                                creatureTarget.Die();
+                                Strings.DeathMessages.TryGetValue(DamageType.Base, out var messages);
+                                player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(messages[0], target.Name), ChatMessageType.Broadcast));
+                                player.GrantXp((long)target.XpOverride, true);
+                            }
+                            break;
+                        case MagicSchool.ItemEnchantment:
+                            if (guidTarget == Guid)
+                                CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
+                            else
+                                CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                            ItemMagic(target, spell, spellStatMod);
+                            break;
+                        default:
+                            break;
+                    }
+                });
+            }
+
+            spellChain.AddAction(this, () =>
+            {
+                var motionReturnToCastStance = new UniversalMotion(MotionStance.Spellcasting);
+                motionReturnToCastStance.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                motionReturnToCastStance.MovementData.ForwardCommand = (uint)MotionCommand.Invalid;
+                DoMotion(motionReturnToCastStance);
+            });
+
+            spellChain.AddDelaySeconds(1.0f);
+
+            spellChain.AddAction(this, () =>
+            {
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None));
+                player.IsBusy = false;
+            });
+
+            spellChain.EnqueueChain();
+
+            return;
+        }
+
+        /// <summary>
+        /// Method used for handling player untargeted spell casts
+        /// </summary>
+        public void CreatePlayerSpell(uint spellId)
+        {
+            if (IsBusy == true)
+            {
+                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YoureTooBusy));
+                return;
+            }
+            else
+                IsBusy = true;
+
+            SpellTable spellTable = DatManager.PortalDat.SpellTable;
+            if (!spellTable.Spells.ContainsKey(spellId))
+            {
+                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
+                IsBusy = false;
+                return;
+            }
+
+            SpellBase spell = spellTable.Spells[spellId];
+
+            Database.Models.World.Spell spellStatMod = DatabaseManager.World.GetCachedSpell(spellId);
+            if (spellStatMod == null)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
+                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
+                IsBusy = false;
+                return;
+            }
+
+            // Grab player's skill level in the spell's Magic School
+            var magicSkill = GetCreatureSkill(spell.School);
+
+            float scale = SpellAttributes(Session.Account, spellId, out float castingDelay, out MotionCommand windUpMotion, out MotionCommand spellGesture);
+            var formula = SpellTable.GetSpellFormula(spellTable, spellId, Session.Account);
+
+            bool spellCastSuccess = false || ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill.Current, (int)spell.Power)))
+                && (magicSkill.Current >= (int)spell.Power - 50) && (magicSkill.Current > 0));
+
+            // Calculating mana usage
+            #region
+            if (spellCastSuccess == true)
+            {
+                CreatureSkill mc = GetCreatureSkill(Skill.ManaConversion);
+                double z = mc.Current;
+                double baseManaPercent = 1;
+                if (z > spell.Power)
+                {
+                    baseManaPercent = spell.Power / z;
+                }
+                double preCost;
+                uint manaUsed;
+                if ((int)Math.Floor(baseManaPercent) == 1)
+                {
+                    preCost = spell.BaseMana;
+                    manaUsed = (uint)preCost;
+                }
+                else
+                {
+                    preCost = spell.BaseMana * baseManaPercent;
+                    if (preCost < 1)
+                        preCost = 1;
+                    manaUsed = (uint)Physics.Common.Random.RollDice(1, (int)preCost);
+                }
+                if (spell.MetaSpellType == SpellType.Transfer)
+                {
+                    uint vitalChange, casterVitalChange;
+                    vitalChange = (uint)(GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source) * spellStatMod.Proportion);
+                    if (spellStatMod.TransferCap != 0)
+                    {
+                        if (vitalChange > spellStatMod.TransferCap)
+                            vitalChange = (uint)spellStatMod.TransferCap;
+                    }
+                    casterVitalChange = (uint)(vitalChange * (1.0f - spellStatMod.LossPercent));
+                    vitalChange = (uint)(casterVitalChange / (1.0f - spellStatMod.LossPercent));
+
+                    if (spellStatMod.Source == (int)PropertyAttribute2nd.Mana && (vitalChange + 10 + manaUsed) > Mana.Current)
+                    {
+                        ActionChain resourceCheckChain = new ActionChain();
+
+                        resourceCheckChain.AddAction(this, () =>
+                        {
+                            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                        });
+
+                        resourceCheckChain.AddDelaySeconds(2.0f);
+                        resourceCheckChain.AddAction(this, () =>
+                        {
+                            Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
+                            IsBusy = false;
+                        });
+
+                        resourceCheckChain.EnqueueChain();
+
+                        return;
+                    }
+
+                    if ((vitalChange + 10) > GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source))
+                    {
+                        ActionChain resourceCheckChain = new ActionChain();
+
+                        resourceCheckChain.AddAction(this, () =>
+                        {
+                            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                        });
+
+                        resourceCheckChain.AddDelaySeconds(2.0f);
+                        resourceCheckChain.AddAction(this, () => IsBusy = false);
+                        resourceCheckChain.EnqueueChain();
+
+                        return;
+                    }
+                }
+                else if (manaUsed > Mana.Current)
+                {
+                    ActionChain resourceCheckChain = new ActionChain();
+
+                    resourceCheckChain.AddAction(this, () =>
+                    {
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
+                    });
+
+                    resourceCheckChain.AddDelaySeconds(2.0f);
+                    resourceCheckChain.AddAction(this, () =>
+                    {
+                        Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
+                        IsBusy = false;
+                    });
+
+                    resourceCheckChain.EnqueueChain();
+
+                    return;
+                }
+                else
+                    Mana.Current = Mana.Current - manaUsed;
+            }
+            #endregion
+
+            ActionChain spellChain = new ActionChain();
+
+            uint fastCast = (spell.Bitfield >> 14) & 0x1u;
+            if (fastCast != 1)
+            {
+                spellChain.AddAction(this, () =>
+                {
+                    var motionWindUp = new UniversalMotion(MotionStance.Spellcasting);
+                    motionWindUp.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                    motionWindUp.MovementData.ForwardCommand = (uint)windUpMotion;
+                    motionWindUp.MovementData.ForwardSpeed = 2;
+                    DoMotion(motionWindUp);
+                });
+            }
+
+            spellChain.AddAction(this, () =>
+            {
+                CurrentLandblock.EnqueueBroadcast(Location, new GameMessageCreatureMessage(SpellComponentsTable.GetSpellWords(DatManager.PortalDat.SpellComponentsTable,
+                    formula), Name, Guid.Full, ChatMessageType.Magic));
+            });
+
+            spellChain.AddAction(this, () =>
+            {
+                var motionCastSpell = new UniversalMotion(MotionStance.Spellcasting);
+                motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
+                motionCastSpell.MovementData.ForwardSpeed = 2;
+                DoMotion(motionCastSpell);
+            });
+
+            if (fastCast == 1)
+            {
+                spellChain.AddDelaySeconds(castingDelay * 0.26f);
+            }
+            else
+                spellChain.AddDelaySeconds(castingDelay);
+
+            if (spellCastSuccess == false)
+                spellChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
+            else
+            {
+                // TODO - Successful spell casting code goes here for untargeted spells to replace line below
+                Session.Network.EnqueueSend(new GameMessageSystemChat("Targeted SpellID " + spellId + " not yet implemented!", ChatMessageType.System));
+            }
+
+            spellChain.AddAction(this, () =>
+            {
+                var motionReturnToCastStance = new UniversalMotion(MotionStance.Spellcasting);
+                motionReturnToCastStance.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
+                motionReturnToCastStance.MovementData.ForwardCommand = (uint)MotionCommand.Invalid;
+                DoMotion(motionReturnToCastStance);
+            });
+
+            spellChain.AddDelaySeconds(1.0f);
+
+            spellChain.AddAction(this, () =>
+            {
+                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.None));
+                IsBusy = false;
+            });
+
+            spellChain.EnqueueChain();
+
+            return;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -521,7 +521,7 @@ namespace ACE.Server.WorldObjects
             if (WeenieClassId == 1)
             {
                 // create enchantment
-                var enchantment = new Enchantment(target, spellStatMod.SpellId, 1, (uint)EnchantmentMask.CreatureSpells);
+                var enchantment = new Enchantment(target, spellStatMod.SpellId, 1, (uint)EnchantmentMask.CreatureSpells, null, castByItem);
                 var stackType = target.EnchantmentManager.Add(enchantment, castByItem);
 
                 var player = this as Player;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -520,8 +520,13 @@ namespace ACE.Server.WorldObjects
         {
             if (WeenieClassId == 1)
             {
+                double duration;
+                if (castByItem)
+                    duration = -1;
+                else
+                    duration = spell.Duration;
                 // create enchantment
-                var enchantment = new Enchantment(target, spellStatMod.SpellId, 1, (uint)EnchantmentMask.CreatureSpells, null, castByItem);
+                var enchantment = new Enchantment(target, spellStatMod.SpellId, duration, 1, (uint)EnchantmentMask.CreatureSpells);
                 var stackType = target.EnchantmentManager.Add(enchantment, castByItem);
 
                 var player = this as Player;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1888,6 +1888,30 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.ItemMaxMana); else SetProperty(PropertyInt.ItemMaxMana, value.Value); }
         }
 
+        public double? ManaRate
+        {
+            get => GetProperty(PropertyFloat.ManaRate);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ManaRate); else SetProperty(PropertyFloat.ManaRate, value.Value); }
+        }
+
+        public int? ItemDifficulty
+        {
+            get => GetProperty(PropertyInt.ItemDifficulty);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.ItemDifficulty); else SetProperty(PropertyInt.ItemDifficulty, value.Value); }
+        }
+
+        public int? AppraisalItemSkill
+        {
+            get => GetProperty(PropertyInt.AppraisalItemSkill);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.AppraisalItemSkill); else SetProperty(PropertyInt.AppraisalItemSkill, value.Value); }
+        }
+
+        public int? ItemSkillLevelLimit
+        {
+            get => GetProperty(PropertyInt.ItemSkillLevelLimit);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.ItemSkillLevelLimit); else SetProperty(PropertyInt.ItemSkillLevelLimit, value.Value); }
+        }
+
         public bool? NpcLooksLikeObject
         {
             get => GetProperty(PropertyBool.NpcLooksLikeObject);


### PR DESCRIPTION
- Adds the ability for items with spells to cast them on players
- Fixes the player combat with no weapons equipped, which previously had the potential to create a null exception is two locations
- The refresh of spells in the Enchantment registry needs some work, as they currently don't work correctly, until the client is restarted.