### PR TITLE
Improved stamina usage, added DamageHistory system, refactored death system, monster attributeMod

### DIFF
--- a/Source/ACE.Entity/Enum/PowerAccuracy.cs
+++ b/Source/ACE.Entity/Enum/PowerAccuracy.cs
@@ -1,0 +1,9 @@
+namespace ACE.Entity.Enum
+{
+    public enum PowerAccuracy
+    {
+        Low = 1,
+        Medium = 2,
+        High = 3
+    }
+}

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -20,6 +20,7 @@ namespace ACE.Entity
         }
 
         [JsonIgnore]
+        public uint Landblock { get => landblockId.Raw >> 16;  }
         public uint Cell { get => landblockId.Raw; }
 
         public Vector3 Pos

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -652,7 +652,7 @@ namespace ACE.Server.Command.Handlers
                         var wo = session.Player.CurrentLandblock?.GetObject(guid);
 
                         if (wo is Creature creature)
-                            creature.Smite(session.Player.Guid);
+                            creature.Smite(session.Player);
                     }
                 }
                 else
@@ -681,7 +681,7 @@ namespace ACE.Server.Command.Handlers
                     // playerSession will be null when the character is not found
                     if (playerSession != null)
                     {
-                        playerSession.Player.Smite(session.Player.Guid);
+                        playerSession.Player.Smite(session.Player);
                         return;
                     }
 
@@ -700,7 +700,7 @@ namespace ACE.Server.Command.Handlers
                         return;
 
                     if (wo != null)
