### PR TITLE
Change spell casting busy and Spell words ChatMessageType

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -407,7 +407,8 @@ namespace ACE.Server.WorldObjects
 
             if (player.IsBusy == true)
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YoureTooBusy));
+                player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YoureTooBusy));
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
                 return;
             }
             else
@@ -496,7 +497,7 @@ namespace ACE.Server.WorldObjects
             {
                 string spellWords = spell.SpellWords;
                 if (spellWords != null)
-                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Magic));
+                    CurrentLandblock?.EnqueueBroadcast(Location, new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Spellcasting));
 
                 var motionCastSpell = new UniversalMotion(MotionStance.Spellcasting);
                 motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Spellcasting & 0xFFFF);


### PR DESCRIPTION
-Rearrange spell casting busy state notifications to match PCAPs
-Change ChatMessageType for spell words, allowing VT decal plugin to cast spells without any duplicate casts 