### PR TITLE
Fix Defender notification message length.

### DIFF
--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventDefenderNotification.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventDefenderNotification.cs
@@ -14,8 +14,9 @@ namespace ACE.Server.Network.GameEvent.Events
             Writer.Write((double)percent);
             Writer.Write(damage);
             Writer.Write((uint)damageLocation);
-            Writer.Write(Convert.ToUInt16(criticalHit));
+            Writer.Write(Convert.ToUInt32(criticalHit));
             Writer.Write((UInt64)attackConditions);
+            Writer.Align();
         }
     }
 }


### PR DESCRIPTION
I noticed this message wasn't parsing correctly. This should fix it.