-                        wo.Smite(session.Player.Guid);
+                        wo.Smite(session.Player);
                 }
                 else
                 {

--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// Tracks the recent damage sources for Players / Creatures
+    /// </summary>
+    public class DamageHistory
+    {
+        /// <summary>
+        /// The player or creature this Damage History is tracking
+        /// </summary>
+        public Creature Creature;
+
+        /// <summary>
+        /// A list of damage sources, amounts, and timestamps
+        /// </summary>
+        public List<DamageHistoryEntry> Log;
+
+        /// <summary>
+        /// A lookup table of WorldObjects that have damaged this WorldObject,
+        /// and the total amount of damage they have inflicted
+        /// </summary>
+        public Dictionary<WorldObject, float> TotalDamage;
+
+        /// <summary>
+        /// Constructs a new DamageHistory for a Player / Creature
+        /// </summary>
+        public DamageHistory(Creature creature)
+        {
+            Creature = creature;
+            Init();
+        }
+
+        /// <summary>
+        /// Clears the state of the Log and TotalDamage lists
+        /// </summary>
+        public void Init()
+        {
+            Log = new List<DamageHistoryEntry>();
+            TotalDamage = new Dictionary<WorldObject, float>();
+        }
+
+        /// <summary>
+        /// Logs a damaging event for this player or creature
+        /// </summary>
+        /// <param name="source">The attacker or source of damage</param>
+        /// <param name="amount">The amount of damage hit for</param>
+        public void Add(WorldObject damager, uint amount)
+        {
+            //Console.WriteLine($"DamageHistory.Add({Creature.Name}, {amount})");
+
+            if (amount == 0) return;
+
+            var entry = new DamageHistoryEntry(Creature, damager, -(int)amount);
+            Log.Add(entry);
+
+            AddInternal(damager, amount);
+
+            TryPrune();
+        }
+
+        /// <summary>
+        /// Internally increments the total damage table
+        /// </summary>
+        private void AddInternal(WorldObject damager, uint amount)
+        {
+            if (TotalDamage.ContainsKey(damager))
+                TotalDamage[damager] += amount;
+            else
+                TotalDamage.Add(damager, amount);
+        }
+
+        /// <summary>
+        /// Called when this player or creature regains some health
+        /// </summary>
+        /// <param name="healAmount">The amount of health restored</param>
+        public void OnHeal(uint healAmount)
+        {
+            //Console.WriteLine($"DamageHistory.OnHeal({Creature.Name}, {healAmount})");
+
+            Log.Add(new DamageHistoryEntry(Creature, null, (int)healAmount));
+
+            // calculate previous missingHealth
+            OnHealInternal(healAmount, Creature.Health.Current, Creature.Health.MaxValue);
+        }
+
+        /// <summary>
+        /// Internally scales TotalDamage entries by a healing amount
+        /// </summary>
+        /// <param name="healAmount">The amount of health restored</param>
+        /// <param name="currentHealth">The current health after healing</param>
+        /// <param name="maxHealth">The maximum health at the time of healing</param>
+        private void OnHealInternal(uint healAmount, uint currentHealth, uint maxHealth)
+        {
+            // on heal, scale the damage from each source by 1 - healAmount / previous missingHealth
+            var missingHealth = maxHealth - (currentHealth - healAmount);
+            if (healAmount == 0 || missingHealth == 0) return;
+            var scalar = 1.0f - (float)healAmount / missingHealth;
+
+            var damagers = TotalDamage.Keys.ToList();
+
+            foreach (var damager in damagers)
+                TotalDamage[damager] *= scalar;
+        }
+
+        /// <summary>
+        /// Returns the WorldObject that last damaged this WorldObject
+        /// </summary>
+        public WorldObject LastDamager
+        {
+            get
+            {
+                var lastDamager = Log.LastOrDefault(l => l.Amount < 0);
+                var lastDamagerObj = lastDamager != null ? lastDamager.DamageSource : null;
+                var lastDamagerName = lastDamagerObj != null ? lastDamagerObj.Name : null;
+                //Console.WriteLine($"DamageHistory.LastDamager: {lastDamagerName}");
+                return lastDamagerObj;
+            }
+        }
+
+        /// <summary>
+        /// Returns the WorldObject that did the most damage to this WorldObject
+        /// Used to determine corpse looting rights
+        /// </summary>
+        public WorldObject TopDamager
+        {
+            get
+            {
+                var sorted = TotalDamage.OrderByDescending(wo => wo.Value);
+                var topDamager = sorted.FirstOrDefault().Key;
+                var topDamagerName = topDamager != null ? topDamager.Name : null;
+                //Console.WriteLine($"DamageHistory.TopDamager: {topDamagerName}");
+                return topDamager;
+            }
+        }
+
+        /// <summary>
+        /// Resets the damage log (eg. on player death)
+        /// </summary>
+        public void Reset()
+        {
+            Init();
+        }
+
+        /// <summary>
+        /// The last time the log was pruned
+        /// </summary>
+        public static double LastPruneTime = Timer.CurrentTime;
+
+        /// <summary>
+        /// The number of minutes to keep a history for
+        /// </summary>
+        public static int HistoryMinutes = 3;
+
+        /// <summary>
+        /// Tries pruning the log according to the minimum pruning time
+        /// </summary>
+        public void TryPrune()
+        {
+            // minimum prune interval: 30 seconds
+            if (LastPruneTime + 30 < Timer.CurrentTime)
+                Prune();
+        }
+
+        /// <summary>
+        /// Removes log entries older than HistoryMinutes
+        /// </summary>
+        public void Prune()
+        {
+            var entriesToRemove = 0;
+
+            // convert minutes to seconds
+            var pruneTime = HistoryMinutes * 60;    
+
+            foreach (var entry in Log)
+            {
+                if (entry.Time + pruneTime < Timer.CurrentTime)
+                    entriesToRemove++;
+                else
+                    break;
+            }
+
+            if (entriesToRemove > 0)
+            {
+                Log.RemoveRange(0, entriesToRemove);
+                BuildTotalDamage();
+                //Console.WriteLine($"DamageHistory.Prune() - {entriesToRemove} entries removed");
+            }
+
+            LastPruneTime = Timer.CurrentTime;
+        }
+
+        /// <summary>
+        /// Rebuilds TotalDamage from the current state of the history log
+        /// </summary>
+        public void BuildTotalDamage()
+        {
+            TotalDamage = new Dictionary<WorldObject, float>();
+
+            foreach (var entry in Log)
+            {
+                if (entry.Amount < 0)
+                    AddInternal(entry.DamageSource, (uint)-entry.Amount);
+                else
+                    OnHealInternal((uint)entry.Amount, entry.CurrentHealth, entry.MaxHealth);
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/DamageHistoryEntry.cs
+++ b/Source/ACE.Server/Entity/DamageHistoryEntry.cs
@@ -1,0 +1,30 @@
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    public class DamageHistoryEntry
+    {
+        public Creature Creature;
+        public WorldObject DamageSource;
+        public int Amount;
+        public uint CurrentHealth;
+        public uint MaxHealth;
+        public double Time;
+
+        /// <summary>
+        /// Constructs a new entry for the DamageHistory
+        /// </summary>
+        /// <param name="creature">The player or creature taking damage</param>
+        /// <param name="damageSource">The attacker or source of the damage</param>
+        /// <param name="amount">A negative amount for damage taken, positive for healing</param>
+        public DamageHistoryEntry(Creature creature, WorldObject damageSource, int amount)
+        {
+            Creature = creature;
+            DamageSource = damageSource;
+            Amount = amount;
+            CurrentHealth = creature.Health.Current;
+            MaxHealth = creature.Health.MaxValue;
+            Time = Timer.CurrentTime;
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -299,15 +299,7 @@ namespace ACE.Server.Entity
 
             Parallel.ForEach(wolist, (o) =>
             {
-                //if (o is Creature)
-                //{
-                //    if (((Creature)o).IsAlive)
-                //        player.TrackObject(o);
-                //}
-                //else
-                //{
-                    player.TrackObject(o);
-                //}
+                player.TrackObject(o);
             });
         }
 
@@ -319,7 +311,7 @@ namespace ACE.Server.Entity
 
         public ActionChain GetAddWorldObjectChain(WorldObject wo, Player noBroadcast = null)
         {
-            return new Actions.ActionChain(this, () => AddWorldObjectInternal(wo));
+            return new ActionChain(this, () => AddWorldObjectInternal(wo));
         }
 
         public void AddWorldObjectForPhysics(WorldObject wo)

--- a/Source/ACE.Server/Entity/StaminaTable.cs
+++ b/Source/ACE.Server/Entity/StaminaTable.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Entity
+{
+    public class StaminaCost
+    {
+        public int Burden;
+        public float Stamina;
+
+        public StaminaCost(int burden, float stamina)
+        {
+            Burden = burden;
+            Stamina = stamina;
+        }
+    }
+
+    public static class StaminaTable
+    {
+        public static Dictionary<PowerAccuracy, List<StaminaCost>> Costs;
+
+        static StaminaTable()
+        {
+            BuildTable();
+        }
+
+        public static void BuildTable()
+        {
+            Costs = new Dictionary<PowerAccuracy, List<StaminaCost>>();
+
+            // must be in descending order
+            var lowCosts = new List<StaminaCost>();
+            lowCosts.Add(new StaminaCost(1600, 1.5f));
+            lowCosts.Add(new StaminaCost(1200, 1));
+            lowCosts.Add(new StaminaCost(700, 1));
+
+            var midCosts = new List<StaminaCost>();
+            midCosts.Add(new StaminaCost(1600, 3));
+            midCosts.Add(new StaminaCost(1200, 2));
+            midCosts.Add(new StaminaCost(700, 1));
+
+            var highCosts = new List<StaminaCost>();
+            highCosts.Add(new StaminaCost(1600, 6));
+            highCosts.Add(new StaminaCost(1200, 4));
+            highCosts.Add(new StaminaCost(700, 2));
+
+            Costs.Add(PowerAccuracy.Low, lowCosts);
+            Costs.Add(PowerAccuracy.Medium, midCosts);
+            Costs.Add(PowerAccuracy.High, highCosts);
+        }
+
+        public static float GetStaminaCost(PowerAccuracy powerAccuracy, int burden)
+        {
+            var baseCost = 0.0f;
+            var attackCosts = Costs[powerAccuracy];
+            foreach (var attackCost in attackCosts)
+            {
+                if (burden >= attackCost.Burden)
+                {
+                    var numTimes = burden / attackCost.Burden;
+                    baseCost += attackCost.Stamina * numTimes;
+                    burden -= attackCost.Burden * numTimes;
+                }
+            }
+            return baseCost;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -496,7 +496,7 @@ namespace ACE.Server.Managers
                 case EmoteType.KillSelf:
 
                     if (targetCreature != null)
-                        targetCreature.Smite(targetCreature.Guid);
+                        targetCreature.Smite(targetCreature);
                     break;
 
                 case EmoteType.LocalBroadcast:

--- a/Source/ACE.Server/Managers/EmoteManagerExample.cs
+++ b/Source/ACE.Server/Managers/EmoteManagerExample.cs
@@ -392,7 +392,7 @@ namespace ACE.Server.Managers
                 case EmoteType.KillSelf:
 
                     if (player != null)
-                        player.Smite(WorldObject.Guid);
+                        player.Smite(WorldObject);
                     break;
 
                 case EmoteType.LocalBroadcast:

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -208,9 +208,21 @@ namespace ACE.Server.Managers
             if (vitae.StatModValue < minVitae)
                 vitae.StatModValue = minVitae;
 
+            RemoveAllEnchantments();
             SaveDatabase();
 
             return vitae.StatModValue;
+        }
+
+        /// <summary>
+        /// Removes all enchantments except for vitae
+        /// Called on player death
+        /// </summary>
+        public void RemoveAllEnchantments()
+        {
+            var enchantments = Enchantments.Where(e => e.SpellId != (int)Spell.Vitae).ToList();
+            foreach (var enchantment in enchantments)
+                WorldObject.RemoveEnchantment(enchantment.SpellId);
         }
 
         /// <summary>
@@ -285,7 +297,7 @@ namespace ACE.Server.Managers
         public void SaveDatabase()
         {
             if (Player == null) return;
-            var saveChain = Player.GetSaveChain();
+            var saveChain = Player.GetSaveChain(false);
             saveChain.EnqueueChain();
         }
 
@@ -311,7 +323,7 @@ namespace ACE.Server.Managers
                 entry.Duration = spellBase.Duration;
             else
             {
-                if (caster.WeenieType == WeenieType.Gem)
+                if (caster?.WeenieType == WeenieType.Gem)
                     entry.Duration = spellBase.Duration;
                 else
                 {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionLoginComplete.cs
@@ -11,7 +11,7 @@ namespace ACE.Server.Network.GameAction.Actions
             session.Player.Hidden = false;
             session.Player.EnqueueBroadcastPhysicsState();
             session.Player.Teleporting = false;
-            if (!session.Player.FirstEnterWorldDone)
+            if (!session.Player.FirstEnterWorldDone.Value)
                 session.Player.FirstEnterWorldDone = true;
         }
     }

--- a/Source/ACE.Server/WorldObjects/AdvocateFane.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateFane.cs
@@ -41,12 +41,6 @@ namespace ACE.Server.WorldObjects
 
         private static readonly UniversalMotion bowDeep = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.BowDeep));
 
-        public uint? AllowedActivator
-        {
-            get => GetProperty(PropertyInstanceId.AllowedActivator);
-            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.AllowedActivator); else SetProperty(PropertyInstanceId.AllowedActivator, value.Value); }
-        }
-
         public uint? UseTargetSuccessAnimation
         {
             get => GetProperty(PropertyDataId.UseTargetSuccessAnimation);

--- a/Source/ACE.Server/WorldObjects/Ammunition.cs
+++ b/Source/ACE.Server/WorldObjects/Ammunition.cs
@@ -45,9 +45,10 @@ namespace ACE.Server.WorldObjects
 
             // take damage
             var player = ProjectileSource as Player;
-            if (player != null)
+            var creatureTarget = target as Creature;
+            if (player != null && creatureTarget != null)
             {
-                var damage = player.DamageTarget(target, this);
+                var damage = player.DamageTarget(creatureTarget, this);
 
                 if (damage > 0)
                     player.Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.Collision, 1.0f));    // todo: landblock broadcast?

--- a/Source/ACE.Server/WorldObjects/Cow.cs
+++ b/Source/ACE.Server/WorldObjects/Cow.cs
@@ -31,11 +31,8 @@ namespace ACE.Server.WorldObjects
 
         private void SetEphemeralValues()
         {
-            // TODO we shouldn't be auto setting properties that come from our weenie by default
-
+            // TODO: we shouldn't be auto setting properties that come from our weenie by default
             UseRadius = 1;
-            IsAlive = true;
-            //SetupVitals();
         }
 
         private double? resetTimestamp;
@@ -50,12 +47,6 @@ namespace ACE.Server.WorldObjects
         {
             get { return useTimestamp; }
             set { useTimestamp = Time.GetTimestamp(); }
-        }
-
-        private uint? AllowedActivator
-        {
-            get;
-            set;
         }
 
         /// <summary>
@@ -97,14 +88,14 @@ namespace ACE.Server.WorldObjects
 
             ActionChain autoResetTimer = new ActionChain();
             autoResetTimer.AddDelaySeconds(4);
-            autoResetTimer.AddAction(this, () => Reset());
+            autoResetTimer.AddAction(this, () => ResetCow());
             autoResetTimer.EnqueueChain();
 
             if (activator.Full > 0)
                 UseTimestamp++;
         }
 
-        private void Reset()
+        private void ResetCow()
         {
             AllowedActivator = null;
 

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -32,10 +32,6 @@ namespace ACE.Server.WorldObjects
         public Creature(Weenie weenie, ObjectGuid guid) : base(weenie, guid)
         {
             SetEphemeralValues();
-
-            InitPhysics = true;
-
-            CombatMode = CombatMode.NonCombat;
         }
 
         /// <summary>
@@ -44,14 +40,13 @@ namespace ACE.Server.WorldObjects
         public Creature(Biota biota) : base(biota)
         {
             SetEphemeralValues();
-
-            InitPhysics = true;
-
-            CombatMode = CombatMode.NonCombat;
         }
 
         private void SetEphemeralValues()
         {
+            CombatMode = CombatMode.NonCombat;
+            DamageHistory = new DamageHistory(this);
+
             if (CreatureType == ACE.Entity.Enum.CreatureType.Human && !(WeenieClassId == 1 || WeenieClassId == 4))
                 GenerateNewFace();
 
@@ -225,7 +220,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// This will be false when creature is dead and waits for respawn
         /// </summary>
-        public bool IsAlive { get; set; }
+        public bool IsAlive { get => Health.Current > 0; }
 
         public double RespawnTime { get; set; }
 
@@ -621,6 +616,9 @@ namespace ACE.Server.WorldObjects
                 }
             }
         }
+
+        public bool IsExhausted { get => Stamina.Current == 0; }
+
 
         /// <summary>
         /// Called every ~5 seconds for Creatures

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -145,7 +145,7 @@ namespace ACE.Server.WorldObjects
             if (player != null)
             {
                 CurrentLandblock?.EnqueueBroadcast(arrow.Location, new GameMessagePublicUpdatePropertyInt(
-                    arrow, PropertyInt.PlayerKillerStatus, (int)(player.PlayerKillerStatus ?? ACE.Entity.Enum.PlayerKillerStatus.NPK) ));
+                    arrow, PropertyInt.PlayerKillerStatus, (int)player.PlayerKillerStatus));
             }
             else
             {

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -101,7 +101,7 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.ResistNether); else SetProperty(PropertyFloat.ResistNether, value.Value); }
         }
 
