### PR TITLE
Add check for target death before process Magic Damage

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1124,7 +1124,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
                 });
             }
-            else if ((item.GetProperty(PropertyInt.Attuned) ?? 0) == 1)
+            else if (((item.GetProperty(PropertyInt.Attuned) ?? 0) == 1) && ((target as Player) != null))
             {
                 giveChain.AddAction(this, () =>
                 {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -474,16 +474,12 @@ namespace ACE.Server.WorldObjects
 
                     resourceCheckChain.AddAction(this, () =>
                     {
+                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
                         CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
                     });
 
-                    resourceCheckChain.AddDelaySeconds(2.0f);
-                    resourceCheckChain.AddAction(this, () =>
-                    {
-                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
-                        player.IsBusy = false;
-                    });
-
+                    resourceCheckChain.AddDelaySeconds(1.0f);
+                    resourceCheckChain.AddAction(this, () => player.IsBusy = false);
                     resourceCheckChain.EnqueueChain();
 
                     return;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -343,11 +343,21 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        private enum CastingPreCheckStatus
+        {
+            OutOfMana,
+            OutOfOtherVital,
+            CastFailed,
+            Success
+        }
+
         /// <summary>
         /// Method used for handling player targeted spell casts
         /// </summary>
         public void CreatePlayerSpell(ObjectGuid guidTarget, uint spellId)
         {
+            CastingPreCheckStatus castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
+
             Player player = CurrentLandblock?.GetObject(Guid) as Player;
             WorldObject target = CurrentLandblock?.GetObject(guidTarget);
             TargetCategory targetCategory = TargetCategory.WorldObject;
@@ -449,8 +459,11 @@ namespace ACE.Server.WorldObjects
             float scale = SpellAttributes(player.Session.Account, spellId, out float castingDelay, out MotionCommand windUpMotion, out MotionCommand spellGesture);
             var formula = SpellTable.GetSpellFormula(spellTable, spellId, player.Session.Account);
 
-            bool spellCastSuccess = false || ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill, (int)spell.Power)))
-                && (magicSkill >= (int)spell.Power - 50) && (magicSkill > 0));
+            if ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill, (int)spell.Power)))
+                            && (magicSkill >= (int)spell.Power - 50) && (magicSkill > 0))
+                castingPreCheckStatus = CastingPreCheckStatus.Success;
+            else
+                castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
 
             // Calculating mana usage
             #region
@@ -469,57 +482,12 @@ namespace ACE.Server.WorldObjects
                 vitalChange = (uint)(casterVitalChange / (1.0f - spellStatMod.LossPercent));
 
                 if (spellStatMod.Source == (int)PropertyAttribute2nd.Mana && (vitalChange + 10 + manaUsed) > player.Mana.Current)
-                {
-                    ActionChain resourceCheckChain = new ActionChain();
-
-                    resourceCheckChain.AddAction(this, () =>
-                    {
-                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
-                        CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                    });
-
-                    resourceCheckChain.AddDelaySeconds(1.0f);
-                    resourceCheckChain.AddAction(this, () => player.IsBusy = false);
-                    resourceCheckChain.EnqueueChain();
-
-                    return;
-                }
+                    castingPreCheckStatus = CastingPreCheckStatus.OutOfMana;
                 else if ((vitalChange + 10) > player.GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source))
-                {
-                    ActionChain resourceCheckChain = new ActionChain();
-
-                    resourceCheckChain.AddAction(this, () =>
-                    {
-                        CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                    });
-
-                    resourceCheckChain.AddDelaySeconds(2.0f);
-                    resourceCheckChain.AddAction(this, () => player.IsBusy = false);
-                    resourceCheckChain.EnqueueChain();
-
-                    return;
-                }
+                    castingPreCheckStatus = CastingPreCheckStatus.OutOfOtherVital;
             }
             else if (manaUsed > player.Mana.Current)
