### PR TITLE
More enums added from the client/ACLogView to ACE.Entity.Enum

### DIFF
--- a/Source/ACE.Entity/Enum/AetheriaBitfield.cs
+++ b/Source/ACE.Entity/Enum/AetheriaBitfield.cs
@@ -1,0 +1,13 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum AetheriaBitfield
+    {
+        NoSlotsUnlocked,
+        OneSlotUnlocked,
+        // Skip 1
+        TwoSlotsUnlocked    = 3,
+        // Skip 3
+        ThreeSlotsUnlocked  = 7
+    }
+}

--- a/Source/ACE.Entity/Enum/AttackType.cs
+++ b/Source/ACE.Entity/Enum/AttackType.cs
@@ -5,24 +5,24 @@ namespace ACE.Entity.Enum
     [Flags]
     public enum AttackType
     {
-        Undef_AttackType                = 0,
-        Punch_AttackType                = (1 << 0),
-        Thrust_AttackType               = (1 << 1),
-        Slash_AttackType                = (1 << 2),
-        Kick_AttackType                 = (1 << 3),
-        OffhandPunch_AttackType         = (1 << 4),
-        DoubleSlash_AttackType          = (1 << 5),
-        TripleSlash_AttackType          = (1 << 6),
-        DoubleThrust_AttackType         = (1 << 7),
-        TripleThrust_AttackType         = (1 << 8),
-        OffhandThrust_AttackType        = (1 << 9),
-        OffhandSlash_AttackType         = (1 << 10),
-        OffhandDoubleSlash_AttackType   = (1 << 11),
-        OffhandTripleSlash_AttackType   = (1 << 12),
-        OffhandDoubleThrust_AttackType  = (1 << 13),
-        OffhandTripleThrust_AttackType  = (1 << 14),
+        Undef               = 0,
+        Punch               = (1 << 0),
+        Thrust              = (1 << 1),
+        Slash               = (1 << 2),
+        Kick                = (1 << 3),
+        OffhandPunch        = (1 << 4),
+        DoubleSlash         = (1 << 5),
+        TripleSlash         = (1 << 6),
+        DoubleThrust        = (1 << 7),
+        TripleThrust        = (1 << 8),
+        OffhandThrust       = (1 << 9),
+        OffhandSlash        = (1 << 10),
+        OffhandDoubleSlash  = (1 << 11),
+        OffhandTripleSlash  = (1 << 12),
+        OffhandDoubleThrust = (1 << 13),
+        OffhandTripleThrust = (1 << 14),
 
-        Unarmed_AttackType              = Punch_AttackType | Kick_AttackType | OffhandPunch_AttackType, // 25
-        MultiStrike_AttackType          = DoubleSlash_AttackType | TripleSlash_AttackType | DoubleThrust_AttackType | TripleThrust_AttackType | OffhandDoubleSlash_AttackType | OffhandTripleSlash_AttackType | OffhandDoubleThrust_AttackType | OffhandTripleThrust_AttackType // 31200
+        Unarmed             = Punch | Kick | OffhandPunch, // 25
+        MultiStrike         = DoubleSlash | TripleSlash | DoubleThrust | TripleThrust | OffhandDoubleSlash | OffhandTripleSlash | OffhandDoubleThrust | OffhandTripleThrust // 31200
     }
 }

--- a/Source/ACE.Entity/Enum/AttackType.cs
+++ b/Source/ACE.Entity/Enum/AttackType.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ACE.Entity.Enum
+{
+    [Flags]
+    public enum AttackType
+    {
+        Undef_AttackType                = 0,
+        Punch_AttackType                = (1 << 0),
+        Thrust_AttackType               = (1 << 1),
+        Slash_AttackType                = (1 << 2),
+        Kick_AttackType                 = (1 << 3),
+        OffhandPunch_AttackType         = (1 << 4),
+        DoubleSlash_AttackType          = (1 << 5),
+        TripleSlash_AttackType          = (1 << 6),
+        DoubleThrust_AttackType         = (1 << 7),
+        TripleThrust_AttackType         = (1 << 8),
+        OffhandThrust_AttackType        = (1 << 9),
+        OffhandSlash_AttackType         = (1 << 10),
+        OffhandDoubleSlash_AttackType   = (1 << 11),
+        OffhandTripleSlash_AttackType   = (1 << 12),
+        OffhandDoubleThrust_AttackType  = (1 << 13),
+        OffhandTripleThrust_AttackType  = (1 << 14),
+
+        Unarmed_AttackType              = Punch_AttackType | Kick_AttackType | OffhandPunch_AttackType, // 25
+        MultiStrike_AttackType          = DoubleSlash_AttackType | TripleSlash_AttackType | DoubleThrust_AttackType | TripleThrust_AttackType | OffhandDoubleSlash_AttackType | OffhandTripleSlash_AttackType | OffhandDoubleThrust_AttackType | OffhandTripleThrust_AttackType // 31200
+    }
+}

--- a/Source/ACE.Entity/Enum/AttunedStatus.cs
+++ b/Source/ACE.Entity/Enum/AttunedStatus.cs
@@ -1,0 +1,10 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum AttunedStatus
+    {
+        Normal,
+        Attuned,
+        Sticky
+    }
+}

--- a/Source/ACE.Entity/Enum/BondedStatus.cs
+++ b/Source/ACE.Entity/Enum/BondedStatus.cs
@@ -1,0 +1,12 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum BondedStatus
+    {
+        Destroy     = -2,
+        Slippery    = -1,
+        Normal      = 0,
+        Bonded      = 1,
+        Sticky      = 2
+    }
+}