-        public double GetNaturalResistence(ResistanceType resistance)
+        public double GetNaturalResistance(ResistanceType resistance)
         {
             switch (resistance)
             {
@@ -148,12 +148,6 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyFloat.StaminaRate);
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.StaminaRate); else SetProperty(PropertyFloat.StaminaRate, value.Value); }
-        }
-
-        public double? ManaRate
-        {
-            get => GetProperty(PropertyFloat.ManaRate);
-            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ManaRate); else SetProperty(PropertyFloat.ManaRate, value.Value); }
         }
 
         public double? ArmorModVsSlash

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
@@ -77,19 +77,12 @@ namespace ACE.Server.WorldObjects.Entity
         {
             get
             {
-                uint total = Base;
+                var total = (int)Base;
 
-                var attrMod = creature.EnchantmentManager.GetAttributeMod(Attribute);
-                total += (uint)attrMod;    // can be negative?
+                var attributeMod = creature.EnchantmentManager.GetAttributeMod(Attribute);
+                total += attributeMod;
 
-                if (creature is Player)
-                {
-                    var player = creature as Player;
-
-                    if (player.HasVitae)
-                        total = (uint)Math.Round(total * player.Vitae);
-                }
-                return total;
+                return (uint)Math.Max(total, 10);    // minimum value for an attribute: 10
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
@@ -91,7 +91,7 @@ namespace ACE.Server.WorldObjects.Entity
                     derivationTotal += wil * creature.Self.Current;
 
                     derivationTotal *= formula.AbilityMultiplier;
-                    total = (uint)Math.Ceiling((double)derivationTotal / (double)formula.Divisor);
+                    total = (uint)Math.Round((double)derivationTotal / (double)formula.Divisor);
                 }
 
                 total += StartingValue + Ranks;

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -92,8 +92,9 @@ namespace ACE.Server.WorldObjects
             // heal up
             var healAmount = GetHealAmount(healer, target, out var critical, out var staminaCost);
 
-            healer.UpdateVitalDelta(healer.Stamina, -staminaCost);
+            healer.UpdateVitalDelta(healer.Stamina, (int)(-staminaCost));
             target.UpdateVitalDelta(target.Health, healAmount);
+            target.DamageHistory.OnHeal(healAmount);
 
             var updateHealth = new GameMessagePrivateUpdateAttribute2ndLevel(target, Vital.Health, target.Health.Current);
             var crit = critical ? "expertly " : "";

--- a/Source/ACE.Server/WorldObjects/Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Monster.cs
@@ -93,7 +93,7 @@ namespace ACE.Server.WorldObjects
             IsTurning = false;
             IsMoving = false;
 
-            SetFinalPosition();
+            //SetFinalPosition();
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -117,6 +117,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void CastSpell()
         {
+            bool? resisted;
             var spellBase = GetCurrentSpellBase();
             var spell = GetCurrentSpell();
 
@@ -135,38 +136,30 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    if (!targetSelf && ResistSpell(Skill.LifeMagic))break;
+                    resisted = ResistSpell(target, spellBase);
+                    if (!targetSelf && (resisted == true))break;
+                    if (resisted == null)
+                    {
+                        log.Error("Something went wrong with the Magic resistance check");
+                        break;
+                    }
                     LifeMagic(target, spellBase, spell, out uint damage, out bool critical, out var msg);
                     if (CurrentLandblock != null) CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
                     break;
 
                 case MagicSchool.CreatureEnchantment:
 
-                    if (!targetSelf && ResistSpell(Skill.CreatureEnchantment)) break;
+                    resisted = ResistSpell(target, spellBase);
+                    if (!targetSelf && (resisted == true)) break;
+                    if (resisted == null)
+                    {
+                        log.Error("Something went wrong with the Magic resistance check");
+                        break;
+                    }
                     CreatureMagic(target, spellBase, spell);
                     if (CurrentLandblock != null) CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spellBase.TargetEffect, scale));
                     break;
             }
