### PR TITLE
Fix Enchant Registry for duration and layering and Redirect Aura spells

### DIFF
--- a/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
@@ -319,7 +319,7 @@ namespace ACE.Server.Command.Handlers
             if (spellID < 1) throw new Exception("spell not found");
             buff.SpellBase = DatManager.PortalDat.SpellTable.Spells[spellID]; if (buff.SpellBase == null) return null; // the portal data doesn't have the spell, throw here instead?
             buff.Spell = DatabaseManager.World.GetCachedSpell(spellID); if (buff.Spell == null) return null; // the database doesn't have the spell
-            buff.Enchantment = new Enchantment(null, spellID, (double)buff.Spell.Duration, 1, buff.Spell.StatModType, buff.Spell.StatModVal);
+            buff.Enchantment = new Enchantment(null, null, spellID, (double)buff.Spell.Duration, 1, buff.Spell.StatModType, buff.Spell.StatModVal);
             return buff;
         }
 
@@ -363,7 +363,7 @@ namespace ACE.Server.Command.Handlers
                         session.Network.EnqueueSend(new GameMessageSystemChat("Run speed boost is currently INACTIVE", ChatMessageType.Broadcast));
                     break;
                 case "on":
-                    var runEnchantment = new Enchantment(session.Player, spellID, (double)spell.Duration, 1, spell.StatModType, spell.StatModVal);
+                    var runEnchantment = new Enchantment(session.Player, session.Player.Guid, spellID, (double)spell.Duration, 1, spell.StatModType, spell.StatModVal);
                     var msgRunEnchantment = new GameEventMagicUpdateEnchantment(session, runEnchantment);
                     session.Player.CurrentLandblock.EnqueueBroadcast(session.Player.Location, new GameMessageScript(session.Player.Guid, (PlayScript)spell.TargetEffect, 1f));
                     session.Player.EnchantmentManager.Add(runEnchantment, null);

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -110,10 +110,10 @@ namespace ACE.Server.Managers
                             break;
                         }
 
+                        // item cast spell of equal power should override an existing spell, especially one with a duration
                         if ((caster as Creature) == null)
                         {
-                            // item cast spell of equal power should override an existing spell, especially one with a duration
-                            enchantment.Layer++;
+                            enchantment.Layer = entry.LayerId; // Should be a higher layer than existing enchant
                             var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
                             newEntry.LayerId = enchantment.Layer;
                             WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);
@@ -144,7 +144,7 @@ namespace ACE.Server.Managers
                         }
                     }
 
