### PR TITLE
physics state sync between WorldObject and PhysicsObj

### DIFF
--- a/Source/ACE.Entity/Enum/PhysicsState.cs
+++ b/Source/ACE.Entity/Enum/PhysicsState.cs
@@ -30,7 +30,5 @@ namespace ACE.Entity.Enum
         EdgeSlide                     = 0x00400000,
         Sledding                      = 0x00800000,
         Frozen                        = 0x01000000,
-
-        DefaultState                  = EdgeSlide | LightingOn | Gravity | ReportCollisions
     }
 }

--- a/Source/ACE.Entity/Enum/PhysicsState.cs
+++ b/Source/ACE.Entity/Enum/PhysicsState.cs
@@ -1,34 +1,36 @@
-﻿using System;
+using System;
 
 namespace ACE.Entity.Enum
 {
     [Flags]
     public enum PhysicsState
     {
-        Static                      = 0x00000001,
-        Unused1                     = 0x00000002,
-        Ethereal                    = 0x00000004,
-        ReportCollision             = 0x00000008,
-        IgnoreCollision             = 0x00000010,
-        NoDraw                      = 0x00000020,
-        Missile                     = 0x00000040,
-        Pushable                    = 0x00000080,
-        AlignPath                   = 0x00000100,
-        PathClipped                 = 0x00000200,
-        Gravity                     = 0x00000400,
-        LightingOn                  = 0x00000800,
-        ParticleEmitter             = 0x00001000,
-        Unused2                     = 0x00002000,
-        Hidden                      = 0x00004000,
-        ScriptedCollision           = 0x00008000,
-        HasPhysicsBsp               = 0x00010000,
-        Inelastic                   = 0x00020000,
-        HasDefaultAnim              = 0x00040000,
-        HasDefaultScript            = 0x00080000,
-        Cloaked                     = 0x00100000,
-        ReportCollisionAsEnviroment = 0x00200000,
-        EdgeSlide                   = 0x00400000,
-        Sledding                    = 0x00800000,
-        Frozen                      = 0x01000000,
+        Static                        = 0x00000001,
+        Unused1                       = 0x00000002,
+        Ethereal                      = 0x00000004,
+        ReportCollisions              = 0x00000008,
+        IgnoreCollisions              = 0x00000010,
+        NoDraw                        = 0x00000020,
+        Missile                       = 0x00000040,
+        Pushable                      = 0x00000080,
+        AlignPath                     = 0x00000100,
+        PathClipped                   = 0x00000200,
+        Gravity                       = 0x00000400,
+        LightingOn                    = 0x00000800,
+        ParticleEmitter               = 0x00001000,
+        Unused2                       = 0x00002000,
+        Hidden                        = 0x00004000,
+        ScriptedCollision             = 0x00008000,
+        HasPhysicsBSP                 = 0x00010000,
+        Inelastic                     = 0x00020000,
+        HasDefaultAnim                = 0x00040000,
+        HasDefaultScript              = 0x00080000,
+        Cloaked                       = 0x00100000,
+        ReportCollisionsAsEnvironment = 0x00200000,
+        EdgeSlide                     = 0x00400000,
+        Sledding                      = 0x00800000,
+        Frozen                        = 0x01000000,
+
+        DefaultState                  = EdgeSlide | LightingOn | Gravity | ReportCollisions
     }
 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -328,6 +328,9 @@ namespace ACE.Server.Entity
 
             wo.SetParent(this);
 
+            if (wo.PhysicsObj == null)
+                wo.InitPhysicsObj();
+
             wo.PhysicsObj.Position.Frame.Origin = wo.Location.Pos;
             wo.PhysicsObj.Position.Frame.Orientation = wo.Location.Rotation;
 

--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -25,88 +25,83 @@ namespace ACE.Server.Factories
         {
             var objWeenieType = (WeenieType)weenie.Type;
 
-            WorldObject wo = null;
-
             switch (objWeenieType)
             {
                 case WeenieType.Undef:
                     return null;
                 case WeenieType.LifeStone:
-                    wo = new Lifestone(weenie, guid); break;
+                    return new Lifestone(weenie, guid);
                 case WeenieType.Door:
-                    wo = new Door(weenie, guid); break;
+                    return new Door(weenie, guid);
                 case WeenieType.Portal:
-                    wo = new Portal(weenie, guid); break;
+                    return new Portal(weenie, guid);
                 case WeenieType.Book:
-                    wo = new Book(weenie, guid); break;
+                    return new Book(weenie, guid);
                 case WeenieType.PKModifier:
-                    wo = new PKModifier(weenie, guid); break;
+                    return new PKModifier(weenie, guid);
                 case WeenieType.Cow:
-                    wo = new Cow(weenie, guid); break;
+                    return new Cow(weenie, guid);
                 case WeenieType.Creature:
-                    wo = new Creature(weenie, guid); break;
+                    return new Creature(weenie, guid);
                 case WeenieType.Container:
-                    wo = new Container(weenie, guid); break;
+                    return new Container(weenie, guid);
                 case WeenieType.Scroll:
-                    wo = new Scroll(weenie, guid); break;
+                    return new Scroll(weenie, guid);
                 case WeenieType.Vendor:
-                    wo = new Vendor(weenie, guid); break;
+                    return new Vendor(weenie, guid);
                 case WeenieType.Coin:
-                    wo = new Coin(weenie, guid); break;
+                    return new Coin(weenie, guid);
                 case WeenieType.Key:
-                    wo = new Key(weenie, guid); break;
+                    return new Key(weenie, guid);
                 case WeenieType.Food:
-                    wo = new Food(weenie, guid); break;
+                    return new Food(weenie, guid);
                 case WeenieType.Gem:
-                    wo = new Gem(weenie, guid); break;
+                    return new Gem(weenie, guid);
                 case WeenieType.Game:
-                    wo = new Game(weenie, guid); break;
+                    return new Game(weenie, guid);
                 case WeenieType.GamePiece:
-                    wo = new GamePiece(weenie, guid); break;
+                    return new GamePiece(weenie, guid);
                 case WeenieType.AllegianceBindstone:
-                    wo = new Bindstone(weenie, guid); break;
+                    return new Bindstone(weenie, guid);
                 case WeenieType.Clothing:
-                    wo = new Clothing(weenie, guid); break;
+                    return new Clothing(weenie, guid);
                 case WeenieType.MeleeWeapon:
-                    wo = new MeleeWeapon(weenie, guid); break;
+                    return new MeleeWeapon(weenie, guid);
                 case WeenieType.MissileLauncher:
-                    wo = new MissileLauncher(weenie, guid); break;
+                    return new MissileLauncher(weenie, guid);
                 case WeenieType.Ammunition:
-                    wo = new Ammunition(weenie, guid); break;
+                    return new Ammunition(weenie, guid);
                 case WeenieType.Missile:
-                    wo = new Missile(weenie, guid); break;
+                    return new Missile(weenie, guid);
                 case WeenieType.Corpse:
-                    wo = new Corpse(weenie, guid); break;
+                    return new Corpse(weenie, guid);
                 case WeenieType.Chest:
-                    wo = new Chest(weenie, guid); break;
+                    return new Chest(weenie, guid);
                 case WeenieType.Stackable:
-                    wo = new Stackable(weenie, guid); break;
+                    return new Stackable(weenie, guid);
                 case WeenieType.SpellComponent:
-                    wo = new SpellComponent(weenie, guid); break;
+                    return new SpellComponent(weenie, guid);
                 case WeenieType.Switch:
-                    wo = new Switch(weenie, guid); break;
+                    return new Switch(weenie, guid);
                 case WeenieType.AdvocateFane:
-                    wo = new AdvocateFane(weenie, guid); break;
+                    return new AdvocateFane(weenie, guid);
                 case WeenieType.AdvocateItem:
-                    wo = new AdvocateItem(weenie, guid); break;
+                    return new AdvocateItem(weenie, guid);
                 case WeenieType.Healer:
-                    wo = new Healer(weenie, guid); break;
+                    return new Healer(weenie, guid);
                 case WeenieType.Lockpick:
-                    wo = new Lockpick(weenie, guid); break;
+                    return new Lockpick(weenie, guid);
                 case WeenieType.Caster:
-                    wo = new Caster(weenie, guid); break;
+                    return new Caster(weenie, guid);
                 case WeenieType.ProjectileSpell:
-                    wo = new SpellProjectile(weenie, guid); break;
+                    return new SpellProjectile(weenie, guid);
                 case WeenieType.HotSpot:
-                    wo = new Hotspot(weenie, guid); break;
+                    return new Hotspot(weenie, guid);
                 case WeenieType.ManaStone:
-                    wo = new ManaStone(weenie, guid); break;
+                    return new ManaStone(weenie, guid);
                 default:
-                    wo = new GenericObject(weenie, guid); break;
+                    return new GenericObject(weenie, guid);
             }
-
-            wo.InitPhysicsObj();
-            return wo;
         }
 
         /// <summary>
@@ -117,86 +112,81 @@ namespace ACE.Server.Factories
         {
             var objWeenieType = (WeenieType)biota.WeenieType;
 
-            WorldObject wo = null;
-
             switch (objWeenieType)
             {
                 case WeenieType.Undef:
                     return null;
                 case WeenieType.LifeStone:
-                    wo = new Lifestone(biota); break;
+                    return new Lifestone(biota);
                 case WeenieType.Door:
-                    wo = new Door(biota); break;
+                    return new Door(biota);
                 case WeenieType.Portal:
-                    wo = new Portal(biota); break;
+                    return new Portal(biota);
                 case WeenieType.Book:
-                    wo = new Book(biota); break;
+                    return new Book(biota);
                 case WeenieType.PKModifier:
-                    wo = new PKModifier(biota); break;
+                    return new PKModifier(biota);
                 case WeenieType.Cow:
-                    wo = new Cow(biota); break;
+                    return new Cow(biota);
                 case WeenieType.Creature:
-                    wo = new Creature(biota); break;
+                    return new Creature(biota);
                 case WeenieType.Container:
-                    wo = new Container(biota); break;
+                    return new Container(biota);
                 case WeenieType.Scroll:
-                    wo = new Scroll(biota); break;
+                    return new Scroll(biota);
                 case WeenieType.Vendor:
-                    wo = new Vendor(biota); break;
+                    return new Vendor(biota);
                 case WeenieType.Coin:
-                    wo = new Coin(biota); break;
+                    return new Coin(biota);
                 case WeenieType.Key:
-                    wo = new Key(biota); break;
+                    return new Key(biota);
                 case WeenieType.Food:
-                    wo = new Food(biota); break;
+                    return new Food(biota);
                 case WeenieType.Gem:
-                    wo = new Gem(biota); break;
+                    return new Gem(biota);
                 case WeenieType.Game:
-                    wo = new Game(biota); break;
+                    return new Game(biota);
                 case WeenieType.GamePiece:
-                    wo = new GamePiece(biota); break;
+                    return new GamePiece(biota);
                 case WeenieType.AllegianceBindstone:
-                    wo = new Bindstone(biota); break;
+                    return new Bindstone(biota);
                 case WeenieType.Clothing:
-                    wo = new Clothing(biota); break;
+                    return new Clothing(biota);
                 case WeenieType.MeleeWeapon:
-                    wo = new MeleeWeapon(biota); break;
+                    return new MeleeWeapon(biota);
                 case WeenieType.MissileLauncher:
-                    wo = new MissileLauncher(biota); break;
+                    return new MissileLauncher(biota);
                 case WeenieType.Ammunition:
-                    wo = new Ammunition(biota); break;
+                    return new Ammunition(biota);
                 case WeenieType.Missile:
-                    wo = new Missile(biota); break;
+                    return new Missile(biota);
                 case WeenieType.Corpse:
-                    wo = new Corpse(biota); break;
+                    return new Corpse(biota);
                 case WeenieType.Chest:
-                    wo = new Chest(biota); break;
+                    return new Chest(biota);
                 case WeenieType.Stackable:
-                    wo = new Stackable(biota); break;
+                    return new Stackable(biota);
                 case WeenieType.SpellComponent:
-                    wo = new SpellComponent(biota); break;
+                    return new SpellComponent(biota);
                 case WeenieType.Switch:
-                    wo = new Switch(biota); break;
+                    return new Switch(biota);
                 case WeenieType.AdvocateFane:
-                    wo = new AdvocateFane(biota); break;
+                    return new AdvocateFane(biota);
                 case WeenieType.AdvocateItem:
-                    wo = new AdvocateItem(biota); break;
+                    return new AdvocateItem(biota);
                 case WeenieType.Healer:
-                    wo = new Healer(biota); break;
+                    return new Healer(biota);
                 case WeenieType.Lockpick:
-                    wo = new Lockpick(biota); break;
+                    return new Lockpick(biota);
                 case WeenieType.Caster:
-                    wo = new Caster(biota); break;
+                    return new Caster(biota);
                 case WeenieType.HotSpot:
-                    wo = new Hotspot(biota); break;
+                    return new Hotspot(biota);
                 case WeenieType.ManaStone:
-                    wo = new ManaStone(biota); break;
+                    return new ManaStone(biota);
                 default:
-                    wo = new GenericObject(biota); break;
+                    return new GenericObject(biota);
             }
-
-            wo.InitPhysicsObj();
-            return wo;
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -60,7 +60,6 @@ namespace ACE.Server.Managers
                     player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, session);
 
                 player.Name = session.Character.Name;
-                player.InitPhysicsObj();
 
                 session.SetPlayer(player);
                 session.Player.PlayerEnterWorld();

--- a/Source/ACE.Server/Physics/Animation/ObjectInfo.cs
+++ b/Source/ACE.Server/Physics/Animation/ObjectInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Physics.Animation
 {

--- a/Source/ACE.Server/Physics/Animation/Transition.cs
+++ b/Source/ACE.Server/Physics/Animation/Transition.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Numerics;
+using ACE.Entity.Enum;
 using ACE.Server.Physics.Collision;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Extensions;

--- a/Source/ACE.Server/Physics/Common/LandCell.cs
+++ b/Source/ACE.Server/Physics/Common/LandCell.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using ACE.Entity.Enum;
 using ACE.Server.Physics.Animation;
 
 namespace ACE.Server.Physics.Common

--- a/Source/ACE.Server/Physics/Common/ObjCell.cs
+++ b/Source/ACE.Server/Physics/Common/ObjCell.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using ACE.Entity.Enum;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Combat;
 

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Physics.Common
 {

--- a/Source/ACE.Server/Physics/PhysicsEngine.cs
+++ b/Source/ACE.Server/Physics/PhysicsEngine.cs
@@ -5,36 +5,6 @@ using ACE.Server.Physics.Common;
 namespace ACE.Server.Physics
 {
     [Flags]
-    public enum PhysicsState
-    {
-        Static = 0x1,
-        Unused1 = 0x2,
-        Ethereal = 0x4,
-        ReportCollisions = 0x8,
-        IgnoreCollisions = 0x10,
-        NoDraw = 0x20,
-        Missile = 0x40,
-        Pushable = 0x80,
-        AlignPath = 0x100,
-        PathClipped = 0x200,
-        Gravity = 0x400,
-        LightingOn = 0x800,
-        ParticleEmitter = 0x1000,
-        Unused2 = 0x2000,
-        Hidden = 0x4000,
-        ScriptedCollision = 0x8000,
-        HasPhysicsBSP = 0x10000,
-        Inelastic = 0x20000,
-        HasDefaultAnim = 0x40000,
-        HasDefaultScript = 0x80000,
-        Cloaked = 0x100000,
-        ReportCollisionsAsEnvironment = 0x200000,
-        EdgeSlide = 0x400000,
-        Sledding = 0x800000,
-        Frozen = 0x1000000
-    };
-
-    [Flags]
     public enum TransientStateFlags
     {
         Contact = 0x1,

--- a/Source/ACE.Server/Physics/PhysicsGlobals.cs
+++ b/Source/ACE.Server/Physics/PhysicsGlobals.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Physics
 {

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -12,7 +12,6 @@ using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Motion;
 using ACE.Server.Physics;
 using ACE.Server.Physics.Animation;
-using PhysicsState = ACE.Server.Physics.PhysicsState;
 
 namespace ACE.Server.WorldObjects
 {
@@ -221,15 +220,14 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void SetProjectilePhysicsState(WorldObject obj, WorldObject target)
         {
+            obj.InitPhysicsObj();
+
             obj.ReportCollisions = true;
             obj.Missile = true;
             obj.AlignPath = true;
             obj.PathClipped = true;
             obj.Ethereal = false;
             obj.IgnoreCollisions = false;
-
-            obj.PhysicsObj.State |= PhysicsState.ReportCollisions | PhysicsState.Missile | PhysicsState.AlignPath | PhysicsState.PathClipped;
-            obj.PhysicsObj.State &= ~(PhysicsState.Ethereal | PhysicsState.IgnoreCollisions);
 
             var pos = obj.Location.Pos;
             var rotation = obj.Location.Rotation;

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -212,7 +212,6 @@ namespace ACE.Server.WorldObjects
             CurrentLandblock?.EnqueueBroadcastMotion(this, motionOpen);
             CurrentMotionState = motionOpen;
             Ethereal = true;
-            PhysicsObj.State |= Physics.PhysicsState.Ethereal;  // FIXME: 1 PhysicsState
             IsOpen = true;
             //CurrentLandblock?.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessagePublicUpdatePropertyBool(Sequences, Guid, PropertyBool.Ethereal, Ethereal ?? true));
             //CurrentLandblock?.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessagePublicUpdatePropertyBool(Sequences, Guid, PropertyBool.Open, IsOpen ?? true));
@@ -228,7 +227,6 @@ namespace ACE.Server.WorldObjects
             CurrentLandblock?.EnqueueBroadcastMotion(this, motionClosed);
             CurrentMotionState = motionClosed;
             Ethereal = false;
-            PhysicsObj.State &= ~Physics.PhysicsState.Ethereal;
             IsOpen = false;
             //CurrentLandblock?.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessagePublicUpdatePropertyBool(Sequences, Guid, PropertyBool.Ethereal, Ethereal ?? false));
             //CurrentLandblock?.EnqueueBroadcast(Location, Landblock.MaxObjectRange, new GameMessagePublicUpdatePropertyBool(Sequences, Guid, PropertyBool.Open, IsOpen ?? false));

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -337,7 +337,7 @@ namespace ACE.Server.WorldObjects
 
             // TODO: Physics description timestamps (sequence numbers) don't seem to be getting updated
 
-            Console.WriteLine("Projectile PhysicsState: " + PhysicsObj.State);
+            //Console.WriteLine("SpellProjectile PhysicsState: " + PhysicsObj.State);
 
             var pos = Location.Pos;
             var rotation = Location.Rotation;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -15,7 +15,6 @@ using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Managers;
 
-using PhysicsState = ACE.Server.Physics.PhysicsState;
 using Spell = ACE.Database.Models.World.Spell;
 
 namespace ACE.Server.WorldObjects
@@ -56,19 +55,6 @@ namespace ACE.Server.WorldObjects
             // Override weenie description defaults
             ValidLocations = null;
             DefaultScriptId = null;
-
-            // Override physics state defaults
-            ReportCollisions = true;
-            Missile = true;
-            AlignPath = true;
-            PathClipped = true;
-            Ethereal = false;
-            IgnoreCollisions = false;
-            CurrentMotionState = null;
-            Placement = null;
-
-            // TODO: Physics description timestamps (sequence numbers) don't seem to be getting updated
-            InitPhysicsObj();
         }
 
         /// <summary>
@@ -77,6 +63,8 @@ namespace ACE.Server.WorldObjects
         /// <param name="spellId"></param>
         public void Setup(uint spellId)
         {
+            InitPhysicsObj();
+
             SpellId = spellId;
 
             SpellType = GetProjectileSpellType(spellId);
@@ -199,9 +187,6 @@ namespace ACE.Server.WorldObjects
                 NoDraw = true;
                 Cloaked = true;
                 LightsStatus = false;
-
-                PhysicsObj.State |= PhysicsState.Ethereal | PhysicsState.IgnoreCollisions | PhysicsState.NoDraw | PhysicsState.Cloaked;
-                PhysicsObj.State &= ~(PhysicsState.ReportCollisions | PhysicsState.LightingOn);
 
                 PhysicsObj.set_active(false);
 
@@ -337,15 +322,22 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void SetProjectilePhysicsState(WorldObject target, bool useGravity)
         {
-            // TODO: Right now WorldObjects have two fields for physics states: one under the root object and another
-            // under PhysicsObj. These should be combined into one field to eliminate the duplicaiton.
-            // Also: the physics state should be set on object creation so some of this code may need to be removed
-            // once the field duplication is done.
-            PhysicsObj.State = PhysicsState.ReportCollisions | PhysicsState.Missile | PhysicsState.AlignPath | PhysicsState.PathClipped;
-            PhysicsObj.State &= ~(PhysicsState.Ethereal | PhysicsState.IgnoreCollisions);
+            // runtime changes to default state
+            ReportCollisions = true;
+            Missile = true;
+            AlignPath = true;
+            PathClipped = true;
+            Ethereal = false;
+            IgnoreCollisions = false;
 
-            if (useGravity)
-                PhysicsObj.State |= PhysicsState.Gravity;
+            if (useGravity) GravityStatus = true;
+
+            CurrentMotionState = null;
+            Placement = null;
+
+            // TODO: Physics description timestamps (sequence numbers) don't seem to be getting updated
+
+            Console.WriteLine("Projectile PhysicsState: " + PhysicsObj.State);
 
             var pos = Location.Pos;
             var rotation = Location.Rotation;

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -104,7 +104,6 @@ namespace ACE.Server.WorldObjects
         {
             PhysicsObj = new PhysicsObj();
             PhysicsObj.set_object_guid(Guid);
-            //PhysicsObj.TransientState |= TransientStateFlags.Contact | TransientStateFlags.OnWalkable;
 
             // will eventually map directly to WorldObject
             PhysicsObj.set_weenie_obj(new WeenieObject(this));
@@ -124,9 +123,8 @@ namespace ACE.Server.WorldObjects
 
             PhysicsObj.SetScaleStatic(ObjScale ?? 1.0f);
 
-            var physicsState = GetProperty(PropertyInt.PhysicsState);
-            if (physicsState != null)
-                PhysicsObj.State |= (Physics.PhysicsState)physicsState;
+            PhysicsObj.State = CalculatedPhysicsState();
+            Console.WriteLine($"InitPhysicsObj({Name}) - {PhysicsObj.State}");
 
             /*var player = this as Player;
             if (creature != null && player == null)
@@ -479,7 +477,7 @@ namespace ACE.Server.WorldObjects
                         sb.AppendLine($"{prop.Name} = {physicsDescriptionFlag.ToString()}" + " (" + (uint)physicsDescriptionFlag + ")");
                         break;
                     case "physicsstate":
-                        var physicsState = CalculatedPhysicsState();
+                        var physicsState = PhysicsObj.State;
                         sb.AppendLine($"{prop.Name} = {physicsState.ToString()}" + " (" + (uint)physicsState + ")");
                         break;
                     //case "propertiesspellid":
@@ -570,23 +568,11 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        // This fully replaces the PhysicsState of the WO, use sparingly?
-        //public void SetPhysicsState(PhysicsState state, bool packet = true)
-        //{
-        //    PhysicsState = state;
-
-        //    if (packet)
-        //    {
-        //        EnqueueBroadcastPhysicsState();
-        //    }
-        //}
-
         public void EnqueueBroadcastPhysicsState()
         {
             if (CurrentLandblock != null)
             {
-                var physicsState = CalculatedPhysicsState();
-                GameMessage msg = new GameMessageSetState(this, physicsState);
+                GameMessage msg = new GameMessageSetState(this, PhysicsObj.State);
                 CurrentLandblock?.EnqueueBroadcast(Location, Landblock.MaxObjectRange, msg);
             }
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -124,7 +124,7 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.SetScaleStatic(ObjScale ?? 1.0f);
 
             PhysicsObj.State = CalculatedPhysicsState();
-            Console.WriteLine($"InitPhysicsObj({Name}) - {PhysicsObj.State}");
+            //Console.WriteLine($"InitPhysicsObj({Name}) - {PhysicsObj.State}");
 
             /*var player = this as Player;
             if (creature != null && player == null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -15,6 +15,7 @@ using ACE.Server.Network;
 using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Sequence;
+using ACE.Server.Physics;
 using ACE.Server.Physics.Extensions;
 
 namespace ACE.Server.WorldObjects
@@ -227,7 +228,8 @@ namespace ACE.Server.WorldObjects
 
             writer.Write((uint)physicsDescriptionFlag);
 
-            var physicsState = PhysicsObj != null ? PhysicsObj.State : PhysicsState.DefaultState;
+            var defaultObjState = GetProperty(PropertyInt.PhysicsState);
+            var physicsState = PhysicsObj != null ? PhysicsObj.State : defaultObjState != null ? (PhysicsState)defaultObjState : PhysicsGlobals.DefaultState;
             writer.Write((uint)physicsState);
 
             // PhysicsDescriptionFlag.Movement takes priorty over PhysicsDescription.FlagAnimationFrame

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -224,10 +224,10 @@ namespace ACE.Server.WorldObjects
         private void SerializePhysicsData(BinaryWriter writer)
         {
             var physicsDescriptionFlag = CalculatedPhysicsDescriptionFlag();
-            var physicsState = CalculatedPhysicsState();
 
             writer.Write((uint)physicsDescriptionFlag);
 
+            var physicsState = PhysicsObj != null ? PhysicsObj.State : PhysicsState.DefaultState;
             writer.Write((uint)physicsState);
 
             // PhysicsDescriptionFlag.Movement takes priorty over PhysicsDescription.FlagAnimationFrame
@@ -421,6 +421,8 @@ namespace ACE.Server.WorldObjects
             if ((WielderId != null && ParentLocation != null))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Parent;
 
+            // where did this epsilon value come from?
+            // why is it different from the physics engine epsilon?
             if ((ObjScale != null) && (Math.Abs(ObjScale ?? 0) >= 0.001))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.ObjScale;
 
@@ -453,10 +455,9 @@ namespace ACE.Server.WorldObjects
 
         private PhysicsState CalculatedPhysicsState()
         {
-            // todo: This is doing 2 things. It's pulling the flag values from the PropertyInt.PhysicsState, then in turn, setting the bool value counterparts.
-            // That seem a bit redundant
+            // This is doing 2 things. It's pulling the default flags from the PropertyInt.PhysicsState, then in turn, setting the PropertyBool counterparts ONLY if they are null.
+            // This seems a bit confusing...
             // If we really want to set default states on create or load, we need to separate this function into two parts.
-            // Right now, every time this is called, defaults are being set.
 
             // Read in Object's Default PhysicsState
             var physicsState = (PhysicsState)(GetProperty(PropertyInt.PhysicsState) ?? 0);
@@ -467,10 +468,10 @@ namespace ACE.Server.WorldObjects
             if (physicsState.HasFlag(PhysicsState.Ethereal))
                 if (!Ethereal.HasValue)
                     Ethereal = true;
-            if (physicsState.HasFlag(PhysicsState.ReportCollision))
+            if (physicsState.HasFlag(PhysicsState.ReportCollisions))
                 if (!ReportCollisions.HasValue)
                     ReportCollisions = true;
-            if (physicsState.HasFlag(PhysicsState.IgnoreCollision))
+            if (physicsState.HasFlag(PhysicsState.IgnoreCollisions))
                 if (!IgnoreCollisions.HasValue)
                     IgnoreCollisions = true;
             if (physicsState.HasFlag(PhysicsState.NoDraw))
@@ -509,7 +510,7 @@ namespace ACE.Server.WorldObjects
             if (physicsState.HasFlag(PhysicsState.Cloaked))
                 if (!Cloaked.HasValue)
                     Cloaked = true;
-            if (physicsState.HasFlag(PhysicsState.ReportCollisionAsEnviroment))
+            if (physicsState.HasFlag(PhysicsState.ReportCollisionsAsEnvironment))
                 if (!ReportCollisionsAsEnvironment.HasValue)
                     ReportCollisionsAsEnvironment = true;
             if (physicsState.HasFlag(PhysicsState.EdgeSlide))
@@ -535,14 +536,14 @@ namespace ACE.Server.WorldObjects
                 physicsState &= ~PhysicsState.Ethereal;
             ////ReportCollision             = 0x00000008,
             if (ReportCollisions ?? false)
-                physicsState |= PhysicsState.ReportCollision;
+                physicsState |= PhysicsState.ReportCollisions;
             else
-                physicsState &= ~PhysicsState.ReportCollision;
+                physicsState &= ~PhysicsState.ReportCollisions;
             ////IgnoreCollision             = 0x00000010,
             if (IgnoreCollisions ?? false)
-                physicsState |= PhysicsState.IgnoreCollision;
+                physicsState |= PhysicsState.IgnoreCollisions;
             else
-                physicsState &= ~PhysicsState.IgnoreCollision;
+                physicsState &= ~PhysicsState.IgnoreCollisions;
             ////NoDraw                      = 0x00000020,
             if (NoDraw ?? false)
                 physicsState |= PhysicsState.NoDraw;
@@ -594,11 +595,11 @@ namespace ACE.Server.WorldObjects
                 physicsState |= PhysicsState.ScriptedCollision;
             else
                 physicsState &= ~PhysicsState.ScriptedCollision;
-            ////HasPhysicsBsp               = 0x00010000,
+            ////HasPhysicsBSP               = 0x00010000,
             if (CSetup.HasPhysicsBSP)
-                physicsState |= PhysicsState.HasPhysicsBsp;
+                physicsState |= PhysicsState.HasPhysicsBSP;
             else
-                physicsState &= ~PhysicsState.HasPhysicsBsp;
+                physicsState &= ~PhysicsState.HasPhysicsBSP;
             ////Inelastic                   = 0x00020000,
             if (Inelastic ?? false)
                 physicsState |= PhysicsState.Inelastic;
@@ -621,9 +622,9 @@ namespace ACE.Server.WorldObjects
                 physicsState &= ~PhysicsState.Cloaked;
             ////ReportCollisionAsEnviroment = 0x00200000,
             if (ReportCollisionsAsEnvironment ?? false)
-                physicsState |= PhysicsState.ReportCollisionAsEnviroment;
+                physicsState |= PhysicsState.ReportCollisionsAsEnvironment;
             else
-                physicsState &= ~PhysicsState.ReportCollisionAsEnviroment;
+                physicsState &= ~PhysicsState.ReportCollisionsAsEnvironment;
             ////EdgeSlide                   = 0x00400000,
             if (AllowEdgeSlide ?? false)
                 physicsState |= PhysicsState.EdgeSlide;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -523,92 +523,159 @@ namespace ACE.Server.WorldObjects
         }
 
 
+        public bool GetPhysicsState(PhysicsState state)
+        {
+            if (PhysicsObj == null) return false;
+            return PhysicsObj.State.HasFlag(state);
+        }
+
+        public void SetPhysicsState(PhysicsState state, bool? value)
+        {
+            if (PhysicsObj != null)
+            {
+                if (value.HasValue && value.Value)
+                    PhysicsObj.State |= state;
+                else
+                    PhysicsObj.State &= ~state;   // default to false for null, should get real physics default for this field
+            }
+        }
+
+        public void SetPhysicsPropertyState(PropertyBool property, PhysicsState state, bool? value)
+        {
+            if (value.HasValue)
+            {
+                SetProperty(property, value.Value);
+                SetPhysicsState(state, value);
+            }
+            else
+            {
+                RemoveProperty(property);
+                SetPhysicsState(state, false);  // default to false for null, should get real physics default for this field
+            }
+        }
+
         // ========================================
         // ======= Physics State Properties =======
         // ========================================
         // used in CalculatedPhysicsState()
-        public bool? Static { get; set; }
+        public bool? Static
+        {
+            get => GetPhysicsState(PhysicsState.Static);
+            set => SetPhysicsState(PhysicsState.Static, value);
+        }
 
         public bool? Ethereal
         {
-            get => GetProperty(PropertyBool.Ethereal);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.Ethereal); else SetProperty(PropertyBool.Ethereal, value.Value); }
+            get => GetProperty(PropertyBool.Ethereal);  // TODO: property or physics state?
+            set => SetPhysicsPropertyState(PropertyBool.Ethereal, PhysicsState.Ethereal, value);
         }
 
         public bool? ReportCollisions
         {
             get => GetProperty(PropertyBool.ReportCollisions);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.ReportCollisions); else SetProperty(PropertyBool.ReportCollisions, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.ReportCollisions, PhysicsState.ReportCollisions, value);
         }
 
         public bool? IgnoreCollisions
         {
             get => GetProperty(PropertyBool.IgnoreCollisions);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.IgnoreCollisions); else SetProperty(PropertyBool.IgnoreCollisions, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.IgnoreCollisions, PhysicsState.IgnoreCollisions, value);
         }
 
         public bool? NoDraw
         {
             get => GetProperty(PropertyBool.NoDraw);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.NoDraw); else SetProperty(PropertyBool.NoDraw, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.NoDraw, PhysicsState.NoDraw, value);
         }
 
-        public bool? Missile { get; set; }
+        public bool? Missile
+        {
+            get => GetPhysicsState(PhysicsState.Missile);
+            set => SetPhysicsState(PhysicsState.Missile, value);
+        }
 
-        public bool? Pushable { get; set; }
+        public bool? Pushable
+        {
+            get => GetPhysicsState(PhysicsState.Pushable);
+            set => SetPhysicsState(PhysicsState.Missile, value);
+        }
 
-        public bool? AlignPath { get; set; }
+        public bool? AlignPath
+        {
+            get => GetPhysicsState(PhysicsState.AlignPath);
+            set => SetPhysicsState(PhysicsState.AlignPath, value);
+        }
 
-        public bool? PathClipped { get; set; }
+        public bool? PathClipped
+        {
+            get => GetPhysicsState(PhysicsState.PathClipped);
+            set => SetPhysicsState(PhysicsState.PathClipped, value);
+        }
 
         public bool? GravityStatus
         {
             get => GetProperty(PropertyBool.GravityStatus);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.GravityStatus); else SetProperty(PropertyBool.GravityStatus, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.GravityStatus, PhysicsState.Gravity, value);
         }
 
         public bool? LightsStatus
         {
             get => GetProperty(PropertyBool.LightsStatus);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.LightsStatus); else SetProperty(PropertyBool.LightsStatus, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.LightsStatus, PhysicsState.LightingOn, value);
         }
 
-        public bool? ParticleEmitter { get; set; }
+        public bool? ParticleEmitter
+        {
+            get => GetPhysicsState(PhysicsState.ParticleEmitter);
+            set => SetPhysicsState(PhysicsState.ParticleEmitter, value);
+        }
 
-        public bool? Hidden { get; set; }
+        public bool? Hidden
+        {
+            get => GetPhysicsState(PhysicsState.Hidden);
+            set => SetPhysicsState(PhysicsState.Hidden, value);
+        }
 
         public bool? ScriptedCollision
         {
             get => GetProperty(PropertyBool.ScriptedCollision);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.ScriptedCollision); else SetProperty(PropertyBool.ScriptedCollision, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.ScriptedCollision, PhysicsState.ScriptedCollision, value);
         }
 
         public bool? Inelastic
         {
             get => GetProperty(PropertyBool.Inelastic);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.Inelastic); else SetProperty(PropertyBool.Inelastic, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.Inelastic, PhysicsState.Inelastic, value);
         }
 
-        public bool? Cloaked { get; set; }
+        public bool? Cloaked
+        {
+            get => GetPhysicsState(PhysicsState.Cloaked);
+            set => SetPhysicsState(PhysicsState.Cloaked, value);
+        }
 
         public bool? ReportCollisionsAsEnvironment
         {
             get => GetProperty(PropertyBool.ReportCollisionsAsEnvironment);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.ReportCollisionsAsEnvironment); else SetProperty(PropertyBool.ReportCollisionsAsEnvironment, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.ReportCollisionsAsEnvironment, PhysicsState.ReportCollisionsAsEnvironment, value);
         }
 
         public bool? AllowEdgeSlide
         {
             get => GetProperty(PropertyBool.AllowEdgeSlide);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.AllowEdgeSlide); else SetProperty(PropertyBool.AllowEdgeSlide, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.AllowEdgeSlide, PhysicsState.EdgeSlide, value);
         }
 
-        public bool? Sledding { get; set; }
+        public bool? Sledding
+        {
+            get => GetPhysicsState(PhysicsState.Sledding);
+            set => SetPhysicsState(PhysicsState.Sledding, value);
+        }
 
         public bool? IsFrozen
         {
             get => GetProperty(PropertyBool.IsFrozen);
-            set { if (!value.HasValue) RemoveProperty(PropertyBool.IsFrozen); else SetProperty(PropertyBool.IsFrozen, value.Value); }
+            set => SetPhysicsPropertyState(PropertyBool.IsFrozen, PhysicsState.Frozen, value);
         }
 
 


### PR DESCRIPTION
This patch synchronizes the physics state between WorldObject and PhysicsObj

PhysicsObj.State should be the backing store, with WorldObject having easily accessible bool properties, which also persist to PropertyBool for the appropriate fields

This patch also re-introduces Jyrus' change to move InitPhysicsObj() to LandblockManager.AddWorldObjectInternal(). This still needs additional testing, and it seems like we should be initting the PhysicsObjs before this method is called. It is a very convenient entrypoint at the moment though, as it ensures only PhysicsObjs are created for objects upon entry into the 3D world.

There could still be some possible issues though (multithreading?), for example the bug with players entering portals and re-appearing in their original location.