-            {
-                ActionChain resourceCheckChain = new ActionChain();
-
-                resourceCheckChain.AddAction(this, () =>
-                {
-                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                });
-
-                resourceCheckChain.AddDelaySeconds(2.0f);
-                resourceCheckChain.AddAction(this, () =>
-                {
-                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
-                    player.IsBusy = false;
-                });
-
-                resourceCheckChain.EnqueueChain();
-
-                return;
-            }
+                castingPreCheckStatus = CastingPreCheckStatus.OutOfMana;
             else
                 player.UpdateVital(player.Mana, player.Mana.Current - manaUsed);
             #endregion
@@ -539,16 +507,12 @@ namespace ACE.Server.WorldObjects
                 });
             }
 
-
             spellChain.AddAction(this, () =>
             {
                 string spellWords = spell.SpellWords;
                 if (spellWords != null)
                     CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Magic));
-            });
 
-            spellChain.AddAction(this, () =>
-            {
                 var motionCastSpell = new UniversalMotion(MotionStance.Spellcasting);
                 motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
                 motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
@@ -563,57 +527,27 @@ namespace ACE.Server.WorldObjects
             else
                 spellChain.AddDelaySeconds(castingDelay);
 
-            if (spellCastSuccess == false)
-                spellChain.AddAction(this, () => CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
-            else
+            switch(castingPreCheckStatus)
             {
-                spellChain.AddAction(this, () =>
-                {
-                    bool targetDeath;
-                    EnchantmentStatus enchantmentStatus = default(EnchantmentStatus);
-
-                    switch (spell.School)
+                case CastingPreCheckStatus.Success:
+                    spellChain.AddAction(this, () =>
                     {
-                        case MagicSchool.WarMagic:
-                            WarMagic(target, spell, spellStatMod);
-                            break;
-                        case MagicSchool.VoidMagic:
-                            VoidMagic(target, spell, spellStatMod);
-                            break;
-                        case MagicSchool.CreatureEnchantment:
+                        bool targetDeath;
+                        EnchantmentStatus enchantmentStatus = default(EnchantmentStatus);
 
-                            if (player != null && !(target is Player))
-                                player.OnAttackMonster(creatureTarget);
+                        switch (spell.School)
+                        {
+                            case MagicSchool.WarMagic:
+                                WarMagic(target, spell, spellStatMod);
+                                break;
+                            case MagicSchool.VoidMagic:
+                                VoidMagic(target, spell, spellStatMod);
+                                break;
+                            case MagicSchool.CreatureEnchantment:
 
-                            if (IsSpellHarmful(spell))
-                            {
-                                // Retrieve player's skill level in the Magic School
-                                var playerMagicSkill = player.GetCreatureSkill(spell.School).Current;
+                                if (player != null && !(target is Player))
+                                    player.OnAttackMonster(creatureTarget);
 
-                                // Retrieve target's Magic Defense Skill
-                                Creature creature = (Creature)target;
-                                var targetMagicDefenseSkill = creature.GetCreatureSkill(Skill.MagicDefense).Current;
-
-                                if (MagicDefenseCheck(playerMagicSkill, targetMagicDefenseSkill))
-                                {
-                                    CurrentLandblock?.EnqueueBroadcastSound(player, Sound.ResistSpell);
-                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists {spell.Name}", ChatMessageType.Magic));
-                                    break;
-                                }
-                            }
-                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
-                            enchantmentStatus = CreatureMagic(target, spell, spellStatMod);
-                            if (enchantmentStatus.message != null)
-                                player.Session.Network.EnqueueSend(enchantmentStatus.message);
-                            break;
-
-                        case MagicSchool.LifeMagic:
-
-                            if (player != null && !(target is Player))
-                                player.OnAttackMonster(creatureTarget);
-
-                            if (spell.MetaSpellType != SpellType.LifeProjectile)
-                            {
                                 if (IsSpellHarmful(spell))
                                 {
                                     // Retrieve player's skill level in the Magic School
@@ -630,50 +564,66 @@ namespace ACE.Server.WorldObjects
                                         break;
                                     }
                                 }
-                            }
-
-                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
-                            targetDeath = LifeMagic(target, spell, spellStatMod, out uint damage, out bool critical, out enchantmentStatus);
-
-                            if (damage != 0)
-                                AttackList.Add(new AttackDamage(player, damage, critical));
-
-                            if (enchantmentStatus.message != null)
-                                player.Session.Network.EnqueueSend(enchantmentStatus.message);
-                            if (targetDeath == true)
-                            {
-                                creatureTarget.UpdateVital(creatureTarget.Health, 0);
-                                creatureTarget.OnDeath();
-                                creatureTarget.Die();
-
-                                Strings.DeathMessages.TryGetValue(DamageType.Base, out var messages);
-                                player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(messages[0], target.Name), ChatMessageType.Broadcast));
-
-                                var topDamager = AttackDamage.GetTopDamager(AttackList);
-                                if (topDamager != null)
-                                    creatureTarget.Killer = topDamager.Guid.Full;
-
-                                if ((creatureTarget as Player) == null)
-                                    player.EarnXP((long)target.XpOverride, true);
-                            }
-                            break;
-                        case MagicSchool.ItemEnchantment:
-                            if (((spell.Category >= (ushort)SpellCategory.ArmorValueRaising) && (spell.Category <= (ushort)SpellCategory.AcidicResistanceLowering)) == false)
-                            {
-                                // Non-impen/bane spells
-                                enchantmentStatus = ItemMagic(target, spell, spellStatMod);
-                                if (guidTarget == Guid)
-                                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
-                                else
-                                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                enchantmentStatus = CreatureMagic(target, spell, spellStatMod);
                                 if (enchantmentStatus.message != null)
                                     player.Session.Network.EnqueueSend(enchantmentStatus.message);
-                            }
-                            else
-                            {
-                                if ((target as Player) == null)
+                                break;
+
+                            case MagicSchool.LifeMagic:
+
+                                if (player != null && !(target is Player))
+                                    player.OnAttackMonster(creatureTarget);
+
+                                if (spell.MetaSpellType != SpellType.LifeProjectile)
                                 {
-                                    // Individual impen/bane WeenieType.Clothing target
+                                    if (IsSpellHarmful(spell))
+                                    {
+                                        // Retrieve player's skill level in the Magic School
+                                        var playerMagicSkill = player.GetCreatureSkill(spell.School).Current;
+
+                                        // Retrieve target's Magic Defense Skill
+                                        Creature creature = (Creature)target;
+                                        var targetMagicDefenseSkill = creature.GetCreatureSkill(Skill.MagicDefense).Current;
+
+                                        if (MagicDefenseCheck(playerMagicSkill, targetMagicDefenseSkill))
+                                        {
+                                            CurrentLandblock?.EnqueueBroadcastSound(player, Sound.ResistSpell);
+                                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists {spell.Name}", ChatMessageType.Magic));
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                targetDeath = LifeMagic(target, spell, spellStatMod, out uint damage, out bool critical, out enchantmentStatus);
+
+                                if (damage != 0)
+                                    AttackList.Add(new AttackDamage(player, damage, critical));
+
+                                if (enchantmentStatus.message != null)
+                                    player.Session.Network.EnqueueSend(enchantmentStatus.message);
+                                if (targetDeath == true)
+                                {
+                                    creatureTarget.UpdateVital(creatureTarget.Health, 0);
+                                    creatureTarget.OnDeath();
+                                    creatureTarget.Die();
+
+                                    Strings.DeathMessages.TryGetValue(DamageType.Base, out var messages);
+                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(messages[0], target.Name), ChatMessageType.Broadcast));
+
+                                    var topDamager = AttackDamage.GetTopDamager(AttackList);
+                                    if (topDamager != null)
+                                        creatureTarget.Killer = topDamager.Guid.Full;
+
+                                    if ((creatureTarget as Player) == null)
+                                        player.EarnXP((long)target.XpOverride, true);
+                                }
+                                break;
+                            case MagicSchool.ItemEnchantment:
+                                if (((spell.Category >= (ushort)SpellCategory.ArmorValueRaising) && (spell.Category <= (ushort)SpellCategory.AcidicResistanceLowering)) == false)
+                                {
+                                    // Non-impen/bane spells
                                     enchantmentStatus = ItemMagic(target, spell, spellStatMod);
                                     if (guidTarget == Guid)
                                         CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
@@ -684,25 +634,42 @@ namespace ACE.Server.WorldObjects
                                 }
                                 else
                                 {
-                                    // Impen/bane targeted at a player
-                                    var items = (target as Player).GetAllWieldedItems();
-                                    foreach (var item in items)
+                                    if ((target as Player) == null)
                                     {
-                                        if (item.WeenieType == WeenieType.Clothing)
-                                        {
-                                            enchantmentStatus = ItemMagic(item, spell, spellStatMod);
+                                        // Individual impen/bane WeenieType.Clothing target
+                                        enchantmentStatus = ItemMagic(target, spell, spellStatMod);
+                                        if (guidTarget == Guid)
+                                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
+                                        else
                                             CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
-                                            if (enchantmentStatus.message != null)
-                                                player.Session.Network.EnqueueSend(enchantmentStatus.message);
+                                        if (enchantmentStatus.message != null)
+                                            player.Session.Network.EnqueueSend(enchantmentStatus.message);
+                                    }
+                                    else
+                                    {
+                                        // Impen/bane targeted at a player
+                                        var items = (target as Player).GetAllWieldedItems();
+                                        foreach (var item in items)
+                                        {
+                                            if (item.WeenieType == WeenieType.Clothing)
+                                            {
+                                                enchantmentStatus = ItemMagic(item, spell, spellStatMod);
+                                                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                                if (enchantmentStatus.message != null)
+                                                    player.Session.Network.EnqueueSend(enchantmentStatus.message);
+                                            }
                                         }
                                     }
                                 }
-                            }
-                            break;
-                        default:
-                            break;
-                    }
-                });
+                                break;
+                            default:
+                                break;
+                        }
+                    });
+                    break;
+                default:
+                    spellChain.AddAction(this, () => CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
+                    break;
             }
 
             spellChain.AddAction(this, () =>
@@ -713,14 +680,18 @@ namespace ACE.Server.WorldObjects
                 DoMotion(motionReturnToCastStance);
             });
 
-            spellChain.AddDelaySeconds(1.0f);
-
-            spellChain.AddAction(this, () =>
+            switch (castingPreCheckStatus)
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None));
-                player.IsBusy = false;
-            });
+                case CastingPreCheckStatus.OutOfMana:
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast)));
+                    break;
+                default:
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None)));
+                    break;
+            }
 