-        }
-
-        /// <summary>
-        /// Returns TRUE if player resists the magic spell
-        /// </summary>
-        public bool ResistSpell(Skill skill)
-        {
-            var player = AttackTarget as Player;
-
-            var magicSkill = GetCreatureSkill(skill).Current;
-            var difficulty = player.GetCreatureSkill(Skill.MagicDefense).Current;
-
-            var resisted = MagicDefenseCheck(magicSkill, difficulty);
-
-            if (resisted)
-            {
-                player.Session.Network.EnqueueSend(new GameMessageSystemChat("You resist the spell cast by " + Name, ChatMessageType.Magic));
-                player.Session.Network.EnqueueSend(new GameMessageSound(player.Guid, Sound.ResistSpell, 1.0f));
-            }
-            return resisted;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/PKModifier.cs
+++ b/Source/ACE.Server/WorldObjects/PKModifier.cs
@@ -41,12 +41,6 @@ namespace ACE.Server.WorldObjects
 
         private static readonly UniversalMotion twitch = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Twitch1));
 
-        public uint? AllowedActivator
-        {
-            get => GetProperty(PropertyInstanceId.AllowedActivator);
-            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.AllowedActivator); else SetProperty(PropertyInstanceId.AllowedActivator, value.Value); }
-        }
-
         public uint? UseTargetSuccessAnimation
         {
             get => GetProperty(PropertyDataId.UseTargetSuccessAnimation);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -163,9 +163,9 @@ namespace ACE.Server.WorldObjects
                 //    character.IsAdvocate= true;
             }*/
 
