### PR TITLE
Improved monster transitions between landblocks and cell boundaries

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DebugCommands.cs
@@ -1090,5 +1090,65 @@ namespace ACE.Server.Command.Handlers
             session.Network.EnqueueSend(contractMsg);
             ChatPacket.SendServerMessage(session, "You just added " + contractTracker.ContractDetails.ContractName, ChatMessageType.Broadcast);
         }
+
+        // ==================================
+        // Monster movement
+        // ==================================
+
+        [CommandHandler("turnto", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Turns the input object to the player", "turnto <object_id>")]
+        public static void HandleRequestTurnTo(Session session, params string[] parameters)
+        {
+            if (parameters.Length < 1) return;
+
+            var objectID = Convert.ToUInt32(parameters[0], 16);
+            var guid = new ObjectGuid(objectID);
+            var player = session.Player;
+
+            var obj = player.CurrentLandblock.GetObject(guid);
+            if (obj == null)
+            {
+                Console.WriteLine("Couldn't find " + guid);
+                return;
+            }
+
+            var creature = obj as Creature;
+            creature.TurnTo(player);
+        }
+
+        [CommandHandler("debugmove", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Toggles movement debugging for a monster", "debugmove <object_id> <on/off>")]
+        public static void ToggleMovementDebug(Session session, params string[] parameters)
+        {
+            if (parameters.Length < 1) return;
+
+            var objectID = Convert.ToUInt32(parameters[0], 16);
+            var guid = new ObjectGuid(objectID);
+            var player = session.Player;
+
+            var obj = player.CurrentLandblock.GetObject(guid);
+            if (obj == null)
+            {
+                Console.WriteLine("Couldn't find " + guid);
+                return;
+            }
+
+            bool enabled = true;
+            if (parameters.Length > 1 && parameters[1].Equals("off"))
+                enabled = false;
+
+            var creature = obj as Creature;
+            creature.DebugMove = enabled;
+        }
+
+        [CommandHandler("forcepos", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Toggles server monster position", "forcepos <on/off>")]
+        public static void ToggleForcePos(Session session, params string[] parameters)
+        {
+            bool enabled = true;
+            if (parameters.Length > 0 && parameters[0].Equals("off"))
+                enabled = false;
+
+            Console.WriteLine("Setting forcepos to " + enabled);
+
+            Creature.ForcePos = enabled;
+        }
     }
 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -339,7 +339,7 @@ namespace ACE.Server.Entity
             wo.PhysicsObj.Position.Frame.Origin = wo.Location.Pos;
             wo.PhysicsObj.Position.Frame.Orientation = wo.Location.Rotation;
 
-            //wo.AdjustDungeonCells(wo.Location);
+            wo.AdjustDungeonCells(wo.Location);
 
             var cell = LScape.get_landcell(wo.Location.Cell);
             if (cell != null)

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -48,6 +48,8 @@ namespace ACE.Server.Network.Structure
         /// </summary>
         public AppraiseInfo(WorldObject wo, bool success = true)
         {
+            //Console.WriteLine("Appraise: " + wo.Guid);
+
             Success = success;
             if (!Success)
                 return;

--- a/Source/ACE.Server/Physics/Animation/Transition.cs
+++ b/Source/ACE.Server/Physics/Animation/Transition.cs
@@ -499,8 +499,13 @@ namespace ACE.Server.Physics.Animation
 
             CalcNumSteps(ref offset, ref offsetPerStep, ref numSteps);  // restructure as retval?
 
-            var maxSteps = 30;
-            if (numSteps > maxSteps) return false;
+            //var maxSteps = 30;
+            var maxSteps = 200; // for debugging
+            if (numSteps > maxSteps)
+            {
+                //Console.WriteLine("NumSteps: " + numSteps);
+                return false;
+            }
 
             if (ObjectInfo.State.HasFlag(ObjectInfoState.FreeRotate))
                 SpherePath.CurPos.Frame.Rotate(SpherePath.EndPos.Frame.Orientation);

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -3250,7 +3250,11 @@ namespace ACE.Server.Physics
         {
             RequestPos.Frame.Origin = pos;
             RequestPos.Frame.Orientation = rotation;
-            RequestPos.ObjCellID = cell.ID;
+
+            if (cell == null)
+                RequestPos.ObjCellID = RequestPos.GetCell(CurCell.ID);
+            else
+                RequestPos.ObjCellID = cell.ID;
         }
 
         public void set_sequence_animation(int animID, bool interrupt, int startFrame, float framerate)

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -3246,10 +3246,17 @@ namespace ACE.Server.Physics
         /// Sets the requested position to the AutonomousPosition
         /// received from the client
         /// </summary>
-        public void set_request_pos(Vector3 pos, Quaternion rotation, ObjCell cell)
+        public void set_request_pos(Vector3 pos, Quaternion rotation, ObjCell cell, uint blockCellID)
         {
             RequestPos.Frame.Origin = pos;
             RequestPos.Frame.Orientation = rotation;
+
+            if (CurCell == null)
+            {
+                CurCell = LScape.get_landcell(blockCellID);
+                if (CurCell == null)
+                    return;
+            }
 
             if (cell == null)
                 RequestPos.ObjCellID = RequestPos.GetCell(CurCell.ID);

--- a/Source/ACE.Server/Physics/Util/AdjustCell.cs
+++ b/Source/ACE.Server/Physics/Util/AdjustCell.cs
@@ -10,13 +10,6 @@ namespace ACE.Server.Physics.Util
         public List<Environment> EnvCells;
         public static Dictionary<uint, AdjustCell> AdjustCells = new Dictionary<uint, AdjustCell>();
 
-        //Maybe it's OK to bypass the whitelist and take the performance hit if the adjustcell test is run after login and after teleport. fartwhif
-        public static List<uint> AdjustDungeons = new List<uint>()
-        {
-            0x18A,   // Hotel Swank
-            0x2AB    // Beyond the Mines of Despair
-        };
-
         public AdjustCell(uint dungeonID)
         {
             uint blockInfoID = dungeonID << 16 | 0xFFFE;

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -31,6 +31,9 @@ namespace ACE.Server.WorldObjects
         public int GetArmorVsType(DamageType damageType, int armorVsType)
         {
             var resistance = (float)armorVsType / Biota.BaseArmor;
+            if (double.IsNaN(resistance))
+                resistance = 1.0f;
+
             var mod = EnchantmentManager.GetResistanceMod(damageType);
 
             var baseArmorMod = BaseArmorMod;

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -101,6 +101,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Attack()
         {
+            if (DebugMove)
+                Console.WriteLine(Name + " Attack");
+
             switch (CurrentAttack)
             {
                 case AttackType.Melee:
@@ -124,6 +127,9 @@ namespace ACE.Server.WorldObjects
             // wait for missile to strike
             if (CurrentAttack == AttackType.Missile)
                 return;
+
+            IsTurning = false;
+            IsMoving = false;
 
             CurrentAttack = null;
             MaxRange = 0.0f;

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -255,7 +255,7 @@ namespace ACE.Server.WorldObjects
 
             var cell = LScape.get_landcell(Location.Cell);
 
-            PhysicsObj.set_request_pos(requestPos, Location.Rotation, null);
+            PhysicsObj.set_request_pos(requestPos, Location.Rotation, null, Location.LandblockId.Raw);
 
             // simulate running forward for this amount of time
             PhysicsObj.update_object_server(false);

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -55,6 +55,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public double LastMoveTime;
 
+        public bool DebugMove;
+
         /// <summary>
         /// Starts the process of monster turning towards target
         /// </summary>
@@ -75,6 +77,9 @@ namespace ACE.Server.WorldObjects
             actionChain.AddDelaySeconds(time);
             actionChain.AddAction(this, () => OnTurnComplete());
             actionChain.EnqueueChain();
+
+            if (DebugMove)
+                Console.WriteLine($"{Name} ({Guid})StartTurn");
         }
 
         /// <summary>
@@ -195,6 +200,8 @@ namespace ACE.Server.WorldObjects
                 Sleep();
         }
 
+        public static bool ForcePos = false;
+
         /// <summary>
         /// Updates monster position and rotation
         /// </summary>
@@ -220,7 +227,11 @@ namespace ACE.Server.WorldObjects
             var velocity = movement / deltaTime;
             PhysicsObj.CachedVelocity = velocity;
 
-            SendUpdatePosition(false);
+            SendUpdatePosition(ForcePos);
+            //MoveTo(AttackTarget, RunRate, true);
+
+            if (DebugMove)
+                Console.WriteLine($"{Name} ({Guid}) UpdatePosition()");
         }
 
         public void UpdatePosition_Inner(Vector3 newPos, Vector3 dir)
@@ -237,24 +248,42 @@ namespace ACE.Server.WorldObjects
                 UpdateCell();
         }
 
-        public void UpdatePosition_PhysicsInner(Vector3 newPos, Vector3 dir)
+        public void UpdatePosition_PhysicsInner(Vector3 requestPos, Vector3 dir)
         {
             Location.Rotate(dir);
             PhysicsObj.Position.Frame.Orientation = Location.Rotation;
 
             var cell = LScape.get_landcell(Location.Cell);
 
-            PhysicsObj.set_request_pos(newPos, Location.Rotation, cell);
+            PhysicsObj.set_request_pos(requestPos, Location.Rotation, null);
 
             // simulate running forward for this amount of time
             PhysicsObj.update_object_server(false);
 
             // was the position successfully moved to?
             // use the physics position as the source-of-truth?
-            Location.Pos = PhysicsObj.Position.Frame.Origin;
-            if (PhysicsObj.CurCell != null && PhysicsObj.CurCell.ID != Location.Cell)
-                Location.LandblockId = new LandblockId(PhysicsObj.CurCell.ID);
+            var newPos = PhysicsObj.Position.Frame.Origin;
+            if (Location.LandblockId.Raw != PhysicsObj.Position.ObjCellID)
+            {
+                var prevBlock = Location.LandblockId.Raw >> 16;
+                var prevCell = Location.LandblockId.Raw & 0xFFFF;
 
+                var newBlock = PhysicsObj.Position.ObjCellID >> 16;
+                var newCell = PhysicsObj.Position.ObjCellID & 0xFFFF;
+
+                Location.LandblockId = new LandblockId(PhysicsObj.Position.ObjCellID);
+
+                if (prevBlock != newBlock)
+                {
+                    PreviousLocation = Location;
+                    LandblockManager.RelocateObjectForPhysics(this);
+                    PhysicsObj.Position.Frame.Origin = newPos;
+                    //Console.WriteLine("Relocating " + Name + " to " + Location.LandblockId.Raw.ToString("X8"));
+                }
+                //else
+                    //Console.WriteLine("Moving " + Name + " to " + Location.LandblockId.Raw.ToString("X8"));
+            }
+            Location.Pos = newPos;
             //DebugDistance();
         }
 
@@ -296,6 +325,7 @@ namespace ACE.Server.WorldObjects
         {
             PreviousLocation = Location;
             LandblockManager.RelocateObjectForPhysics(this);
+            //Console.WriteLine("Relocating " + Name + " to " + Location.LandblockId);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -279,6 +279,7 @@ namespace ACE.Server.WorldObjects
                                 break;
                             }
                     }
+                    player.AdjustDungeonCells(portalDest);
 
 #if DEBUG
                     serverMessage = "Portal sending player to destination";

--- a/Source/ACE.Server/WorldObjects/SkillFormula.cs
+++ b/Source/ACE.Server/WorldObjects/SkillFormula.cs
@@ -28,6 +28,10 @@ namespace ACE.Server.WorldObjects
             return attributeBonus;
         }
 
+        /// <summary>
+        /// Converts AL from an additive linear value
+        /// to a scaled damage multiplier
+        /// </summary>
         public static float CalcArmorMod(float armorLevel)
         {
             if (armorLevel > 0)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -728,9 +728,12 @@ namespace ACE.Server.WorldObjects
 
         public bool AdjustDungeonCells(Position pos)
         {
+            if (pos == null) return false;
+
+            var landblock = LScape.get_landblock(pos.Cell);
+            if (landblock == null || !landblock.IsDungeon) return false;
+
             var dungeonID = pos.Cell >> 16;
-            //if (!AdjustCell.AdjustDungeons.Contains(dungeonID))
-            //    return;
 
             var adjustCell = AdjustCell.Get(dungeonID);
             var cellID = adjustCell.GetCell(pos.Pos);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -992,7 +992,7 @@ namespace ACE.Server.WorldObjects
                         //if (PhysicsObj.CurCell == null || curCell.ID != PhysicsObj.CurCell.ID)
                             //PhysicsObj.change_cell_server(curCell);
 
-                        PhysicsObj.set_request_pos(newPosition.Pos, newPosition.Rotation, curCell);
+                        PhysicsObj.set_request_pos(newPosition.Pos, newPosition.Rotation, curCell, Location.LandblockId.Raw);
                         PhysicsObj.update_object_server();
 
                         if (PhysicsObj.CurCell == null)


### PR DESCRIPTION
- Fixed various bugs with monsters crossing between landblock and cell boundaries.
- Monsters should be able to chase the player through dungeons and indoor areas more consistently
- Added monster movement debug commands
- Fixed the missing portals in Hotel Swank
- Fixed a bug with some dungeons having black screens on portal entry