+            spellChain.AddDelaySeconds(1.0f);
+            spellChain.AddAction(this, () => player.IsBusy = false);
             spellChain.EnqueueChain();
 
             return;
@@ -731,6 +702,10 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void CreatePlayerSpell(uint spellId)
         {
+            CastingPreCheckStatus castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
+
+            Player player = CurrentLandblock?.GetObject(Guid) as Player;
+
             if (IsBusy == true)
             {
                 Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YoureTooBusy));
@@ -759,111 +734,42 @@ namespace ACE.Server.WorldObjects
             }
 
             // Grab player's skill level in the spell's Magic School
-            var magicSkill = GetCreatureSkill(spell.School);
+            var magicSkill = GetCreatureSkill(spell.School).Current;
 
             float scale = SpellAttributes(Session.Account, spellId, out float castingDelay, out MotionCommand windUpMotion, out MotionCommand spellGesture);
             var formula = SpellTable.GetSpellFormula(spellTable, spellId, Session.Account);
 
-            bool spellCastSuccess = false || ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill.Current, (int)spell.Power)))
-                && (magicSkill.Current >= (int)spell.Power - 50) && (magicSkill.Current > 0));
+            if ((Physics.Common.Random.RollDice(0.0f, 1.0f) > (1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill, (int)spell.Power)))
+                && (magicSkill >= (int)spell.Power - 50) && (magicSkill > 0))
+                castingPreCheckStatus = CastingPreCheckStatus.Success;
+            else
+                castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
 
             // Calculating mana usage
             #region