-            FirstEnterWorldDone = false;
+            // FirstEnterWorldDone = false;
 
-            IsAlive = true;
+            // IsAlive = true;
         }
 
 
@@ -323,22 +323,7 @@ namespace ACE.Server.WorldObjects
         //public ReadOnlyCollection<Friend> Friends => Friends;
         public ReadOnlyCollection<Friend> Friends { get; set; }
 
-
-        public bool FirstEnterWorldDone = false;
-
-
-
         public MotionStance stance = MotionStance.Standing;
-
-
-
-
-
-
-
-
-
-
 
         public void ExamineObject(ObjectGuid examinationId)
         {
@@ -1085,16 +1070,9 @@ namespace ACE.Server.WorldObjects
                         break;
                 }
 
-                uint updatedVitalAmount = creatureVital.Current + (uint)boostAmount;
+                var vitalChange = UpdateVitalDelta(creatureVital, (uint)boostAmount);
 
-                if (updatedVitalAmount > creatureVital.MaxValue)
-                    updatedVitalAmount = creatureVital.MaxValue;
-
-                boostAmount = updatedVitalAmount - creatureVital.Current;
-
-                UpdateVital(creatureVital, updatedVitalAmount);
-
-                buffMessage = new GameMessageSystemChat($"You regain {boostAmount} {vitalName}.", ChatMessageType.Craft);
+                buffMessage = new GameMessageSystemChat($"You regain {vitalChange} {vitalName}.", ChatMessageType.Craft);
             }
 
             Session.Network.EnqueueSend(soundEvent, buffMessage);

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -13,14 +13,14 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Gets the ActionChain to save a character
         /// </summary>
