### PR TITLE
Rework AppraisalInfo for Enchants

### DIFF
--- a/Source/ACE.Server/Network/Enum/ArmorMask.cs
+++ b/Source/ACE.Server/Network/Enum/ArmorMask.cs
@@ -20,7 +20,7 @@ namespace ACE.Server.Network.Enum
         /// <summary>
         /// Determines if there is a highlight for each armor protection vs. damage type
         /// </summary>
-        public static ArmorMask GetHighlightMask(WorldObject armor, WorldObject wielder)
+        public static ArmorMask GetHighlightMask(WorldObject armor)
         {
             ArmorMask highlightMask = 0;
 
@@ -51,7 +51,7 @@ namespace ACE.Server.Network.Enum
         /// <summary>
         /// Determines the red/green color for each armor protection vs. damage type
         /// </summary>
-        public static ArmorMask GetColorMask(WorldObject armor, WorldObject wielder)
+        public static ArmorMask GetColorMask(WorldObject armor)
         {
             ArmorMask colorMask = 0;
 

--- a/Source/ACE.Server/Network/Enum/ArmorMask.cs
+++ b/Source/ACE.Server/Network/Enum/ArmorMask.cs
@@ -24,25 +24,25 @@ namespace ACE.Server.Network.Enum
         {
             ArmorMask highlightMask = 0;
 
-            if (wielder == null)
+            if (armor == null)
                 return highlightMask;
 
             // item enchanments are currently being cast on wielder
-            if (wielder.EnchantmentManager.GetArmorMod() != 0)
+            if (armor.EnchantmentManager.GetArmorMod() != 0)
                 highlightMask |= ArmorMask.ArmorLevel;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Slash) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Slash) != 0)
                 highlightMask |= ArmorMask.SlashingProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Pierce) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Pierce) != 0)
                 highlightMask |= ArmorMask.PiercingProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Bludgeon) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Bludgeon) != 0)
                 highlightMask |= ArmorMask.BludgeoningProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Cold) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Cold) != 0)
                 highlightMask |= ArmorMask.ColdProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Fire) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Fire) != 0)
                 highlightMask |= ArmorMask.FireProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Acid) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Acid) != 0)
                 highlightMask |= ArmorMask.AcidProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Electric) != 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Electric) != 0)
                 highlightMask |= ArmorMask.LightningProtection;
 
             return highlightMask;
@@ -55,24 +55,24 @@ namespace ACE.Server.Network.Enum
         {
             ArmorMask colorMask = 0;
 
-            if (wielder == null)
+            if (armor == null)
                 return colorMask;
 
-            if (wielder.EnchantmentManager.GetArmorMod() > 0)
+            if (armor.EnchantmentManager.GetArmorMod() > 0)
                 colorMask |= ArmorMask.ArmorLevel;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Slash) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Slash) > 0)
                 colorMask |= ArmorMask.SlashingProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Pierce) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Pierce) > 0)
                 colorMask |= ArmorMask.PiercingProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Bludgeon) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Bludgeon) > 0)
                 colorMask |= ArmorMask.BludgeoningProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Cold) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Cold) > 0)
                 colorMask |= ArmorMask.ColdProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Fire) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Fire) > 0)
                 colorMask |= ArmorMask.FireProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Acid) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Acid) > 0)
                 colorMask |= ArmorMask.AcidProtection;
-            if (wielder.EnchantmentManager.GetArmorModVsType(DamageType.Electric) > 0)
+            if (armor.EnchantmentManager.GetArmorModVsType(DamageType.Electric) > 0)
                 colorMask |= ArmorMask.LightningProtection;
 
             return colorMask;

--- a/Source/ACE.Server/Network/Enum/WeaponMask.cs
+++ b/Source/ACE.Server/Network/Enum/WeaponMask.cs
@@ -23,7 +23,7 @@ namespace ACE.Server.Network.Enum
             if (wielder == null)
                 return highlightMask;
 
-            // item enchanments are currently being cast on wielder
+            // Enchant applies to all weapons
             if (wielder.EnchantmentManager.GetDefenseMod() != 1.0f)
                 highlightMask |= WeaponMask.MeleeDefense;
 
@@ -52,19 +52,25 @@ namespace ACE.Server.Network.Enum
             if (wielder == null)
                 return colorMask;
 
