### PR TITLE
AdjusSpell Words

### DIFF
--- a/Source/ACE.DatLoader/Entity/SpellBase.cs
+++ b/Source/ACE.DatLoader/Entity/SpellBase.cs
@@ -42,6 +42,8 @@ namespace ACE.DatLoader.Entity
         public uint NonComponentTargetType { get; private set; } // Unknown what this does
         public uint ManaMod { get; private set; } // Additional mana cost per target (e.g. "Incantation of Acid Bane" Mana Cost = 80 + 14 per target)
 
+        public string SpellWords { get; private set; } // Not technically part of this function, but saves numerous looks later.
+
         public SpellBase()
         {
         }
@@ -111,6 +113,8 @@ namespace ACE.DatLoader.Entity
             DisplayOrder = reader.ReadUInt32();
             NonComponentTargetType = reader.ReadUInt32();
             ManaMod = reader.ReadUInt32();
+
+            SpellWords = SpellComponentsTable.GetSpellWords(DatManager.PortalDat.SpellComponentsTable, Formula);
         }
 
         private const uint HIGHEST_COMP_ID = 198; // "Essence of Kemeroi", for Void Spells -- not actually ever in game!

--- a/Source/ACE.DatLoader/FileTypes/SpellComponentsTable.cs
+++ b/Source/ACE.DatLoader/FileTypes/SpellComponentsTable.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.IO;
-
 using ACE.DatLoader.Entity;
 
 namespace ACE.DatLoader.FileTypes
@@ -64,8 +63,18 @@ namespace ACE.DatLoader.FileTypes
                     thirdSpellWord = comps.SpellComponents[formula[i]].Text;
             }
 
-            string result = $"{firstSpellWord} {secondSpellWord}{thirdSpellWord.ToLower()}";
-            return result;
+            // We need to make sure our second spell word, if any, is capitalized
+            // Some spell words have no "secondSpellWord", so we're basically making sure the third word is capitalized.
+            string secondSpellWordSet = (secondSpellWord + thirdSpellWord.ToLower());
+            if(secondSpellWordSet != "")
+            {
+                string firstLetter = secondSpellWordSet.Substring(0, 1).ToUpper();
+                secondSpellWordSet = firstLetter + secondSpellWordSet.Substring(1);
+
+            }
+
+            string result = $"{firstSpellWord} {secondSpellWordSet}";
+            return result.Trim();
         }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/DebugCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DebugCommands.cs
@@ -972,6 +972,7 @@ namespace ACE.Server.Command.Handlers
             SpellComponentsTable comps = DatManager.PortalDat.SpellComponentsTable;
 
             Console.WriteLine("Formula for " + spellTable.Spells[spellid].Name);
+            Console.WriteLine("Spell Words: " + spellTable.Spells[spellid].SpellWords);
             Console.WriteLine(spellTable.Spells[spellid].Desc);
 
             var formula = SpellTable.GetSpellFormula(DatManager.PortalDat.SpellTable, spellid, parameters[0]);

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -503,7 +503,7 @@ namespace ACE.Server.WorldObjects
 
             spellChain.AddAction(this, () =>
             {
-                string spellWords = SpellComponentsTable.GetSpellWords(DatManager.PortalDat.SpellComponentsTable, formula);
+                string spellWords = spell.SpellWords;
                 if (spellWords != null)
                     CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Magic));
             });
@@ -810,8 +810,7 @@ namespace ACE.Server.WorldObjects
 
             spellChain.AddAction(this, () =>
             {
-                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(SpellComponentsTable.GetSpellWords(DatManager.PortalDat.SpellComponentsTable,
-                    formula), Name, Guid.Full, ChatMessageType.Magic));
+                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spell.SpellWords, Name, Guid.Full, ChatMessageType.Magic));
             });
 
             spellChain.AddAction(this, () =>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2018-07-16
+[OptimShi]
+* Fixed proper case of certain spell words and change how they are loaded for efficiency/ease of use.
+
 ### 2018-07-13
 [OptimShi]
 * Fixed remaining issue with Spell Formulas and non-ANSI characters. All spell formulas now appear to be accurate.


### PR DESCRIPTION
Spell Words now load with the SpellTable to make them easier to reference.
Fixed case with certain spells that had no second word (so the resulting third word became the second word but was not properly capitalized)

To verify, in the ACE console type the following commands the resulting spell words that are displayed should appear correct. Note that the third test option below has no spell words, and returns an empty string.

* getspellformula account 1
* getspellformula account 5347
* getspellformula account 2028