### PR TITLE
Fix Null exception of dropping an item

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -647,6 +647,9 @@ namespace ACE.Server.WorldObjects
                     item.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
                     item.Sequences.GetNextSequence(SequenceType.ObjectVector);
 
+                    if (item.PhysicsObj == null)
+                        item.PostInit();
+
                     CurrentLandblock?.AddWorldObject(item);
 
                     //Session.Network.EnqueueSend(new GameMessageUpdateObject(item));


### PR DESCRIPTION
Fix the missing PhysicsObj for items that start life as non-world objects, when item is dropped onto the 3D world