### PR TITLE
EmoteTable Stuff

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -873,6 +873,7 @@ namespace ACE.Server.Managers
 
         public void ExecuteEmote(BiotaPropertiesEmote emote, BiotaPropertiesEmoteAction emoteAction, ActionChain actionChain, WorldObject sourceObject = null, WorldObject targetObject = null)
         {
+            var player = targetObject as Player;
             switch ((EmoteType)emoteAction.Type)
             {
                 case EmoteType.Say:
@@ -886,8 +887,9 @@ namespace ACE.Server.Managers
 
                 case EmoteType.Motion:
 
-                    if (emote.Category != (uint)EmoteCategory.Vendor)
+                    if (emote.Category != (uint)EmoteCategory.Vendor && emote.Style != null)
                     {
+
                         var startingMotion = new UniversalMotion((MotionStance)emote.Style, new MotionItem((MotionCommand)emote.Substyle));
                         var motion = new UniversalMotion((MotionStance)emote.Style, new MotionItem((MotionCommand)emoteAction.Motion, emoteAction.Extent));
 
@@ -943,8 +945,51 @@ namespace ACE.Server.Managers
                     actionChain.AddDelaySeconds(emoteAction.Delay);
                     actionChain.AddAction(sourceObject, () =>
                     {
-                        var player = targetObject as Player;
                         player.Session.Network.EnqueueSend(new GameMessageHearDirectSpeech(sourceObject, emoteAction.Message, player, ChatMessageType.Tell));
+                    });
+                    break;
+
+                case EmoteType.TurnToTarget:
+                    var creature = sourceObject is Creature ? (Creature)sourceObject : null;
+                    actionChain.AddDelaySeconds(creature.Rotate(player));
+                    actionChain.AddAction(sourceObject, () =>
+                    {
+                        creature.Rotate(player);
+                        //WorldObject.PhysicsObj.TurnToObject(player.Guid.Full, new MovementParameters());
+                        //player.Session.Network.EnqueueSend(new GameMessageHearDirectSpeech(sourceObject, emoteAction.Message, player, ChatMessageType.Tell));
+                    });
+                    break;
+
+                case EmoteType.AwardXP:
+                    actionChain.AddAction(sourceObject, () =>
+                    {
+                        if (player != null)
+                        {
+                            player.EarnXP((long)emoteAction.Amount64);
+                            player.Session.Network.EnqueueSend(new GameMessageSystemChat("You've earned " + emoteAction.Amount64 + " experience.", ChatMessageType.System));
+                        }
+                    });
+                    break;
+
+                case EmoteType.Give:
+                    actionChain.AddAction(sourceObject, () =>
+                    {
+                        if (player != null)
+                        {
+                            uint weenie = (uint)emoteAction.WeenieClassId;
+                            WorldObject item = WorldObjectFactory.CreateNewWorldObject(weenie);
+                            if (emoteAction.WeenieClassId != null)
+                            {
+                                if (emoteAction.StackSize > 1)
+                                {
+                                    item.StackSize = (ushort)emoteAction.StackSize;
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat(WorldObject.Name + " gives you " + emoteAction.StackSize + " " + item.Name + ".", ChatMessageType.System));
+                                }
+                                else
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat(WorldObject.Name + " gives you " + item.Name + ".", ChatMessageType.System));
+                                var success = player.TryCreateInInventoryWithNetworking(item);
+                            }
+                        }
                     });
                     break;
 

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -952,12 +952,6 @@ namespace ACE.Server.Managers
                 case EmoteType.TurnToTarget:
                     var creature = sourceObject is Creature ? (Creature)sourceObject : null;
                     actionChain.AddDelaySeconds(creature.Rotate(player));
-                    actionChain.AddAction(sourceObject, () =>
-                    {
-                        creature.Rotate(player);
-                        //WorldObject.PhysicsObj.TurnToObject(player.Guid.Full, new MovementParameters());
-                        //player.Session.Network.EnqueueSend(new GameMessageHearDirectSpeech(sourceObject, emoteAction.Message, player, ChatMessageType.Tell));
-                    });
                     break;
 
                 case EmoteType.AwardXP:

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -709,10 +709,10 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
                     Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name +".", ChatMessageType.System));
                     WorldObject player = this;
-                    //if (target.handleReceive(item, amount, target, player))
-                    //{
-                    //    Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
-                    //}
+                    if (target.handleReceive(item, amount, target, player))
+                    {
+                        Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
+                    }
                     TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
                     Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
                 }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -761,7 +761,7 @@ namespace ACE.Server.WorldObjects
                     }
                     }
             }
-            if (target.GetProperty(PropertyBool.AllowGive) ?? false)
+            if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
             {
                 ///Item accepted by NPC that accepts anything
                 actionChain.AddAction(this, () =>

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -761,6 +761,18 @@ namespace ACE.Server.WorldObjects
                     }
                     }
             }
