### PR TITLE
Various missile combat fixes/additions

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -972,11 +972,15 @@ namespace ACE.Server.Command.Handlers
             string weenieClassDescription = parameters[0];
             bool wcid = uint.TryParse(weenieClassDescription, out uint weenieClassId);
 
-            var isValidStackSize = ushort.TryParse(parameters[1], out var stackSize);
-            if (parameters.Length > 1 && (!isValidStackSize || stackSize == 0))
+            ushort stackSize = 0;
+            if (parameters.Length > 1)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"stacksize must be number between 1 - {ushort.MaxValue}", ChatMessageType.Broadcast));
-                return;
+                var isValidStackSize = ushort.TryParse(parameters[1], out stackSize);
+                if (!isValidStackSize || stackSize == 0)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"stacksize must be number between 1 - {ushort.MaxValue}", ChatMessageType.Broadcast));
+                    return;
+                }
             }
 
             if (parameters.Length > 2 && !int.TryParse(parameters[2], out int palette))
@@ -1003,11 +1007,15 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat($"{weenieClassDescription} is not a valid weenie.", ChatMessageType.Broadcast));
                 return;
             }
+
+            if (stackSize != 0)
+            {
+                if (loot.MaxStackSize != null && stackSize > loot.MaxStackSize)
+                    loot.StackSize = loot.MaxStackSize;
+                else if (loot.MaxStackSize != null && stackSize <= loot.MaxStackSize)
+                    loot.StackSize = stackSize;
+            }
             
-            if (loot.MaxStackSize != null && stackSize > loot.MaxStackSize)
-                loot.StackSize = loot.MaxStackSize;
-            else if (loot.MaxStackSize != null && stackSize <= loot.MaxStackSize)
-                loot.StackSize = stackSize;
 
             // todo set the palette, shade here
 

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -972,7 +972,7 @@ namespace ACE.Server.Command.Handlers
             string weenieClassDescription = parameters[0];
             bool wcid = uint.TryParse(weenieClassDescription, out uint weenieClassId);
 
-            var isValidStackSize = int.TryParse(parameters[1], out var stackSize);
+            var isValidStackSize = ushort.TryParse(parameters[1], out var stackSize);
             if (parameters.Length > 1 && (!isValidStackSize || stackSize == 0))
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"stacksize must be number between 1 - {ushort.MaxValue}", ChatMessageType.Broadcast));
@@ -1007,7 +1007,7 @@ namespace ACE.Server.Command.Handlers
             if (loot.MaxStackSize != null && stackSize > loot.MaxStackSize)
                 loot.StackSize = loot.MaxStackSize;
             else if (loot.MaxStackSize != null && stackSize <= loot.MaxStackSize)
-                loot.StackSize = (ushort)stackSize;
+                loot.StackSize = stackSize;
 
             // todo set the palette, shade here
 

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDeleteObject.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDeleteObject.cs
@@ -3,9 +3,9 @@ using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.GameMessages.Messages
 {
-    public class GameMessageRemoveObject : GameMessage
+    public class GameMessageDeleteObject : GameMessage
     {
-        public GameMessageRemoveObject(WorldObject worldObject) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.SmartboxQueue)
+        public GameMessageDeleteObject(WorldObject worldObject) : base(GameMessageOpcode.ObjectDelete, GameMessageGroup.SmartboxQueue)
         {
             Writer.WriteGuid(worldObject.Guid);
             Writer.Write(worldObject.Sequences.GetCurrentSequence(SequenceType.ObjectInstance));

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -161,6 +161,16 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
+            var ammo = (this as Player)?.GetEquippedAmmo();
+            if (ammo != null)
+            {
+                if (ammo.Guid == objectGuid)
+                {
+                    container = null;
+                    return ammo;
+                }
+            }
+
             container = null;
             return null;
         }
@@ -393,11 +403,11 @@ namespace ACE.Server.WorldObjects
 
             player.Session.Network.EnqueueSend(new GameEventCloseGroundContainer(player.Session, this));
 
-            // send removeobject for all objects in this container's inventory to player
+            // send deleteobject for all objects in this container's inventory to player
             var itemsToSend = new List<GameMessage>();
 
             foreach (var item in Inventory.Values)
-                itemsToSend.Add(new GameMessageRemoveObject(item));
+                itemsToSend.Add(new GameMessageDeleteObject(item));
 
             player.Session.Network.EnqueueSend(itemsToSend.ToArray());
 

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -289,7 +289,10 @@ namespace ACE.Server.WorldObjects
             if (mEquipedAmmo != null)
                 CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectGhostRange, new GameMessagePickupEvent(mEquipedAmmo));
             if (player != null)
