### PR TITLE
Adding landblock unloading system, and player corpses

### DIFF
--- a/Database/Updates/Shard/2018-06-22-alter-anim-texture-keys.sql
+++ b/Database/Updates/Shard/2018-06-22-alter-anim-texture-keys.sql
@@ -1,0 +1,6 @@
+alter table biota_properties_anim_part add column `order` tinyint(3) unsigned;
+alter table biota_properties_texture_map add column `order` tinyint(3) unsigned;
+
+alter table biota_properties_anim_part drop key `object_Id_index_uidx`, add unique key `object_Id_index_uidx`(`object_Id`,`index`,`animation_Id`);
+alter table biota_properties_texture_map drop key `object_Id_index_oldId_uidx`, add unique key `object_Id_index_oldId_uidx`(`object_Id`,`index`,`old_Id`, `new_Id`);
+

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard
@@ -9,6 +9,7 @@ namespace ACE.Database.Models.Shard
         public uint ObjectId { get; set; }
         public byte Index { get; set; }
         public uint AnimationId { get; set; }
+        public byte Order { get; set; }
 
         public Biota Object { get; set; }
     }

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard
@@ -10,6 +10,7 @@ namespace ACE.Database.Models.Shard
         public byte Index { get; set; }
         public uint OldId { get; set; }
         public uint NewId { get; set; }
+        public byte Order { get; set; }
 
         public Biota Object { get; set; }
     }

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -71,7 +71,7 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("biota_properties_anim_part");
 
-                entity.HasIndex(e => new { e.ObjectId, e.Index })
+                entity.HasIndex(e => new { e.ObjectId, e.Index, e.AnimationId })
                     .HasName("object_Id_index_uidx")
                     .IsUnique();
 
@@ -80,6 +80,8 @@ namespace ACE.Database.Models.Shard
                 entity.Property(e => e.AnimationId).HasColumnName("animation_Id");
 
                 entity.Property(e => e.Index).HasColumnName("index");
+
+                entity.Property(e => e.Order).HasColumnName("order");
 
                 entity.Property(e => e.ObjectId)
                     .HasColumnName("object_Id")
@@ -1251,7 +1253,7 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("biota_properties_texture_map");
 
-                entity.HasIndex(e => new { e.ObjectId, e.Index, e.OldId })
+                entity.HasIndex(e => new { e.ObjectId, e.Index, e.OldId, e.NewId })
                     .HasName("object_Id_index_oldId_uidx")
                     .IsUnique();
 
@@ -1266,6 +1268,8 @@ namespace ACE.Database.Models.Shard
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.OldId).HasColumnName("old_Id");
+
+                entity.Property(e => e.Order).HasColumnName("order");
 
                 entity.HasOne(d => d.Object)
                     .WithMany(p => p.BiotaPropertiesTextureMap)

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -361,6 +361,15 @@ namespace ACE.Database
 
         }
 
+        public void GetObjectsByLandblock(ushort landblockId, Action<List<Biota>> callback)
+        {
+            _queue.Add(new Task(() =>
+            {
+                var c = _wrappedDatabase.GetObjectsByLandblock(landblockId);
+                callback?.Invoke(c);
+            }));
+        }
+
 
 
 

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -892,5 +892,26 @@ namespace ACE.Database
 
             return items;
         }
+
+        public List<Biota> GetObjectsByLandblock(ushort landblockId)
+        {
+            var decayables = new List<Biota>();
+
+            using (var context = new ShardDbContext())
+            {
+                // TODO: performance concerns, indexing
+                var results = context.BiotaPropertiesPosition.Where(p => p.ObjCellId >> 16 == landblockId);
+
+                foreach (var result in results)
+                {
+                    var biota = GetBiota(context, result.ObjectId, false);
+
+                    if (biota != null && biota.WeenieType == (int)WeenieType.Corpse)
+                        decayables.Add(biota);
+                }
+                //Console.WriteLine("GetObjectsByLandblock(" + landblockId.ToString("X4") + "): " + decayables.Count);
+            }
+            return decayables;
+        }
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyAttribute2nd.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyAttribute2nd.cs
@@ -40,7 +40,7 @@ namespace ACE.Entity.Enum.Properties
         /// <returns>string with spaces infront of capital letters</returns>
         public static string ToSentence(this PropertyAttribute2nd attribute2nd)
         {
-            return new string(attribute2nd.ToString().Replace("Max", "Maximum").ToCharArray().SelectMany((c, i) => i > 0 && char.IsUpper(c) ? new char[] { ' ', c } : new char[] { c }).ToArray());
+            return new string(attribute2nd.ToString().Replace("Max", "").ToCharArray().SelectMany((c, i) => i > 0 && char.IsUpper(c) ? new char[] { ' ', c } : new char[] { c }).ToArray());
         }
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyAttribute2nd.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyAttribute2nd.cs
@@ -40,7 +40,7 @@ namespace ACE.Entity.Enum.Properties
         /// <returns>string with spaces infront of capital letters</returns>
         public static string ToSentence(this PropertyAttribute2nd attribute2nd)
         {
-            return new string(attribute2nd.ToString().Replace("Max", "").ToCharArray().SelectMany((c, i) => i > 0 && char.IsUpper(c) ? new char[] { ' ', c } : new char[] { c }).ToArray());
+            return new string(attribute2nd.ToString().Replace("Max", "Maximum").ToCharArray().SelectMany((c, i) => i > 0 && char.IsUpper(c) ? new char[] { ' ', c } : new char[] { c }).ToArray());
         }
     }
 }

--- a/Source/ACE.Entity/LandblockId.cs
+++ b/Source/ACE.Entity/LandblockId.cs
@@ -94,5 +94,10 @@ namespace ACE.Entity
         {
             return base.GetHashCode();
         }
+
+        public override string ToString()
+        {
+            return (Raw | 0xFFFF).ToString("X8");
+        }
     }
 }

--- a/Source/ACE.Server/Entity/Adjacency.cs
+++ b/Source/ACE.Server/Entity/Adjacency.cs
@@ -14,4 +14,31 @@ namespace ACE.Server.Entity
         SouthWest       = 6,
         West            = 7
     }
+
+    public static class AdjacencyHelper
+    {
+        public static Adjacency? GetInverse(Adjacency adj)
+        {
+            switch (adj)
+            {
+                case Adjacency.NorthWest:
+                    return Adjacency.SouthEast;
+                case Adjacency.North:
+                    return Adjacency.South;
+                case Adjacency.NorthEast:
+                    return Adjacency.SouthWest;
+                case Adjacency.East:
+                    return Adjacency.West;
+                case Adjacency.SouthEast:
+                    return Adjacency.NorthWest;
+                case Adjacency.South:
+                    return Adjacency.North;
+                case Adjacency.SouthWest:
+                    return Adjacency.NorthEast;
+                case Adjacency.West:
+                    return Adjacency.East;
+            }
+            return null;
+        }
+    }
 }

--- a/Source/ACE.Server/Entity/AttackDamage.cs
+++ b/Source/ACE.Server/Entity/AttackDamage.cs
@@ -50,5 +50,14 @@ namespace ACE.Server.Entity
             else
                 return false;
         }
+
+        /// <summary>
+        /// Returns the top damager on creature death
+        /// </summary>
+        public static WorldObject GetTopDamager(List<AttackDamage> attacks)
+        {
+            // build the attack list
+            return new AttackList(attacks).TopDamager;
+        }
     }
 }