--- a/Source/ACE.Entity/Enum/CombatBodyPart.cs
+++ b/Source/ACE.Entity/Enum/CombatBodyPart.cs
@@ -30,7 +30,7 @@ namespace ACE.Entity.Enum
         Tentacle        = 23,
         UpperTentacle   = 24,
         LowerTentacle   = 25,
-        Claok           = 26,
+        Cloak           = 26,
         Num             = 27
     }
 }

--- a/Source/ACE.Entity/Enum/CombatBodyPart.cs
+++ b/Source/ACE.Entity/Enum/CombatBodyPart.cs
@@ -1,0 +1,36 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum CombatBodyPart
+    {
+        Undefined       = -1,
+        Head            = 0,
+        Chest           = 1,
+        Abdomen         = 2,
+        UpperArm        = 3,
+        LowerArm        = 4,
+        Hand            = 5,
+        UpperLeg        = 6,
+        LowerLeg        = 7,
+        Foot            = 8,
+        Horn            = 9,
+        FrontLeg        = 10,
+        // Skip 11
+        FrontFoot       = 12,
+        RearLeg         = 13,
+        // Skip 14
+        RearFoot        = 15,
+        Torso           = 16,
+        Tail            = 17,
+        Arm             = 18,
+        Leg             = 19,
+        Claw            = 20,
+        Wings           = 21,
+        Breath          = 22,
+        Tentacle        = 23,
+        UpperTentacle   = 24,
+        LowerTentacle   = 25,
+        Claok           = 26,
+        Num             = 27
+    }
+}

--- a/Source/ACE.Entity/Enum/HookTypeEnum.cs
+++ b/Source/ACE.Entity/Enum/HookTypeEnum.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace ACE.Entity.Enum
+{
+    /// <summary>
+    /// The client calls this HookType, but, that name conflicts with HookType that resides in ACE.Server.Physics.Hooks.
+    /// The one in Physics should probably be renamed to PhysicsHookType
+    /// </summary>
+    [Flags]
+    public enum HookTypeEnum
+    {
+        Undef   = 0,
+        Floor   = (1 << 0),
+        Wall    = (1 << 1),
+        Ceiling = (1 << 2),
+        Yard    = (1 << 3),
+        Roof    = (1 << 4)
+    }
+}

--- a/Source/ACE.Entity/Enum/HouseType.cs
+++ b/Source/ACE.Entity/Enum/HouseType.cs
@@ -1,0 +1,12 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum HouseType
+    {
+        Undef,
+        Cottage,
+        Villa,
+        Mansion,
+        Apartment
+    }
+}

--- a/Source/ACE.Entity/Enum/ImbuedEffectType.cs
+++ b/Source/ACE.Entity/Enum/ImbuedEffectType.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace ACE.Entity.Enum
+{
+    [Flags]
+    public enum ImbuedEffectType
+    {
+        Undef                           = 0,
+        CriticalStrike                  = (1 << 0),
+        CripplingBlow                   = (1 << 1),
+        ArmorRending                    = (1 << 2),
+        SlashRending                    = (1 << 3),
+        PierceRending                   = (1 << 4),
+        BludgeonRending                 = (1 << 5),
+        AcidRending                     = (1 << 6),
+        ColdRending                     = (1 << 7),
+        ElectricRending                 = (1 << 8),
+        FireRending                     = (1 << 9),
+        MeleeDefense                    = (1 << 10),
+        MissileDefense                  = (1 << 11),
+        MagicDefense                    = (1 << 12),
+        Spellbook                       = (1 << 13),
+        NetherRending                   = (1 << 14),
+
+        IgnoreSomeMagicProjectileDamage = (1 << 29),
+        AlwaysCritical                  = (1 << 30),
+        IgnoreAllArmor                  = (1 << 31)
+    }
+}

--- a/Source/ACE.Entity/Enum/SubscriptionStatus.cs
+++ b/Source/ACE.Entity/Enum/SubscriptionStatus.cs
@@ -1,0 +1,12 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum SubscriptionStatus
+    {
+        No_Subscription,
+        AsheronsCall_Subscription,
+        DarkMajesty_Subscription,
+        ThroneOfDestiny_Subscription,
+        ThroneOfDestiny_Preordered
+    }
+}

--- a/Source/ACE.Entity/Enum/SummoningMastery.cs
+++ b/Source/ACE.Entity/Enum/SummoningMastery.cs
@@ -1,0 +1,11 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum SummoningMastery
+    {
+        Undef,
+        Primalist,
+        Necromancer,
+        Naturalist
+    }
+}

--- a/Source/ACE.Entity/Enum/WeaponType.cs
+++ b/Source/ACE.Entity/Enum/WeaponType.cs
@@ -1,0 +1,20 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum WeaponType
+    {
+        Undef,
+        Unarmed,
+        Sword,
+        Axe,
+        Mace,
+        Spear,
+        Dagger,
+        Staff,
+        Bow,
+        Crossbow,
+        Thrown,
+        TwoHanded,
+        Magic
+    }
+}

--- a/Source/ACE.Entity/Enum/WieldRequirement.cs
+++ b/Source/ACE.Entity/Enum/WieldRequirement.cs
@@ -1,0 +1,20 @@
+
+namespace ACE.Entity.Enum
+{
+    public enum WieldRequirement
+    {
+        Invalid,
+        Skill,
+        RawSkill,
+        Attrib,
+        RawAttrib,
+        SecondaryAttrib,
+        RawSecondaryAttrib,
+        Level,
+        Training,
+        IntStat,
+        BoolStat,
+        CreatureType,
+        HeritageType
+    }
+}


### PR DESCRIPTION
Note that HookType exists in both:
ACE.Entity.Enum
ACE.Server.Physics.Hooks

The one in Physics should probably be renamed to PhysicsHookType so that the more global one in ACE.Entity.Enum can maintain consistant naming with the client.