### PR TITLE
Enum comments added, Material renamed to MaterialType

### DIFF
--- a/Source/ACE.Entity/Enum/CharacterOption.cs
+++ b/Source/ACE.Entity/Enum/CharacterOption.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -7,7 +7,8 @@ namespace ACE.Entity.Enum
     /// <summary>
     /// This is a combination of the CharacterOption1 and CharacterOption2 enums. For the client, these are split into two groups because they can't be contained in a single uint field.<para />
     /// Only some of these have values, which is intentional.<para />
-    /// Used with F7B1 0005: GameAction -> Set Single Character Option - Only those that have values will trigger that GameAction.
+    /// Used with F7B1 0005: GameAction -> Set Single Character Option - Only those that have values will trigger that GameAction.<para />
+    /// In the client, this is named PlayerOption.
     /// </summary>
     public enum CharacterOption
     {

--- a/Source/ACE.Entity/Enum/CharacterOptions1.cs
+++ b/Source/ACE.Entity/Enum/CharacterOptions1.cs
@@ -1,10 +1,14 @@
+using System;
+
 namespace ACE.Entity.Enum
 {
     /// <summary>
-    /// This is a list of all the options that are sent in the CharacterOptions1 flag
-    /// Used with F7B0 0013: GameEvent -> PlayerDescription - To send some of the options (the others are sent in the CharacterOptions2 flag)
-    /// Used with F7B1 01A1: GameAction -> Set Character Options - Sent as a flag with the "true" values ORed
+    /// This is a list of all the options that are sent in the CharacterOptions1 flag<para />
+    /// Used with F7B0 0013: GameEvent -> PlayerDescription - To send some of the options (the others are sent in the CharacterOptions2 flag)<para />
+    /// Used with F7B1 01A1: GameAction -> Set Character Options - Sent as a flag with the "true" values ORed<para />
+    /// /// In the client, this is named CharacterOption.
     /// </summary>
+    [Flags]
     public enum CharacterOptions1 : uint
     {
         NotUsed1                                = 0x00000001,

--- a/Source/ACE.Entity/Enum/CharacterOptions2.cs
+++ b/Source/ACE.Entity/Enum/CharacterOptions2.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ACE.Entity.Enum
 {
     /// <summary>
@@ -5,6 +7,7 @@ namespace ACE.Entity.Enum
     /// Used with F7B0 0013: GameEvent -> PlayerDescription - To send some of the options (the others are sent in the CharacterOptions1 flag)
     /// Used with F7B1 01A1: GameAction -> Set Character Options - Sent as a flag with the "true" values ORed
     /// </summary>
+    [Flags]
     public enum CharacterOptions2 : uint
     {
         AlwaysDaylightOutdoors                  = 0x00000001,

--- a/Source/ACE.Entity/Enum/MaterialType.cs
+++ b/Source/ACE.Entity/Enum/MaterialType.cs
@@ -1,6 +1,6 @@
-﻿namespace ACE.Entity.Enum
+namespace ACE.Entity.Enum
 {
-    public enum Material : uint
+    public enum MaterialType : uint
     {
         Ceramic         = 0x00000001,
         Porcelain       = 0x00000002,

--- a/Source/ACE.Entity/Enum/MotionCommand.cs
+++ b/Source/ACE.Entity/Enum/MotionCommand.cs
@@ -1,5 +1,7 @@
 namespace ACE.Entity.Enum
 {
+    // TODO: Figure out what bitfield(s) these values map to and replace with OR's
+    // Note: These IDs are from the last version of the client. Earlier versions of the client had different values for some of the enums.
     public enum MotionCommand : uint
     {
         Invalid                               = 0x0,
@@ -273,6 +275,9 @@ namespace ACE.Entity.Enum
         VividTargetIndicator                  = 0x900010c,
         SelectSelf                            = 0x900010d,
         SkillHealSelf                         = 0x1000010e,
+        WoahDuplicate1                        = 0x1000010F, // Appears to be the same as Motion_Woah except it starts with 0x10 instead of 0x13
+        MimeDrinkDuplicate1                   = 0x10000110, // Appears to be the same as Motion_MimeDrink except it starts with 0x10 instead of 0x13
+        MimeDrinkDuplicate2                   = 0x10000111, // Appears to be the same as Motion_MimeDrink except it starts with 0x10 instead of 0x13
         NextMonster                           = 0x900010f,
         PreviousMonster                       = 0x9000110,
         ClosestMonster                        = 0x9000111,
@@ -410,5 +415,6 @@ namespace ACE.Entity.Enum
         OffhandPunchSlowHigh                  = 0x10000198,
         OffhandPunchSlowMed                   = 0x10000199,
         OffhandPunchSlowLow                   = 0x1000019a,
+        WoahDuplicate2                        = 0x1000019b, // Appears to be the same as Motion_Woah except it starts with 0x10 instead of 0x13
     }
 }

--- a/Source/ACE.Entity/Enum/MovementTypes.cs
+++ b/Source/ACE.Entity/Enum/MovementTypes.cs
@@ -1,4 +1,4 @@
-﻿namespace ACE.Entity.Enum
+namespace ACE.Entity.Enum
 {
     /// <summary>
     /// These are used with various movement related messages.
@@ -6,7 +6,7 @@
     /// </summary>
     public enum MovementTypes
     {
-        General                       = 0x0,
+        General                       = 0x0, // This was named Invalid in ACLogView
         RawCommand                    = 0x1,
         InterpretedCommand            = 0x2,
         StopRawCommand                = 0x3,

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -616,7 +616,7 @@ namespace ACE.Entity.Enum.Properties
                 case PropertyInt.ItemXpStyle:
                     return System.Enum.GetName(typeof(ItemXpStyle), value);
                 case PropertyInt.MaterialType:
-                    return System.Enum.GetName(typeof(Material), value);
+                    return System.Enum.GetName(typeof(MaterialType), value);
                 case PropertyInt.PaletteTemplate:
                     return System.Enum.GetName(typeof(PaletteTemplate), value);
                 case PropertyInt.PhysicsState:

--- a/Source/ACE.Entity/Enum/SkillStatus.cs
+++ b/Source/ACE.Entity/Enum/SkillStatus.cs
@@ -1,6 +1,9 @@
 
 namespace ACE.Entity.Enum
 {
+    /// <summary>
+    /// The client calls this Skill Advancement Class, SAC.
+    /// </summary>
     public enum SkillStatus : uint
     {
         Inactive,

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -891,9 +891,9 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyDataId.IconOverlay); else SetProperty(PropertyDataId.IconOverlay, value.Value); }
         }
 
-        public Material? MaterialType
+        public MaterialType? MaterialType
         {
-            get => (Material?)GetProperty(PropertyInt.MaterialType);
+            get => (MaterialType?)GetProperty(PropertyInt.MaterialType);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.MaterialType); else SetProperty(PropertyInt.MaterialType, (int)value.Value); }
         }
 


### PR DESCRIPTION
MaterialType is what the client uses, and follows the patter we've been using for other enum names as well.