### PR TITLE
Move PK checks and spell damage messages and implement SpellType.PortalLink

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -348,6 +348,7 @@ namespace ACE.Server.WorldObjects
             OutOfMana,
             OutOfOtherVital,
             CastFailed,
+            InvalidPKStatus,
             Success
         }
 
@@ -374,7 +375,7 @@ namespace ACE.Server.WorldObjects
             }
             if (target == null)
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.TargetNotAcquired));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.TargetNotAcquired));
                 targetCategory = TargetCategory.UnDef;
                 return;
             }
@@ -383,7 +384,7 @@ namespace ACE.Server.WorldObjects
             SpellTable spellTable = DatManager.PortalDat.SpellTable;
             if (!spellTable.Spells.ContainsKey(spellId))
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicInvalidSpellType));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicInvalidSpellType));
                 return;
             }
 
@@ -392,7 +393,7 @@ namespace ACE.Server.WorldObjects
             if (IsInvalidTarget(spell, target))
             {
                 player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"{spell.Name} cannot be cast on {target.Name}."));
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
                 return;
             }
 
@@ -400,13 +401,13 @@ namespace ACE.Server.WorldObjects
             if (spellStatMod == null)
             {
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicInvalidSpellType));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicInvalidSpellType));
                 return;
             }
 
             if (player.IsBusy == true)
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YoureTooBusy));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YoureTooBusy));
                 return;
             }
             else
@@ -425,31 +426,8 @@ namespace ACE.Server.WorldObjects
 
                     if (distanceTo > spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod)
                     {
-                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.MagicTargetOutOfRange),
+                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicTargetOutOfRange),
                             new GameMessageSystemChat($"{target.Name} is out of range!", ChatMessageType.Magic));
-                        player.IsBusy = false;
-                        return;
-                    }
-                }
-            }
-
-            bool isSpellHarmful = IsSpellHarmful(spell);
-            if (isSpellHarmful)
-            {
-                // Ensure that a non-PK cannot cast harmful spells on another player
-                if ((target is Player) && (player.PlayerKillerStatus == ACE.Entity.Enum.PlayerKillerStatus.NPK))
-                {
-                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.InvalidPkStatus));
-                    player.IsBusy = false;
-                    return;
-                }
-
-                // Ensure that a harmful spell isn't being cast on another player that doesn't have the same PK status
-                if ((target is Player) && (player.PlayerKillerStatus != ACE.Entity.Enum.PlayerKillerStatus.NPK))
-                {
-                    if (player.PlayerKillerStatus != target.PlayerKillerStatus)
-                    {
-                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.InvalidPkStatus));
                         player.IsBusy = false;
                         return;
                     }
@@ -491,6 +469,13 @@ namespace ACE.Server.WorldObjects
             else
                 player.UpdateVital(player.Mana, player.Mana.Current - manaUsed);
             #endregion
+
+            var checkPKStatusVsTarget = CheckPKStatusVsTarget(player, (target as Player), spell);
+            if (checkPKStatusVsTarget != null)
+            {
+                if (checkPKStatusVsTarget == false)
+                    castingPreCheckStatus = CastingPreCheckStatus.InvalidPKStatus;
+            }
 
             ActionChain spellChain = new ActionChain();
 
@@ -589,8 +574,6 @@ namespace ACE.Server.WorldObjects
                                 CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
                                 targetDeath = LifeMagic(target, spell, spellStatMod, out uint damage, out bool critical, out enchantmentStatus);
 
-                                if (enchantmentStatus.message != null)
-                                    player.Session.Network.EnqueueSend(enchantmentStatus.message);
                                 if (targetDeath == true)
                                 {
                                     creatureTarget.Die();
@@ -600,6 +583,11 @@ namespace ACE.Server.WorldObjects
 
                                     if ((creatureTarget as Player) == null)
                                         player.EarnXP((long)target.XpOverride, true);
+                                }
+                                else
+                                {
+                                    if (enchantmentStatus.message != null)
+                                        player.Session.Network.EnqueueSend(enchantmentStatus.message);
                                 }
                                 break;
 
@@ -650,6 +638,26 @@ namespace ACE.Server.WorldObjects
                         }
                     });
                     break;
+                case CastingPreCheckStatus.InvalidPKStatus:
+                    spellChain.AddAction(this, () =>
+                    {
+                        switch (spell.School)
+                        {
+                            case MagicSchool.WarMagic:
+                                WarMagic(target, spell, spellStatMod);
+                                break;
+                            case MagicSchool.VoidMagic:
+                                VoidMagic(target, spell, spellStatMod);
+                                break;
+                            case MagicSchool.ItemEnchantment:
+                                // Do nothing
+                                break;
+                            default:
+                                CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                break;
+                        }
+                    });
+                    break;
                 default:
                     spellChain.AddAction(this, () => CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Fizzle, 0.5f)));
                     break;
@@ -665,11 +673,17 @@ namespace ACE.Server.WorldObjects
 
             switch (castingPreCheckStatus)
             {
+                case CastingPreCheckStatus.InvalidPKStatus:
+                    if (spell.School == MagicSchool.LifeMagic || spell.School == MagicSchool.CreatureEnchantment || spell.School == MagicSchool.ItemEnchantment)
+                        spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.InvalidPkStatus)));
+                    else
+                        spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None)));
+                    break;
                 case CastingPreCheckStatus.OutOfMana:
-                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.YouDontHaveEnoughManaToCast)));
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YouDontHaveEnoughManaToCast)));
                     break;
                 default:
