### PR TITLE
Give Request fix

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -941,7 +941,7 @@ namespace ACE.Server.WorldObjects
         {
             
             WorldObject target = CurrentLandblock.GetObject(targetID) as WorldObject;
-            WorldObject item = GetInventoryItem(itemGuid) as WorldObject ?? GetWieldedItem(itemGuid) as WorldObject; ; ;
+            WorldObject item = GetInventoryItem(itemGuid) as WorldObject ?? GetWieldedItem(itemGuid) as WorldObject; 
             var actionChain = new ActionChain();
             if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -941,7 +941,7 @@ namespace ACE.Server.WorldObjects
         {
             
             WorldObject target = CurrentLandblock.GetObject(targetID) as WorldObject;
-            WorldObject item = GetInventoryItem(itemGuid) as WorldObject;
+            WorldObject item = GetInventoryItem(itemGuid) as WorldObject ?? GetWieldedItem(itemGuid) as WorldObject; ; ;
             var actionChain = new ActionChain();
             if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -941,7 +941,15 @@ namespace ACE.Server.WorldObjects
         {
             
             WorldObject target = CurrentLandblock.GetObject(targetID) as WorldObject;
-            WorldObject item = GetInventoryItem(itemGuid) as WorldObject ?? GetWieldedItem(itemGuid) as WorldObject; 
+            WorldObject item = GetInventoryItem(itemGuid) as WorldObject ?? GetWieldedItem(itemGuid) as WorldObject;
+            if(item == null)
+            {
+                ///This return glitches the client but does prevent the server from crashing when your main pack, which is you, is attempted to be given to a town crier. I cannot find an attempt of this in pcaps so I do not know what the client is expecting so that the hourglass will go away.
+                item = CurrentLandblock.GetObject(itemGuid) as WorldObject;
+                Session.Network.EnqueueSend(new GameMessageSystemChat("Cannot give " + item.Name + " to " + target.Name, ChatMessageType.System));
+                return;
+            }
+            Console.WriteLine("The item's name is " + item.Name);
             var actionChain = new ActionChain();
             if (target.GetProperty(PropertyBool.AiAcceptEverything) ?? false)
             {


### PR DESCRIPTION
Selected Wielded Objects as well as Inventory Objects. This fixes crash of gioving wielded objects to the town crier.