-                    enchantment.Layer = (ushort)(layerBuffer + 1);
+                    enchantment.Layer = (ushort)(layerBuffer + 1); // Should be a higher layer than existing enchant
                     var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
                     newEntry.LayerId = enchantment.Layer;
                     WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -19,6 +19,7 @@ namespace ACE.Server.Managers
 {
     public enum StackType
     {
+        Undef,
         None,
         Initial,
         Refresh,
@@ -56,58 +57,101 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Add/update zero or more enchantments in this object's registry
         /// </summary>
-        public IEnumerable<StackType> AddRange(IEnumerable<Enchantment> enchantment, string castByItem)
+        public IEnumerable<StackType> AddRange(IEnumerable<Enchantment> enchantment, WorldObject caster)
         {
             List<StackType> stacks = new List<StackType>();
-            enchantment.ToList().ForEach(k => stacks.Add(Add(k, castByItem)));
+            enchantment.ToList().ForEach(k => stacks.Add(Add(k, caster)));
             return stacks;
         }
 
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public StackType Add(Enchantment enchantment, string castByItem)
+        public StackType Add(Enchantment enchantment, WorldObject caster)
         {
+            StackType result = StackType.Undef;
+
             // check for existing spell in this category
-            var entry = GetCategory(enchantment.Spell.Category);
+            var entries = GetCategory(enchantment.Spell.Category);
 
             // if none, add new record
-            if (entry == null)
+            if (!entries.Any())
             {
-                entry = BuildEntry(enchantment.Spell.SpellId, castByItem);
-                entry.LayerId = enchantment.Layer;
-                var type = (EnchantmentTypeFlags)entry.StatModType;
-                WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(entry);
+                var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
+                newEntry.LayerId = enchantment.Layer;
+                var type = (EnchantmentTypeFlags)newEntry.StatModType;
+                WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);
 
+                result = StackType.Initial;
                 return StackType.Initial;
             }
 
-            if (enchantment.Spell.Power > entry.PowerLevel)
+            // Check for existing spells in registry that are superior
+            foreach (var entry in entries)
             {
-                // surpass existing spell
-                Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
-                Remove(entry, false);
-                entry = BuildEntry(enchantment.Spell.SpellId, castByItem);
-                entry.LayerId = enchantment.Layer;
-                WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(entry);
-
-                return StackType.Surpass;
+                if (enchantment.Spell.Power < entry.PowerLevel)
+                {
+                    // superior existing spell
+                    Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
+                    result = StackType.Surpassed;
+                }
             }
 
-            if (enchantment.Spell.Power == entry.PowerLevel)
+            if (result != StackType.Surpassed)
             {
-                if (entry.Duration == -1)
-                    return StackType.None;
+                // Check for existing spells in registry that are equal to
+                foreach (var entry in entries)
+                {
+                    if (enchantment.Spell.Power == entry.PowerLevel)
+                    {
+                        if (entry.Duration == -1)
+                        {
+                            result = StackType.None;
+                            break;
+                        }
 
-                // refresh existing spell
-                entry.LayerId++;
-                entry.StartTime = 0;
-                return StackType.Refresh;
+                        if ((caster as Creature) == null)
+                        {
+                            // item cast spell of equal power should override an existing spell, especially one with a duration
+                            enchantment.Layer++;
+                            var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
+                            newEntry.LayerId = enchantment.Layer;
+                            WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);
+
+                            result = StackType.Refresh;
+                            break;
+                        }
+
+                        // refresh existing spell
+                        entry.StartTime = 0;
+                        result = StackType.Refresh;
+                        break;
+                    }
+                }
+
+                // Previous check didn't return any result
+                if (result == StackType.Undef)
+                {
+                    // Check for highest existing spell in registry that is inferior
+                    foreach (var entry in entries)
+                    {
+                        if (enchantment.Spell.Power > entry.PowerLevel)
+                        {
+                            // surpass existing spell
+                            Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
+                        }
+                    }
+
+                    enchantment.Layer++;
+                    var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
+                    newEntry.LayerId = enchantment.Layer;
+                    WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);
+
+                    result = StackType.Surpass;
+                }
             }
 
-            // superior existing spell
-            Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
-            return StackType.Surpassed;
+            return result;
         }
 
         /// <summary>
@@ -209,9 +253,10 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns all of the enchantments for a category
         /// </summary>
-        public BiotaPropertiesEnchantmentRegistry GetCategory(uint categoryID)
+        public IEnumerable<BiotaPropertiesEnchantmentRegistry> GetCategory(uint categoryID)
         {
-            return WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(e => e.SpellCategory == categoryID);
+            var result = WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Where(e => e.SpellCategory == categoryID);
+            return result;
         }
 
         /// <summary>
@@ -243,7 +288,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Builds an enchantment registry entry from a spell ID
         /// </summary>