--- a/Source/ACE.Server/Entity/AttackList.cs
+++ b/Source/ACE.Server/Entity/AttackList.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Tracks top damager
+    /// </summary>
+    public class AttackList
+    {
+        public Dictionary<WorldObject, uint> Damagers;
+
+        public AttackList()
+        {
+            Init();
+        }
+
+        public AttackList(List<AttackDamage> attackDamages)
+        {
+            Init();
+
+            foreach (var attackDamage in attackDamages)
+                Add(attackDamage.Source, attackDamage.Amount);
+        }
+
+        public void Init()
+        {
+            Damagers = new Dictionary<WorldObject, uint>();
+        }
+
+        public void Add(WorldObject damager, uint amount)
+        {
+            if (Damagers.ContainsKey(damager))
+                Damagers[damager] += amount;
+            else
+                Damagers.Add(damager, amount);
+        }
+
+        public WorldObject TopDamager
+        {
+            get
+            {
+                var sorted = Damagers.OrderByDescending(wo => wo.Value);
+                return sorted.FirstOrDefault().Key;
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/AttackList.cs
+++ b/Source/ACE.Server/Entity/AttackList.cs
@@ -47,5 +47,19 @@ namespace ACE.Server.Entity
                 return sorted.FirstOrDefault().Key;
             }
         }
+
+        /// <summary>
+        /// Called when an AttackTarget regains health
+        /// </summary>
+        /// <param name="healAmount">The amount of health restored</param>
+        /// <param name="missingHealth">The amount of health that was missing before healing</param>
+        public void OnHeal(int healAmount, int missingHealth)
+        {
+            // on heal, scale the damage from each source by 1 - healAmount / missingHealth
+            var scalar = 1.0f - healAmount / missingHealth;
+
+            foreach (var damager in Damagers.Keys)
+                Damagers[damager] *= (uint)Math.Round(scalar);
+        }
     }
 }