-            // item enchanments are currently being cast on wielder
-            if (wielder.EnchantmentManager.GetAttackMod() > 1.0f)
-                colorMask |= WeaponMask.AttackSkill;
+            // Enchant applies to all weapons
             if (wielder.EnchantmentManager.GetDefenseMod() > 1.0f)
                 colorMask |= WeaponMask.MeleeDefense;
-            if (wielder.EnchantmentManager.GetWeaponSpeedMod() < 0)
-                colorMask |= WeaponMask.Speed;
-            if (wielder.EnchantmentManager.GetDamageMod() > 0)
-                colorMask |= WeaponMask.Damage;
-            if (wielder.EnchantmentManager.GetVarianceMod() < 1.0f)
-                colorMask |= WeaponMask.DamageVariance;
-            if (wielder.EnchantmentManager.GetDamageModifier() > 1.0f)
-                colorMask |= WeaponMask.DamageMod;
+
+            // Following enchants do not apply to caster weapons
+            if (weapon.WeenieType != ACE.Entity.Enum.WeenieType.Caster)
+            {
+                // item enchanments are currently being cast on wielder
+                if (wielder.EnchantmentManager.GetAttackMod() > 1.0f)
+                    colorMask |= WeaponMask.AttackSkill;
+                if (wielder.EnchantmentManager.GetWeaponSpeedMod() < 0)
+                    colorMask |= WeaponMask.Speed;
+                if (wielder.EnchantmentManager.GetDamageMod() > 0)
+                    colorMask |= WeaponMask.Damage;
+                if (wielder.EnchantmentManager.GetVarianceMod() < 1.0f)
+                    colorMask |= WeaponMask.DamageVariance;
+                if (wielder.EnchantmentManager.GetDamageModifier() > 1.0f)
+                    colorMask |= WeaponMask.DamageMod;
+            }
 
             return colorMask;
         }

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -70,12 +70,12 @@ namespace ACE.Server.Network.Structure
             // get wielder, if applicable
             var wielder = GetWielder(wo);
 
-            BuildProperties(wo, wielder);
+            BuildProperties(wo);
             BuildSpells(wo);
 
             // armor / clothing
             if (wo is Clothing)
-                BuildArmor(wo, wielder);
+                BuildArmor(wo);
 
             if (wo is Creature creature)
                 BuildCreature(creature);
@@ -86,7 +86,7 @@ namespace ACE.Server.Network.Structure
             BuildFlags();
         }
 