-            if (spellCastSuccess == true)
+            uint manaUsed = CalculateManaUsage(player, spell);
+
+            if (spell.MetaSpellType == SpellType.Transfer)
             {
-                CreatureSkill mc = GetCreatureSkill(Skill.ManaConversion);
-                double z = mc.Current;
-                double baseManaPercent = 1;
-                if (z > spell.Power)
+                uint vitalChange, casterVitalChange;
+                vitalChange = (uint)(GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source) * spellStatMod.Proportion);
+                if (spellStatMod.TransferCap != 0)
                 {
-                    baseManaPercent = spell.Power / z;
+                    if (vitalChange > spellStatMod.TransferCap)
+                        vitalChange = (uint)spellStatMod.TransferCap;
                 }
-                double preCost;
-                uint manaUsed;
-                if ((int)Math.Floor(baseManaPercent) == 1)
-                {
-                    preCost = spell.BaseMana;
-                    manaUsed = (uint)preCost;
-                }
-                else
-                {
-                    preCost = spell.BaseMana * baseManaPercent;
-                    if (preCost < 1)
-                        preCost = 1;
-                    manaUsed = (uint)Physics.Common.Random.RollDice(1, (int)preCost);
-                }
-                if (spell.MetaSpellType == SpellType.Transfer)
-                {
-                    uint vitalChange, casterVitalChange;
-                    vitalChange = (uint)(GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source) * spellStatMod.Proportion);
-                    if (spellStatMod.TransferCap != 0)
-                    {
-                        if (vitalChange > spellStatMod.TransferCap)
-                            vitalChange = (uint)spellStatMod.TransferCap;
-                    }
-                    casterVitalChange = (uint)(vitalChange * (1.0f - spellStatMod.LossPercent));
-                    vitalChange = (uint)(casterVitalChange / (1.0f - spellStatMod.LossPercent));
+                casterVitalChange = (uint)(vitalChange * (1.0f - spellStatMod.LossPercent));
+                vitalChange = (uint)(casterVitalChange / (1.0f - spellStatMod.LossPercent));
 