-        public BiotaPropertiesEnchantmentRegistry BuildEntry(uint spellID, string castByItem = null)
+        public BiotaPropertiesEnchantmentRegistry BuildEntry(uint spellID, WorldObject caster = null)
         {
             var spellBase = DatManager.PortalDat.SpellTable.Spells[spellID];
             var spell = DatabaseManager.World.GetCachedSpell(spellID);
@@ -258,15 +303,24 @@ namespace ACE.Server.Managers
             entry.SpellCategory = (ushort)spell.Category;
             entry.PowerLevel = spell.Power;
 
-            if (castByItem != null)
-            {
-                entry.Duration = -1.0;
-                entry.StartTime = 0;
-            }
-            else
+            if (caster is Creature)
                 entry.Duration = spell.Duration ?? 0.0;
+            else
+            {
+                if (caster.WeenieType == WeenieType.Gem)
+                    entry.Duration = spell.Duration ?? 0.0;
+                else
+                {
+                    entry.Duration = -1.0;
+                    entry.StartTime = 0;
+                }
+            }
 
-            entry.CasterObjectId = WorldObject.Guid.Full;   // only works for self?
+            if (caster == null)
+                entry.CasterObjectId = WorldObject.Guid.Full;
+            else
+                entry.CasterObjectId = caster.Guid.Full;
+
             entry.DegradeModifier = spell.DegradeModifier ?? 0.0f;
             entry.DegradeLimit = spell.DegradeLimit ?? 0.0f;
             entry.StatModType = spell.StatModType ?? 0;

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -132,6 +132,7 @@ namespace ACE.Server.Managers
                 // Previous check didn't return any result
                 if (result == StackType.Undef)
                 {
+                    ushort layerBuffer = 1;
                     // Check for highest existing spell in registry that is inferior
                     foreach (var entry in entries)
                     {
@@ -139,10 +140,11 @@ namespace ACE.Server.Managers
                         {
                             // surpass existing spell
                             Surpass = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
+                            layerBuffer = entry.LayerId;
                         }
                     }
 
-                    enchantment.Layer++;
+                    enchantment.Layer = (ushort)(layerBuffer + 1);
                     var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
                     newEntry.LayerId = enchantment.Layer;
                     WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(newEntry);

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -75,7 +75,7 @@ namespace ACE.Server.Managers
             var entries = GetCategory(enchantment.Spell.Category);
 
             // if none, add new record
-            if (!entries.Any())
+            if (entries.Count == 0)
             {
                 var newEntry = BuildEntry(enchantment.Spell.SpellId, caster);
                 newEntry.LayerId = enchantment.Layer;
@@ -255,9 +255,9 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns all of the enchantments for a category
         /// </summary>
-        public IEnumerable<BiotaPropertiesEnchantmentRegistry> GetCategory(uint categoryID)
+        public List<BiotaPropertiesEnchantmentRegistry> GetCategory(uint categoryID)
         {
-            var result = WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Where(e => e.SpellCategory == categoryID);
+            var result = WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Where(e => e.SpellCategory == categoryID).ToList();
             return result;
         }
 

--- a/Source/ACE.Server/Network/Enum/WeaponMask.cs
+++ b/Source/ACE.Server/Network/Enum/WeaponMask.cs
@@ -24,18 +24,23 @@ namespace ACE.Server.Network.Enum
                 return highlightMask;
 
             // item enchanments are currently being cast on wielder
-            if (wielder.EnchantmentManager.GetAttackMod() != 1.0f)
-                highlightMask |= WeaponMask.AttackSkill;
             if (wielder.EnchantmentManager.GetDefenseMod() != 1.0f)
                 highlightMask |= WeaponMask.MeleeDefense;
-            if (wielder.EnchantmentManager.GetWeaponSpeedMod() != 0)
-                highlightMask |= WeaponMask.Speed;
-            if (wielder.EnchantmentManager.GetDamageMod() != 0)
-                highlightMask |= WeaponMask.Damage;
-            if (wielder.EnchantmentManager.GetVarianceMod() != 1.0f)
-                highlightMask |= WeaponMask.DamageVariance;
-            if (wielder.EnchantmentManager.GetDamageModifier() != 1.0f)
-                highlightMask |= WeaponMask.DamageMod;
+
+            // Following enchants do not apply to caster weapons
+            if (weapon.WeenieType != ACE.Entity.Enum.WeenieType.Caster)
+            {
+                if (wielder.EnchantmentManager.GetAttackMod() != 1.0f)
+                    highlightMask |= WeaponMask.AttackSkill;
+                if (wielder.EnchantmentManager.GetWeaponSpeedMod() != 0)
+                    highlightMask |= WeaponMask.Speed;
+                if (wielder.EnchantmentManager.GetDamageMod() != 0)
+                    highlightMask |= WeaponMask.Damage;
+                if (wielder.EnchantmentManager.GetVarianceMod() != 1.0f)
+                    highlightMask |= WeaponMask.DamageVariance;
+                if (wielder.EnchantmentManager.GetDamageModifier() != 1.0f)
+                    highlightMask |= WeaponMask.DamageMod;
+            }
 
             return highlightMask;
         }

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -13,6 +13,7 @@ namespace ACE.Server.Network.Structure
     public class Enchantment
     {
         public WorldObject Target;
+        public ACE.Entity.ObjectGuid CasterGuid;
         public SpellBase SpellBase;
         public Spell Spell;
         public ushort Layer;
@@ -21,9 +22,15 @@ namespace ACE.Server.Network.Structure
         public double Duration;
         public float? StatMod;
 
-        public Enchantment(WorldObject target, uint spellId, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
+        public Enchantment(WorldObject target, ACE.Entity.ObjectGuid? casterGuid, uint spellId, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
         {
             Target = target;
+
+            if (casterGuid == null)
+                CasterGuid = ACE.Entity.ObjectGuid.Invalid;
+            else
+                CasterGuid = (ACE.Entity.ObjectGuid)casterGuid;
+
             SpellBase = DatManager.PortalDat.SpellTable.Spells[spellId];
             Spell = DatabaseManager.World.GetCachedSpell(spellId);
             Layer = layer;
@@ -32,9 +39,15 @@ namespace ACE.Server.Network.Structure
             StatMod = statMod ?? Spell.StatModVal;
         }
 
-        public Enchantment(WorldObject target, SpellBase spellBase, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
+        public Enchantment(WorldObject target, ACE.Entity.ObjectGuid? casterGuid, SpellBase spellBase, double duration, ushort layer, uint? enchantmentMask, float? statMod = null)
         {
             Target = target;
+
+            if (casterGuid == null)
+                CasterGuid = ACE.Entity.ObjectGuid.Invalid;
+            else
+                CasterGuid = (ACE.Entity.ObjectGuid)casterGuid;
+
             SpellBase = spellBase;
             Layer = layer;
             Duration = duration;
@@ -45,6 +58,7 @@ namespace ACE.Server.Network.Structure
         public Enchantment(WorldObject target, BiotaPropertiesEnchantmentRegistry entry)
         {
             Target = target;
+            CasterGuid = new ACE.Entity.ObjectGuid(entry.CasterObjectId);
             SpellBase = DatManager.PortalDat.SpellTable.Spells[(uint)entry.SpellId];
             Spell = DatabaseManager.World.GetCachedSpell((uint)entry.SpellId);
             Layer = entry.LayerId;
@@ -83,7 +97,7 @@ namespace ACE.Server.Network.Structure
             writer.Write(enchantment.SpellBase.Power);
             writer.Write(enchantment.StartTime);
             writer.Write(enchantment.Duration);
-            writer.Write(enchantment.Target.Guid.Full);
+            writer.Write(enchantment.CasterGuid.Full);
             writer.Write(enchantment.SpellBase.DegradeModifier);
             writer.Write(enchantment.SpellBase.DegradeLimit);
             writer.Write(LastTimeDegraded);     // always 0 / spell economy?

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -139,7 +139,7 @@ namespace ACE.Server.WorldObjects
                 //const uint spellCategory = 0x8000; // FIXME: Not sure where we get this from
                 var spellBase = new SpellBase(0, CooldownDuration.Value, 0, -666);
                 // cooldown not being used in network packet?
-                var gem = new Enchantment(player, spellBase, spellBase.Duration, layer, /*CooldownId.Value,*/ (uint)EnchantmentTypeFlags.Cooldown);
+                var gem = new Enchantment(player, player.Guid, spellBase, spellBase.Duration, layer, /*CooldownId.Value,*/ (uint)EnchantmentTypeFlags.Cooldown);
                 player.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(player.Session, gem));
 
                 // Ok this was not known to us, so we used the contract - now remove it from inventory.

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -58,7 +58,7 @@ namespace ACE.Server.WorldObjects
             var spellID = (uint)Network.Enum.Spell.Vitae;
             var spellBase = DatManager.PortalDat.SpellTable.Spells[spellID];
             var spell = DatabaseManager.World.GetCachedSpell(spellID);
-            var vitaeEnchantment = new Enchantment(this, spellID, (double)spell.Duration, 0, spell.StatModType, vitae);
+            var vitaeEnchantment = new Enchantment(this, Guid, spellID, (double)spell.Duration, 0, spell.StatModType, vitae);
             var msgVitaeEnchantment = new GameEventMagicUpdateEnchantment(Session, vitaeEnchantment);
 
             var msgHealthUpdate = new GameMessagePrivateUpdateAttribute2ndLevel(this, Vital.Health, 0);

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -191,8 +191,18 @@ namespace ACE.Server.WorldObjects
                             player.Session.Network.EnqueueSend(message);
                         break;
                     case MagicSchool.ItemEnchantment:
-                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(item.Guid, (PlayScript)spell.TargetEffect, scale));
-                        message = ItemMagic(item, spell, spellStatMod, item.Name);
+                        CurrentLandblock.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.TargetEffect, scale));
+                        if ((spell.Category == (uint)SpellCategory.AttackModRaising)
+                            || (spell.Category == (uint)SpellCategory.DamageRaising)
+                            || (spell.Category == (uint)SpellCategory.DefenseModRaising)
+                            || (spell.Category == (uint)SpellCategory.WeaponTimeRaising)
+                            || (spell.Category == (uint)SpellCategory.AppraisalResistanceLowering)
+                            || (spell.Category == (uint)SpellCategory.SpellDamageRaising))
+                        {
+                            message = ItemMagic(player, spell, spellStatMod, item.Name);
+                        }
+                        else
+                            message = ItemMagic(item, spell, spellStatMod, item.Name);
                         created = true;
                         if (message != null)
                             player.Session.Network.EnqueueSend(message);

--- a/Source/ACE.Server/WorldObjects/Switch.cs
+++ b/Source/ACE.Server/WorldObjects/Switch.cs
@@ -138,9 +138,9 @@ namespace ACE.Server.WorldObjects
                         if (!spellTable.Spells.ContainsKey((uint)SpellDID)) return;
                         var spellBase = DatManager.PortalDat.SpellTable.Spells[(uint)SpellDID];
                         var spell = DatabaseManager.World.GetCachedSpell((uint)SpellDID);
-                        GameMessageSystemChat msg;
+                        EnchantmentStatus enchantmentStatus = default(EnchantmentStatus);
                         player.PlayParticleEffect((PlayScript)spellBase.TargetEffect, player.Guid);
-                        LifeMagic(player, spellBase, spell, out uint damage, out bool critical, out msg);
+                        LifeMagic(player, spellBase, spell, out uint damage, out bool critical, out enchantmentStatus);
                         //player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session));
                         player.SendUseDoneEvent();
                         return;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -19,6 +19,12 @@ namespace ACE.Server.WorldObjects
 {
     partial class WorldObject
     {
+        public struct EnchantmentStatus
+        {
+            public StackType stackType;
+            public GameMessageSystemChat message;
+        }
+
         public enum SpellLevel
         {
             One = 1,
@@ -245,12 +251,14 @@ namespace ACE.Server.WorldObjects
         /// <param name="spell"></param>
         /// <param name="spellStatMod"></param>
         /// <param name="message"></param>
-        /// <param name="castByItem"></param>
+        /// <param name="itemCaster"></param>
         /// <returns></returns>
-        protected bool LifeMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, out uint damage, out bool critical, out GameMessageSystemChat message, string castByItem = null)
+        protected bool LifeMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, out uint damage, out bool critical, out EnchantmentStatus enchantmentStatus, WorldObject itemCaster = null)
         {
             critical = false;
             string srcVital, destVital;
+            enchantmentStatus = default(EnchantmentStatus);
+            enchantmentStatus.stackType = StackType.None;
             GameMessageSystemChat targetMsg = null;
 
             Player player = null;
@@ -337,19 +345,19 @@ namespace ACE.Server.WorldObjects
                             if (boost <= 0)
                             {
                                 msg = $"You drain {Math.Abs(boost).ToString()} points of {srcVital} from {spellTarget.Name}";
-                                message = new GameMessageSystemChat(msg, ChatMessageType.Combat);
+                                enchantmentStatus.message = new GameMessageSystemChat(msg, ChatMessageType.Combat);
                             }
                             else
                             {
                                 msg = $"You restore {Math.Abs(boost).ToString()} points of {srcVital} to {spellTarget.Name}";
-                                message = new GameMessageSystemChat(msg, ChatMessageType.Magic);
+                                enchantmentStatus.message = new GameMessageSystemChat(msg, ChatMessageType.Magic);
                             }
                         }
                         else
-                            message = new GameMessageSystemChat($"You restore {Math.Abs(boost).ToString()} {srcVital}", ChatMessageType.Magic);
+                            enchantmentStatus.message = new GameMessageSystemChat($"You restore {Math.Abs(boost).ToString()} {srcVital}", ChatMessageType.Magic);
                     }
                     else
-                        message = null;
+                        enchantmentStatus.message = null;
 
                     if (target is Player && spell.BaseRangeConstant > 0)
                     {
@@ -454,13 +462,13 @@ namespace ACE.Server.WorldObjects
                     {
                         if (target.Guid == player.Guid)
                         {
-                            message = new GameMessageSystemChat($"You drain {vitalChange.ToString()} points of {srcVital} and apply {casterVitalChange.ToString()} points of {destVital} to yourself", ChatMessageType.Magic);
+                            enchantmentStatus.message = new GameMessageSystemChat($"You drain {vitalChange.ToString()} points of {srcVital} and apply {casterVitalChange.ToString()} points of {destVital} to yourself", ChatMessageType.Magic);
                         }
                         else
-                            message = new GameMessageSystemChat($"You drain {vitalChange.ToString()} points of {srcVital} from {spellTarget.Name} and apply {casterVitalChange.ToString()} to yourself", ChatMessageType.Combat);
+                            enchantmentStatus.message = new GameMessageSystemChat($"You drain {vitalChange.ToString()} points of {srcVital} from {spellTarget.Name} and apply {casterVitalChange.ToString()} to yourself", ChatMessageType.Combat);
                     }
                     else
-                        message = null;
+                        enchantmentStatus.message = null;
 
                     if (target is Player && target != this)
                         targetMsg = new GameMessageSystemChat($"You lose {vitalChange} points of {srcVital} due to {Name} casting {spell.Name} on you", ChatMessageType.Combat);
@@ -514,19 +522,22 @@ namespace ACE.Server.WorldObjects
                             player.Session.Network.EnqueueSend(new GameMessageSystemChat("You have killed yourself", ChatMessageType.Broadcast));
                         }
                     }
-                    message = null;
+                    enchantmentStatus.message = null;
                     break;
                 case SpellType.Dispel:
                     damage = 0;
-                    message = new GameMessageSystemChat("Spell not implemented, yet!", ChatMessageType.Magic);
+                    enchantmentStatus.message = new GameMessageSystemChat("Spell not implemented, yet!", ChatMessageType.Magic);
                     break;
                 case SpellType.Enchantment:
                     damage = 0;
-                    message = CreateEnchantment(target, spell, spellStatMod, castByItem);
+                    if (itemCaster != null)
+                        enchantmentStatus = CreateEnchantment(target, itemCaster, spell, spellStatMod);
+                    else
+                        enchantmentStatus = CreateEnchantment(target, this, spell, spellStatMod);
                     break;
                 default:
                     damage = 0;
-                    message = new GameMessageSystemChat("Spell not implemented, yet!", ChatMessageType.Magic);
+                    enchantmentStatus.message = new GameMessageSystemChat("Spell not implemented, yet!", ChatMessageType.Magic);
                     break;
             }
 
@@ -545,11 +556,14 @@ namespace ACE.Server.WorldObjects
         /// <param name="target"></param>
         /// <param name="spell"></param>
         /// <param name="spellStatMod"></param>
-        /// <param name="castByItem"></param>
+        /// <param name="itemCaster"></param>
         /// <returns></returns>
-        protected GameMessageSystemChat CreatureMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, string castByItem = null)
+        protected EnchantmentStatus CreatureMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, WorldObject itemCaster = null)
         {
-            return CreateEnchantment(target, spell, spellStatMod, castByItem);
+            if (itemCaster != null)
+                return CreateEnchantment(target, itemCaster, spell, spellStatMod);
+
+            return CreateEnchantment(target, this, spell, spellStatMod);
         }
 
         /// <summary>