-        public ActionChain GetSaveChain()
+        public ActionChain GetSaveChain(bool showMsg = true)
         {
-            return new ActionChain(this, SavePlayer);
+            return new ActionChain(this, () => SavePlayer(showMsg));
         }
 
-        public void SaveDatabase()
+        public void SaveDatabase(bool showMsg = true)
         {
-            var saveChain = GetSaveChain();
+            var saveChain = GetSaveChain(showMsg);
             saveChain.EnqueueChain();
         }
 
@@ -29,7 +29,7 @@ namespace ACE.Server.WorldObjects
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.<para />
         /// Will also save any possessions that are marked with ChangesDetected.
         /// </summary>
-        private void SavePlayer()
+        private void SavePlayer(bool showMsg = true)
         {
             LastRequestedDatabaseSave = DateTime.UtcNow;
 
@@ -47,7 +47,7 @@ namespace ACE.Server.WorldObjects
             }
 
             #if DEBUG
-            if (Session.Player != null)
+            if (Session.Player != null && showMsg)
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"{Session.Player.Name} has been saved.", ChatMessageType.Broadcast));
             #endif
         }

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -19,6 +19,16 @@ namespace ACE.Server.WorldObjects
 
         public WorldObject MissileTarget;
 
+        public PowerAccuracy GetAccuracyRange()
+        {
+            if (AccuracyLevel < 0.33f)
+                return PowerAccuracy.Low;
+            else if (AccuracyLevel < 0.66f)
+                return PowerAccuracy.Medium;
+            else
+                return PowerAccuracy.High;
+        }
+
         /// <summary>
         /// Called by network packet handler 0xA - GameActionTargetedMissileAttack
         /// </summary>
@@ -66,7 +76,7 @@ namespace ACE.Server.WorldObjects
                 return;
 
             var creature = target as Creature;
-            if (MissileTarget == null || creature.Health.Current <= 0)
+            if (!IsAlive || MissileTarget == null || creature.Health.Current <= 0)
             {
                 MissileTarget = null;
                 return;
@@ -95,16 +105,22 @@ namespace ACE.Server.WorldObjects
             }
             else
                 MissileTarget = null;