--- a/Source/ACE.Server/Entity/DeathItem.cs
+++ b/Source/ACE.Server/Entity/DeathItem.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ACE.Entity.Enum;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// The different categories death items are sorted into
+    /// This is used to determine the adjusted value
+    /// </summary>
+    public enum DeathItemCategory
+    {
+        None,
+        MeleeWeapon,
+        MissileWeapon,
+        MagicCaster,
+        Armor,
+        Clothing,
+        Jewelry,
+        Food,
+        Gem,
+        SpellComponent,
+        ManaStone,
+        CraftingIngredient,
+        ParchmentBook,
+        Key,
+        TradeNote,
+        Misc
+    };
+
+    /// <summary>
+    /// An inventory sorted by which items drop first during death
+    /// </summary>
+    public class DeathItems
+    {
+        public List<DeathItem> Inventory;
+
+        public Dictionary<DeathItemCategory, List<DeathItem>> InventoryGroups;  // for debugging
+
+        /// <summary>
+        /// Constructs a list of death items
+        /// </summary>
+        /// <param name="inventory">The list of possible inventory items that can be dropped on death</param>
+        public DeathItems(List<WorldObject> inventory)
+        {
+            Inventory = new List<DeathItem>();
+
+            foreach (var item in inventory)
+                Inventory.Add(new DeathItem(item));
+
+            BuildGroups();
+
+            // Here's the system, taken straight from the developer spec, that Asheron's Call uses to determine the way items are lost: 
+
+            // First, we sort the inventory by order of value.
+            // Second, we go back through the inventory starting at the most expensive item and look at each item's category.
+            // If we've seen the item category before, we divide the value of the item in half.
+            // At this point, we add a random 0 - 10 % variance to each item's value.
+
+            // Reference: http://acpedia.org/wiki/Recovering_from_Death
+
+            // exclude unknown types
+            Inventory = Inventory.Where(i => i.Category != DeathItemCategory.None).ToList();
+
+            // sort by original value and category
+            Inventory = Inventory.OrderByDescending(i => i.AdjustedValue).OrderBy(i => i.Category).ToList();
+
+            // halve the values of every item, except the most valued item in each category
+            HalfValues(Inventory);
+
+            // adjusted value by randomized variance
+            foreach (var item in Inventory)
+                item.AdjustedValue = GetValueWithVariance(item.AdjustedValue);
+
+            // re-sort by final adjusted value
+            Inventory = Inventory.OrderByDescending(i => i.AdjustedValue).ToList();
+        }
+
+        /// <summary>
+        /// Builds the list of death items grouped by category
+        /// </summary>
+        public void BuildGroups()
+        {
+            InventoryGroups = new Dictionary<DeathItemCategory, List<DeathItem>>();
+
+            foreach (var item in Inventory)
+            {
+                if (!InventoryGroups.ContainsKey(item.Category))
+                    InventoryGroups.Add(item.Category, new List<DeathItem>());
+
+                InventoryGroups[item.Category].Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Randomize the original item values by a variance %
+        /// </summary>
+        public static float MaxVariance = 0.10f;
+
+        /// <summary>
+        /// Returns the input value adjusted between -variance and +variance
+        /// </summary>
+        public static int GetValueWithVariance(int value)
+        {
+            // At this point, we add a random 0 - 10 % variance to each item's value.
+            // should this be -10% - 10% ??
+
+            var variance = Physics.Common.Random.RollDice(0, MaxVariance);
+
+            return (int)(value + value * variance);
+        }
+
+        /// <summary>
+        /// Halves the values of every item, except the most valued item in each category
+        /// </summary>
+        public static void HalfValues(List<DeathItem> inventory)
+        {
+            var prevCategory = DeathItemCategory.None;
+
+            // assumes list has been pre-sorted by category and item value
+            foreach (var item in inventory)
+            {
+                if (item.Category != prevCategory)
+                    prevCategory = item.Category;
+                else
+                    item.AdjustedValue /= 2;
+            }
+        }
+
+        /// <summary>
+        /// An inventory item that can be possibly dropped on death
+        /// </summary>
+        public class DeathItem
+        {
+            public WorldObject WorldObject;
+            public DeathItemCategory Category;
+            public string Name;
+
+            /// <summary>
+            /// The original value is randomized slightly,
+            /// and the non-most expensive items in each category are halved
+            /// </summary>
+            public int AdjustedValue;
+
+            public DeathItem(WorldObject wo)
+            {
+                WorldObject = wo;
+                Name = wo.Name;
+                Category = GetCategory(wo);
+                AdjustedValue = wo.Value ?? 0;  // stack size?
+            }
+
+            public static DeathItemCategory GetCategory(WorldObject wo)
+            {
+                switch (wo.ItemType)
+                {
+                    case ItemType.MeleeWeapon:
+                        return DeathItemCategory.MeleeWeapon;
+                    case ItemType.MissileWeapon:
+                        return DeathItemCategory.MissileWeapon;
+                    case ItemType.Caster:
+                    case ItemType.MagicWieldable:
+                        return DeathItemCategory.MagicCaster;
+                    case ItemType.Armor:
+                        return DeathItemCategory.Armor;
+                    case ItemType.Clothing:
+                        return DeathItemCategory.Clothing;
+                    case ItemType.Jewelry:
+                        return DeathItemCategory.Jewelry;
+                    case ItemType.Food:
+                        return DeathItemCategory.Food;
+                    case ItemType.Gem:
+                        return DeathItemCategory.Gem;
+                    case ItemType.SpellComponents:
+                        return DeathItemCategory.SpellComponent;
+                    case ItemType.ManaStone:
+                        return DeathItemCategory.ManaStone;
+                    case ItemType.CraftAlchemyBase:
+                    case ItemType.CraftAlchemyIntermediate:
+                    case ItemType.CraftCookingBase:
+                    case ItemType.CraftFletchingBase:
+                    case ItemType.CraftFletchingIntermediate:
+                        return DeathItemCategory.CraftingIngredient;
+                    case ItemType.Writable:
+                        return DeathItemCategory.ParchmentBook;
+                    case ItemType.Key:
+                        return DeathItemCategory.Key;
+                    case ItemType.PromissoryNote:
+                        return DeathItemCategory.TradeNote; // should not drop?
+                    case ItemType.Misc:
+                        return DeathItemCategory.Misc;
+                    case ItemType.Container:
+                        return DeathItemCategory.None;  // containers don't drop?
+                    default:
+                        Console.WriteLine("Unknown death item type: " + wo.ItemType);
+                        return DeathItemCategory.None;
+                }
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/DeathItem.cs
+++ b/Source/ACE.Server/Entity/DeathItem.cs
@@ -105,9 +105,12 @@ namespace ACE.Server.Entity
         public static int GetValueWithVariance(int value)
         {
             // At this point, we add a random 0 - 10 % variance to each item's value.
-            // should this be -10% - 10% ??
+            // should this be +/- 10%, or even +/- 5%?
 
-            var variance = Physics.Common.Random.RollDice(0, MaxVariance);
+            // http://www.postcount.net/forum/showthread.php?79784-death-item-formula
+            // according to this post, it could be +/- 10%
+
+            var variance = Physics.Common.Random.RollDice(-MaxVariance, MaxVariance);
 
             return (int)(value + value * variance);
         }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1071,7 +1071,7 @@ namespace ACE.Server.Entity
         public void SaveDB()
         {
             // only updates corpses atm
-            var biotas = worldObjects.Values.Where(wo => wo is Corpse).Select(wo => wo.Biota).ToList();
+            var biotas = worldObjects.Values.Where(wo => wo is Corpse && (wo as Corpse).IsMonster == false).Select(wo => wo.Biota).ToList();
 
             DatabaseManager.Shard.SaveBiotas(biotas, result => { });
         }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -99,7 +99,7 @@ namespace ACE.Server.Entity
         public Landblock(LandblockId id)
         {
             Id = id;
-            Console.WriteLine("Landblock contructor(" + (id.Raw | 0xFFFF).ToString("X8") + ")");
+            //Console.WriteLine("Landblock constructor(" + (id.Raw | 0xFFFF).ToString("X8") + ")");
 
             UpdateStatus(LandBlockStatusFlag.IdleUnloaded);
 
@@ -1041,7 +1041,7 @@ namespace ACE.Server.Entity
         /// </summary>
         public void Unload()
         {
-            Console.WriteLine("Landblock.Unload(" + (Id.Raw | 0xFFFF).ToString("X8") + ")");
+            //Console.WriteLine("Landblock.Unload(" + (Id.Raw | 0xFFFF).ToString("X8") + ")");
             SaveDB();
 
             // dungeon landblocks do not handle adjacents

--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -247,6 +247,24 @@ namespace ACE.Server.Factories
         }
 
         /// <summary>
+        /// Creates a list of WorldObjects from a list of Biotas
+        /// </summary>
+        public static List<WorldObject> CreateWorldObjects(List<Biota> biotas)
+        {
+            var results = new List<WorldObject>();
+
+            foreach (var biota in biotas)
+            {
+                var worldObject = CreateWorldObject(biota);
+                //worldObject.CalculateObjDesc();
+
+                if (worldObject != null)
+                    results.Add(worldObject);
+            }
+            return results;
+        }
+
+        /// <summary>
         /// This will create a new WorldObject with a new GUID.
         /// </summary>
         public static WorldObject CreateNewWorldObject(Weenie weenie)

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -275,7 +275,7 @@ namespace ACE.Server.Managers
 
             foreach (var enchantment in Enchantments)
             {
-                enchantment.StartTime -= 5;
+                enchantment.StartTime -= WorldObject.HeartbeatInterval ?? 5;
 
                 // StartTime ticks backwards to -Duration
                 if (enchantment.Duration > 0 && enchantment.StartTime <= -enchantment.Duration)

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -155,7 +155,7 @@ namespace ACE.Server.Managers
                 var session = FindOrCreateSession(endPoint);
                 if (session != null)
                     session.ProcessPacket(packet);
-
+                
             }
             else if (sessionMap.Length > packet.Header.Id && loggedInClients.Contains(endPoint))
             {
@@ -497,6 +497,9 @@ namespace ACE.Server.Managers
 
                 lastTick = (double)worldTickTimer.ElapsedTicks / Stopwatch.Frequency;
                 PortalYearTicks += lastTick;
+
+                // clean up inactive landblocks
+                LandblockManager.UnloadLandblocks();
             }
 
             // World has finished operations and concedes the thread to garbage collection
@@ -516,7 +519,7 @@ namespace ACE.Server.Managers
             // System.InvalidOperationException: 'Collection was modified; enumeration operation may not execute.'
             try
             {
-                Parallel.ForEach(LandblockManager.ActiveLandblocks, landblock =>
+                Parallel.ForEach(LandblockManager.ActiveLandblocks.Keys, landblock =>
                 {
                     foreach (WorldObject wo in landblock.GetPhysicsWorldObjects())
                     {
@@ -584,6 +587,5 @@ namespace ACE.Server.Managers
         {
             return elapsedTimeSeconds;
         }
-        //
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionNoLongerViewingContents.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionNoLongerViewingContents.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Network.GameAction.Actions
 
             var wo = session.Player.CurrentLandblock.GetObject(objectGuid) as Container;
 
-            if (wo.Viewer == session.Player.Guid.Full)
+            if (wo != null && wo.Viewer == session.Player.Guid.Full)
                 wo.Close(session.Player);
         }
     }

--- a/Source/ACE.Server/Physics/Common/Landblock.cs
+++ b/Source/ACE.Server/Physics/Common/Landblock.cs
@@ -201,7 +201,7 @@ namespace ACE.Server.Physics.Common
                         var ly = cellY * LandDefs.CellLength + position.Y;
 
                         // TODO: ensure walkable slope
-                        if (lx < 0 || ly < 0 || lx > LandDefs.BlockLength || ly > LandDefs.BlockLength || OnRoad(obj, lx, ly)) continue;
+                        if (lx < 0 || ly < 0 || lx >= LandDefs.BlockLength || ly >= LandDefs.BlockLength || OnRoad(obj, lx, ly)) continue;
 
                         // load scenery
                         var pos = new Position(ID);
@@ -209,6 +209,8 @@ namespace ACE.Server.Physics.Common
                         pos.Frame.Orientation = Quaternion.CreateFromYawPitchRoll(0, 0, RotateObj(obj, globalCellX, globalCellY, j));
                         var outside = LandDefs.AdjustToOutside(pos);
                         var cell = get_landcell(pos.ObjCellID);
+                        //if (cell == null) continue;
+
                         Polygon walkable = null;
                         var terrainPoly = cell.find_terrain_poly(pos.Frame.Origin, ref walkable);
                         walkable.Plane.set_height(ref pos.Frame.Origin);
@@ -435,6 +437,36 @@ namespace ACE.Server.Physics.Common
         {
             // legacy method
             //EnvCell.release_visible(StabList);
+        }
+
+        private bool? isDungeon;
+
+        /// <summary>
+        /// Returns TRUE if this landblock is a dungeon
+        /// </summary>
+        public bool IsDungeon
+        {
+            get
+            {
+                // return cached value
+                if (isDungeon != null)
+                    return isDungeon.Value;
+
+                // a dungeon landblock is determined by:
+                // - all heights being 0
+                // - having at least 1 EnvCell (0x100+)
+                // - contains no buildings
+                foreach (var height in Height)
+                {
+                    if (height != 0)
+                    {
+                        isDungeon = false;
+                        return isDungeon.Value;
+                    }
+                }
+                isDungeon = Info != null && Info.NumCells > 0 && Info.Buildings != null && Info.Buildings.Count > 0;
+                return isDungeon.Value;
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -367,7 +367,7 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public void Open(Player player)
+        public virtual void Open(Player player)
         {
             if (IsOpen ?? false)
                 return;

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -18,6 +18,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static readonly double DefaultDecayTime = 120.0;
 
+        /// <summary>
+        /// Flag indicates if a corpse is from a monster of a player
+        /// </summary>
         public bool IsMonster = false;
 
         /// <summary>
@@ -48,13 +51,12 @@ namespace ACE.Server.WorldObjects
             ItemCapacity = 120;
 
             var timeToRot = GetProperty(PropertyFloat.TimeToRot);
-            Console.WriteLine("Corpse.TimeToRot: " + timeToRot);
+            //Console.WriteLine("Corpse.TimeToRot: " + timeToRot);
         }
 
         /// <summary>
         /// Sets the object description for a corpse
         /// </summary>
-        /// <returns></returns>
         public override ObjDesc CalculateObjDesc()
         {
             if (Biota.BiotaPropertiesAnimPart.Count == 0 && Biota.BiotaPropertiesPalette.Count == 0 && Biota.BiotaPropertiesTextureMap.Count == 0)
@@ -87,6 +89,12 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// The maximum number of seconds
+        /// for an empty corpse to stick around
+        /// </summary>
+        public static readonly double EmptyDecayTime = 15.0;
+
+        /// <summary>
         /// Handles corpse decay and removal
         /// </summary>
         public override void HeartBeat()
@@ -94,7 +102,8 @@ namespace ACE.Server.WorldObjects
             TimeToRot -= HeartbeatInterval ?? 5;
 
             // empty corpses decay faster?
-            if (Inventory.Count == 0) TimeToRot = 0;
+            if (Inventory.Count == 0 && TimeToRot > EmptyDecayTime)
+                TimeToRot = EmptyDecayTime;
 
             if (TimeToRot <= 0)
             {

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -6,6 +6,7 @@ using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Motion;
 
 namespace ACE.Server.WorldObjects
@@ -92,7 +93,7 @@ namespace ACE.Server.WorldObjects
 
             if (TimeToRot <= 0)
             {
-                // if items are left on corpse,
+                // TODO: if items are left on corpse,
                 // create these items in the world
                 // http://asheron.wikia.com/wiki/Item_Decay
 
@@ -102,6 +103,24 @@ namespace ACE.Server.WorldObjects
                 return;
             }
             QueueNextHeartBeat();
+        }
+
+        /// <summary>
+        /// Called when a player attempts to loot a corpse
+        /// </summary>
+        public override void Open(Player player)
+        {
+            // check for looting permission
+            if (Name != null && Name.StartsWith("Corpse of "))
+            {
+                var corpseName = Name.Replace("Corpse of ", "");
+                if (!player.Name.Equals(corpseName) && player.Guid.Full != AllowedActivator)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat("You don't have permission to loot the " + Name, ChatMessageType.Broadcast));
+                    return;
+                }
+            }
+            base.Open(player);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -1,21 +1,20 @@
+using System;
+using System.Linq;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
-using ACE.Server.Network.Motion;
-using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
+using ACE.Server.Network.Motion;
 
 namespace ACE.Server.WorldObjects
 {
     public class Corpse : Container
     {
-        private static readonly UniversalMotion dead = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Dead));
-
         /// <summary>
-        /// Timer's value is in heartbeats, which is every 5 seconds. This value equates for five minutes, including the first heartbeat queued at WO creation.
+        /// The number of seconds for a corpse to disappear
         /// </summary>
-        int rotTimer = 55;
+        public double DecayTime = 120;
 
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
@@ -37,49 +36,65 @@ namespace ACE.Server.WorldObjects
         {
             BaseDescriptionFlags |= ObjectDescriptionFlag.Corpse;
 
-            CurrentMotionState = dead;
+            CurrentMotionState = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Dead));
 
             ContainerCapacity = 10;
             ItemCapacity = 120;
         }
 
         /// <summary>
-        /// Put in place to clean corpses, until more global cleanup management can be implemented
+        /// Sets the object description for a corpse
         /// </summary>
-        public override void HeartBeat()
-        {
-            --rotTimer;
-
-            if (rotTimer <= 0)
-            {
-                ActionChain selfDestructChain = new ActionChain();
-                selfDestructChain.AddAction(this, () => LandblockManager.RemoveObject(this));
-                selfDestructChain.EnqueueChain();
-                return;
-            }
-
-            QueueNextHeartBeat();
-        }
-
-        public override ACE.Entity.ObjDesc CalculateObjDesc()
+        /// <returns></returns>
+        public override ObjDesc CalculateObjDesc()
         {
             if (Biota.BiotaPropertiesAnimPart.Count == 0 && Biota.BiotaPropertiesPalette.Count == 0 && Biota.BiotaPropertiesTextureMap.Count == 0)
                 return base.CalculateObjDesc(); // No Saved ObjDesc, let base handle it.
 
-            ACE.Entity.ObjDesc objDesc = new ACE.Entity.ObjDesc();
+            var objDesc = new ObjDesc();
 
             AddBaseModelData(objDesc);
 
-            foreach (var animPart in Biota.BiotaPropertiesAnimPart)
-                objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = (byte)animPart.Index, PartID = animPart.AnimationId });
+            foreach (var animPart in Biota.BiotaPropertiesAnimPart.OrderBy(b => b.Order))
+                objDesc.AnimPartChanges.Add(new AnimationPartChange { PartIndex = animPart.Index, PartID = animPart.AnimationId });
 
             foreach (var subPalette in Biota.BiotaPropertiesPalette)
-                objDesc.SubPalettes.Add(new ACE.Entity.SubPalette { SubID = subPalette.SubPaletteId, Offset = subPalette.Offset, NumColors = subPalette.Length });
+                objDesc.SubPalettes.Add(new SubPalette { SubID = subPalette.SubPaletteId, Offset = subPalette.Offset, NumColors = subPalette.Length });
 
-            foreach (var textureMap in Biota.BiotaPropertiesTextureMap)
-                objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = (byte)textureMap.Index, OldTexture = textureMap.OldId, NewTexture = textureMap.NewId });
+            foreach (var textureMap in Biota.BiotaPropertiesTextureMap.OrderBy(b => b.Order))
+                objDesc.TextureChanges.Add(new TextureMapChange { PartIndex = textureMap.Index, OldTexture = textureMap.OldId, NewTexture = textureMap.NewId });
 
             return objDesc;
+        }
+
+        /// <summary>
+        /// Sets the decay time for player corpse
+        /// </summary>
+        public void SetDecayTime(Player player)
+        {
+            // a player corpse decays after 5 mins * playerLevel
+            // with a minimum of 1 hour
+            DecayTime = Math.Max(3600, (player.Level ?? 1) * 300);
+        }
+
+        /// <summary>
+        /// Handles corpse decay and removal
+        /// </summary>
+        public override void HeartBeat()
+        {
+            DecayTime -= HeartbeatInterval ?? 5;
+
+            if (DecayTime <= 0)
+            {
+                // if items are left on corpse,
+                // create these items in the world
+
+                // http://asheron.wikia.com/wiki/Item_Decay
+
+                Destroy();
+                return;
+            }
+            QueueNextHeartBeat();
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -18,6 +18,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static readonly double DefaultDecayTime = 120.0;
 
+        public bool IsMonster = false;
+
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
         /// </summary>
@@ -91,13 +93,17 @@ namespace ACE.Server.WorldObjects
         {
             TimeToRot -= HeartbeatInterval ?? 5;
 
+            // empty corpses decay faster?
+            if (Inventory.Count == 0) TimeToRot = 0;
+
             if (TimeToRot <= 0)
             {
                 // TODO: if items are left on corpse,
                 // create these items in the world
                 // http://asheron.wikia.com/wiki/Item_Decay
 
-                DatabaseManager.Shard.RemoveBiota(Biota, result => { } );
+                if (!IsMonster)
+                    DatabaseManager.Shard.RemoveBiota(Biota, result => { });
 
                 Destroy();
                 return;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -102,14 +102,17 @@ namespace ACE.Server.WorldObjects
                 corpse.SetProperty(PropertyInstanceId.AllowedActivator, Killer.Value); // Think this will be what limits corpses to Killer first.
 
             var player = this as Player;
-            if (player == null)
-                GenerateTreasure(corpse);
-            else
+            if (player != null)
             {
                 corpse.SetPosition(PositionType.Location, corpse.Location);
                 corpse.SetDecayTime(player);
 
                 player.CalculateDeathItems(corpse);
+            }
+            else
+            {
+                corpse.IsMonster = true;
+                GenerateTreasure(corpse);
             }
 
             corpse.RemoveProperty(PropertyInt.Value);

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -65,14 +65,16 @@ namespace ACE.Server.WorldObjects
             {
                 var objDesc = CalculateObjDesc();
 
+                byte i = 0;
                 foreach (var animPartChange in objDesc.AnimPartChanges)
-                    corpse.Biota.BiotaPropertiesAnimPart.Add(new Database.Models.Shard.BiotaPropertiesAnimPart { ObjectId = corpse.Guid.Full, AnimationId = animPartChange.PartID, Index = animPartChange.PartIndex });
+                    corpse.Biota.BiotaPropertiesAnimPart.Add(new Database.Models.Shard.BiotaPropertiesAnimPart { ObjectId = corpse.Guid.Full, AnimationId = animPartChange.PartID, Index = animPartChange.PartIndex, Order = i++ });
 
                 foreach (var subPalette in objDesc.SubPalettes)
                     corpse.Biota.BiotaPropertiesPalette.Add(new Database.Models.Shard.BiotaPropertiesPalette { ObjectId = corpse.Guid.Full, SubPaletteId = subPalette.SubID, Length = (ushort)subPalette.NumColors, Offset = (ushort)subPalette.Offset });
 
+                i = 0;
                 foreach (var textureChange in objDesc.TextureChanges)
-                    corpse.Biota.BiotaPropertiesTextureMap.Add(new Database.Models.Shard.BiotaPropertiesTextureMap { ObjectId = corpse.Guid.Full, Index = textureChange.PartIndex, OldId = textureChange.OldTexture, NewId = textureChange.NewTexture });
+                    corpse.Biota.BiotaPropertiesTextureMap.Add(new Database.Models.Shard.BiotaPropertiesTextureMap { ObjectId = corpse.Guid.Full, Index = textureChange.PartIndex, OldId = textureChange.OldTexture, NewId = textureChange.NewTexture, Order = i++ });
             }
 
             //corpse.Location = Location;
@@ -99,8 +101,29 @@ namespace ACE.Server.WorldObjects
             if (Killer.HasValue)
                 corpse.SetProperty(PropertyInstanceId.AllowedActivator, Killer.Value); // Think this will be what limits corpses to Killer first.
 
-            // Transfer of generated treasure from creature to corpse here
+            var player = this as Player;
+            if (player == null)
+                GenerateTreasure(corpse);
+            else
+            {
+                corpse.SetPosition(PositionType.Location, corpse.Location);
+                corpse.SetDecayTime(player);
 
+                player.CalculateDeathItems();
+            }
+
+            corpse.RemoveProperty(PropertyInt.Value);
+            LandblockManager.AddObject(corpse);
+
+            if (player != null)
+                corpse.SaveBiotaToDatabase();
+        }
+
+        /// <summary>
+        /// Transfers generated treasure from creature to corpse
+        /// </summary>
+        private void GenerateTreasure(Corpse corpse)
+        {
             var random = new Random((int)DateTime.UtcNow.Ticks);
             int level = (int)Level;
             int tier;
@@ -140,7 +163,7 @@ namespace ACE.Server.WorldObjects
             foreach (var trophy in Biota.BiotaPropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Contain || x.DestinationType == (int)DestinationType.Treasure || x.DestinationType == (int)DestinationType.ContainTreasure || x.DestinationType == (int)DestinationType.ShopTreasure || x.DestinationType == (int)DestinationType.WieldTreasure).OrderBy(x => x.Shade))
             {
                 if (random.NextDouble() < trophy.Shade || trophy.Shade == 1 || trophy.Shade == 0) // Shade in this context is Probability
-                    // Should there be rolls for each item or one roll to rule them all?
+                                                                                                  // Should there be rolls for each item or one roll to rule them all?
                 {
                     if (trophy.WeenieClassId == 0) // Randomized Loot
                     {
@@ -175,33 +198,32 @@ namespace ACE.Server.WorldObjects
                     }
                 }
             }
-            corpse.RemoveProperty(PropertyInt.Value);
-            LandblockManager.AddObject(corpse);
         }
 
         private ActionChain GetCreateCorpseChain()
         {
             ActionChain createCorpseChain = new ActionChain(this, () =>
             {
-                ////// Create Corspe and set a location on the ground
-                ////// TODO: set text of killer in description and find a better computation for the location, some corpse could end up in the ground
-                ////var corpse = CorpseObjectFactory.CreateCorpse(this, this.Location);
-                ////// FIXME(ddevec): We don't have a real corpse yet, so these come in null -- this hack just stops them from crashing the game
-                ////corpse.Location.PositionY -= (corpse.ObjScale ?? 0);
-                ////corpse.Location.PositionZ -= (corpse.ObjScale ?? 0) / 2;
+                /*
+                // Create Corpse and set a location on the ground
+                // TODO: set text of killer in description and find a better computation for the location, some corpse could end up in the ground
+                var corpse = CorpseObjectFactory.CreateCorpse(this, this.Location);
+                // FIXME(ddevec): We don't have a real corpse yet, so these come in null -- this hack just stops them from crashing the game
+                corpse.Location.PositionY -= (corpse.ObjScale ?? 0);
+                corpse.Location.PositionZ -= (corpse.ObjScale ?? 0) / 2;
 
-                ////// Corpses stay on the ground for 5 * player level but minimum 1 hour
-                ////// corpse.DespawnTime = Math.Max((int)session.Player.PropertiesInt[Enum.Properties.PropertyInt.Level] * 5, 360) + WorldManager.PortalYearTicks; // as in live
-                ////// corpse.DespawnTime = 20 + WorldManager.PortalYearTicks; // only for testing
-                ////float despawnTime = GetCorpseSpawnTime();
+                // Corpses stay on the ground for 5 * player level but minimum 1 hour
+                corpse.DespawnTime = Math.Max((int)Session.Player.PropertiesInt[Enum.Properties.PropertyInt.Level] * 5, 360) + WorldManager.PortalYearTicks; // as in live
+                 corpse.DespawnTime = 20 + WorldManager.PortalYearTicks; // only for testing
+                float despawnTime = GetCorpseSpawnTime();
 
-                ////// Create corpse
-                ////CurrentLandblock.AddWorldObject(corpse);
-                ////// Create corpse decay
-                ////ActionChain despawnChain = new ActionChain();
-                ////despawnChain.AddDelaySeconds(despawnTime);
-                ////despawnChain.AddAction(CurrentLandblock, () => corpse.CurrentLandblock.RemoveWorldObject(corpse.Guid, false));
-                ////despawnChain.EnqueueChain();
+                // Create corpse
+                CurrentLandblock.AddWorldObject(corpse);
+                // Create corpse decay
+                ActionChain despawnChain = new ActionChain();
+                despawnChain.AddDelaySeconds(despawnTime);
+                despawnChain.AddAction(CurrentLandblock, () => corpse.CurrentLandblock.RemoveWorldObject(corpse.Guid, false));
+                despawnChain.EnqueueChain();*/
             });
             return createCorpseChain;
         }
@@ -240,7 +262,8 @@ namespace ACE.Server.WorldObjects
             // Wait, then run kill animation
             ActionChain onKillChain = new ActionChain();
             onKillChain.AddDelaySeconds(2);
-            onKillChain.AddChain(GetCreateCorpseChain());
+            //onKillChain.AddChain(GetCreateCorpseChain());
+            onKillChain.AddAction(this, CreateCorpse);
 
             return onKillChain;
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -109,7 +109,7 @@ namespace ACE.Server.WorldObjects
                 corpse.SetPosition(PositionType.Location, corpse.Location);
                 corpse.SetDecayTime(player);
 
-                player.CalculateDeathItems();
+                player.CalculateDeathItems(corpse);
             }
 
             corpse.RemoveProperty(PropertyInt.Value);

--- a/Source/ACE.Server/WorldObjects/Creature_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Networking.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -141,15 +142,19 @@ namespace ACE.Server.WorldObjects
                     // Check if the player model has data. Gear Knights, this is usually you.
                     {
                         // Add the model and texture(s)
-                        ClothingBaseEffect clothingBaseEffec = item.ClothingBaseEffects[thisSetupId];
-                        foreach (CloObjectEffect t in clothingBaseEffec.CloObjectEffects)
+                        ClothingBaseEffect clothingBaseEffect = item.ClothingBaseEffects[SetupTableId];
+                        foreach (CloObjectEffect t in clothingBaseEffect.CloObjectEffects)
                         {
                             byte partNum = (byte)t.Index;
-                            objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = (byte)t.Index, PartID = t.ModelId });
+                            if (objDesc.AnimPartChanges.FirstOrDefault(c => c.PartIndex == (byte)t.Index && c.PartID == t.ModelId) == null)
+                                objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = (byte)t.Index, PartID = t.ModelId });
                             //AddModel((byte)t.Index, (ushort)t.ModelId);
                             coverage.Add(partNum);
                             foreach (CloTextureEffect t1 in t.CloTextureEffects)
-                                objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = (byte)t.Index, OldTexture = t1.OldTexture, NewTexture = t1.NewTexture });
+                            {
+                                if (objDesc.TextureChanges.FirstOrDefault(c => c.PartIndex == (byte)t.Index && c.OldTexture == t1.OldTexture && c.NewTexture == t1.NewTexture) == null)
+                                    objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = (byte)t.Index, OldTexture = t1.OldTexture, NewTexture = t1.NewTexture });
+                            }
                             //AddTexture((byte)t.Index, (ushort)t1.OldTexture, (ushort)t1.NewTexture);
                         }
 