@@ -558,8 +572,8 @@ namespace ACE.Server.WorldObjects
         /// <param name="target"></param>
         /// <param name="spell"></param>
         /// <param name="spellStatMod"></param>
-        /// <param name="castByItem"></param>
-        protected GameMessageSystemChat ItemMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, string castByItem = null)
+        /// <param name="itemCaster"></param>
+        protected EnchantmentStatus ItemMagic(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, WorldObject itemCaster = null)
         {
             Player player = CurrentLandblock.GetObject(Guid) as Player;
 
@@ -604,10 +618,16 @@ namespace ACE.Server.WorldObjects
             }
             else if (spell.MetaSpellType == SpellType.Enchantment)
             {
-                return CreateEnchantment(target, spell, spellStatMod, castByItem);
+                if (itemCaster != null)
+                    return CreateEnchantment(target, itemCaster, spell, spellStatMod);
+
+                return CreateEnchantment(target, this, spell, spellStatMod);
             }
 
-            return null;
+            EnchantmentStatus enchantmentStatus = default(EnchantmentStatus);
+            enchantmentStatus.message = null;
+            enchantmentStatus.stackType = StackType.None;
+            return enchantmentStatus;
         }
 
         /// <summary>
@@ -654,20 +674,28 @@ namespace ACE.Server.WorldObjects
         /// Used by Life, Creature, Item, and Void magic
         /// </summary>
         /// <param name="target"></param>