+
+            // stamina usage
+            // TODO: ensure enough stamina for attack
+            // TODO: verify formulas - double/triple cost for bow/xbow?
+            var staminaCost = GetAttackStamina(GetAccuracyRange());
+            UpdateVitalDelta(Stamina, -staminaCost);
         }
 
         public override float GetAimHeight(WorldObject target)
         {
-            switch (AttackHeight)
+            switch (AttackHeight.Value)
             {
-                case AttackHeight.High: return 1.0f;
-                case AttackHeight.Medium: return 2.0f;
+                case ACE.Entity.Enum.AttackHeight.High: return 1.0f;
+                case ACE.Entity.Enum.AttackHeight.Medium: return 2.0f;
                 //case AttackHeight.Low: return target.Height;
-                case AttackHeight.Low: return 3.0f;
+                case ACE.Entity.Enum.AttackHeight.Low: return 3.0f;
             }
             return 2.0f;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -21,7 +21,6 @@ namespace ACE.Server.WorldObjects
     {
         public void PlayerEnterWorld()
         {
-            IsAlive = true; // seems like something that should be handled differently...
             IsOnline = true;
 
             // Save the the LoginTimestamp

--- a/Source/ACE.Server/WorldObjects/Player_Titles.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Titles.cs
@@ -44,7 +44,7 @@ namespace ACE.Server.WorldObjects
                 sendMsg = true;
             }
 
-            if (sendMsg && FirstEnterWorldDone)
+            if (sendMsg && FirstEnterWorldDone.Value)
             {
                 var message = new GameEventUpdateTitle(Session, titleId, setAsDisplayTitle);
                 Session.Network.EnqueueSend(message);

--- a/Source/ACE.Server/WorldObjects/Player_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Vitals.cs
@@ -135,17 +135,22 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Sets the current vital to a new value
         /// </summary>
-        public override void UpdateVital(CreatureVital vital, uint newVal)
+        /// <returns>The actual change in the vital, after clamping between 0 and MaxVital</returns>
+        public override int UpdateVital(CreatureVital vital, int newVal)
         {
+            var change = base.UpdateVital(vital, newVal);
+
+            if (change != 0)
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(this, vital.ToEnum(), vital.Current));
+
             // check for exhaustion
             if (vital.Vital == PropertyAttribute2nd.Stamina || vital.Vital == PropertyAttribute2nd.MaxStamina)
             {
-                if (vital.Current != newVal && newVal <= 0)
+                if (change != 0 && vital.Current == 0)
                     OnExhausted();
-            }
 
-            base.UpdateVital(vital, newVal);
-            Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(this, vital.ToEnum(), vital.Current));
+            }
+            return change;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO;
-using System.Numerics;
 
 using ACE.Database;
 using ACE.Database.Models.Shard;
@@ -10,14 +8,15 @@ using ACE.DatLoader.FileTypes;
 using ACE.DatLoader.Entity;
 using ACE.Entity;
 using ACE.Entity.Enum;
-using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
+using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Managers;
 
 using PhysicsState = ACE.Server.Physics.PhysicsState;
+using Spell = ACE.Database.Models.World.Spell;
 
 namespace ACE.Server.WorldObjects
 {
@@ -81,14 +80,14 @@ namespace ACE.Server.WorldObjects
             SpellId = spellId;
 
             SpellType = GetProjectileSpellType(spellId);
-            var spellPower = DatManager.PortalDat.SpellTable.Spells[SpellId].Power;
+            var spell = DatManager.PortalDat.SpellTable.Spells[SpellId];
 
             if (SpellType == ProjectileSpellType.Bolt || SpellType == ProjectileSpellType.Streak
                                                       || SpellType == ProjectileSpellType.Arc)
             {
                 PhysicsObj.DefaultScript = ACE.Entity.Enum.PlayScript.ProjectileCollision;
                 PhysicsObj.DefaultScriptIntensity = 1.0f;
-                var spellLevel = CalculateSpellLevel(spellPower);
+                var spellLevel = CalculateSpellLevel(spell);
                 PlayscriptIntensity = GetProjectileScriptIntensity(SpellType, spellLevel);
             }
 
@@ -210,7 +209,7 @@ namespace ACE.Server.WorldObjects
 
                 SpellType = GetProjectileSpellType(spellId);
                 var spellPower = spell.Power;
-                var spellLevel = CalculateSpellLevel(spellPower);
+                var spellLevel = CalculateSpellLevel(spell);
                 PlayscriptIntensity = GetProjectileScriptIntensity(SpellType, spellLevel);
 
                 CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Explode, PlayscriptIntensity));
@@ -253,7 +252,7 @@ namespace ACE.Server.WorldObjects
             // Projectile struck some target that isn't a player or creature
             if (target.WeenieType != WeenieType.Creature)
             {
-                if (target.WeenieClassId != 1)
+                if ((target is Player) == false)
                 {
                     OnCollideEnvironment();
                     return;
@@ -274,81 +273,58 @@ namespace ACE.Server.WorldObjects
             var damage = MagicDamageTarget(projectileCaster, target, spell, spellStatMod, out DamageType damageType, ref critical, LifeProjectileDamage);
 
             // null damage -> target resisted; damage of -1 -> target already dead
-            if (damage != null || damage == -1)
+            if (damage != null && damage != -1)
             {
-                int newSpellTargetVital;
+                uint amount;
                 var percent = 0.0f;
 
                 if (spell.School == MagicSchool.LifeMagic && (spell.Name.Contains("Blight") || spell.Name.Contains("Tenacity")))
                 {
                     if (spell.Name.Contains("Blight"))
                     {
-                        newSpellTargetVital = (int)(target.GetCurrentCreatureVital(PropertyAttribute2nd.Mana) - damage);
                         percent = (float)damage / targetPlayer.Mana.MaxValue;
-                        if (newSpellTargetVital <= 0)
-                            target.UpdateVital(target.Mana, 0);
-                        else
-                            target.UpdateVital(target.Mana, (uint)newSpellTargetVital);
+                        amount = (uint)-target.UpdateVitalDelta(target.Mana, (int)-Math.Round(damage.Value));
                     }
                     else
                     {
-                        newSpellTargetVital = (int)(target.GetCurrentCreatureVital(PropertyAttribute2nd.Stamina) - damage);
                         percent = (float)damage / targetPlayer.Stamina.MaxValue;
-                        if (newSpellTargetVital <= 0)
-                            target.UpdateVital(target.Stamina, 0);
-                        else
-                            target.UpdateVital(target.Stamina, (uint)newSpellTargetVital);
+                        amount = (uint)-target.UpdateVitalDelta(target.Stamina, (int)-Math.Round(damage.Value));
                     }
                 }
                 else
                 {
-                    newSpellTargetVital = (int)(target.GetCurrentCreatureVital(PropertyAttribute2nd.Health) - damage);
-                    if (newSpellTargetVital <= 0)
-                        target.UpdateVital(target.Health, 0);
-                    else
-                        target.UpdateVital(target.Health, (uint)newSpellTargetVital);
+                    percent = (float)damage / target.Health.MaxValue;
+                    amount = (uint)-target.UpdateVitalDelta(target.Health, (int)-Math.Round(damage.Value));
+                    target.DamageHistory.Add(projectileCaster, amount);
                 }
 
                 string verb = null, plural = null;
-                percent = (float)damage / target.Health.MaxValue;
                 Strings.DeathMessages.TryGetValue(damageType, out var messages);
                 Strings.GetAttackVerb(damageType, percent, ref verb, ref plural);
                 var type = damageType.GetName().ToLower();
 
-                var amount = (uint)Math.Round(damage ?? 0.0f);
-                AttackList.Add(new AttackDamage(projectileCaster, amount, critical));
+                amount = (uint)Math.Round(damage.Value);    // full amount for debugging
+
+                if (player != null)
+                {
+                    // is percent for the vital, or always based on health?
+                    var attackerMsg = new GameEventAttackerNotification(player.Session, target.Name, damageType, percent, amount, critical, new AttackConditions());
+                    player.Session.Network.EnqueueSend(attackerMsg, new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
+                }
+
+                if (targetPlayer != null)
+                    targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} {plural} you for {amount} points of {type} damage!", ChatMessageType.Magic));
+                    //targetPlayer.Session.Network.EnqueueSend(new GameEventDefenderNotification(targetPlayer.Session, projectileCaster.Name, damageType, percent, amount, DamageLocation.Chest, critical, new AttackConditions()));    // damageLocation?
 
                 if (target.Health.Current <= 0)
                 {
-                    target.UpdateVital(target.Health, 0);
-                    //target.OnDeath();
                     target.Die();
 
                     if (player != null)
                     {
-                        if ((target as Player) == null)
-                            player.EarnXP((long)target.XpOverride, true);
-
-                        var topDamager = AttackDamage.GetTopDamager(AttackList);
-                        if (topDamager != null)
-                            target.Killer = topDamager.Guid.Full;
-
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(string.Format(messages[0], target.Name), ChatMessageType.Broadcast));
-
-                        if (targetPlayer != null)
-                            targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} has killed you!", ChatMessageType.Broadcast));
+                        player.EarnXP((long)target.XpOverride);
                     }
-                }
-                else
-                {
-                    if (player != null)
-                    {
-                        var attackerMsg = new GameEventAttackerNotification(player.Session, target.Name, damageType, percent, amount, critical, new Network.Enum.AttackConditions());
-                        player.Session.Network.EnqueueSend(attackerMsg, new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
-                    }
-
-                    if (targetPlayer != null)
-                        targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{projectileCaster.Name} {plural} you for {amount} points of {type} damage!", ChatMessageType.Magic));
                 }
             }
             else

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2399,10 +2399,10 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.PkLevelModifier); else SetProperty(PropertyInt.PkLevelModifier, value.Value); }
         }
 