@@ -210,6 +215,20 @@ namespace ACE.Server.WorldObjects
 
             if (coverage.Count == 0 && ClothingBase.HasValue)
                 return base.CalculateObjDesc();
+
+            /*var p = this as Player;
+            if (p != null)
+            {
+                Console.WriteLine("AnimPart changes:");
+                Console.WriteLine("PartIndex\tPartID\n====================================");
+                foreach (var animPartChange in objDesc.AnimPartChanges)
+                    Console.WriteLine(animPartChange.PartIndex + "\t" + animPartChange.PartID.ToString("X8"));
+
+                Console.WriteLine("TextureMap changes:");
+                Console.WriteLine("PartIndex\tOldTex\tNewTex\n====================================");
+                foreach (var texChange in objDesc.TextureChanges)
+                    Console.WriteLine(texChange.PartIndex + "\t" + texChange.OldTexture.ToString("X8") + "\t" + texChange.NewTexture.ToString("X8"));
+            }*/
 
             return objDesc;
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -85,7 +85,8 @@ namespace ACE.Server.WorldObjects
             //motion.TargetGuid = target.Guid;
             CurrentMotionState = motion;
 
-            CurrentLandblock.EnqueueBroadcastMotion(this, motion);
+            if (CurrentLandblock != null)
+                CurrentLandblock.EnqueueBroadcastMotion(this, motion);
         }
 
         /// <summary>