+        /// <param name="caster"></param>
         /// <param name="spell"></param>
         /// <param name="spellStatMod"></param>
-        /// <param name="castByItem"></param>
         /// <returns></returns>
-        private GameMessageSystemChat CreateEnchantment(WorldObject target, SpellBase spell, Database.Models.World.Spell spellStatMod, string castByItem = null)
+        private EnchantmentStatus CreateEnchantment(WorldObject target, WorldObject caster, SpellBase spell, Database.Models.World.Spell spellStatMod)
         {
+            EnchantmentStatus enchantmentStatus = default(EnchantmentStatus);
             double duration;
-            if (castByItem == null)
+
+            if (caster is Creature)
                 duration = spell.Duration;
             else
-                duration = -1;
+            {
+                if (caster.WeenieType == WeenieType.Gem)
+                    duration = spell.Duration;
+                else
+                    duration = -1;
+            }
+
             // create enchantment
-            var enchantment = new Enchantment(target, spellStatMod.SpellId, duration, 1, (uint)EnchantmentMask.CreatureSpells);
-            var stackType = target.EnchantmentManager.Add(enchantment, castByItem);
+            var enchantment = new Enchantment(target, caster.Guid, spellStatMod.SpellId, duration, 1, (uint)EnchantmentMask.CreatureSpells);
+            var stackType = target.EnchantmentManager.Add(enchantment, caster);
 
             var player = this as Player;
             var playerTarget = target as Player;
@@ -691,27 +719,41 @@ namespace ACE.Server.WorldObjects
             var targetName = this == target ? "yourself" : target.Name;
 
             string message;
-            if (castByItem != null)
-            {
-                if (target.Name != castByItem)
-                    message = $"{castByItem} casts {spell.Name} on you";
-                else
-                    message = null;
-            }
+            if (stackType == StackType.Undef)
+                message = null;
             else
-                message = $"You cast {spell.Name} on {targetName}{suffix}";
-
+            {
+                if (stackType == StackType.None)
+                    message = null;
+                else
+                {
+                    if (caster is Creature)
+                        message = $"You cast {spell.Name} on {targetName}{suffix}";
+                    else
+                    {
+                        if (target.Name != caster.Name)
+                            message = $"{caster.Name} casts {spell.Name} on you{suffix}";
+                        else
+                            message = null;
+                    }
+                }
+            }
 
             if (target is Player)
             {
-                if (stackType != StackType.Surpassed)
-                    playerTarget.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(playerTarget.Session, enchantment));
+                if (stackType != StackType.Undef)
+                {
+                    if (stackType != StackType.Surpassed)
+                        playerTarget.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(playerTarget.Session, enchantment));
 
-                if (playerTarget != this)
-                    playerTarget.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} cast {spell.Name} on you{suffix}", ChatMessageType.Magic));
+                    if (playerTarget != this)
+                        playerTarget.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} cast {spell.Name} on you{suffix}", ChatMessageType.Magic));
+                }
             }
 
