### PR TITLE
WAN reliability, message queues, refactoring

### DIFF
--- a/Source/ACE.Server/Network/MessageFragment.cs
+++ b/Source/ACE.Server/Network/MessageFragment.cs
@@ -1,0 +1,101 @@
+using ACE.Server.Network.GameMessages;
+using log4net;
+using System;
+using System.IO;
+
+namespace ACE.Server.Network
+{
+    internal class MessageFragment
+    {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public GameMessage Message { get; private set; }
+
+        public uint Sequence { get; set; }
+
+        public ushort Index { get; set; }
+
+        public ushort Count { get; set; }
+
+        public uint DataLength => (uint)Message.Data.Length;
+
+        public uint DataRemaining { get; private set; }
+
+        public uint NextSize
+        {
+            get
+            {
+                var dataSize = DataRemaining;
+                if (dataSize > ServerPacketFragment.MaxFragmentDataSize)
+                    dataSize = ServerPacketFragment.MaxFragmentDataSize;
+                return PacketFragmentHeader.HeaderSize + dataSize;
+            }
+        }
+
+        public uint TailSize => PacketFragmentHeader.HeaderSize + (DataLength % ServerPacketFragment.MaxFragmentDataSize);
+
+        public bool TailSent { get; private set; }
+
+        public MessageFragment(GameMessage message, uint sequence)
+        {
+            Message = message;
+            DataRemaining = DataLength;
+            Sequence = sequence;
+            Count = (ushort)(Math.Ceiling((double)DataLength / PacketFragment.MaxFragmentDataSize));
+            Index = 0;
+            if (Count == 1)
+                TailSent = true;
+            log.DebugFormat("Sequence {0}, count {1}, DataRemaining {2}", sequence, Count, DataRemaining);
+        }
+
+        public ServerPacketFragment GetTailFragment()
+        {
+            var index = (ushort)(Count - 1);
+            TailSent = true;
+            return CreateServerFragment(index);
+        }
+
+        public ServerPacketFragment GetNextFragment()
+        {
+            return CreateServerFragment(Index++);
+        }
+
+        private ServerPacketFragment CreateServerFragment(ushort index)
+        {
+            log.DebugFormat("Creating ServerFragment for index {0}", index);
+            if (index >= Count)
+                throw new ArgumentOutOfRangeException("index", index, "Passed index is greater then computed count");
+
+            var position = index * ServerPacketFragment.MaxFragmentDataSize;
+            if (position > DataLength)
+                throw new ArgumentOutOfRangeException("index", index, "Passed index computes to invalid position size");
+
+            if (DataRemaining <= 0)
+                throw new InvalidOperationException("There is no data remaining");
+
+            var dataToSend = DataLength - position;
+            if (dataToSend > ServerPacketFragment.MaxFragmentDataSize)
+                dataToSend = ServerPacketFragment.MaxFragmentDataSize;
+
+            if (DataRemaining < dataToSend)
+                throw new InvalidOperationException("More data to send then data remaining!");
+
+            // Read data starting at position reading dataToSend bytes
+            Message.Data.Seek(position, SeekOrigin.Begin);
+            byte[] data = new byte[dataToSend];
+            Message.Data.Read(data, 0, (int)dataToSend);
+
+            // Build ServerPacketFragment structure
+            ServerPacketFragment fragment = new ServerPacketFragment(data);
+            fragment.Header.Sequence = Sequence;
+            fragment.Header.Id = 0x80000000;
+            fragment.Header.Count = Count;
+            fragment.Header.Index = index;
+            fragment.Header.Group = (ushort)Message.Group;
+
+            DataRemaining -= dataToSend;
+            log.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);
+            return fragment;
+        }
+    }
+}

--- a/Source/ACE.Server/Network/MessageFragment.cs
+++ b/Source/ACE.Server/Network/MessageFragment.cs
@@ -91,7 +91,7 @@ namespace ACE.Server.Network
             fragment.Header.Id = 0x80000000;
             fragment.Header.Count = Count;
             fragment.Header.Index = index;
-            fragment.Header.Group = (ushort)Message.Group;
+            fragment.Header.Queue = (ushort)Message.Group;
 
             DataRemaining -= dataToSend;
             log.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);

--- a/Source/ACE.Server/Network/PacketFragmentHeader.cs
+++ b/Source/ACE.Server/Network/PacketFragmentHeader.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace ACE.Server.Network
@@ -13,7 +13,7 @@ namespace ACE.Server.Network
         public ushort Count { get; set; }
         public ushort Size { get; set; }
         public ushort Index { get; set; }
-        public ushort Group { get; set; }
+        public ushort Queue { get; set; }
 
         public PacketFragmentHeader() { }
 
@@ -24,7 +24,7 @@ namespace ACE.Server.Network
             Count = payload.ReadUInt16();
             Size = payload.ReadUInt16();
             Index = payload.ReadUInt16();
-            Group = payload.ReadUInt16();
+            Queue = payload.ReadUInt16();
         }
 
         public byte[] GetRaw()