@@ -136,14 +137,14 @@ namespace ACE.Server.WorldObjects
 
                     if (!targetSelf && ResistSpell(Skill.LifeMagic))break;
                     LifeMagic(target, spellBase, spell, out var msg);
-                    CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
+                    if (CurrentLandblock != null) CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
                     break;
 
                 case MagicSchool.CreatureEnchantment:
 
                     if (!targetSelf && ResistSpell(Skill.CreatureEnchantment)) break;
                     CreatureMagic(target, spellBase, spell);
-                    CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
+                    if (CurrentLandblock != null) CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
                     break;
             }
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -73,7 +73,8 @@ namespace ACE.Server.WorldObjects
             motion.TargetGuid = target.Guid;
             CurrentMotionState = motion;
 
-            CurrentLandblock.EnqueueBroadcastMotion(this, motion);
+            if (CurrentLandblock != null)
+                CurrentLandblock.EnqueueBroadcastMotion(this, motion);
 
             return null;
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -68,7 +68,9 @@ namespace ACE.Server.WorldObjects
 
             var weapon = GetEquippedWeapon();
             var sound = weapon.DefaultCombatStyle == CombatStyle.Crossbow ? Sound.CrossbowRelease : Sound.BowRelease;
-            CurrentLandblock.EnqueueBroadcast(Location, new GameMessageSound(Guid, sound, 1.0f));
+
+            if (CurrentLandblock != null)
+                CurrentLandblock.EnqueueBroadcast(Location, new GameMessageSound(Guid, sound, 1.0f));
 
             var player = AttackTarget as Player;
             var bodyPart = GetBodyPart();

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -159,6 +159,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public override void HeartBeat()
         {
+            NotifyLandblocks();
+
             EnchantmentManager.HeartBeat();
             VitalTick();
 

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -87,7 +87,7 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
-        private bool SpendCurrency(uint amount, WeenieType type)
+        private List<WorldObject> SpendCurrency(uint amount, WeenieType type)
         {
             if (CoinValue - amount >= 0)
             {
@@ -120,6 +120,7 @@ namespace ACE.Server.WorldObjects
                             change = payment - amount;
                             // add new change object.
                             changeobj.StackSize = (ushort)change;
+                            wo.StackSize -= (ushort)change;
                         }
                         break;
                     }
@@ -150,10 +151,9 @@ namespace ACE.Server.WorldObjects
                 }
 
                 UpdateCurrencyClientCalculations(WeenieType.Coin);