-        private void BuildProperties(WorldObject wo, WorldObject wielder)
+        private void BuildProperties(WorldObject wo)
         {
             PropertiesInt = wo.GetAllPropertyInt().Where(x => ClientProperties.PropertiesInt.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesInt64 = wo.GetAllPropertyInt64().Where(x => ClientProperties.PropertiesInt64.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
@@ -95,15 +95,15 @@ namespace ACE.Server.Network.Structure
             PropertiesString = wo.GetAllPropertyString().Where(x => ClientProperties.PropertiesString.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesDID = wo.GetAllPropertyDataId().Where(x => ClientProperties.PropertiesDataId.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
 
-            AddPropertyEnchantments(wo, wielder);
+            AddPropertyEnchantments(wo);
         }
 
-        private void AddPropertyEnchantments(WorldObject wo, WorldObject wielder)
+        private void AddPropertyEnchantments(WorldObject wo)
         {
-            if (wielder == null) return;
+            if (wo == null) return;
 
             if (PropertiesInt.ContainsKey(PropertyInt.ArmorLevel))
-                PropertiesInt[PropertyInt.ArmorLevel] += wielder.EnchantmentManager.GetArmorMod();
+                PropertiesInt[PropertyInt.ArmorLevel] += wo.EnchantmentManager.GetArmorMod();
         }
 
         private void BuildSpells(WorldObject wo)
@@ -207,11 +207,11 @@ namespace ACE.Server.Network.Structure
             return spellTable.Spells[spellId].Name;
         }
 
-        private void BuildArmor(WorldObject wo, WorldObject wielder)
+        private void BuildArmor(WorldObject wo)
         {
-            ArmorProfile = new ArmorProfile(wo, wielder);
-            ArmorHighlight = ArmorMaskHelper.GetHighlightMask(wo, wielder);
-            ArmorColor = ArmorMaskHelper.GetColorMask(wo, wielder);
+            ArmorProfile = new ArmorProfile(wo);
+            ArmorHighlight = ArmorMaskHelper.GetHighlightMask(wo);
+            ArmorColor = ArmorMaskHelper.GetColorMask(wo);
 
             AddSpells(SpellBook, wo);
         }

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ACE.Database.Models.Shard;
+using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Managers;
@@ -67,7 +69,7 @@ namespace ACE.Server.Network.Structure
             if (wo is Creature creature)
                 BuildCreature(creature);
 
-            if (wo is Ammunition || wo is MeleeWeapon || wo is Missile || wo is MissileLauncher || wo is SpellProjectile)
+            if (wo is MeleeWeapon || wo is Missile || wo is MissileLauncher || wo is Caster)
                 BuildWeapon(wo, wielder);
 
             BuildFlags();
@@ -104,7 +106,7 @@ namespace ACE.Server.Network.Structure
             SpellBook.AddRange(wo.Biota.BiotaPropertiesSpellBook);
         }
 
-        public void AddSpells(List<BiotaPropertiesSpellBook> activeSpells, WorldObject wielder)
+        public void AddSpells(List<BiotaPropertiesSpellBook> activeSpells, WorldObject wielder, WeenieType weenieType = WeenieType.Undef)
         {
             if (wielder == null) return;
 
@@ -114,7 +116,35 @@ namespace ACE.Server.Network.Structure
             // item enchantments can also be on wielder currently
             // get any spells from wielder that should be shown in this item's appraise panel
             foreach (var enchantment in enchantments)
-                activeSpells.Add(new BiotaPropertiesSpellBook() { Spell = enchantment.SpellId });
+            {
+                if (weenieType == WeenieType.Clothing)
+                {
+                    if ((enchantment.SpellCategory >= (ushort)SpellCategory.ArmorValueRaising) && (enchantment.SpellCategory <= (ushort)SpellCategory.AcidicResistanceLowering))
+                        activeSpells.Add(new BiotaPropertiesSpellBook() { Spell = enchantment.SpellId });
+                }
+                else
+                {
+                    if ((enchantment.SpellCategory == (uint)SpellCategory.AttackModRaising)
+                        || (enchantment.SpellCategory == (uint)SpellCategory.DamageRaising)
+                        || (enchantment.SpellCategory == (uint)SpellCategory.DefenseModRaising)
+                        || (enchantment.SpellCategory == (uint)SpellCategory.WeaponTimeRaising)
+                        || (enchantment.SpellCategory == (uint)SpellCategory.AppraisalResistanceLowering)
+                        || (enchantment.SpellCategory == (uint)SpellCategory.SpellDamageRaising))
+                        activeSpells.Add(new BiotaPropertiesSpellBook() { Spell = enchantment.SpellId });
+                }
+            }
+        }
+
+        private SpellCategory GetSpellCategory(uint spellId)
+        {
+            uint spellCategory;
+
+            SpellTable spellTable = DatManager.PortalDat.SpellTable;
+            if (!spellTable.Spells.ContainsKey(spellId))
+                return SpellCategory.Undef;
+
+            spellCategory = spellTable.Spells[spellId].Category;
+            return (SpellCategory)spellCategory;
         }
 
         public void BuildArmor(WorldObject wo, WorldObject wielder)
@@ -124,7 +154,7 @@ namespace ACE.Server.Network.Structure
             ArmorColor = ArmorMaskHelper.GetColorMask(wo, wielder);
 
             // item enchantments can also be on wielder currently
-            AddSpells(SpellBook, wielder);
+            AddSpells(SpellBook, wielder, wo.WeenieType);
         }
 
         public void BuildCreature(Creature creature)
@@ -145,7 +175,7 @@ namespace ACE.Server.Network.Structure
             WeaponColor = WeaponMaskHelper.GetColorMask(weapon, wielder);
 
             // item enchantments can also be on wielder currently
-            AddSpells(SpellBook, wielder);
+            AddSpells(SpellBook, wielder, weapon.WeenieType);
         }
 
         public WorldObject GetWielder(WorldObject weapon)

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -13,6 +13,17 @@ using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.Structure
 {
+    public class AppraisalSpellBook
+    {
+        public enum _EnchantmentState : uint
+        {
+            Off = 0x00000000u,
+            On = 0x80000000u
+        }
+
+        public ushort SpellId { get; set; }
+        public _EnchantmentState EnchantmentState { get; set; }
+    }
     /// <summary>
     /// Handles calculating and sending all object appraisal info
     /// </summary>
@@ -29,7 +40,7 @@ namespace ACE.Server.Network.Structure
         public Dictionary<PropertyString, string> PropertiesString;
         public Dictionary<PropertyDataId, uint> PropertiesDID;
 
-        public List<BiotaPropertiesSpellBook> SpellBook;
+        public List<AppraisalSpellBook> SpellBook;
 
         public ArmorProfile ArmorProfile;
         public CreatureProfile CreatureProfile;
@@ -75,7 +86,7 @@ namespace ACE.Server.Network.Structure
             BuildFlags();
         }
 