+            if (target.GetProperty(PropertyBool.AllowGive) ?? false)
+            {
+                ///Item accepted by NPC that accepts anything
+                actionChain.AddAction(this, () =>
+                {
+                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name + ".", ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
+                    TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
+                    Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
+                });
+            }
             actionChain.EnqueueChain();
             //SendUseDoneEvent();
         }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -697,28 +697,77 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionGiveObjectRequest(ObjectGuid targetID, ObjectGuid itemGuid, uint amount)
         {
-
+            
             WorldObject target = CurrentLandblock.GetObject(targetID) as WorldObject;
             WorldObject item = GetInventoryItem(itemGuid) as WorldObject;
             var actionChain = new ActionChain();
-            actionChain.AddDelaySeconds(Rotate(target));
-            actionChain.AddAction(this, () =>
+            if (!target.GetProperty(PropertyBool.AllowGive)??false)
             {
-                if (target.GetProperty(PropertyBool.AllowGive) == true)
+                Console.WriteLine("Allow give is false.");
+                actionChain.AddAction(this, () =>
                 {
-                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
-                    Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name +".", ChatMessageType.System));
-                    WorldObject player = this;
-                    if (target.HandleReceive(item, amount, target, player))
+                    Session.Network.EnqueueSend(new GameMessageSystemChat(target.Name + WeenieErrorWithString._IsNotAcceptingGiftsRightNow , ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
+                });
+                
+            }
+            else if(item.GetProperty(PropertyBool.Retained)??false)
+            {
+                Console.WriteLine("Item is retained.");
+                actionChain.AddAction(this, () =>
+                {
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("You can't give this item away.(Retained)", ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
+                });
+            }
+            else
+            {
+                Console.WriteLine("Turning to player.");
+                actionChain.AddDelaySeconds(Rotate(target));
+                
+                    if (target.GetProperty(PropertyBool.AllowGive) == true)
                     {
-                        Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
+                    var result = target.Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId);
+                    WorldObject player = this;
+                        if (target.HandleReceive(item, amount, target, player))
+                        {
+                        
+                            if (result.ElementAt(0).Category == 6)
+                            {
+                            Console.WriteLine("Inside handle receive, npc accepting item.");
+                            ///Item accepted by collector/NPC
+                            actionChain.AddAction(this, () =>
+                                {
+                                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
+                                    Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name + ".", ChatMessageType.System));
+                                    Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
+                                    TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
+                                    Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
+                                });
+                            }
+                            else if (result.ElementAt(0).Category == 1)
+                            {
+                            ////Item rejected by npc
+                            Console.WriteLine("Inside handle receive, npc NOT accepting item.");
+                            actionChain.AddAction(this, () =>
+                            {
+                                Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
+                                Session.Network.EnqueueSend(new GameMessageSystemChat(target.Name + " does not accept this item.", ChatMessageType.System));
+                            });
+                            }
+                        }
+                        else
+                        {
+                        actionChain.AddAction(this, () =>
+                        {
+                            Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
+                            Session.Network.EnqueueSend(new GameMessageSystemChat(target.Name + " does not accept this item.", ChatMessageType.System));
+                        });
                     }
-                    TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
-                    Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
-                }
-            });
+                    }
+            }
             actionChain.EnqueueChain();
-
+            //SendUseDoneEvent();
         }
 
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -701,8 +701,22 @@ namespace ACE.Server.WorldObjects
             WorldObject target = CurrentLandblock.GetObject(targetID) as WorldObject;
             WorldObject item = GetInventoryItem(itemGuid) as WorldObject;
             var actionChain = new ActionChain();
-            if (!target.GetProperty(PropertyBool.AllowGive)??false)
+            if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
             {
+                ///Item accepted by NPC that accepts anything
+                actionChain.AddDelaySeconds(Rotate(target));
+                actionChain.AddAction(this, () =>
+                {
+                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name + ".", ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
+                    TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
+                    Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
+                });
+            }
+            else if (!target.GetProperty(PropertyBool.AllowGive)??false)
+            {
+                actionChain.AddDelaySeconds(Rotate(target));
                 actionChain.AddAction(this, () =>
                 {
                     Session.Network.EnqueueSend(new GameMessageSystemChat(target.Name + WeenieErrorWithString._IsNotAcceptingGiftsRightNow , ChatMessageType.System));
@@ -712,6 +726,7 @@ namespace ACE.Server.WorldObjects
             }
             else if(item.GetProperty(PropertyBool.Retained)??false)
             {
+                actionChain.AddDelaySeconds(Rotate(target));
                 actionChain.AddAction(this, () =>
                 {
                     Session.Network.EnqueueSend(new GameMessageSystemChat("You can't give this item away.(Retained)", ChatMessageType.System));
@@ -761,20 +776,8 @@ namespace ACE.Server.WorldObjects
                     }
                     }
             }
-            if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
-            {
-                ///Item accepted by NPC that accepts anything
-                actionChain.AddAction(this, () =>
-                {
-                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
-                    Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name + ".", ChatMessageType.System));
-                    Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
-                    TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
-                    Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
-                });
-            }
+            
             actionChain.EnqueueChain();