+            {
+                player.stance = MotionStance.Standing;
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat));
+            } 
         }
 
         public void HandleSwitchToMissileCombatMode(ActionChain combatModeChain)
@@ -348,11 +351,12 @@ namespace ACE.Server.WorldObjects
                     SetMotionState(this, mm);
                     // FIXME: (Og II)<this is a hack for now to be removed. Need to pull delay from dat file
                     combatModeChain.AddDelaySeconds(0.40);
-                    combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessageParentEvent(this, mEquipedAmmo, 1, 1)));
 
                     // add to player tracking
                     var wielder = CurrentLandblock.GetObject(new ObjectGuid(mEquipedAmmo.WielderId.Value));
                     combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueActionBroadcast(Location, Landblock.MaxObjectRange, (Player p) => p.TrackObject(wielder)));
+
+                    combatModeChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessageParentEvent(this, mEquipedAmmo, 1, 1)));
                 }
 
                 var player = this as Player;

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -2,6 +2,8 @@ using System;
 using System.Numerics;
 using ACE.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
@@ -42,6 +44,12 @@ namespace ACE.Server.WorldObjects
                 CurrentMotionState = motion;
             });
 
+            var ammo = GetEquippedAmmo();
+            if (ammo != null)
+                actionChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(Location,
+                    new GameMessageParentEvent(this, ammo, (int)ACE.Entity.Enum.ParentLocation.RightHand,
+                        (int)ACE.Entity.Enum.Placement.RightHandCombat)));
+
             actionChain.AddDelaySeconds(animLength);
 
             var player = this as Player;
@@ -49,6 +57,7 @@ namespace ACE.Server.WorldObjects
             {
                 actionChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventAttackDone(player.Session)));
                 actionChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventCombatCommmenceAttack(player.Session)));
+                // TODO: This gets rid of the hourglass but doesn't seem to be sent in retail pcaps...
                 actionChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventAttackDone(player.Session)));
             }
             actionChain.EnqueueChain();
@@ -59,8 +68,8 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-                 /// Gets the reload animation for the current weapon
-                 /// </summary>
+        /// Gets the reload animation for the current weapon
+        /// </summary>
         public MotionCommand GetReloadAnimation()
         {
             MotionCommand motion = new MotionCommand();
@@ -102,14 +111,42 @@ namespace ACE.Server.WorldObjects
             arrow.Location = new Position(loc.LandblockId.Raw, origin.X, origin.Y, origin.Z, loc.Rotation.X, loc.Rotation.Y, loc.Rotation.Z, loc.RotationW);
             SetProjectilePhysicsState(arrow);
 
-            LandblockManager.AddObject(arrow);
-            CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessageScript(arrow.Guid, ACE.Entity.Enum.PlayScript.Launch, 1.0f));
-
             var actionChain = new ActionChain();
-            actionChain.AddDelaySeconds(time);
 
-            // todo: landblock broadcast?
+            // TODO: Get correct aim level based on arrow velocity and add aim motion delay.
+            var motion = new UniversalMotion(CurrentMotionState.Stance);
+            motion.MovementData.CurrentStyle = (uint)CurrentMotionState.Stance;
+            motion.MovementData.ForwardCommand = (uint)MotionCommand.AimLevel;
+            CurrentMotionState = motion;
+
+            actionChain.AddAction(this, () => DoMotion(motion));
+            //actionChain.AddDelaySeconds(animLength);
+
+            actionChain.AddAction(this, () => LandblockManager.AddObject(arrow));
+            actionChain.AddAction(this, () => CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessagePickupEvent(ammo)));
+
             var player = this as Player;
