### PR TITLE
@addallspells dev command

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -855,6 +855,21 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
+        // addallspells
+        [CommandHandler("addallspells", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Adds all known spells to your own spellbook.")]
+        public static void HandleAddAllSpells(Session session, params string[] parameters)
+        {
+            var spells = DatManager.PortalDat.SpellTable.Spells;
+
+            foreach(var spell in spells)
+            {
+                uint spellId = spell.Key;
+
+                if (Enum.IsDefined(typeof(Network.Enum.Spell), spellId))
+                    session.Player.LearnSpellWithNetworking((uint)spellId);
+            }
+        }
+
         // adminhouse
         [CommandHandler("adminhouse", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0)]
         public static void HandleAdminhouse(Session session, params string[] parameters)


### PR DESCRIPTION
Be gentle... I am a novice developer at best, and this is my first pull request ever, let alone first pull request on the ACE project.

I humbly submit a developer command to be used to learn all known spells on the current character.

I acknowledge this results in spells being learned that will never be castable by the player, and I also note that it asks the client to display way too many 'bubble' messages upon learning each spell, but the client seems to handle it more or less gracefully.

I had thought about learning all spells, except for the last spell with the AddKnownSpell() Method, and then just calling LearnSpellWithNetworking() on the last spell to update the client, but that seemed more hacky than having the client ingest lots of updateSpellEvent GameEvents.

Feedback is welcomed and encouraged.