-                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, errorType: WeenieError.None)));
+                    spellChain.AddAction(this, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None)));
                     break;
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -599,7 +599,12 @@ namespace ACE.Server.WorldObjects
                                     if (guidTarget == Guid)
                                         CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
                                     else
-                                        CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                    {
+                                        if (spell.MetaSpellType == SpellType.PortalLink)
+                                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(Guid, (PlayScript)spell.CasterEffect, scale));
+                                        else
+                                            CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, scale));
+                                    }
                                     if (enchantmentStatus.message != null)
                                         player.Session.Network.EnqueueSend(enchantmentStatus.message);
                                 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -681,7 +681,7 @@ namespace ACE.Server.WorldObjects
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToLifestoneToRecall));
                                 }
                                 else
-                                    recall = PositionType.LastPortal;
+                                    recall = PositionType.LinkedLifestone;
                                 break;
                             case 48: // Primary Portal Recall
                                 if (!player.Positions.ContainsKey(PositionType.LinkedPortalOne))
@@ -690,7 +690,7 @@ namespace ACE.Server.WorldObjects
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToPortalToRecall));
                                 }
                                 else
-                                    recall = PositionType.LastPortal;
+                                    recall = PositionType.LinkedPortalOne;
                                 break;
                             case 2647: // Secondary Portal Recall
                                 if (!player.Positions.ContainsKey(PositionType.LinkedPortalTwo))
@@ -699,7 +699,7 @@ namespace ACE.Server.WorldObjects
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToPortalToRecall));
                                 }
                                 else
-                                    recall = PositionType.LastPortal;
+                                    recall = PositionType.LinkedPortalTwo;
                                 break;
                         }
 
@@ -727,8 +727,42 @@ namespace ACE.Server.WorldObjects
                         }
                         break;
                     case SpellType.PortalLink:
-                        if (targetPlayer != null)
-                            enchantmentStatus.message = new GameMessageSystemChat("Spell not implemented, yet!", ChatMessageType.Magic);
+                        if (player != null)
+                        {
+                            switch (spell.MetaSpellId)
+                            {
+                                case 47:    // Primary Portal Tie
+                                    if (target.WeenieType == WeenieType.Portal)
+                                    {
+                                        var targetPortal = target as Portal;
+                                        if (!targetPortal.NoTie)
+                                            player.LinkedPortalOne = targetPortal.Destination;
+                                        else
+                                            player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouCannotLinkToThatPortal));
+                                    }
+                                    else
+                                        player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"Primary Portal Tie cannot be cast on {target.Name}"));
+                                    break;
+                                case 2644:  // Lifestone Tie
+                                    if (target.WeenieType == WeenieType.LifeStone)
+                                        player.LinkedLifestone = target.Location;
+                                    else
+                                        player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"Lifestone Tie cannot be cast on {target.Name}"));
+                                    break;
+                                case 2646:  // Secondary Portal Tie
+                                    if (target.WeenieType == WeenieType.Portal)
+                                    {
+                                        var targetPortal = target as Portal;
+                                        if (!targetPortal.NoTie)
+                                            player.LinkedPortalTwo = targetPortal.Destination;
+                                        else
+                                            player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouCannotLinkToThatPortal));
+                                    }
+                                    else
+                                        player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"Secondary Portal Tie cannot be cast on {target.Name}"));
+                                    break;
+                            }
+                        }
                         break;
                     case SpellType.PortalSummon:
                         uint portalId = 0;
@@ -766,7 +800,7 @@ namespace ACE.Server.WorldObjects
                             portal.EnterWorld();
 
                             // Create portal decay
-                            double portalDespawnTime = spellStatMod.PortalLifetime ?? 15.0f;
+                            double portalDespawnTime = spellStatMod.PortalLifetime ?? 60.0f;
                             ActionChain despawnChain = new ActionChain();
                             despawnChain.AddDelaySeconds(portalDespawnTime);
                             despawnChain.AddAction(portal, () => portal.CurrentLandblock?.RemoveWorldObject(portal.Guid, false));

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -197,6 +197,40 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// Determine Player's PK status and whether it matches the target Player
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="target"></param>
+        /// <param name="spell"></param>
+        /// <returns>
+        /// A null return signifies either player or target are not Player World objects, so check does not apply
+        /// A true return value indicates that the Player passed the PK status check
+        /// A false return value indicates that the Player failed the PK status check
+        /// </returns>
+        protected bool? CheckPKStatusVsTarget(Player player, Player target, SpellBase spell)
+        {
+            if (player == null || target == null)
+                return null;
+
+            bool isSpellHarmful = IsSpellHarmful(spell);
+            if (isSpellHarmful)
+            {
+                // Ensure that a non-PK cannot cast harmful spells on another player
+                if (player.PlayerKillerStatus == PlayerKillerStatus.NPK)
+                    return false;
+
+                // Ensure that a harmful spell isn't being cast on another player that doesn't have the same PK status
+                if (player.PlayerKillerStatus != PlayerKillerStatus.NPK)
+                {
+                    if (player.PlayerKillerStatus != target.PlayerKillerStatus)
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Determines whether the target for the spell being cast is invalid
         /// </summary>
         /// <param name="spell"></param>


### PR DESCRIPTION
-Move PK checks to after start of spell cast and one spell projectile collision
-Move spell damage messages to be mutually exclusive with the death messages
-Implement SpellType.PortalLink (Primary Portal, Secondary Portal, and LIfestone Tie)