### PR TITLE
Remove the five unneeded start items

### DIFF
--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -215,8 +215,9 @@ namespace ACE.Server.Network.Handlers
                 return;
             }
 
-            if (weenie.WeeniePropertiesCreateList.Any())
-                weenie.WeeniePropertiesCreateList.Clear();
+            // Removes the generic knife and buckler, hidden Javelin, 30 stack of arrows, and 5 stack of coins that are given to all characters
+            // Starter Gear from the JSON file are added to the character later in the CharacterCreateEx() process
+            weenie.WeeniePropertiesCreateList.Clear();
 
             var guid = GuidManager.NewPlayerGuid();
 

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -215,6 +215,8 @@ namespace ACE.Server.Network.Handlers
                 return;
             }
 
+            if (weenie.WeeniePropertiesCreateList.Any())
+                weenie.WeeniePropertiesCreateList.Clear();
 
             var guid = GuidManager.NewPlayerGuid();
 


### PR DESCRIPTION
-Remove the five unneeded start items from WeeniePropertiesCreateList that get generated for all characters.