-        public void BuildProperties(WorldObject wo, WorldObject wielder)
+        private void BuildProperties(WorldObject wo, WorldObject wielder)
         {
             PropertiesInt = wo.GetAllPropertyInt().Where(x => ClientProperties.PropertiesInt.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
             PropertiesInt64 = wo.GetAllPropertyInt64().Where(x => ClientProperties.PropertiesInt64.Contains((ushort)x.Key)).ToDictionary(x => x.Key, x => x.Value);
@@ -87,7 +98,7 @@ namespace ACE.Server.Network.Structure
             AddPropertyEnchantments(wo, wielder);
         }
 
-        public void AddPropertyEnchantments(WorldObject wo, WorldObject wielder)
+        private void AddPropertyEnchantments(WorldObject wo, WorldObject wielder)
         {
             if (wielder == null) return;
 
@@ -95,69 +106,117 @@ namespace ACE.Server.Network.Structure
                 PropertiesInt[PropertyInt.ArmorLevel] += wielder.EnchantmentManager.GetArmorMod();
         }
 
-        public void BuildSpells(WorldObject wo)
+        private void BuildSpells(WorldObject wo)
         {
-            SpellBook = new List<BiotaPropertiesSpellBook>();
+            SpellBook = new List<AppraisalSpellBook>();
 
             // add primary spell, if exists
             if (wo.SpellDID.HasValue)
-                SpellBook.Add(new BiotaPropertiesSpellBook { Spell = (int)wo.SpellDID.Value });
+                SpellBook.Add(new AppraisalSpellBook { SpellId = (ushort)wo.SpellDID.Value, EnchantmentState = AppraisalSpellBook._EnchantmentState.Off });
 
-            SpellBook.AddRange(wo.Biota.BiotaPropertiesSpellBook);
+            foreach ( var biotaPropertiesSpellBook in wo.Biota.BiotaPropertiesSpellBook)
+                SpellBook.Add(new AppraisalSpellBook { SpellId = (ushort)biotaPropertiesSpellBook.Spell, EnchantmentState = AppraisalSpellBook._EnchantmentState.Off });
         }
 
-        public void AddSpells(List<BiotaPropertiesSpellBook> activeSpells, WorldObject wielder, WeenieType weenieType = WeenieType.Undef)
+        private void AddSpells(List<AppraisalSpellBook> activeSpells, WorldObject worldObject, WorldObject wielder = null)
         {
-            if (wielder == null) return;
+            List<BiotaPropertiesEnchantmentRegistry> wielderEnchantments = null;
+            if (worldObject == null) return;
 
-            // get all currently active item enchantments
-            var enchantments = wielder.EnchantmentManager.GetEnchantments(MagicSchool.ItemEnchantment);
+            // get all currently active item enchantments on the item
+            var woEnchantments = worldObject.EnchantmentManager.GetEnchantments(MagicSchool.ItemEnchantment);
 
-            // item enchantments can also be on wielder currently
-            // get any spells from wielder that should be shown in this item's appraise panel
-            foreach (var enchantment in enchantments)
+            // get all currently active item enchantment auras on the player
+            if (wielder != null)
+                wielderEnchantments = wielder.EnchantmentManager.GetEnchantments(MagicSchool.ItemEnchantment);
+
+            if (worldObject.WeenieType == WeenieType.Clothing)
             {
-                if (weenieType == WeenieType.Clothing)
+                // Only show Clothing type item emchantments
+                foreach (var enchantment in woEnchantments)
                 {
                     if ((enchantment.SpellCategory >= (ushort)SpellCategory.ArmorValueRaising) && (enchantment.SpellCategory <= (ushort)SpellCategory.AcidicResistanceLowering))
-                        activeSpells.Add(new BiotaPropertiesSpellBook() { Spell = enchantment.SpellId });
+                        activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
                 }
-                else
+            }
+            else
+            {
+                // Show debuff item emchantments on weapons
+                foreach (var enchantment in woEnchantments)
                 {
-                    if ((enchantment.SpellCategory == (uint)SpellCategory.AttackModRaising)
-                        || (enchantment.SpellCategory == (uint)SpellCategory.DamageRaising)
-                        || (enchantment.SpellCategory == (uint)SpellCategory.DefenseModRaising)
-                        || (enchantment.SpellCategory == (uint)SpellCategory.WeaponTimeRaising)
-                        || (enchantment.SpellCategory == (uint)SpellCategory.AppraisalResistanceLowering)
-                        || (enchantment.SpellCategory == (uint)SpellCategory.SpellDamageRaising))
-                        activeSpells.Add(new BiotaPropertiesSpellBook() { Spell = enchantment.SpellId });
+                    if (worldObject is Caster)
+                    {
+                        // Caster weapon only item Auras
+                        if ((enchantment.SpellCategory == (uint)SpellCategory.DefenseModLowering)
+                            || (enchantment.SpellCategory == (uint)SpellCategory.AppraisalResistanceRaising)
+                            || (GetSpellName((uint)enchantment.SpellId).Contains("Spirit"))) // Spirit Loather spells
+                        {
+                            activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
+                        }
+                    }
+                    else
+                    {
+                        // Other weapon type Auras
+                        if ((enchantment.SpellCategory == (uint)SpellCategory.AttackModLowering)
+                            || (enchantment.SpellCategory == (uint)SpellCategory.DamageLowering)
+                            || (enchantment.SpellCategory == (uint)SpellCategory.DefenseModLowering)
+                            || (enchantment.SpellCategory == (uint)SpellCategory.WeaponTimeLowering))
+                        {
+                            activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
+                        }
+                    }
+                }
+
+                if (wielder != null)
+                {
+                    // Only show reflected Auras from player appropriate for wielded weapons
+                    foreach (var enchantment in wielderEnchantments)
+                    {
+                        if (worldObject is Caster)
+                        {
+                            // Caster weapon only item Auras
+                            if ((enchantment.SpellCategory == (uint)SpellCategory.DefenseModRaising)
+                                || (enchantment.SpellCategory == (uint)SpellCategory.AppraisalResistanceLowering)
+                                || (enchantment.SpellCategory == (uint)SpellCategory.SpellDamageRaising))
+                            {
+                                activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
+                            }
+                        }
+                        else
+                        {
+                            // Other weapon type Auras
+                            if ((enchantment.SpellCategory == (uint)SpellCategory.AttackModRaising)
+                                || (enchantment.SpellCategory == (uint)SpellCategory.DamageRaising)
+                                || (enchantment.SpellCategory == (uint)SpellCategory.DefenseModRaising)
+                                || (enchantment.SpellCategory == (uint)SpellCategory.WeaponTimeRaising))
+                            {
+                                activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        private SpellCategory GetSpellCategory(uint spellId)
+        private string GetSpellName(uint spellId)
         {
-            uint spellCategory;
-
             SpellTable spellTable = DatManager.PortalDat.SpellTable;
             if (!spellTable.Spells.ContainsKey(spellId))
-                return SpellCategory.Undef;
+                return null;
 
-            spellCategory = spellTable.Spells[spellId].Category;
-            return (SpellCategory)spellCategory;
+            return spellTable.Spells[spellId].Name;
         }
 
-        public void BuildArmor(WorldObject wo, WorldObject wielder)
+        private void BuildArmor(WorldObject wo, WorldObject wielder)
         {
             ArmorProfile = new ArmorProfile(wo, wielder);
             ArmorHighlight = ArmorMaskHelper.GetHighlightMask(wo, wielder);
             ArmorColor = ArmorMaskHelper.GetColorMask(wo, wielder);
 
-            // item enchantments can also be on wielder currently
-            AddSpells(SpellBook, wielder, wo.WeenieType);
+            AddSpells(SpellBook, wo);
         }
 
-        public void BuildCreature(Creature creature)
+        private void BuildCreature(Creature creature)
         {
             CreatureProfile = new CreatureProfile(creature);
 
@@ -168,17 +227,19 @@ namespace ACE.Server.Network.Structure
             ArmorLevels = new ArmorLevel(creature);
         }
 
-        public void BuildWeapon(WorldObject weapon, WorldObject wielder)
+        private void BuildWeapon(WorldObject weapon, WorldObject wielder)
         {
-            WeaponProfile = new WeaponProfile(weapon, wielder);
+            if ((weapon as Caster) == null)
+                WeaponProfile = new WeaponProfile(weapon, wielder);
+
             WeaponHighlight = WeaponMaskHelper.GetHighlightMask(weapon, wielder);
             WeaponColor = WeaponMaskHelper.GetColorMask(weapon, wielder);
 
             // item enchantments can also be on wielder currently
-            AddSpells(SpellBook, wielder, weapon.WeenieType);
+            AddSpells(SpellBook, weapon, wielder);
         }
 
-        public WorldObject GetWielder(WorldObject weapon)
+        private WorldObject GetWielder(WorldObject weapon)
         {
             if (weapon.WielderId == null)
                 return null;
@@ -189,7 +250,7 @@ namespace ACE.Server.Network.Structure
         /// <summary>
         /// Constructs the bitflags for appraising a WorldObject
         /// </summary>
-        public void BuildFlags()
+        private void BuildFlags()
         {
             if (PropertiesInt.Count > 0)
                 Flags |= IdentifyResponseFlags.IntStatsTable;
@@ -335,13 +396,12 @@ namespace ACE.Server.Network.Structure
             }
         }
 
-        public static void Write(this BinaryWriter writer, List<BiotaPropertiesSpellBook> spells)
+        public static void Write(this BinaryWriter writer, List<AppraisalSpellBook> spells)
         {
             writer.Write((uint)spells.Count);
             foreach (var spell in spells)
             {
-                writer.Write((ushort)spell.Spell);
-                writer.Write((ushort)0);    // layered spell
+                writer.Write((uint)spell.EnchantmentState | spell.SpellId);
             }
         }
     }

--- a/Source/ACE.Server/Network/Structure/ArmorProfile.cs
+++ b/Source/ACE.Server/Network/Structure/ArmorProfile.cs
@@ -19,32 +19,32 @@ namespace ACE.Server.Network.Structure
         public float NetherProtection;
         public float LightningProtection;
 
-        public ArmorProfile(WorldObject armor, WorldObject wielder)
+        public ArmorProfile(WorldObject armor)
         {
-            SlashingProtection = GetArmorMod(armor, wielder, DamageType.Slash);
-            PiercingProtection = GetArmorMod(armor, wielder, DamageType.Pierce);
-            BludgeoningProtection = GetArmorMod(armor, wielder, DamageType.Bludgeon);
-            ColdProtection = GetArmorMod(armor, wielder, DamageType.Cold);
-            FireProtection = GetArmorMod(armor, wielder, DamageType.Fire);
-            AcidProtection = GetArmorMod(armor, wielder, DamageType.Acid);
-            NetherProtection = GetArmorMod(armor, wielder, DamageType.Nether);
-            LightningProtection = GetArmorMod(armor, wielder, DamageType.Electric);
+            SlashingProtection = GetArmorMod(armor, DamageType.Slash);
+            PiercingProtection = GetArmorMod(armor, DamageType.Pierce);
+            BludgeoningProtection = GetArmorMod(armor, DamageType.Bludgeon);
+            ColdProtection = GetArmorMod(armor,DamageType.Cold);
+            FireProtection = GetArmorMod(armor, DamageType.Fire);
+            AcidProtection = GetArmorMod(armor, DamageType.Acid);
+            NetherProtection = GetArmorMod(armor, DamageType.Nether);
+            LightningProtection = GetArmorMod(armor, DamageType.Electric);
         }
 
         /// <summary>
         /// Calculates the effective RL for a piece of armor or clothing
         /// against a particular damage type
         /// </summary>
-        public float GetArmorMod(WorldObject armor, WorldObject wielder, DamageType damageType)
+        public float GetArmorMod(WorldObject armor, DamageType damageType)
         {
             var type = armor.EnchantmentManager.GetImpenBaneKey(damageType);
             var baseResistance = armor.GetProperty(type) ?? 1.0f;
 
-            if (wielder == null)
+            if (armor == null)
                 return (float)baseResistance;
 
             // banes/lures
-            var resistanceMod = wielder != null ? wielder.EnchantmentManager.GetArmorModVsType(damageType) : 0.0f;
+            var resistanceMod = armor != null ? armor.EnchantmentManager.GetArmorModVsType(damageType) : 0.0f;
 
             var effectiveRL = (float)(baseResistance + resistanceMod);
 


### PR DESCRIPTION
Rework AppraisalInfo to differentiate between intrinsic spells and applied spells
- "spellbook" data sent in AppraisalInfo packet uses highest bit of uint to indicated whether intrinsic spell of item or applied enchant
- WeenieType.Cothing enchants are applied to the item
- Account for debuffs applied to wielded weapons
- Enchants applied to armor affecting armor stats fixed to display correctly

![image](https://user-images.githubusercontent.com/22699181/42639077-0bbc2ce8-85a4-11e8-82c1-292c516b7f66.png)
