### PR TITLE
Fix for using recipe items located in Packs

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -94,7 +94,8 @@ namespace ACE.Server.Managers
 
                     if (destroyTarget)
                     {
-                        if (target.OwnerId == player.Guid.Full)
+                        // TODO - Check if the target is wielded and handle appropriately
+                        if (target.OwnerId == player.Guid.Full  || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)targetSuccess.DestroyAmount);
                         }
@@ -112,7 +113,8 @@ namespace ACE.Server.Managers
 
                     if (destroySource)
                     {
-                        if (source.OwnerId == player.Guid.Full)
+                        // TODO - Check if the source is wielded and handle appropriately
+                        if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)sourceSuccess.DestroyAmount);
                         }
@@ -154,7 +156,8 @@ namespace ACE.Server.Managers
 
                     if (destroyTarget)
                     {
-                        if (target.OwnerId == player.Guid.Full)
+                        // TODO - Check if the target is wielded and handle appropriately
+                        if (target.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)targetFail.DestroyAmount);
                         }
@@ -172,7 +175,8 @@ namespace ACE.Server.Managers
 
                     if (destroySource)
                     {
-                        if (source.OwnerId == player.Guid.Full)
+                        // TODO - Check if the source is wielded and handle appropriately
+                        if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)sourceFail.DestroyAmount);
                         }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -94,10 +94,13 @@ namespace ACE.Server.Managers
 
                     if (destroyTarget)
                     {
-                        // TODO - Check if the target is wielded and handle appropriately
                         if (target.OwnerId == player.Guid.Full  || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)targetSuccess.DestroyAmount);
+                        }
+                        else if (target.WielderId == player.Guid.Full)
+                        {
+                            if (!player.TryRemoveItemWithNetworking(target)) throw new Exception($"Failed to remove {target.Name} from player inventory.");
                         }
                         else
                         {
@@ -113,10 +116,13 @@ namespace ACE.Server.Managers
 
                     if (destroySource)
                     {
-                        // TODO - Check if the source is wielded and handle appropriately
                         if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)sourceSuccess.DestroyAmount);
+                        }
+                        else if (source.WielderId == player.Guid.Full)
+                        {
+                            if (!player.TryRemoveItemWithNetworking(source)) throw new Exception($"Failed to remove {source.Name} from player inventory.");
                         }
                         else
                         {
@@ -156,10 +162,13 @@ namespace ACE.Server.Managers
 
                     if (destroyTarget)
                     {
-                        // TODO - Check if the target is wielded and handle appropriately
                         if (target.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)targetFail.DestroyAmount);
+                        }
+                        else if (target.WielderId == player.Guid.Full)
+                        {
+                            if (!player.TryRemoveItemWithNetworking(target)) throw new Exception($"Failed to remove {target.Name} from player inventory.");
                         }
                         else
                         {
@@ -175,10 +184,13 @@ namespace ACE.Server.Managers
 
                     if (destroySource)
                     {
-                        // TODO - Check if the source is wielded and handle appropriately
                         if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
                             player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)sourceFail.DestroyAmount);
+                        }
+                        else if (source.WielderId == player.Guid.Full)
+                        {
+                            if (!player.TryRemoveItemWithNetworking(source)) throw new Exception($"Failed to remove {source.Name} from player inventory.");
                         }
                         else
                         {

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -223,6 +223,8 @@ namespace ACE.Server.WorldObjects
                         var stone = invSource as ManaStone;
                         stone.HandleActionUseOnTarget(this, invWielded);
                     }
+                    else
+                        RecipeManager.UseObjectOnTarget(this, invSource, invWielded);
                 }
                 else
                 {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2018-07-11
+[OptimShi]
+* Updated recipe manager to properly destroy items in packs (as opposed to main backpack). Added in functionality to handle equipped items in recipes, but there are downstream issues related to inventory management (such as enchantments not being removed)
+
 ### 2018-07-09
 [OptimShi]
 * Fixed a few console commands that either should not run in the console or had no use case if they did.


### PR DESCRIPTION
This addresses Issue #779 

To test:

* /ci 8327 (Gold Pea)
* /ci 8283 (Splitting Tool)
* /ci 136 (Pack)
* Place these items in the Pack.
* Use the Splitting Tool on the Gold Pea in Pack.

Gold Pea should be removed and Gold Scarabs placed in main backpack.