+            // TODO: Add support for monster ammo depletion. For now only players will use up ammo.
+            if (player != null)
+                actionChain.AddAction(this, () => UpdateAmmoAfterLaunch(ammo));
+            // Not sure why this would be needed but it is sent in retail pcaps.
+            actionChain.AddAction(arrow, () => CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessageSetStackSize(arrow)));
+
+            if (player != null)
+            {
+                actionChain.AddAction(arrow, () => CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessagePublicUpdatePropertyInt(
+                    arrow, PropertyInt.PlayerKillerStatus, (int)(player.PlayerKillerStatus ?? ACE.Entity.Enum.PlayerKillerStatus.NPK) )));
+            }
+            else
+            {
+                actionChain.AddAction(arrow, () => CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessagePublicUpdatePropertyInt(
+                    arrow, PropertyInt.PlayerKillerStatus, (int)ACE.Entity.Enum.PlayerKillerStatus.Creature)));
+            }
+            
+            actionChain.AddAction(arrow, () => CurrentLandblock.EnqueueBroadcast(arrow.Location, new GameMessageScript(arrow.Guid, ACE.Entity.Enum.PlayScript.Launch, 0f)));
+            actionChain.AddDelaySeconds(time);
+            // todo: landblock broadcast?
+            
             if (player != null)
                 actionChain.AddAction(arrow, () => player.Session.Network.EnqueueSend(new GameMessageSound(arrow.Guid, Sound.Collision, 1.0f)));
 
@@ -117,6 +154,28 @@ namespace ACE.Server.WorldObjects
             actionChain.EnqueueChain();
 
             return time;
+        }
+
+        /// <summary>
+        /// Updates the ammo count or destroys the ammo after launching the projectile.
+        /// </summary>
+        /// <param name="ammo">The missile ammo object</param>
+        public void UpdateAmmoAfterLaunch(WorldObject ammo)
+        {
+            var player = this as Player;
+
+            if (ammo.StackSize == 1)
+            {
+                TryDequipObject(ammo.Guid);
+                player?.Session.Network.EnqueueSend(new GameMessageDeleteObject(ammo));
+                CurrentLandblock.EnqueueActionBroadcast(Location, Landblock.MaxObjectRange, p => p.StopTrackingObject(ammo, true));
+            }
+            else
+            {
+                ammo.StackSize--;
+                player?.Session.Network.EnqueueSend(new GameMessageSetStackSize(ammo));
+                CurrentLandblock.EnqueueBroadcast(Location, new GameMessagePickupEvent(ammo));
+            }
         }
 
         /// <summary>
@@ -150,6 +209,8 @@ namespace ACE.Server.WorldObjects
             obj.PathClipped = true;
             obj.Ethereal = false;
             obj.IgnoreCollisions = false;
+            obj.CurrentMotionState = null;
+            obj.Placement = ACE.Entity.Enum.Placement.MissileFlight;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -88,7 +88,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a projectile from player to target
         /// </summary>