-                    if (spellStatMod.Source == (int)PropertyAttribute2nd.Mana && (vitalChange + 10 + manaUsed) > Mana.Current)
-                    {
-                        ActionChain resourceCheckChain = new ActionChain();
-
-                        resourceCheckChain.AddAction(this, () =>
-                        {
-                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                        });
-
-                        resourceCheckChain.AddDelaySeconds(2.0f);
-                        resourceCheckChain.AddAction(this, () =>
-                        {
-                            Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
-                            IsBusy = false;
-                        });
-
-                        resourceCheckChain.EnqueueChain();
-
-                        return;
-                    }
-
-                    if ((vitalChange + 10) > GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source))
-                    {
-                        ActionChain resourceCheckChain = new ActionChain();
-
-                        resourceCheckChain.AddAction(this, () =>
-                        {
-                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                        });
-
-                        resourceCheckChain.AddDelaySeconds(2.0f);
-                        resourceCheckChain.AddAction(this, () => IsBusy = false);
-                        resourceCheckChain.EnqueueChain();
-
-                        return;
-                    }
-                }
-                else if (manaUsed > Mana.Current)
-                {
-                    ActionChain resourceCheckChain = new ActionChain();
-
-                    resourceCheckChain.AddAction(this, () =>
-                    {
-                        CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f));
-                    });
-
-                    resourceCheckChain.AddDelaySeconds(2.0f);
-                    resourceCheckChain.AddAction(this, () =>
-                    {
-                        Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.YouDontHaveEnoughManaToCast));
-                        IsBusy = false;
-                    });
-
-                    resourceCheckChain.EnqueueChain();
-
-                    return;
-                }
-                else
-                    UpdateVital(Mana, Mana.Current - manaUsed);
+                if (spellStatMod.Source == (int)PropertyAttribute2nd.Mana && (vitalChange + 10 + manaUsed) > Mana.Current)
+                    castingPreCheckStatus = CastingPreCheckStatus.OutOfMana;
+                else if ((vitalChange + 10) > GetCurrentCreatureVital((PropertyAttribute2nd)spellStatMod.Source))
+                    castingPreCheckStatus = CastingPreCheckStatus.OutOfOtherVital;
             }
