### PR TITLE
All 3 databases rescaffolded

### DIFF
--- a/Source/ACE.Database/Models/Auth/AuthDbContext.cs
+++ b/Source/ACE.Database/Models/Auth/AuthDbContext.cs
@@ -6,6 +6,15 @@ namespace ACE.Database.Models.Auth
 {
     public partial class AuthDbContext : DbContext
     {
+        public AuthDbContext()
+        {
+        }
+
+        public AuthDbContext(DbContextOptions<AuthDbContext> options)
+            : base(options)
+        {
+        }
+
         public virtual DbSet<Accesslevel> Accesslevel { get; set; }
         public virtual DbSet<Account> Account { get; set; }
 
@@ -35,11 +44,11 @@ namespace ACE.Database.Models.Auth
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnName("name")
-                    .HasMaxLength(45);
+                    .HasColumnType("varchar(45)");
 
                 entity.Property(e => e.Prefix)
                     .HasColumnName("prefix")
-                    .HasMaxLength(45)
+                    .HasColumnType("varchar(45)")
                     .HasDefaultValueSql("''");
             });
 
@@ -63,17 +72,17 @@ namespace ACE.Database.Models.Auth
                 entity.Property(e => e.AccountName)
                     .IsRequired()
                     .HasColumnName("accountName")
-                    .HasMaxLength(50);
+                    .HasColumnType("varchar(50)");
 
                 entity.Property(e => e.PasswordHash)
                     .IsRequired()
                     .HasColumnName("passwordHash")
-                    .HasMaxLength(88);
+                    .HasColumnType("varchar(88)");
 
                 entity.Property(e => e.PasswordSalt)
                     .IsRequired()
                     .HasColumnName("passwordSalt")
-                    .HasMaxLength(88);
+                    .HasColumnType("varchar(88)");
 
                 entity.HasOne(d => d.AccessLevelNavigation)
                     .WithMany(p => p.Account)

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -6,6 +6,15 @@ namespace ACE.Database.Models.Shard
 {
     public partial class ShardDbContext : DbContext
     {
+        public ShardDbContext()
+        {
+        }
+
+        public ShardDbContext(DbContextOptions<ShardDbContext> options)
+            : base(options)
+        {
+        }
+
         public virtual DbSet<Biota> Biota { get; set; }
         public virtual DbSet<BiotaPropertiesAnimPart> BiotaPropertiesAnimPart { get; set; }
         public virtual DbSet<BiotaPropertiesAttribute> BiotaPropertiesAttribute { get; set; }
@@ -360,7 +369,7 @@ namespace ACE.Database.Models.Shard
                 entity.Property(e => e.AuthorAccount)
                     .IsRequired()
                     .HasColumnName("author_Account")
-                    .HasMaxLength(255)
+                    .HasColumnType("varchar(255)")
                     .HasDefaultValueSql("'prewritten'");
 
                 entity.Property(e => e.AuthorId)
@@ -370,7 +379,7 @@ namespace ACE.Database.Models.Shard
                 entity.Property(e => e.AuthorName)
                     .IsRequired()
                     .HasColumnName("author_Name")
-                    .HasMaxLength(255)
+                    .HasColumnType("varchar(255)")
                     .HasDefaultValueSql("''");
 
                 entity.Property(e => e.IgnoreAuthor)
@@ -1334,7 +1343,7 @@ namespace ACE.Database.Models.Shard
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnName("name")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.TotalLogins)
                     .HasColumnName("total_Logins")
@@ -1484,7 +1493,7 @@ namespace ACE.Database.Models.Shard
                 entity.Property(e => e.QuestName)
                     .IsRequired()
                     .HasColumnName("quest_Name")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.HasOne(d => d.Object)
                     .WithMany(p => p.CharacterPropertiesQuestRegistry)
@@ -1593,7 +1602,7 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Key)
                     .HasColumnName("key")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.Description)
                     .HasColumnName("description")
@@ -1612,7 +1621,7 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Key)
                     .HasColumnName("key")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.Description)
                     .HasColumnName("description")
@@ -1629,7 +1638,7 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Key)
                     .HasColumnName("key")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.Description)
                     .HasColumnName("description")
@@ -1648,7 +1657,7 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Key)
                     .HasColumnName("key")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.Description)
                     .HasColumnName("description")

--- a/Source/ACE.Database/Models/World/WorldDbContext.cs
+++ b/Source/ACE.Database/Models/World/WorldDbContext.cs
@@ -6,6 +6,15 @@ namespace ACE.Database.Models.World
 {
     public partial class WorldDbContext : DbContext
     {
+        public WorldDbContext()
+        {
+        }
+
+        public WorldDbContext(DbContextOptions<WorldDbContext> options)
+            : base(options)
+        {
+        }
+
         public virtual DbSet<CookBook> CookBook { get; set; }
         public virtual DbSet<Encounter> Encounter { get; set; }
         public virtual DbSet<Event> Event { get; set; }
@@ -151,7 +160,7 @@ namespace ACE.Database.Models.World
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnName("name")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
 
                 entity.Property(e => e.StartTime)
                     .HasColumnName("start_Time")
@@ -302,7 +311,7 @@ namespace ACE.Database.Models.World
                 entity.Property(e => e.Name)
                     .IsRequired()
                     .HasColumnName("name")
-                    .HasMaxLength(255);
+                    .HasColumnType("varchar(255)");
             });
 
             modelBuilder.Entity<Recipe>(entity =>
@@ -1428,7 +1437,7 @@ namespace ACE.Database.Models.World
                 entity.Property(e => e.ClassName)
                     .IsRequired()
                     .HasColumnName("class_Name")
-                    .HasMaxLength(100);
+                    .HasColumnType("varchar(100)");
 
                 entity.Property(e => e.Type)
                     .HasColumnName("type")
@@ -1727,7 +1736,7 @@ namespace ACE.Database.Models.World
                 entity.Property(e => e.AuthorAccount)
                     .IsRequired()
                     .HasColumnName("author_Account")
-                    .HasMaxLength(255)
+                    .HasColumnType("varchar(255)")
                     .HasDefaultValueSql("'prewritten'");
 
                 entity.Property(e => e.AuthorId)
@@ -1737,7 +1746,7 @@ namespace ACE.Database.Models.World
                 entity.Property(e => e.AuthorName)
                     .IsRequired()
                     .HasColumnName("author_Name")
-                    .HasMaxLength(255)
+                    .HasColumnType("varchar(255)")
                     .HasDefaultValueSql("''");
 
                 entity.Property(e => e.IgnoreAuthor)


### PR DESCRIPTION
This simply updates the files to the latest formats generated by Pomelo.

This gets format changes out of the way so that future schema changes show only the fields changed, and not additional format changes.