-            return new GameMessageSystemChat(message, ChatMessageType.Magic);
+            enchantmentStatus.message = new GameMessageSystemChat(message, ChatMessageType.Magic);
+            enchantmentStatus.stackType = stackType;
+            return enchantmentStatus;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -662,9 +662,9 @@ namespace ACE.Server.WorldObjects
         {
             double duration;
             if (castByItem == null)
-                duration = -1;
-            else
                 duration = spell.Duration;
+            else
+                duration = -1;
             // create enchantment
             var enchantment = new Enchantment(target, spellStatMod.SpellId, duration, 1, (uint)EnchantmentMask.CreatureSpells);
             var stackType = target.EnchantmentManager.Add(enchantment, castByItem);
@@ -692,7 +692,12 @@ namespace ACE.Server.WorldObjects
 
             string message;
             if (castByItem != null)
-                message = $"{castByItem} casts {spell.Name} on you";
+            {
+                if (target.Name != castByItem)
+                    message = $"{castByItem} casts {spell.Name} on you";
+                else
+                    message = null;
+            }
             else
                 message = $"You cast {spell.Name} on {targetName}{suffix}";
 


### PR DESCRIPTION
-Redirect Aura spells cast by items to Player
-Fix Enchantment Registry timers
-Account for gems casting spells requiring a duration
-Initial pass at Enchantment layering

TODO: duplicate and overridden item enchants still show up on AppraisalInfo :: will fix in next PR