+            else if (manaUsed > Mana.Current)
+                castingPreCheckStatus = CastingPreCheckStatus.OutOfMana;
+            else
+                player.UpdateVital(Mana, Mana.Current - manaUsed);
             #endregion
 
             ActionChain spellChain = new ActionChain();
@@ -883,11 +789,10 @@ namespace ACE.Server.WorldObjects
 
             spellChain.AddAction(this, () =>
             {
-                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spell.SpellWords, Name, Guid.Full, ChatMessageType.Magic));
-            });
+                string spellWords = spell.SpellWords;
+                if (spellWords != null)
+                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Magic));
 
-            spellChain.AddAction(this, () =>
-            {
                 var motionCastSpell = new UniversalMotion(MotionStance.Spellcasting);
                 motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);
                 motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
@@ -902,12 +807,15 @@ namespace ACE.Server.WorldObjects
             else
                 spellChain.AddDelaySeconds(castingDelay);
 
-            if (spellCastSuccess == false)
-                spellChain.AddAction(this, () => CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
-            else
+            switch (castingPreCheckStatus)
             {
-                // TODO - Successful spell casting code goes here for untargeted spells to replace line below
-                Session.Network.EnqueueSend(new GameMessageSystemChat("Targeted SpellID " + spellId + " not yet implemented!", ChatMessageType.System));
+                case CastingPreCheckStatus.Success:
+                    // TODO - Successful spell casting code goes here for untargeted spells to replace line below
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("Targeted SpellID " + spellId + " not yet implemented!", ChatMessageType.System));
+                    break;
+                default:
+                    spellChain.AddAction(this, () => CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
+                    break;
             }
 
             spellChain.AddAction(this, () =>
@@ -918,14 +826,18 @@ namespace ACE.Server.WorldObjects
                 DoMotion(motionReturnToCastStance);
             });
 
-            spellChain.AddDelaySeconds(1.0f);
-
-            spellChain.AddAction(this, () =>
+            switch (castingPreCheckStatus)
             {
-                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.None));
-                IsBusy = false;
-            });
+                case CastingPreCheckStatus.OutOfMana:
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast)));
+                    break;
+                default:
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None)));
+                    break;
+            }
 
+            spellChain.AddDelaySeconds(1.0f);
+            spellChain.AddAction(this, () => player.IsBusy = false);
             spellChain.EnqueueChain();
 
             return;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -639,7 +639,8 @@ namespace ACE.Server.WorldObjects
                             CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
                             targetDeath = LifeMagic(target, spell, spellStatMod, out uint damage, out bool critical, out enchantmentStatus);
 
-                            AttackList.Add(new AttackDamage(player, damage, critical));
+                            if (damage != 0)
+                                AttackList.Add(new AttackDamage(player, damage, critical));
 
                             if (enchantmentStatus.message != null)
                                 player.Session.Network.EnqueueSend(enchantmentStatus.message);

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -658,7 +658,7 @@ namespace ACE.Server.WorldObjects
                                     creatureTarget.Killer = topDamager.Guid.Full;
 
                                 if ((creatureTarget as Player) == null)