-        public float LaunchProjectile(WorldObject target)
+        public WorldObject LaunchProjectile(WorldObject target, out float time)
         {
             var ammo = GetEquippedAmmo();
             var arrow = WorldObjectFactory.CreateNewWorldObject(ammo.WeenieClassId);
@@ -104,7 +104,7 @@ namespace ACE.Server.WorldObjects
 
             origin += dir * 2.0f;
 
-            arrow.Velocity = GetProjectileVelocity(target, origin, dir, dest, speed, out var time);
+            arrow.Velocity = GetProjectileVelocity(target, origin, dir, dest, speed, out time);
 
             var loc = Location;
             origin = Position.FromGlobal(origin).Pos;
@@ -153,7 +153,7 @@ namespace ACE.Server.WorldObjects
             actionChain.AddAction(arrow, () => CurrentLandblock.RemoveWorldObject(arrow.Guid, false));
             actionChain.EnqueueChain();
 
-            return time;
+            return arrow;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -74,7 +74,7 @@ namespace ACE.Server.WorldObjects
             var bodyPart = GetBodyPart();
 
             float targetTime = 0.0f;
-            targetTime = LaunchProjectile(AttackTarget);
+            var damageSource = LaunchProjectile(AttackTarget, out targetTime);
             var animLength = ReloadMotion();
 
             var actionChain = new ActionChain();

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -228,7 +228,7 @@ namespace ACE.Server.WorldObjects
 
 
 
-        private MotionStance stance = MotionStance.Standing;
+        public MotionStance stance = MotionStance.Standing;
 
 
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -75,7 +75,7 @@ namespace ACE.Server.WorldObjects
             {
                 // notify attacker
                 var intDamage = (uint)Math.Round(damage);
-                if (damageSource.ItemType == ItemType.MissileWeapon)
+                if (damageSource?.ItemType == ItemType.MissileWeapon)
                 {
                     var damageType = (DamageType)damageSource.GetProperty(PropertyInt.DamageType);
                     Session.Network.EnqueueSend(new GameEventAttackerNotification(Session, target.Name, damageType, (float)intDamage / creature.Health.MaxValue, intDamage, critical, new AttackConditions()));
@@ -151,7 +151,7 @@ namespace ACE.Server.WorldObjects
 
             // get target resistance
             DamageType damageType;
-            if (damageSource.ItemType == ItemType.MissileWeapon)
+            if (damageSource?.ItemType == ItemType.MissileWeapon)
             {
                 damageType = (DamageType) damageSource.GetProperty(PropertyInt.DamageType);
             }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -57,7 +57,7 @@ namespace ACE.Server.WorldObjects
             return attackType;
         }
 
-        public void DamageTarget(WorldObject target)
+        public void DamageTarget(WorldObject target, WorldObject damageSource)
         {
             var creature = target as Creature;
 
@@ -65,7 +65,7 @@ namespace ACE.Server.WorldObjects
                 return;
 
             var critical = false;
-            var damage = CalculateDamage(target, ref critical);
+            var damage = CalculateDamage(target, damageSource, ref critical);
             if (damage > 0.0f)
                 target.TakeDamage(this, damage, critical);
             else
@@ -75,7 +75,15 @@ namespace ACE.Server.WorldObjects
             {
                 // notify attacker
                 var intDamage = (uint)Math.Round(damage);
-                Session.Network.EnqueueSend(new GameEventAttackerNotification(Session, target.Name, GetDamageType(), (float)intDamage / creature.Health.MaxValue, intDamage, critical, new AttackConditions()));
+                if (damageSource.ItemType == ItemType.MissileWeapon)
+                {
+                    var damageType = (DamageType)damageSource.GetProperty(PropertyInt.DamageType);
+                    Session.Network.EnqueueSend(new GameEventAttackerNotification(Session, target.Name, damageType, (float)intDamage / creature.Health.MaxValue, intDamage, critical, new AttackConditions()));
+                }
+                else
+                {
+                    Session.Network.EnqueueSend(new GameEventAttackerNotification(Session, target.Name, GetDamageType(), (float)intDamage / creature.Health.MaxValue, intDamage, critical, new AttackConditions()));
+                }
 
                 // splatter effects
                 Session.Network.EnqueueSend(new GameMessageSound(target.Guid, Sound.HitFlesh1, 0.5f));
@@ -111,7 +119,7 @@ namespace ACE.Server.WorldObjects
             return damageSource != null ? damageSource.GetDamageMod(this) : new Range(1, 5);
         }
 
-        public float CalculateDamage(WorldObject target, ref bool criticalHit)
+        public float CalculateDamage(WorldObject target, WorldObject damageSource, ref bool criticalHit)
         {
             // evasion chance
             var evadeChance = GetEvadeChance(target);
@@ -142,7 +150,13 @@ namespace ACE.Server.WorldObjects
             var armor = GetArmor(target, bodyPart);
 
             // get target resistance
-            var damageType = GetDamageType();
+            DamageType damageType;
+            if (damageSource.ItemType == ItemType.MissileWeapon)
+            {
+                damageType = (DamageType) damageSource.GetProperty(PropertyInt.DamageType);
+            }
+            else
+                damageType = GetDamageType();
             var resistance = GetResistance(target, bodyPart, damageType);
 
             // scale damage for armor

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -130,7 +130,7 @@ namespace ACE.Server.WorldObjects
                 // destroy all stacks of currency required / sale
                 foreach (WorldObject wo in cost)
                 {
-                    TryDestroyFromInventoryWithNetworking(wo);
+                    TryRemoveFromInventoryWithNetworking(wo);
 
                     /*TryRemoveFromInventory(wo.Guid);
                     ObjectGuid clearContainer = new ObjectGuid(0);
@@ -140,7 +140,7 @@ namespace ACE.Server.WorldObjects
                     throw new NotImplementedException();
                     // todo fix for EF
                     //DatabaseManager.Shard.DeleteObject(wo.SnapShotOfAceObject(), null);*/
-                    Session.Network.EnqueueSend(new GameMessageRemoveObject(wo));
+                    Session.Network.EnqueueSend(new GameMessageDeleteObject(wo));
                 }
 
                 // if there is change - readd - do this at the end to try to prevent exploiting
@@ -270,7 +270,7 @@ namespace ACE.Server.WorldObjects
                 // todo fix for EF
                 //DatabaseManager.Shard.DeleteObject(item.SnapShotOfAceObject(), null);
 
-                Session.Network.EnqueueSend(new GameMessageRemoveObject(item));
+                Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
                 purchaselist.Add(item);
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -86,7 +86,8 @@ namespace ACE.Server.WorldObjects
             var creature = target as Creature;
             var actionChain = DoSwingMotion(target, out float animLength);
 
-            DamageTarget(target);
+            // TODO: Send correct damage source.
+            DamageTarget(target, null);
 
             if (creature.Health.Current > 0 && GetCharacterOption(CharacterOption.AutoRepeatAttacks))
             { 

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -77,12 +77,12 @@ namespace ACE.Server.WorldObjects
             CurrentLandblock.EnqueueBroadcast(Location, new GameMessageSound(Guid, sound, 1.0f));
 
             float targetTime = 0.0f;
-            targetTime = LaunchProjectile(target);
+            var damageSource = LaunchProjectile(target, out targetTime);
             var animLength = ReloadMotion();
 
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(targetTime);
-            actionChain.AddAction(this, () => DamageTarget(target));
+            actionChain.AddAction(this, () => DamageTarget(target, damageSource));
             if (creature.Health.Current > 0 && GetCharacterOption(CharacterOption.AutoRepeatAttacks))
             {
                 // reload animation, accuracy bar refill

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -62,6 +62,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void LaunchMissile(WorldObject target)
         {
+            if (GetEquippedAmmo() == null || CombatMode == CombatMode.NonCombat)
+                return;
+
             var creature = target as Creature;
             if (MissileTarget == null || creature.Health.Current <= 0)
             {
@@ -71,7 +74,7 @@ namespace ACE.Server.WorldObjects
 
             var weapon = GetEquippedWeapon();
             var sound = weapon.DefaultCombatStyle == CombatStyle.Crossbow ? Sound.CrossbowRelease : Sound.BowRelease;
-            Session.Network.EnqueueSend(new GameMessageSound(Guid, sound, 1.0f));
+            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageSound(Guid, sound, 1.0f));
 
             float targetTime = 0.0f;
             targetTime = LaunchProjectile(target);

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -120,7 +120,8 @@ namespace ACE.Server.WorldObjects
                 if (item.CurrentWieldedLocation == EquipMask.MissileAmmo)
                 {
                     item.ParentLocation = null;
-                    item.Placement = null;
+                    item.Placement = ACE.Entity.Enum.Placement.Resting;
+                    item.Location = null;
                 }
                 session.Network.EnqueueSend(new GameMessageCreateObject(item));
             }

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -106,16 +106,22 @@ namespace ACE.Server.WorldObjects
 
             foreach (var item in EquippedObjects.Values)
             {
-                if ((item.CurrentWieldedLocation != null) && (((EquipMask)item.CurrentWieldedLocation & EquipMask.Selectable) != 0))
+                if (item.CurrentWieldedLocation != null
+                    && ((EquipMask)item.CurrentWieldedLocation & EquipMask.Selectable) != 0
+                    && item.CurrentWieldedLocation != EquipMask.MissileAmmo)
                 {
                     int placementId;
                     int parentLocation;
                     session.Player.SetChild(item, (int)item.CurrentWieldedLocation, out placementId, out parentLocation);
                     item.CurrentMotionState = null;
-                    item.Placement = (Placement)placementId;
-                    item.ParentLocation = (ParentLocation)parentLocation;
                 }
 
+                // We don't want missile ammo to appear in the players right hand on login.
+                if (item.CurrentWieldedLocation == EquipMask.MissileAmmo)
+                {
+                    item.ParentLocation = null;
+                    item.Placement = null;
+                }
                 session.Network.EnqueueSend(new GameMessageCreateObject(item));
             }
         }

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -178,7 +178,7 @@ namespace ACE.Server.WorldObjects
 
             // Don't remove it if it went into our inventory...
             if (removed && remove)
-                Session.Network.EnqueueSend(new GameMessageRemoveObject(worldObject));
+                Session.Network.EnqueueSend(new GameMessageDeleteObject(worldObject));
 
             return removed;
         }

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -194,7 +194,7 @@ namespace ACE.Server.WorldObjects
                 {
                     player.LearnSpellWithNetworking(SpellId);
                     player.HandleActionMotion(motionReady);
-                    if (player.TryDestroyFromInventoryWithNetworking(this))
+                    if (player.TryRemoveFromInventoryWithNetworking(this))
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat("The scroll is destroyed.", ChatMessageType.Magic));
                 });
             }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,19 @@
 # ACEmulator Change Log
 
 ### 2018-05-24
+[Slushnas]
+* Renamed GameMessageRemoveObject to GameMessageDeleteObject to avoid confusion with other messages.
+* Renamed TryDestroyFromInventoryWithNetworking() to TryRemoveFromInventoryWithNetworking() as that function sends InventoryRemoveObject messages.
+* Cleaned up some stack merging code and added support for merging missile ammo to currently equipped ammo.
+* Added the ability to set the stacksize of spawned items created with the /ci command.
+* Fix for observed players improperly playing last combat mode animation when moving.
+* Fixed missile ammo appearing in players hands on login.
+* Fixed arrows being fired after switching to peace mode.
+* Added ammo usage to player missile attacks.
+* Added damageSource parameter to damage functions to better support edge cases.
+* Various other minor tweaks to bring sent game messages more in line with retail pcaps.
+
+### 2018-05-24
 **ACE-World-16PY world db release v0.0.14+ required with this update**
 
 **You will need drop and recreate both Shard and World databases with this update**


### PR DESCRIPTION
* Renamed GameMessageRemoveObject to GameMessageDeleteObject to avoid confusion with other messages.
* Renamed TryDestroyFromInventoryWithNetworking() to TryRemoveFromInventoryWithNetworking() as that function sends InventoryRemoveObject messages.
* Cleaned up some stack merging code and added support for merging missile ammo to currently equipped ammo.
* Added the ability to set the stacksize of spawned items created with the /ci command.
* Fix for observed players improperly playing last combat mode animation when moving.
* Fixed missile ammo appearing in players hands on login.
* Fixed arrows being fired after switching to peace mode.
* Added ammo usage to player missile attacks.
* Added damageSource parameter to damage functions to better support edge cases.
* Various other minor tweaks to bring sent game messages more in line with retail pcaps.