-                return true;
+                return cost;
             }
-
-            return false;
+            return null;
         }
 
 
@@ -176,7 +176,7 @@ namespace ACE.Server.WorldObjects
             // vendor accepted the transaction
             if (valid)
             {
-                if (SpendCurrency(goldcost, WeenieType.Coin))
+                if (SpendCurrency(goldcost, WeenieType.Coin) != null)
                 {
                     foreach (WorldObject wo in uqlist)
                     {

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using ACE.Database;
 using ACE.DatLoader;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network;
 using ACE.Server.Network.Structure;
@@ -72,7 +74,7 @@ namespace ACE.Server.WorldObjects
             OnKill(killerSession);
 
             // Then get onKill from our parent
-            ActionChain killChain = base.OnKillInternal(killerSession);
+            ActionChain killChain = OnKillInternal(killerSession);
 
             // Send the teleport out after we animate death
             killChain.AddAction(this, () =>
@@ -130,6 +132,236 @@ namespace ACE.Server.WorldObjects
         public override void Smite(ObjectGuid smiter)
         {
             HandleActionDie();
+        }
+
+        public void CreateCorpse()
+        {
+
+        }
+
+        public void CalculateDeathItems()
+        {
+            // https://web.archive.org/web/20140712134108/http://support.turbine.com/link/portal/24001/24001/Article/464/How-do-death-items-work-in-Asheron-s-Call-Could-you-explain-how-the-game-decides-what-you-drop-when-you-die-in-Asheron-s-Call
+
+            // Original formula:
+
+            // - When you are level 5 or under, you don't drop anything when you die.
+            // - From level 6 to level 10, you lose half your coins (not trade notes) and nothing else.
+            // - From level 11 to level 20, you lose half your coins and possibly one non-wielded item (that is, something that you were neither wearing nor holding in your hands).
+            // - From level 21 to level 35, you lose half your coins and some number of non-wielded items.
+            // - After level 35, you lose half your coins and some number of items. At this point, you can drop items that you were wearing or holding.
+
+            // Now, in those last two cases, I said 'some number'. Some number here is equal to your level divided by 10, rounded down, plus a random number between 0 and 2.
+            // So from level 21 to 29 you can lose between 2 and 4 items; from level 30 to 39 you can lose 3-5 items; from 40-49 you can lose 4-6 items, and so forth.
+            // By level 126 you can be losing up to 14 items.
+
+            // (one caveat here: if you were killed in a PK battle, you always lose items as if you were over level 35, although the exact number you lose
+            // is still determined by your real level / 10. In other words, PK deaths do not get the special protection from item loss that NPK deaths get under level 35.)
+
+            // So that's how many items you lose on death -- but how do we determine which items are lost? This is where the categories come into it.
+
+            // Each item in the game has a particular item type associated with it. The actual types (categories) are listed below.
+            // When we are deciding what items you drop on death, we make a list of all the items you are carrying, sorted by value (high value first).
+            // But we may adjust their values in two ways. If the item is not the most valuable item in that category, then we cut its value in half.
+            // And whether or not it is the most valuable item in its category, we randomize its value a little bit to mix things up.
+            // (To answer your first question explicitly, the cutting-the-value-in-half is not cumulative -- the second- and third- and fourth-most valuable items
+            // of one category all have their values halved, not halved and then quartered and then eighthed).
+
+            // Now note that we still keep these things in a list sorted by adjusted value -- so its possible to have your two expensive weapons
+            // listed first and second, if the value of the second weapon cut in half is still higher than the value of the third item. What I am trying to get at here is
+            // that we do not segregate the list based on item type; we only use item type to determine how we adjust the value of the item.
+
+            // Finally, we go down the list and mark the first # things as dropped, where # is the number of items we have calculated that you are going to drop this death.
+            // For instance, if you are level 48, you will drop the first 4-6 items on that list.
+
+            // The categories of items are:
+
+            // - Melee weapons
+            // - Missile weapons
+            // - Magic casters (like orbs & wands)
+            // - Armor
+            // - Clothing
+            // - Jewelry
+            // - Food
+            // - Gems
+            // - Components
+            // - Mana stones
+            // - Crafting ingredients
+            // - Parchments & books
+            // - Keys
+            // - Tradenotes
+            // - Miscellaneous
+
+            // A few categories are left out such as lifestones -- because you aren't likely to be carrying an item of that type.
+
+            // http://asheron.wikia.com/wiki/Death_Penalty
+            // The first item to drop will be the highest value item regardless of type.
+            // All items of the same type will now be counted at half their face value. This process repeats (next highest value item,
+            // if an item of the same type has already dropped, the face value is halved.)
+
+            // The number of items you drop can be reduced with the Clutch of the Miser augmentation. If you get the
+            // augmentation three times you will no longer drop any items (except half of your Pyreals and all Rares except if you're a PK).
+            // If you drop no items, you will not leave a corpse.
+
+            // Some players use gems, particularly the Archmage Portal Gems as death items, so it's important to note how
+            // stackable items work with the death system. When you die, a stack is considered to be one item for the purposes
+            // of death items. However if that stack is selected, only one item off the stack will drop. For example, let's say you
+            // can currently cover all of your items with 5 Portal Gems. After the event, if you do not stack these gems, there
+            // will be no change. However, if you combine the 5 Gems into a single stack, you would drop 1 gem and 4 other items on death.
+
+            // When you die there is a notification in your chat dialog stating what items you dropped, and your corpse location
+            // (if on the landscape). If you do not leave a corpse the notification will state so.
+
+            // Accounts with the Throne of Destiny expansion received a new formula for death items to prevent losing a
+            // pack per death at high levels. The formula was changed to divide by 20 levels instead of 10, thereby making
+            // the maximum dropped items the same.
+            // Tier 1 and 2 Rares will always drop, and do not count toward your death item count, so store them in a safe place.
+            // PKLite - no items or pyreals are lost on PKL death.
+
+            // Death items
+
+            // You can protect important items like your armor and weapons by carrying death items. THese are items that are
+            // ideally light weight as well as high in value. You can tinker loot items with bags of Salvaged Gold to raise their
+            // face value. Although tinkering special items can remove some of the beneift, as you feel obligated to recover
+            // them. Items that can be purchased can just be left if the corpse would be too difficult to recover.
+
+            // Popular items to use as Death Items:
+
+            // - Massive Mana Charges (most common death item)
+            // - Pristine Mana Shards
+            // - Crowns (tinkered with gold)
+            // - Robes sold by the Mastermages
+            // - Nanner Island Portal Gems (somewhat difficult to obtain)
+
+            // Bonded items:
+
+            // Items that have the Special Property Bonded will never drop on death. Some notable bonded items include:
+            // - Academy Weapons (Starter weapons)
+            // - Augmentation Gems (Asheron's Benediction and Blackmoor's Favor)
+            // - Pathwarden Armor (Starter armor)
+            // - Trade Notes
+
+            // http://acpedia.org/wiki/Recovering_from_Death
+
+            // Recovering from Death
+
+            // Fortunately, you won't be in immediate danger of being killed again, because you're invulnerable to attack for a full minute if you don't attack another
+            // creature of cast any spells. Also, your secondary attributes, even if all had been reduced to 0 when you died, will be at 75 percent of their new
+            // maximum score, and any poisons or harmful enchantments afflicting you just before you died will be gone, giving you a fighting chance of making it
+            // back to town or meeting up with your allies.
+            // You can also find the location of your last corpse outdoors by typing @corpse.
+
+            // Corpse timer = Math.Max(1 hour, 5 mins * level)
+            // TODO: @permit and @consent commands
+            // You can have up to 20 people in your consent list at once. However, when you log off, all permissions to loot corpses will be removed.
+
+            // First, we sort the inventory by order of value.
+            // Second, we go back through the inventory starting at the most expensive item and look at each item's category.
+            // If we've seen the item category before, we divide the value of the item in half.
+            // At this point, we add a random 0-10% variance to each item's value.
+
+            // http://acpedia.org/wiki/Death_Item
+
+            // A Reign of Stone (April 2001) - Corpse permission commands added.
+            // The Changing of the Ways (May 2001) - Players are now given the coordinates of their characters' corpses when they die.
+            // Hidden Vein (May 2002) - Many changes made on the way item loss on death works. See http://acpedia.org/wiki/Hidden_Vein and http://acpedia.org/wiki/Announcements_-_2002/05_-_Hidden_Vein#Letter_to_the_Players for more details
+            // Throne of Destiny expansion (July 2005) - The formula used for working out how many items a character drops was updated. For details on the old formula and how it changed see http://acpedia.org/wiki/Announcements_-_2005/07_-_Throne_of_Destiny_(expansion)#FAQ_-_AC:TD_Level_Cap_Update
+
+            var numItemsDropped = GetNumItemsDropped();
+
+            var numCoinsDropped = GetNumCoinsDropped();
+
+            var level = Level ?? 1;
+            var canDropWielded = level >= 35;
+
+            // get all items in inventory
+            var inventory = GetAllPossessions();
+
+            // exclude pyreals from randomized death item calculation
+            inventory = inventory.Where(i => !i.Name.Equals("Pyreal")).ToList();
+
+            // exclude wielded items if < level 35
+            if (!canDropWielded)
+                inventory = inventory.Where(i => i.CurrentWieldedLocation != null).ToList();
+
+            // exclude bonded items
+            inventory = inventory.Where(i => (i.GetProperty(PropertyInt.Bonded) ?? 0) == 0).ToList();
+
+            // construct the list of death items
+            var deathItems = new DeathItems(inventory);
+
+            for (var i = 0; i < numItemsDropped && i < deathItems.Inventory.Count; i++)
+            {
+                var deathItem = deathItems.Inventory[i];
+
+                var stackSize = deathItem.WorldObject.StackSize ?? 1;
+                var stackMsg = stackSize > 1 ? " (stack)" : "";
+                Console.WriteLine("Dropping " + deathItem.WorldObject.Name + stackMsg);
+            }
+        }
+
+        /// <summary>
+        /// The maximum # of items a player can drop
+        /// </summary>
+        public static readonly int MaxItemsDropped = 12;
+
+        /// <summary>
+        /// Rolls for the # of items to drop for a player death
+        /// </summary>
+        /// <returns></returns>
+        public int GetNumItemsDropped()
+        {
+            // Original formula:
+
+            // - When you are level 5 or under, you don't drop anything when you die.
+            // - From level 6 to level 10, you lose half your coins (not trade notes) and nothing else.
+            // - From level 11 to level 20, you lose half your coins and possibly one non-wielded item (that is, something that you were neither wearing nor holding in your hands).
+            // - From level 21 to level 35, you lose half your coins and some number of non-wielded items.
+            // - After level 35, you lose half your coins and some number of items. At this point, you can drop items that you were wearing or holding.
+
+            // Now, in those last two cases, I said 'some number'. Some number here is equal to your level divided by 10 (*20 after patch), rounded down, plus a random number between 0 and 2.
+            // So from level 21 to 29 you can lose between 2 and 4 items; from level 30 to 39 you can lose 3-5 items; from 40-49 you can lose 4-6 items, and so forth.
+            // By level 126 you can be losing up to 14 items.
+
+            // (one caveat here: if you were killed in a PK battle, you always lose items as if you were over level 35, although the exact number you lose
+            // is still determined by your real level / 10. In other words, PK deaths do not get the special protection from item loss that NPK deaths get under level 35.)
+
+            // So that's how many items you lose on death -- but how do we determine which items are lost? This is where the categories come into it.
+
+            // take augments into consideration?
+
+            var level = Level ?? 1;
+
+            if (level <= 10)
+                return 0;
+
+            if (level >= 11 && level <= 20)
+                return Physics.Common.Random.RollDice(0, 1);
+
+            // level 21+
+            var numItemsDropped = (level / 20) + Physics.Common.Random.RollDice(0, 2);
+
+            numItemsDropped = Math.Min(numItemsDropped, MaxItemsDropped);
+
+            // TODO: PK deaths
+
+            // The number of items you drop can be reduced with the Clutch of the Miser augmentation. If you get the
+            // augmentation three times you will no longer drop any items(except half of your Pyreals and all Rares except if you're a PK).
+            // If you drop no items, you will not leave a corpse.
+
+            return numItemsDropped;
+        }
+
+        public int GetNumCoinsDropped()
+        {
+            // if level > 5, lose half coins
+            // (trade notes excluded)
+            var level = Level ?? 1;
+            var coins = CoinValue ?? 0;
+
+            var numCoinsDropped = level > 5 ? coins / 2 : 0;
+
+            return numCoinsDropped;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -299,7 +299,7 @@ namespace ACE.Server.WorldObjects
                 // add pyreals to dropped items
                 var pyreals = SpendCurrency((uint)numCoinsDropped, WeenieType.Coin);
                 dropItems.AddRange(pyreals);
-                Console.WriteLine($"Dropping {numCoinsDropped} pyreals");
+                //Console.WriteLine($"Dropping {numCoinsDropped} pyreals");
             }
 
             for (var i = 0; i < numItemsDropped && i < sorted.Inventory.Count; i++)
@@ -320,7 +320,7 @@ namespace ACE.Server.WorldObjects
                     TryAddToInventory(dropItem);
                 }
 
-                Console.WriteLine("Dropping " + deathItem.WorldObject.Name + stackMsg);
+                //Console.WriteLine("Dropping " + deathItem.WorldObject.Name + stackMsg);
                 dropItems.Add(dropItem);
             }
 
@@ -445,7 +445,7 @@ namespace ACE.Server.WorldObjects
                 if (stackSize == 1)
                     msg += dropItem.Name;
                 else
-                    msg += stackSize + " " + dropItem.GetPluralName();
+                    msg += stackSize.ToString("N0") + " " + dropItem.GetPluralName();
             }
             if (msg.Length > 0)
                 msg += "!";

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -305,10 +305,13 @@ namespace ACE.Server.WorldObjects
                 dropItems.Add(deathItem.WorldObject);
             }
 