-            //SendUseDoneEvent();
         }
 
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -703,7 +703,6 @@ namespace ACE.Server.WorldObjects
             var actionChain = new ActionChain();
             if (!target.GetProperty(PropertyBool.AllowGive)??false)
             {
-                Console.WriteLine("Allow give is false.");
                 actionChain.AddAction(this, () =>
                 {
                     Session.Network.EnqueueSend(new GameMessageSystemChat(target.Name + WeenieErrorWithString._IsNotAcceptingGiftsRightNow , ChatMessageType.System));
@@ -713,7 +712,6 @@ namespace ACE.Server.WorldObjects
             }
             else if(item.GetProperty(PropertyBool.Retained)??false)
             {
-                Console.WriteLine("Item is retained.");
                 actionChain.AddAction(this, () =>
                 {
                     Session.Network.EnqueueSend(new GameMessageSystemChat("You can't give this item away.(Retained)", ChatMessageType.System));
@@ -722,7 +720,6 @@ namespace ACE.Server.WorldObjects
             }
             else
             {
-                Console.WriteLine("Turning to player.");
                 actionChain.AddDelaySeconds(Rotate(target));
                 
                     if (target.GetProperty(PropertyBool.AllowGive) == true)
@@ -734,7 +731,6 @@ namespace ACE.Server.WorldObjects
                         
                             if (result.ElementAt(0).Category == 6)
                             {
-                            Console.WriteLine("Inside handle receive, npc accepting item.");
                             ///Item accepted by collector/NPC
                             actionChain.AddAction(this, () =>
                                 {
@@ -748,7 +744,6 @@ namespace ACE.Server.WorldObjects
                             else if (result.ElementAt(0).Category == 1)
                             {
                             ////Item rejected by npc
-                            Console.WriteLine("Inside handle receive, npc NOT accepting item.");
                             actionChain.AddAction(this, () =>
                             {
                                 Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -709,7 +709,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
                     Session.Network.EnqueueSend(new GameMessageSystemChat("You give " + target.Name + " " + item.Name +".", ChatMessageType.System));
                     WorldObject player = this;
-                    if (target.handleReceive(item, amount, target, player))
+                    if (target.HandleReceive(item, amount, target, player))
                     {
                         Session.Network.EnqueueSend(new GameMessageSound(this.Guid, Sound.ReceiveItem, 1));
                     }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -269,14 +269,14 @@ namespace ACE.Server.WorldObjects
         public bool HandleReceive(WorldObject item, uint amount, WorldObject receiver, WorldObject giver)
         {
             var emoteChain = new ActionChain();
-
+             
             var rng = Physics.Common.Random.RollDice(0.0f, 1.0f);
             var result = Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId && rng >= emote.Probability);
             if (result.Count() < 1)
             {
                 result = Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId);
             }
-
+            Console.WriteLine("Result.Count = " + result.Count());
             if (result.Count() > 0)
             {
                 var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == result.ElementAt(result.Count() - 1).EmoteSetId && action.EmoteCategory == result.ElementAt<BiotaPropertiesEmote>(0).Category);

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -276,7 +276,6 @@ namespace ACE.Server.WorldObjects
             {
                 result = Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId);
             }
-            Console.WriteLine("Result.Count = " + result.Count());
             if (result.Count() > 0)
             {
                 var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == result.ElementAt(result.Count() - 1).EmoteSetId && action.EmoteCategory == result.ElementAt<BiotaPropertiesEmote>(0).Category);

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -266,7 +266,34 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool Teleporting { get; set; } = false;
 
+        public bool HandleReceive(WorldObject item, uint amount, WorldObject receiver, WorldObject giver)
+        {
+            var emoteChain = new ActionChain();
 
+            var rng = Physics.Common.Random.RollDice(0.0f, 1.0f);
+            var result = Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId && rng >= emote.Probability);
+            if (result.Count() < 1)
+            {
+                result = Biota.BiotaPropertiesEmote.Where(emote => emote.WeenieClassId == item.WeenieClassId);
+            }
+
+            if (result.Count() > 0)
+            {
+                var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == result.ElementAt(result.Count() - 1).EmoteSetId && action.EmoteCategory == result.ElementAt<BiotaPropertiesEmote>(0).Category);
+
+                foreach (var action in actions)
+                {
+                    EmoteManager.ExecuteEmote(result.ElementAt(result.Count() - 1), action, emoteChain, receiver, giver);
+                }
+                emoteChain.EnqueueChain();
+                return true;
+
+            }
+            else
+            {
+                return false;
+            }
+        }
 
 
 


### PR DESCRIPTION
Added HandleReceive in WorldObjects
Checking within PlayerInventory if a HandleReceive is true.
Added new cases inside of ExecuteEmote.
Thiss allows all collectors and rng hand-ins, such as GamesMasters, to work.