--- a/Source/ACE.Server/Network/PacketHeader.cs
+++ b/Source/ACE.Server/Network/PacketHeader.cs
@@ -15,7 +15,7 @@ namespace ACE.Server.Network
         public ushort Id { get; set; }
         public ushort Time { get; set; }
         public ushort Size { get; set; }
-        public ushort Table { get; set; }
+        public ushort Iteration { get; set; }
 
         public PacketHeader() { }
 
@@ -27,7 +27,7 @@ namespace ACE.Server.Network
             Id = payload.ReadUInt16();
             Time = payload.ReadUInt16();
             Size = payload.ReadUInt16();
-            Table = payload.ReadUInt16();
+            Iteration = payload.ReadUInt16();
         }
 
         public byte[] GetRaw()

--- a/Source/ACE.Server/Network/PacketHeaderFlags.cs
+++ b/Source/ACE.Server/Network/PacketHeaderFlags.cs
@@ -1,28 +1,32 @@
-﻿using System;
+using System;
 
 namespace ACE.Server.Network
 {
     [Flags]
-    public enum PacketHeaderFlags : uint
+    public enum PacketHeaderFlags : uint  //ACE
     {
-        None              = 0x00000000,
-        Retransmission    = 0x00000001,
-        EncryptedChecksum = 0x00000002, // can't be paired with 0x00000001, see FlowQueue::DequeueAck
-        BlobFragments     = 0x00000004,
-        ServerSwitch      = 0x00000100,
-        Referral          = 0x00000800,
-        RequestRetransmit = 0x00001000,
-        RejectRetransmit  = 0x00002000,
-        AckSequence       = 0x00004000,
-        Disconnect        = 0x00008000,
-        LoginRequest      = 0x00010000,
-        WorldLoginRequest = 0x00020000,
-        ConnectRequest    = 0x00040000,
-        ConnectResponse   = 0x00080000,
-        CICMDCommand      = 0x00400000,
-        TimeSynch         = 0x01000000,
-        EchoRequest       = 0x02000000,
-        EchoResponse      = 0x04000000,
-        Flow              = 0x08000000
+        None = 0x00000000,
+        Retransmission = 0x00000001,
+        EncryptedChecksum = 0x00000002,     // can't be paired with 0x00000001, see FlowQueue::DequeueAck
+        BlobFragments = 0x00000004,
+        ServerSwitch = 0x00000100,          // Server Switch
+        LogonServerAddr = 0x00000200,       // Logon Server Addr
+        EmptyHeader1 = 0x00000400,          // Empty Header 1
+        Referral = 0x00000800,              // Referral
+        RequestRetransmit = 0x00001000,     // Nak
+        RejectRetransmit = 0x00002000,      // Empty Ack
+        AckSequence = 0x00004000,           // Pak
+        Disconnect = 0x00008000,            // Empty Header 2
+        LoginRequest = 0x00010000,          // Login
+        WorldLoginRequest = 0x00020000,     // ULong 1
+        ConnectRequest = 0x00040000,        // Connect
+        ConnectResponse = 0x00080000,       // ULong 2
+        NetError = 0x00100000,              // Net Error
+        NetErrorDisconnect = 0x00200000,    // Net Error Disconnect
+        CICMDCommand = 0x00400000,          // ICmd
+        TimeSync = 0x01000000,              // Time Sync
+        EchoRequest = 0x02000000,           // Echo Request
+        EchoResponse = 0x04000000,          // Echo Response
+        Flow = 0x08000000                   // Flow
     }
 }

--- a/Source/ACE.Server/Network/PacketHeaderOptional.cs
+++ b/Source/ACE.Server/Network/PacketHeaderOptional.cs
@@ -82,7 +82,7 @@ namespace ACE.Server.Network
                 writer.Write(payload.ReadBytes(8));
             }
 
-            if (header.HasFlag(PacketHeaderFlags.TimeSynch)) // 0x1000000
+            if (header.HasFlag(PacketHeaderFlags.TimeSync)) // 0x1000000
             {
                 TimeSynch = payload.ReadDouble();
                 writer.Write(TimeSynch);

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -248,7 +248,7 @@ namespace ACE.Server.Network
             if (packet.Header.HasFlag(PacketHeaderFlags.ConnectResponse) && State != SessionState.AuthConnectResponse)
                 return false;
 
-            if (packet.Header.HasFlag(PacketHeaderFlags.AckSequence | PacketHeaderFlags.TimeSynch | PacketHeaderFlags.EchoRequest | PacketHeaderFlags.Flow) && State == SessionState.AuthLoginRequest)
+            if (packet.Header.HasFlag(PacketHeaderFlags.AckSequence | PacketHeaderFlags.TimeSync | PacketHeaderFlags.EchoRequest | PacketHeaderFlags.Flow) && State == SessionState.AuthLoginRequest)
                 return false;
 
             return true;


### PR DESCRIPTION
WAN sessions are now at least reliable enough to test with
message fragments are now grouped by queue
refactor PacketFragmentHeader.Queue to match aclogview
refactor Packet.Header.Iteration to match aclogview
included some missing header flags from aclogview
include aclogview packet header flag names as comments
refactor typo in packet header flag names