-            // add pyreals to dropped items
-            var pyreals = SpendCurrency((uint)numCoinsDropped, WeenieType.Coin);
-            dropItems.AddRange(pyreals);
-            Console.WriteLine($"Dropping {numCoinsDropped} pyreals");
+            if (numCoinsDropped > 0)
+            {
+                // add pyreals to dropped items
+                var pyreals = SpendCurrency((uint)numCoinsDropped, WeenieType.Coin);
+                dropItems.AddRange(pyreals);
+                Console.WriteLine($"Dropping {numCoinsDropped} pyreals");
+            }
 
             // add items to corpse
             foreach (var dropItem in dropItems)

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -134,5 +134,18 @@ namespace ACE.Server.WorldObjects
             lock (clientObjectList)
                 clientObjectList.Clear();
         }
+
+        public void NotifyLandblocks()
+        {
+            // the original implementations of this were done on landblock heartbeat,
+            // with checks for players in the current landblock, as well as adjacent outdoor landblocks
+
+            // for performance reasons, this is being reimplemented in the reverse manner,
+            // with players notifying landblocks of their activity
+
+            // notify current landblock of player activity
+            if (CurrentLandblock != null)
+                CurrentLandblock.SetActive();
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -923,6 +923,11 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public string GetPluralName()
+        {
+            return Name + "s";
+        }
+
         public int CompareTo(WorldObject wo)
         {
             return Guid.Full.CompareTo(wo.Guid.Full);

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -783,6 +783,10 @@ namespace ACE.Server.WorldObjects
 
                 if (player != null)
                 {
+                    var topDamager = AttackDamage.GetTopDamager(AttackList);
+                    if (topDamager != null)
+                        monster.Killer = topDamager.Guid.Full;
+
                     var deathMessage = monster.GetDeathMessage(source, crit);
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(deathMessage, monster.Name), ChatMessageType.Broadcast));
                     player.EarnXP((long)monster.XpOverride);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -98,11 +98,13 @@ namespace ACE.Server.WorldObjects
                 var queue = new GeneratorQueueNode();
 
                 queue.Slot = (uint)slot;
-                double when = Common.Time.GetFutureTimestamp((RegenerationInterval ?? 0) + (GeneratorProfiles[slot].Delay ?? 0));
+                //double when = Common.Time.GetFutureTimestamp((RegenerationInterval ?? 0) + (GeneratorProfiles[slot].Delay ?? 0));
+                double when = Time.GetFutureTimestamp(Physics.Common.Random.RollDice(0, (float)(RegenerationInterval ?? 0)) + (GeneratorProfiles[0].Delay ?? 0));
+                //Console.WriteLine(Name + " RegenerationInterval: " + RegenerationInterval + ", Delay: " + GeneratorProfiles[slot].Delay);
 
                 if (GeneratorRegistry.Count < InitGeneratedObjects)
                     if (CurrentlyPoweringUp ?? false)
-                        when = Common.Time.GetFutureTimestamp((GeneratorInitialDelay ?? 0));
+                        when = Time.GetFutureTimestamp((GeneratorInitialDelay ?? 0));
 
                 queue.When = when;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2418,5 +2418,11 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyFloat.TimeToRot);
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.TimeToRot); else SetProperty(PropertyFloat.TimeToRot, value.Value); }
         }
+
+        public uint? AllowedActivator
+        {
+            get => GetProperty(PropertyInstanceId.AllowedActivator);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.AllowedActivator); else SetProperty(PropertyInstanceId.AllowedActivator, value.Value); }
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2412,5 +2412,11 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyInstanceId.ActivationTarget);
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.ActivationTarget); else SetProperty(PropertyInstanceId.ActivationTarget, value.Value); }
         }
+
+        public double? TimeToRot
+        {
+            get => GetProperty(PropertyFloat.TimeToRot);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.TimeToRot); else SetProperty(PropertyFloat.TimeToRot, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
- Adding landblock unloading / reloading system
- Fixed a bug where generators were spawning monsters too quickly
- Adding player corpses
- Adding dungeon/outdoor landblock detection
- Fixed a bug with spawning certain scenery (Redspire)
- Added player death items list calculation
- Added dropped items to corpse containers
- Added corpse looting permissions
- Added permaload flag for landblocks