-        public PlayerKillerStatus? PlayerKillerStatus
+        public PlayerKillerStatus PlayerKillerStatus
         {
-            get => (PlayerKillerStatus?)GetProperty(PropertyInt.PlayerKillerStatus);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.PlayerKillerStatus); else SetProperty(PropertyInt.PlayerKillerStatus, (int)value.Value); }
+            get => (PlayerKillerStatus?)GetProperty(PropertyInt.PlayerKillerStatus) ?? ACE.Entity.Enum.PlayerKillerStatus.NPK;
+            set => SetProperty(PropertyInt.PlayerKillerStatus, (int)value);
         }
 
         public CloakStatus? CloakStatus
@@ -2431,7 +2431,7 @@ namespace ACE.Server.WorldObjects
 
         public bool? FirstEnterWorldDone
         {
-            get => GetProperty(PropertyBool.FirstEnterWorldDone);
+            get => GetProperty(PropertyBool.FirstEnterWorldDone) ?? false;
             set { if (!value.HasValue) RemoveProperty(PropertyBool.FirstEnterWorldDone); else SetProperty(PropertyBool.FirstEnterWorldDone, value.Value); }
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # ACEmulator Change Log
 
+### 2018-08-01
+[gmriggs]
+* Added player stamina usage on melee / missile attack
+* Refactored the death system
+* Added Damage History system to track damage and healing sources - for corpse looting rights
+* Fixed a bug where player death was removing enchantments on the client only
+* Improved player exhaustion system. Both players and monsters now receive attack and defense penalties when stamina = 0
+* Added attribute mod to monster damage. Some monsters now deal significantly more damage, so beware!
+* Fixed a bug where a player autoattack could occur after death
+* Fixed a bug where attributes could be debuffed below 10 on the server
+* Fixed a bug with MaxVital calculation with vitae
+* Updated shield effective angle to match retail
+
 ### 2018-07-31
 [Mag-nus]
 * Updated all NuGet packages to latest stable. Most notably EF Core 2.1.


### PR DESCRIPTION
- Added player stamina usage on melee / missile attack
- Refactored the death system
- Added Damage History system to track damage and healing sources - for corpse looting rights
- Fixed a bug where player death was removing enchantments on the client only
- Improved player exhaustion system. Both players and monsters now receive attack and defense penalties when stamina = 0
- Added attribute mod to monster damage. Some monsters now deal significantly more damage, so beware!
- Fixed a bug where a player autoattack could occur after death
- Fixed a bug where attributes could be debuffed below 10 on the server
- Fixed a bug with MaxVital calculation with vitae
- Updated shield effective angle to match retail