-                                    player.EarnXP((long)target.XpOverride);
+                                    player.EarnXP((long)target.XpOverride, true);
                             }
                             break;
                         case MagicSchool.ItemEnchantment:

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -336,7 +336,7 @@ namespace ACE.Server.WorldObjects
                     if (player != null)
                     {
                         if ((target as Player) == null)
-                            player.EarnXP((long)target.XpOverride);
+                            player.EarnXP((long)target.XpOverride, true);
 
                         var topDamager = AttackDamage.GetTopDamager(AttackList);
                         if (topDamager != null)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -318,15 +318,6 @@ namespace ACE.Server.WorldObjects
                 var amount = (uint)Math.Round(damage ?? 0.0f);
                 AttackList.Add(new AttackDamage(projectileCaster, amount, critical));
 
-                if (player != null)
-                {
-                    var attackerMsg = new GameEventAttackerNotification(player.Session, target.Name, damageType, percent, amount, critical, new Network.Enum.AttackConditions());
-                    player.Session.Network.EnqueueSend(attackerMsg, new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
-                }
-
-                if (targetPlayer != null)
-                    targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} {plural} you for {amount} points of {type} damage!", ChatMessageType.Magic));
-
                 if (target.Health.Current <= 0)
                 {
                     target.UpdateVital(target.Health, 0);
@@ -343,7 +334,21 @@ namespace ACE.Server.WorldObjects
                             target.Killer = topDamager.Guid.Full;
 
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(messages[0], target.Name), ChatMessageType.Broadcast));
+
+                        if (targetPlayer != null)
+                            targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} has killed you!", ChatMessageType.Broadcast));
                     }
+                }
+                else
+                {
+                    if (player != null)
+                    {
+                        var attackerMsg = new GameEventAttackerNotification(player.Session, target.Name, damageType, percent, amount, critical, new Network.Enum.AttackConditions());
+                        player.Session.Network.EnqueueSend(attackerMsg, new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
+                    }
+
+                    if (targetPlayer != null)
+                        targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} {plural} you for {amount} points of {type} damage!", ChatMessageType.Magic));
                 }
             }
             else

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -276,6 +276,14 @@ namespace ACE.Server.WorldObjects
             else
                 spellTarget = this as Creature;
 
+            if (spellTarget.Health.Current <=0)
+            {
+                enchantmentStatus.message = null;
+                damage = 0;
+                return false;
+            }
+
+
             int newSpellTargetVital;
             switch (spell.MetaSpellType)
             {
@@ -326,8 +334,13 @@ namespace ACE.Server.WorldObjects
                                 spellTarget.UpdateVital(spellTarget.Stamina, spellTarget.Stamina.MaxValue);
                             break;
                         default:   // Health
-                            newSpellTargetVital = (int)(spellTarget.Health.Current + boost);
                             srcVital = "health";
+                            if ((spellTarget.Health.Current < 1) && (boost < 0))
+                            {
+                                boost = 0;
+                                break;
+                            }
+                            newSpellTargetVital = (int)(spellTarget.Health.Current + boost);
                             if (newSpellTargetVital < spellTarget.Health.MaxValue)
                             {
                                 if (newSpellTargetVital <= 0)
@@ -339,6 +352,7 @@ namespace ACE.Server.WorldObjects
                                 spellTarget.UpdateVital(spellTarget.Health, spellTarget.Health.MaxValue);
                             break;
                     }
+
                     if (this is Player)
                     {
                         if (spell.BaseRangeConstant > 0)
@@ -432,6 +446,12 @@ namespace ACE.Server.WorldObjects
                             break;
                         default:   // Health
                             srcVital = "health";
+                            if (spellTarget.Health.Current < 1)
+                            {
+                                casterVitalChange = 0;
+                                vitalChange = 0;
+                                break;
+                            }
                             if (newSpellTargetVital <= 0)
                                 spellTarget.UpdateVital(spellTarget.Health, 0);
                             else
@@ -1037,6 +1057,13 @@ namespace ACE.Server.WorldObjects
 
         public static double? MagicDamageTarget(Creature source, Creature target, SpellBase spell, Database.Models.World.Spell spellStatMod, out DamageType damageType, ref bool criticalHit, uint lifeMagicDamage = 0)
         {
+            if (target.Health.Current < 1)
+            {
+                // Target already dead
+                damageType = DamageType.Undef;
+                return -1;
+            }
+
             double damageBonus = 0.0f, minDamageBonus = 0, maxDamageBonus = 0, warSkillBonus = 0.0f, finalDamage = 0.0f;
             MagicCritType magicCritType;
 


### PR DESCRIPTION
-Add checks before Magic Damage is calculated to ensure target isn't already dead
-Change EarnXP on creature kill to sharable
-Rearranged the flow of player spell casting, predominately moving the out-of-mana fizzle to after the spell windup animation and the speaking of the spell words
