### PR TITLE
On use emotes

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -987,6 +987,10 @@ namespace ACE.Server.Managers
                     });
                     break;
 
+                case EmoteType.UpdateQuest:
+                    //This is for the quest NPC's. This will be filled out when quests are added.
+                    break;
+
                 default:
                     log.Debug($"EmoteManager.Execute - Encountered Unhandled EmoteType {(EmoteType)emoteAction.Type} for {sourceObject.Name} ({sourceObject.WeenieClassId})");
                     break;

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -570,12 +570,21 @@ namespace ACE.Server.WorldObjects
             actionChain.AddDelaySeconds(player.Rotate(this));
             if (Biota.BiotaPropertiesEmote.Count > 0)
             {
-                var result = Biota.BiotaPropertiesEmote.Where(emote => emote.Category == 7) ?? null;
-                var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == 0 && action.EmoteCategory == result.ElementAt<BiotaPropertiesEmote>(0).Category);
+                var rng = Physics.Common.Random.RollDice(0.0f, 1.0f);
+                var result = Biota.BiotaPropertiesEmote.Where(emote => emote.Category == 7 && rng >= emote.Probability);
 
-                foreach (var action in actions)
+                if (result.Count() < 1)
                 {
-                    EmoteManager.ExecuteEmote(result.ElementAt(0), action, actionChain, this, player);
+                    result = Biota.BiotaPropertiesEmote.Where(emote => emote.Category == 7);
+                }
+                if (result.Count() > 0)
+                {
+                    var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == result.ElementAt(result.Count() - 1).EmoteSetId && action.EmoteCategory == result.ElementAt(result.Count() - 1).Category);
+
+                    foreach (var action in actions)
+                    {
+                        EmoteManager.ExecuteEmote(result.ElementAt(result.Count() - 1), action, actionChain, this, player);
+                    }
                 }
                 actionChain.EnqueueChain();
                 //OnAutonomousMove(player.Location, this.Sequences, MovementTypes.TurnToObject, playerId);

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -566,11 +566,27 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public override void ActOnUse(Player player)
         {
-            //OnAutonomousMove(player.Location, this.Sequences, MovementTypes.TurnToObject, playerId);
+            var actionChain = new ActionChain();
+            actionChain.AddDelaySeconds(player.Rotate(this));
+            if (Biota.BiotaPropertiesEmote.Count > 0)
+            {
+                var result = Biota.BiotaPropertiesEmote.Where(emote => emote.Category == 7) ?? null;
+                var actions = Biota.BiotaPropertiesEmoteAction.Where(action => action.EmoteSetId == 0 && action.EmoteCategory == result.ElementAt<BiotaPropertiesEmote>(0).Category);
 
-            //GameEventUseDone sendUseDoneEvent = new GameEventUseDone(player.Session);
-            //player.Session.Network.EnqueueSend(sendUseDoneEvent);
-            player.SendUseDoneEvent();
+                foreach (var action in actions)
+                {
+                    EmoteManager.ExecuteEmote(result.ElementAt(0), action, actionChain, this, player);
+                }
+                actionChain.EnqueueChain();
+                //OnAutonomousMove(player.Location, this.Sequences, MovementTypes.TurnToObject, playerId);
+                //GameEventUseDone sendUseDoneEvent = new GameEventUseDone(player.Session);
+                //player.Session.Network.EnqueueSend(sendUseDoneEvent);
+                player.SendUseDoneEvent();
+            }
+            else
+            {
+                player.SendUseDoneEvent();
+            }
         }
 
         public static readonly float TickInterval = 1.0f;


### PR DESCRIPTION
This code works for all collectors and should work for many more things. The only problem is is that there are emote tables missing. Also, with quest NPCs, the first emote for onUse is to update the quest. Once the quest is updated, It will then give dialogue about the quest. We do not have quest tables in to update it, so you will not see any information regarding quests.