### PR TITLE
Character refactor

### DIFF
--- a/Database/Base/ShardBase.sql
+++ b/Database/Base/ShardBase.sql
@@ -603,9 +603,8 @@ DROP TABLE IF EXISTS `character`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Character',
+  `id` int(10) unsigned NOT NULL COMMENT 'Id of the Biota for this Character',
   `account_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the Biota for this Character',
-  `biota_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the Biota for this Character',
   `name` varchar(255) NOT NULL COMMENT 'Name of Character',
   `is_Deleted` bit(1) NOT NULL COMMENT 'Is this Character deleted?',
   `delete_Time` bigint(10) unsigned NOT NULL DEFAULT '0' COMMENT 'The character will be marked IsDeleted=True after this timestamp',
@@ -618,9 +617,7 @@ CREATE TABLE `character` (
   `default_Hair_Texture` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `character_account_idx` (`account_Id`),
-  KEY `character_name_idx` (`name`),
-  UNIQUE KEY `biota_UNIQUE` (`biota_Id`),
-  CONSTRAINT `biota_character` FOREIGN KEY (`biota_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  KEY `character_name_idx` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Int Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -633,7 +630,7 @@ DROP TABLE IF EXISTS `character_properties_contract`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_contract` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `contract_Id` int(10) unsigned NOT NULL,
   `version` int(10) unsigned NOT NULL,
   `stage` int(10) unsigned NOT NULL,
@@ -642,8 +639,8 @@ CREATE TABLE `character_properties_contract` (
   `delete_Contract` bit(1) NOT NULL,
   `set_As_Display_Contract` bit(1) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_contract_uidx` (`object_Id`,`contract_Id`),
-  CONSTRAINT `wcid_contract` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_contract_uidx` (`character_Id`,`contract_Id`),
+  CONSTRAINT `wcid_contract` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -656,12 +653,12 @@ DROP TABLE IF EXISTS `character_properties_fill_comp_book`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_fill_comp_book` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `spell_Component_Id` int(10) NOT NULL DEFAULT '0' COMMENT 'Id of Spell Component',
   `quantity_To_Rebuy` int(10) NOT NULL DEFAULT '0' COMMENT 'Amount of this component to add to the buy list for repurchase',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_fillcompbook_type_uidx` (`object_Id`,`spell_Component_Id`),
-  CONSTRAINT `wcid_fillcompbook` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_fillcompbook_type_uidx` (`character_Id`,`spell_Component_Id`),
+  CONSTRAINT `wcid_fillcompbook` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='FillCompBook Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -674,12 +671,12 @@ DROP TABLE IF EXISTS `character_properties_friend_list`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_friend_list` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `friend_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of Friend',
   `account_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Account Id of object this property belongs to',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_friend_uidx` (`object_Id`,`friend_Id`),
-  CONSTRAINT `wcid_friend` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_friend_uidx` (`character_Id`,`friend_Id`),
+  CONSTRAINT `wcid_friend` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='FriendList Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -692,13 +689,13 @@ DROP TABLE IF EXISTS `character_properties_quest_registry`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_quest_registry` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `quest_Name` varchar(255) NOT NULL COMMENT 'Unique Name of Quest',
   `last_Time_Completed` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Timestamp of last successful completion',
   `num_Times_Completed` int(10) NOT NULL DEFAULT '0' COMMENT 'Number of successful completions',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_questbook_name_uidx` (`object_Id`,`quest_Name`),
-  CONSTRAINT `wcid_questbook` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_questbook_name_uidx` (`character_Id`,`quest_Name`),
+  CONSTRAINT `wcid_questbook` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='QuestBook Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -711,12 +708,12 @@ DROP TABLE IF EXISTS `character_properties_shortcut_bar`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_shortcut_bar` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `shortcut_Bar_Index` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Position (Slot) on the Shortcut Bar for this Object',
   `shortcut_Object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Guid of the object at this Slot',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_shortcutbar_barIndex_ObjectId_uidx` (`object_Id`,`shortcut_Bar_Index`,`shortcut_Object_Id`),
-  CONSTRAINT `wcid_shortcutbar` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_shortcutbar_barIndex_ObjectId_uidx` (`character_Id`,`shortcut_Bar_Index`,`shortcut_Object_Id`),
+  CONSTRAINT `wcid_shortcutbar` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='ShortcutBar Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -729,13 +726,13 @@ DROP TABLE IF EXISTS `character_properties_spell_bar`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_spell_bar` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `spell_Bar_Number` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of Spell Bar',
   `spell_Bar_Index` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Position (Slot) on this Spell Bar for this Spell',
   `spell_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of Spell on this Spell Bar at this Slot',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_spellbar_barId_spellId_uidx` (`object_Id`,`spell_Bar_Number`,`spell_Id`),
-  CONSTRAINT `wcid_spellbar` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_spellbar_barId_spellId_uidx` (`character_Id`,`spell_Bar_Number`,`spell_Id`),
+  CONSTRAINT `wcid_spellbar` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='SpellBar Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -748,11 +745,11 @@ DROP TABLE IF EXISTS `character_properties_title_book`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `character_properties_title_book` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique Id of this Property',
-  `object_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the object this property belongs to',
+  `character_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of the character this property belongs to',
   `title_Id` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Id of Title',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `wcid_titlebook_type_uidx` (`object_Id`,`title_Id`),
-  CONSTRAINT `wcid_titlebook` FOREIGN KEY (`object_Id`) REFERENCES `biota` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+  UNIQUE KEY `wcid_titlebook_type_uidx` (`character_Id`,`title_Id`),
+  CONSTRAINT `wcid_titlebook` FOREIGN KEY (`character_Id`) REFERENCES `character` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='TitleBook Properties of Weenies';
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/Source/ACE.Database/Models/Shard/Biota.cs
+++ b/Source/ACE.Database/Models/Shard/Biota.cs
@@ -29,13 +29,6 @@ namespace ACE.Database.Models.Shard
             BiotaPropertiesSpellBook = new HashSet<BiotaPropertiesSpellBook>();
             BiotaPropertiesString = new HashSet<BiotaPropertiesString>();
             BiotaPropertiesTextureMap = new HashSet<BiotaPropertiesTextureMap>();
-            CharacterPropertiesContract = new HashSet<CharacterPropertiesContract>();
-            CharacterPropertiesFillCompBook = new HashSet<CharacterPropertiesFillCompBook>();
-            CharacterPropertiesFriendList = new HashSet<CharacterPropertiesFriendList>();
-            CharacterPropertiesQuestRegistry = new HashSet<CharacterPropertiesQuestRegistry>();
-            CharacterPropertiesShortcutBar = new HashSet<CharacterPropertiesShortcutBar>();
-            CharacterPropertiesSpellBar = new HashSet<CharacterPropertiesSpellBar>();
-            CharacterPropertiesTitleBook = new HashSet<CharacterPropertiesTitleBook>();
         }
 
         public uint Id { get; set; }
@@ -43,7 +36,6 @@ namespace ACE.Database.Models.Shard
         public int WeenieType { get; set; }
 
         public BiotaPropertiesBook BiotaPropertiesBook { get; set; }
-        public Character Character { get; set; }
         public ICollection<BiotaPropertiesAnimPart> BiotaPropertiesAnimPart { get; set; }
         public ICollection<BiotaPropertiesAttribute> BiotaPropertiesAttribute { get; set; }
         public ICollection<BiotaPropertiesAttribute2nd> BiotaPropertiesAttribute2nd { get; set; }
@@ -66,12 +58,5 @@ namespace ACE.Database.Models.Shard
         public ICollection<BiotaPropertiesSpellBook> BiotaPropertiesSpellBook { get; set; }
         public ICollection<BiotaPropertiesString> BiotaPropertiesString { get; set; }
         public ICollection<BiotaPropertiesTextureMap> BiotaPropertiesTextureMap { get; set; }
-        public ICollection<CharacterPropertiesContract> CharacterPropertiesContract { get; set; }
-        public ICollection<CharacterPropertiesFillCompBook> CharacterPropertiesFillCompBook { get; set; }
-        public ICollection<CharacterPropertiesFriendList> CharacterPropertiesFriendList { get; set; }
-        public ICollection<CharacterPropertiesQuestRegistry> CharacterPropertiesQuestRegistry { get; set; }
-        public ICollection<CharacterPropertiesShortcutBar> CharacterPropertiesShortcutBar { get; set; }
-        public ICollection<CharacterPropertiesSpellBar> CharacterPropertiesSpellBar { get; set; }
-        public ICollection<CharacterPropertiesTitleBook> CharacterPropertiesTitleBook { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -48,11 +48,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static CharacterPropertiesContract GetContract(this Biota biota, uint contractId)
-        {
-            return biota.CharacterPropertiesContract.FirstOrDefault(x => x.ContractId == contractId);
-        }
-
         public static BiotaPropertiesCreateList GetCreateList(this Biota biota, sbyte destinationType)
         {
             return biota.BiotaPropertiesCreateList.FirstOrDefault(x => x.DestinationType == destinationType);
@@ -81,8 +76,6 @@ namespace ACE.Database.Models.Shard
             return biota.BiotaPropertiesEmote.Where(x => x.Category == category);
         }
 
-        // BiotaPropertiesEmoteAction
-
         public static BiotaPropertiesEventFilter GetEventFilter(this Biota biota, int eventId)
         {
             return biota.BiotaPropertiesEventFilter.FirstOrDefault(x => x.Event == eventId);
@@ -100,8 +93,6 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitReadLock();
             }
         }
-
-        // BiotaPropertiesFriendList
 
         // BiotaPropertiesGenerator
 
@@ -280,6 +271,8 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitUpgradeableReadLock();
             }
         }
+
+        // BiotaPropertiesGenerator
 
         public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock)
         {
@@ -516,6 +509,8 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        // BiotaPropertiesGenerator
+
         public static bool TryRemoveProperty(this Biota biota, PropertyInstanceId property, out BiotaPropertiesIID entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -668,34 +663,6 @@ namespace ACE.Database.Models.Shard
                     try
                     {
                         biota.BiotaPropertiesEnchantmentRegistry.Remove(entity);
-                        entity.Object = null;
-                        return true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
-                }
-                return false;
-            }
-            finally
-            {
-                rwLock.ExitUpgradeableReadLock();
-            }
-        }
-
-        public static bool TryRemoveFriend(this Biota biota, ObjectGuid friendGuid, out CharacterPropertiesFriendList entity, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterUpgradeableReadLock();
-            try
-            {
-                entity = biota.CharacterPropertiesFriendList.FirstOrDefault(x => x.FriendId == friendGuid.Full);
-                if (entity != null)
-                {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        biota.CharacterPropertiesFriendList.Remove(entity);
                         entity.Object = null;
                         return true;
                     }

--- a/Source/ACE.Database/Models/Shard/Character.cs
+++ b/Source/ACE.Database/Models/Shard/Character.cs
@@ -5,9 +5,19 @@ namespace ACE.Database.Models.Shard
 {
     public partial class Character
     {
+        public Character()
+        {
+            CharacterPropertiesContract = new HashSet<CharacterPropertiesContract>();
+            CharacterPropertiesFillCompBook = new HashSet<CharacterPropertiesFillCompBook>();
+            CharacterPropertiesFriendList = new HashSet<CharacterPropertiesFriendList>();
+            CharacterPropertiesQuestRegistry = new HashSet<CharacterPropertiesQuestRegistry>();
+            CharacterPropertiesShortcutBar = new HashSet<CharacterPropertiesShortcutBar>();
+            CharacterPropertiesSpellBar = new HashSet<CharacterPropertiesSpellBar>();
+            CharacterPropertiesTitleBook = new HashSet<CharacterPropertiesTitleBook>();
+        }
+
         public uint Id { get; set; }
         public uint AccountId { get; set; }
-        public uint BiotaId { get; set; }
         public string Name { get; set; }
         public bool IsDeleted { get; set; }
         public ulong DeleteTime { get; set; }
@@ -19,6 +29,12 @@ namespace ACE.Database.Models.Shard
         public uint HairTexture { get; set; }
         public uint DefaultHairTexture { get; set; }
 
-        public Biota Biota { get; set; }
+        public ICollection<CharacterPropertiesContract> CharacterPropertiesContract { get; set; }
+        public ICollection<CharacterPropertiesFillCompBook> CharacterPropertiesFillCompBook { get; set; }
+        public ICollection<CharacterPropertiesFriendList> CharacterPropertiesFriendList { get; set; }
+        public ICollection<CharacterPropertiesQuestRegistry> CharacterPropertiesQuestRegistry { get; set; }
+        public ICollection<CharacterPropertiesShortcutBar> CharacterPropertiesShortcutBar { get; set; }
+        public ICollection<CharacterPropertiesSpellBar> CharacterPropertiesSpellBar { get; set; }
+        public ICollection<CharacterPropertiesTitleBook> CharacterPropertiesTitleBook { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterExtensions.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+
+using ACE.Entity;
+
+namespace ACE.Database.Models.Shard
+{
+    public static class CharacterExtensions
+    {
+        public static bool TryRemoveFriend(this Character character, ObjectGuid friendGuid, out CharacterPropertiesFriendList entity)
+        {
+            entity = character.CharacterPropertiesFriendList.FirstOrDefault(x => x.FriendId == friendGuid.Full);
+
+            if (entity != null)
+            {
+                character.CharacterPropertiesFriendList.Remove(entity);
+                entity.Character = null;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesContract.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesContract.cs
@@ -6,7 +6,7 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesContract
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public uint ContractId { get; set; }
         public uint Version { get; set; }
         public uint Stage { get; set; }
@@ -15,6 +15,6 @@ namespace ACE.Database.Models.Shard
         public bool DeleteContract { get; set; }
         public bool SetAsDisplayContract { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
@@ -6,10 +6,10 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesFillCompBook
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public int SpellComponentId { get; set; }
         public int QuantityToRebuy { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
@@ -6,10 +6,10 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesFriendList
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public uint FriendId { get; set; }
         public uint AccountId { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
@@ -6,11 +6,11 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesQuestRegistry
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public string QuestName { get; set; }
         public uint LastTimeCompleted { get; set; }
         public int NumTimesCompleted { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
@@ -6,10 +6,10 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesShortcutBar
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public uint ShortcutBarIndex { get; set; }
         public uint ShortcutObjectId { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
@@ -6,11 +6,11 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesSpellBar
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public uint SpellBarNumber { get; set; }
         public uint SpellBarIndex { get; set; }
         public uint SpellId { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
@@ -6,9 +6,9 @@ namespace ACE.Database.Models.Shard
     public partial class CharacterPropertiesTitleBook
     {
         public uint Id { get; set; }
-        public uint ObjectId { get; set; }
+        public uint CharacterId { get; set; }
         public uint TitleId { get; set; }
 
-        public Biota Object { get; set; }
+        public Character Character { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -1188,10 +1188,6 @@ namespace ACE.Database.Models.Shard
                 entity.HasIndex(e => e.AccountId)
                     .HasName("character_account_idx");
 
-                entity.HasIndex(e => e.BiotaId)
-                    .HasName("biota_UNIQUE")
-                    .IsUnique();
-
                 entity.HasIndex(e => e.Name)
                     .HasName("character_name_idx");
 
@@ -1199,10 +1195,6 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.AccountId)
                     .HasColumnName("account_Id")
-                    .HasDefaultValueSql("'0'");
-
-                entity.Property(e => e.BiotaId)
-                    .HasColumnName("biota_Id")
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.CharacterOptions1)
@@ -1248,32 +1240,27 @@ namespace ACE.Database.Models.Shard
                     .HasColumnName("total_Logins")
                     .HasColumnType("int(10)")
                     .HasDefaultValueSql("'0'");
-
-                entity.HasOne(d => d.Biota)
-                    .WithOne(p => p.Character)
-                    .HasForeignKey<Character>(d => d.BiotaId)
-                    .HasConstraintName("biota_character");
             });
 
             modelBuilder.Entity<CharacterPropertiesContract>(entity =>
             {
                 entity.ToTable("character_properties_contract");
 
-                entity.HasIndex(e => new { e.ObjectId, e.ContractId })
+                entity.HasIndex(e => new { e.CharacterId, e.ContractId })
                     .HasName("wcid_contract_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
+
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
+                    .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.ContractId).HasColumnName("contract_Id");
 
                 entity.Property(e => e.DeleteContract)
                     .HasColumnName("delete_Contract")
                     .HasColumnType("bit(1)");
-
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
-                    .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.SetAsDisplayContract)
                     .HasColumnName("set_As_Display_Contract")
@@ -1287,9 +1274,9 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Version).HasColumnName("version");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesContract)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_contract");
             });
 
@@ -1297,14 +1284,14 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_fill_comp_book");
 
-                entity.HasIndex(e => new { e.ObjectId, e.SpellComponentId })
+                entity.HasIndex(e => new { e.CharacterId, e.SpellComponentId })
                     .HasName("wcid_fillcompbook_type_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.QuantityToRebuy)
@@ -1317,9 +1304,9 @@ namespace ACE.Database.Models.Shard
                     .HasColumnType("int(10)")
                     .HasDefaultValueSql("'0'");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesFillCompBook)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_fillcompbook");
             });
 
@@ -1327,7 +1314,7 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_friend_list");
 
-                entity.HasIndex(e => new { e.ObjectId, e.FriendId })
+                entity.HasIndex(e => new { e.CharacterId, e.FriendId })
                     .HasName("wcid_friend_uidx")
                     .IsUnique();
 
@@ -1337,17 +1324,17 @@ namespace ACE.Database.Models.Shard
                     .HasColumnName("account_Id")
                     .HasDefaultValueSql("'0'");
 
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
+                    .HasDefaultValueSql("'0'");
+
                 entity.Property(e => e.FriendId)
                     .HasColumnName("friend_Id")
                     .HasDefaultValueSql("'0'");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
-                    .HasDefaultValueSql("'0'");
-
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesFriendList)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_friend");
             });
 
@@ -1355,11 +1342,15 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_quest_registry");
 
-                entity.HasIndex(e => new { e.ObjectId, e.QuestName })
+                entity.HasIndex(e => new { e.CharacterId, e.QuestName })
                     .HasName("wcid_questbook_name_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
+
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
+                    .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.LastTimeCompleted)
                     .HasColumnName("last_Time_Completed")
@@ -1370,18 +1361,14 @@ namespace ACE.Database.Models.Shard
                     .HasColumnType("int(10)")
                     .HasDefaultValueSql("'0'");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
-                    .HasDefaultValueSql("'0'");
-
                 entity.Property(e => e.QuestName)
                     .IsRequired()
                     .HasColumnName("quest_Name")
                     .HasColumnType("varchar(255)");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesQuestRegistry)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_questbook");
             });
 
@@ -1389,14 +1376,14 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_shortcut_bar");
 
-                entity.HasIndex(e => new { e.ObjectId, e.ShortcutBarIndex, e.ShortcutObjectId })
+                entity.HasIndex(e => new { e.CharacterId, e.ShortcutBarIndex, e.ShortcutObjectId })
                     .HasName("wcid_shortcutbar_barIndex_ObjectId_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.ShortcutBarIndex)
@@ -1407,9 +1394,9 @@ namespace ACE.Database.Models.Shard
                     .HasColumnName("shortcut_Object_Id")
                     .HasDefaultValueSql("'0'");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesShortcutBar)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_shortcutbar");
             });
 
@@ -1417,14 +1404,14 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_spell_bar");
 
-                entity.HasIndex(e => new { e.ObjectId, e.SpellBarNumber, e.SpellId })
+                entity.HasIndex(e => new { e.CharacterId, e.SpellBarNumber, e.SpellId })
                     .HasName("wcid_spellbar_barId_spellId_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.SpellBarIndex)
@@ -1439,9 +1426,9 @@ namespace ACE.Database.Models.Shard
                     .HasColumnName("spell_Id")
                     .HasDefaultValueSql("'0'");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesSpellBar)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_spellbar");
             });
 
@@ -1449,23 +1436,23 @@ namespace ACE.Database.Models.Shard
             {
                 entity.ToTable("character_properties_title_book");
 
-                entity.HasIndex(e => new { e.ObjectId, e.TitleId })
+                entity.HasIndex(e => new { e.CharacterId, e.TitleId })
                     .HasName("wcid_titlebook_type_uidx")
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasColumnName("id");
 
-                entity.Property(e => e.ObjectId)
-                    .HasColumnName("object_Id")
+                entity.Property(e => e.CharacterId)
+                    .HasColumnName("character_Id")
                     .HasDefaultValueSql("'0'");
 
                 entity.Property(e => e.TitleId)
                     .HasColumnName("title_Id")
                     .HasDefaultValueSql("'0'");
 
-                entity.HasOne(d => d.Object)
+                entity.HasOne(d => d.Character)
                     .WithMany(p => p.CharacterPropertiesTitleBook)
-                    .HasForeignKey(d => d.ObjectId)
+                    .HasForeignKey(d => d.CharacterId)
                     .HasConstraintName("wcid_titlebook");
             });
 

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -1,15 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+
+using log4net;
 
 using ACE.Database.Entity;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
-using Microsoft.EntityFrameworkCore;
-using System.Linq;
-using log4net;
 
 namespace ACE.Database
 {
@@ -115,11 +117,11 @@ namespace ACE.Database
             return _wrappedDatabase.IsCharacterPlussed(biotaId);
         }
 
-        public void AddCharacter(Character character, Biota biota, IEnumerable<Biota> possessions, Action<bool> callback)
+        public void AddCharacter(Biota biota, IEnumerable<Biota> possessions, Character character, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
-                var result = _wrappedDatabase.AddCharacter(character, biota, possessions);
+                var result = _wrappedDatabase.AddCharacter(biota, possessions, character);
                 callback?.Invoke(result);
             }));
         }
@@ -150,6 +152,7 @@ namespace ACE.Database
                 callback?.Invoke(result);
             }));
         }
+
 
         public void AddBiota(Biota biota, Action<bool> callback)
         {
@@ -205,6 +208,7 @@ namespace ACE.Database
             }));
         }
 
+
         public void AddeEntity(object entity, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
@@ -222,6 +226,7 @@ namespace ACE.Database
                 callback?.Invoke(result);
             }));
         }
+
 
         public void RemoveEntity(BiotaPropertiesBool entity, Action<bool> callback)
         {
@@ -295,24 +300,6 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveEntity(CharacterPropertiesShortcutBar entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(CharacterPropertiesSpellBar entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
         public void RemoveEntity(BiotaPropertiesSpellBook entity, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
@@ -323,6 +310,25 @@ namespace ACE.Database
         }
 
         public void RemoveEntity(BiotaPropertiesString entity, Action<bool> callback)
+        {
+            _queue.Add(new Task(() =>
+            {
+                var result = _wrappedDatabase.RemoveEntity(entity);
+                callback?.Invoke(result);
+            }));
+        }
+
+
+        public void RemoveEntity(CharacterPropertiesShortcutBar entity, Action<bool> callback)
+        {
+            _queue.Add(new Task(() =>
+            {
+                var result = _wrappedDatabase.RemoveEntity(entity);
+                callback?.Invoke(result);
+            }));
+        }
+
+        public void RemoveEntity(CharacterPropertiesSpellBar entity, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -369,8 +375,6 @@ namespace ACE.Database
                 callback?.Invoke(c);
             }));
         }
-
-
 
 
 

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -125,8 +125,6 @@ namespace ACE.Database
 
         public bool IsCharacterPlussed(uint biotaId)
         {
-            var ret = false;
-
             using (var context = new ShardDbContext())
             {
                 var result = context.Biota
@@ -138,22 +136,22 @@ namespace ACE.Database
                     return false;
 
                 if (result.GetProperty(PropertyBool.IsAdmin, new ReaderWriterLockSlim()) ?? false)
-                    ret = true;
+                    return true;
                 if (result.GetProperty(PropertyBool.IsArch, new ReaderWriterLockSlim()) ?? false)
-                    ret = true;
+                    return true;
                 if (result.GetProperty(PropertyBool.IsPsr, new ReaderWriterLockSlim()) ?? false)
-                    ret = true;
+                    return true;
                 if (result.GetProperty(PropertyBool.IsSentinel, new ReaderWriterLockSlim()) ?? false)
-                    ret = true;
+                    return true;
 
                 if (result.WeenieType == (int)WeenieType.Admin || result.WeenieType == (int)WeenieType.Sentinel)
-                    ret = true;
+                    return true;
 
-                return ret;
+                return false;
             }
         }
 
-        public bool AddCharacter(Character character, Biota biota, IEnumerable<Biota> possessions)
+        public bool AddCharacter(Biota biota, IEnumerable<Biota> possessions, Character character)
         {
             using (var context = new ShardDbContext())
             {
@@ -184,7 +182,7 @@ namespace ACE.Database
             using (var context = new ShardDbContext())
             {
                 var result = context.Character
-                    .FirstOrDefault(r => r.BiotaId == guid);
+                    .FirstOrDefault(r => r.Id == guid);
 
                 if (result != null)
                 {
@@ -212,12 +210,10 @@ namespace ACE.Database
             using (var context = new ShardDbContext())
             {
                 var result = context.Character
-                    .FirstOrDefault(r => r.BiotaId == guid);
+                    .FirstOrDefault(r => r.Id == guid);
 
                 if (result != null)
-                {
                     result.IsDeleted = true;
-                }
                 else
                     return false;
 
@@ -324,30 +320,23 @@ namespace ACE.Database
                 .Include(r => r.BiotaPropertiesBook)
                 .Include(r => r.BiotaPropertiesBookPageData)
                 .Include(r => r.BiotaPropertiesBool)
-                .Include(r => r.CharacterPropertiesContract)
                 .Include(r => r.BiotaPropertiesCreateList)
                 .Include(r => r.BiotaPropertiesDID)                
                 .Include(r => r.BiotaPropertiesEmote)
                     .ThenInclude(r => r.BiotaPropertiesEmoteAction)
                 .Include(r => r.BiotaPropertiesEnchantmentRegistry)
                 .Include(r => r.BiotaPropertiesEventFilter)
-                .Include(r => r.CharacterPropertiesFillCompBook)
                 .Include(r => r.BiotaPropertiesFloat)
-                .Include(r => r.CharacterPropertiesFriendList)
                 .Include(r => r.BiotaPropertiesGenerator)
                 .Include(r => r.BiotaPropertiesIID)
                 .Include(r => r.BiotaPropertiesInt)
                 .Include(r => r.BiotaPropertiesInt64)
                 .Include(r => r.BiotaPropertiesPalette)
                 .Include(r => r.BiotaPropertiesPosition)
-                .Include(r => r.CharacterPropertiesShortcutBar)
-                .Include(r => r.CharacterPropertiesQuestRegistry)
                 .Include(r => r.BiotaPropertiesSkill)
-                .Include(r => r.CharacterPropertiesSpellBar)
                 .Include(r => r.BiotaPropertiesSpellBook)
                 .Include(r => r.BiotaPropertiesString)
                 .Include(r => r.BiotaPropertiesTextureMap)
-                .Include(r => r.CharacterPropertiesTitleBook)
                 .FirstOrDefault(r => r.Id == id);
         }
 
@@ -367,29 +356,21 @@ namespace ACE.Database
                     //.Include(r => r.BiotaPropertiesBook)
                     //.Include(r => r.BiotaPropertiesBookPageData)
                     .Include(r => r.BiotaPropertiesBool)
-                    .Include(r => r.CharacterPropertiesContract)                // Player Only
                     //.Include(r => r.BiotaPropertiesCreateList)
                     .Include(r => r.BiotaPropertiesDID)
                     //.Include(r => r.BiotaPropertiesEmote).ThenInclude(emote => emote.BiotaPropertiesEmoteAction)
-                    //.Include(r => r.BiotaPropertiesEmoteAction)
-                    //.Include(r => r.BiotaPropertiesEventFilter)
                     .Include(r => r.BiotaPropertiesEnchantmentRegistry)
-                    .Include(r => r.CharacterPropertiesFillCompBook)            // Player Only
+                    //.Include(r => r.BiotaPropertiesEventFilter)
                     .Include(r => r.BiotaPropertiesFloat)
-                    .Include(r => r.CharacterPropertiesFriendList)        // Player Only
                     //.Include(r => r.BiotaPropertiesGenerator)
                     .Include(r => r.BiotaPropertiesIID)
                     .Include(r => r.BiotaPropertiesInt)
                     .Include(r => r.BiotaPropertiesInt64)
                     //.Include(r => r.BiotaPropertiesPalette)
                     .Include(r => r.BiotaPropertiesPosition)
-                    .Include(r => r.CharacterPropertiesQuestRegistry)
-                    .Include(r => r.CharacterPropertiesShortcutBar)       // Player Only
                     .Include(r => r.BiotaPropertiesSkill)
-                    .Include(r => r.CharacterPropertiesSpellBar)                // Player Only
                     .Include(r => r.BiotaPropertiesSpellBook)
                     .Include(r => r.BiotaPropertiesString)
-                    .Include(r => r.CharacterPropertiesTitleBook)               // Player Only
                     //.Include(r => r.BiotaPropertiesTextureMap)
                     .FirstOrDefault(r => r.Id == id);
             }
@@ -431,37 +412,20 @@ namespace ACE.Database
                 biota.BiotaPropertiesBookPageData = context.BiotaPropertiesBookPageData.Where(r => r.ObjectId == biota.Id).ToList();
             }
 
-            // Player only
-            //biota.BiotaPropertiesContract = context.BiotaPropertiesContract.Where(r => r.ObjectId == biota.Id).ToList();
-
             biota.BiotaPropertiesCreateList = context.BiotaPropertiesCreateList.Where(r => r.ObjectId == biota.Id).ToList();
             biota.BiotaPropertiesEmote = context.BiotaPropertiesEmote.Include(r => r.BiotaPropertiesEmoteAction).Where(r => r.ObjectId == biota.Id).ToList();
             biota.BiotaPropertiesEventFilter = context.BiotaPropertiesEventFilter.Where(r => r.ObjectId == biota.Id).ToList();
             biota.BiotaPropertiesEnchantmentRegistry = context.BiotaPropertiesEnchantmentRegistry.Where(r => r.ObjectId == biota.Id).ToList();
-            biota.CharacterPropertiesQuestRegistry = context.CharacterPropertiesQuestRegistry.Where(r => r.ObjectId == biota.Id).ToList();
-            // Player only
-            //biota.BiotaPropertiesFillCompBook = context.BiotaPropertiesFillCompBook.Where(r => r.ObjectId == biota.Id).ToList();
-            //biota.BiotaPropertiesFriendListFriend = context.BiotaPropertiesFriendList.Where(r => r.FriendId == biota.Id).ToList();
-            //biota.BiotaPropertiesFriendListObject = context.BiotaPropertiesFriendList.Where(r => r.ObjectId == biota.Id).ToList();
 
             biota.BiotaPropertiesGenerator = context.BiotaPropertiesGenerator.Where(r => r.ObjectId == biota.Id).ToList();
             biota.BiotaPropertiesPalette = context.BiotaPropertiesPalette.Where(r => r.ObjectId == biota.Id).ToList();
-
-            // Player only
-            //biota.BiotaPropertiesShortcutBarObject = context.BiotaPropertiesShortcutBar.Where(r => r.ObjectId == biota.Id).ToList();
 
             if (isCreature)
             {
                 biota.BiotaPropertiesSkill = context.BiotaPropertiesSkill.Where(r => r.ObjectId == biota.Id).ToList();
             }
 
-            // Player only
-            //biota.BiotaPropertiesSpellBar = context.BiotaPropertiesSpellBar.Where(r => r.ObjectId == biota.Id).ToList();
-
             biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
-
-            // Player only
-            //biota.BiotaPropertiesTitleBook = context.BiotaPropertiesTitleBook.Where(r => r.ObjectId == biota.Id).ToList();
 
             biota.BiotaPropertiesTextureMap = context.BiotaPropertiesTextureMap.Where(r => r.ObjectId == biota.Id).ToList();
 
@@ -900,6 +864,7 @@ namespace ACE.Database
 
             return items;
         }
+
 
         public List<Biota> GetObjectsByLandblock(ushort landblockId)
         {

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1422,8 +1422,7 @@ namespace ACE.Server.Command.Handlers
 
             DatabaseManager.Shard.AddBiotas(possessedBiotas, null);
 
-            session.Character.BiotaId = player.Guid.Full;
-            DatabaseManager.Shard.SaveCharacter(session.Character, null);
+            DatabaseManager.Shard.SaveCharacter(player.Character, null);
 
             session.LogOffPlayer();
         }

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -7,6 +7,7 @@ using log4net;
 
 using ACE.Common;
 using ACE.Database;
+using ACE.Database.Models.Shard;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
@@ -44,22 +45,20 @@ namespace ACE.Server.Managers
 
         public static List<Landblock> DestructionQueue = new List<Landblock>();
 
-        public static void PlayerEnterWorld(Session session, ObjectGuid guid)
+        public static void PlayerEnterWorld(Session session, Character character)
         {
             var start = DateTime.UtcNow;
-            DatabaseManager.Shard.GetPlayerBiotas(guid.Full, biotas =>
+            DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
             {
                 log.Info("GetPlayerBiotas took " + (DateTime.UtcNow - start).TotalMilliseconds + " ms"); // This can be removed after EF performance is at the desired level.
                 Player player;
 
                 if (biotas.Player.WeenieType == (int)WeenieType.Admin)
-                    player = new Admin(biotas.Player, biotas.Inventory, biotas.WieldedItems, session);
+                    player = new Admin(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
                 else if (biotas.Player.WeenieType == (int)WeenieType.Sentinel)
-                    player = new Sentinel(biotas.Player, biotas.Inventory, biotas.WieldedItems, session);
+                    player = new Sentinel(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
                 else
-                    player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, session);
-
-                player.Name = session.Character.Name;
+                    player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
 
                 session.SetPlayer(player);
                 session.Player.PlayerEnterWorld();

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -9,7 +9,7 @@ namespace ACE.Server.Managers
     public class QuestManager
     {
         public Player Player { get; }
-        public ICollection<CharacterPropertiesQuestRegistry> Quests { get => Player.Biota.CharacterPropertiesQuestRegistry; }
+        public ICollection<CharacterPropertiesQuestRegistry> Quests { get => Player.Character.CharacterPropertiesQuestRegistry; }
 
         /// <summary>
         /// Constructs a new QuestManager for a Player
@@ -34,7 +34,7 @@ namespace ACE.Server.Managers
             var quest = new CharacterPropertiesQuestRegistry
             {
                 QuestName = questName,
-                ObjectId = Player.Guid.Full,
+                CharacterId = Player.Guid.Full,
                 LastTimeCompleted = 0,  // TODO: get accurate server time?
                 NumTimesCompleted = 1   // ??
             };
@@ -100,7 +100,7 @@ namespace ACE.Server.Managers
                 Console.WriteLine("Times Completed: " + quest.NumTimesCompleted);
                 Console.WriteLine("Last Time Completed: " + quest.LastTimeCompleted);
                 Console.WriteLine("Quest ID: " + quest.Id.ToString("X8"));
-                Console.WriteLine("Player ID: " + quest.ObjectId.ToString("X8"));
+                Console.WriteLine("Player ID: " + quest.CharacterId.ToString("X8"));
                 Console.WriteLine("----");
             }
         }

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -11,7 +11,6 @@ using log4net;
 
 using ACE.Common;
 using ACE.Entity;
-using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.WorldObjects;
 using ACE.Server.Network;
@@ -88,10 +87,10 @@ namespace ACE.Server.Managers
             {
                 foreach (var character in characters)
                 {
-                    DatabaseManager.Shard.GetPlayerBiotas(character.BiotaId, biotas =>
+                    DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
                     {
                         var session = new Session();
-                        var player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, session);
+                        var player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
                         AllPlayers.Add(player);
                     });
                 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Server.Network.Enum;
-using ACE.Server.Network.Structure;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -172,15 +171,8 @@ namespace ACE.Server.Network.GameAction.Actions
 
                 byte[] gameplayOptions = new byte[size];
                 gameplayOptions = message.Payload.ReadBytes(size);
-                session.Character.GameplayOptions = gameplayOptions;
-
-                // Not sure if this is the best way to do this, but only way it saves.
-                // Is this thread safe?
-                ACE.Database.DatabaseManager.Shard.SaveCharacter(session.Character, null);
+                session.Player.Character.GameplayOptions = gameplayOptions;
             }
-
-            // Save the options
-            session.Player.SaveBiotaToDatabase();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventCharacterTitle.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventCharacterTitle.cs
@@ -7,9 +7,9 @@ namespace ACE.Server.Network.GameEvent.Events
         {
             Writer.Write(1u);
             Writer.Write(session.Player.CharacterTitleId ?? 0);
-            session.Player.NumCharacterTitles = session.Player.Biota.CharacterPropertiesTitleBook.Count;
+            session.Player.NumCharacterTitles = session.Player.Character.CharacterPropertiesTitleBook.Count;
             Writer.Write(session.Player.NumCharacterTitles ?? 0);
-            foreach (var title in session.Player.Biota.CharacterPropertiesTitleBook)
+            foreach (var title in session.Player.Character.CharacterPropertiesTitleBook)
                 Writer.Write(title.TitleId);
         }
     }

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventFriendsListUpdate.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventFriendsListUpdate.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Collections.Generic;
 
 using ACE.Database.Models.Shard;
-using ACE.Entity;
 using ACE.Server.Managers;
 
 namespace ACE.Server.Network.GameEvent.Events
@@ -59,7 +58,7 @@ namespace ACE.Server.Network.GameEvent.Events
             List<CharacterPropertiesFriendList> friendList;
 
             if (updateType == FriendsUpdateTypeFlag.FullList)
-                friendList = Session.Player.Biota.CharacterPropertiesFriendList.ToList();
+                friendList = Session.Player.Character.CharacterPropertiesFriendList.ToList();
             else
                 friendList = new List<CharacterPropertiesFriendList>() { friend };
 
@@ -89,13 +88,13 @@ namespace ACE.Server.Network.GameEvent.Events
                 Writer.WriteString16L(friendName);  // Name of the friend
 
                 // send the list of friend's friends
-                Writer.Write((uint)offlinePlayer.Biota.CharacterPropertiesFriendList.Count);
-                foreach (var friendFriend in offlinePlayer.Biota.CharacterPropertiesFriendList)
+                Writer.Write((uint)offlinePlayer.Character.CharacterPropertiesFriendList.Count);
+                foreach (var friendFriend in offlinePlayer.Character.CharacterPropertiesFriendList)
                     Writer.Write(friendFriend.FriendId);
 
                 // todo: send the inverse list of friend's friends
-                Writer.Write((uint)offlinePlayer.Biota.CharacterPropertiesFriendList.Count);
-                foreach (var friendFriend in offlinePlayer.Biota.CharacterPropertiesFriendList)
+                Writer.Write((uint)offlinePlayer.Character.CharacterPropertiesFriendList.Count);
+                foreach (var friendFriend in offlinePlayer.Character.CharacterPropertiesFriendList)
                     Writer.Write(friendFriend.FriendId);
             }
 

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPlayerDescription.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPlayerDescription.cs
@@ -299,7 +299,7 @@ namespace ACE.Server.Network.GameEvent.Events
             if (shortcuts.Count > 0)
                 optionFlags |= CharacterOptionDataFlag.Shortcut;
 
-            if (Session.Character.GameplayOptions != null && Session.Character.GameplayOptions.Length > 0)
+            if (Session.Player.Character.GameplayOptions != null && Session.Player.Character.GameplayOptions.Length > 0)
                 optionFlags |= CharacterOptionDataFlag.GameplayOptions;
 
             Writer.Write((uint)optionFlags);
@@ -339,7 +339,7 @@ namespace ACE.Server.Network.GameEvent.Events
             }*/
 
             if ((optionFlags & CharacterOptionDataFlag.GameplayOptions) != 0)
-                Writer.Write(Session.Character.GameplayOptions);
+                Writer.Write(Session.Player.Character.GameplayOptions);
 
             /*if ((optionFlags & DescriptionOptionFlag.Unk400) != 0)
             {

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageCharacterList.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageCharacterList.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
@@ -24,10 +25,10 @@ namespace ACE.Server.Network.GameMessages.Messages
 
             foreach (var character in charactersTrimmed)
             {                
-                Writer.WriteGuid(new ObjectGuid(character.BiotaId));
+                Writer.WriteGuid(new ObjectGuid(character.Id));
                 if (ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions && session.AccessLevel > ACE.Entity.Enum.AccessLevel.Advocate)
                     Writer.WriteString16L("+" + character.Name);
-                else if (DatabaseManager.Shard.IsCharacterPlussed(character.BiotaId))
+                else if (DatabaseManager.Shard.IsCharacterPlussed(character.Id))
                     Writer.WriteString16L("+" + character.Name);
                 else
                     Writer.WriteString16L(character.Name);

--- a/Source/ACE.Server/WorldObjects/Admin.cs
+++ b/Source/ACE.Server/WorldObjects/Admin.cs
@@ -21,7 +21,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Restore a WorldObject from the database.
         /// </summary>
-        public Admin(Biota biota, IEnumerable<Biota> inventory, IEnumerable<Biota> wieldedItems, Session session) : base(biota, inventory, wieldedItems, session)
+        public Admin(Biota biota, IEnumerable<Biota> inventory, IEnumerable<Biota> wieldedItems, Character character, Session session) : base(biota, inventory, wieldedItems, character, session)
         {
             SetEphemeralValues();
         }

--- a/Source/ACE.Server/WorldObjects/Player_Client.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Client.cs
@@ -85,7 +85,7 @@ namespace ACE.Server.WorldObjects
         {
             var shortcuts = new List<Shortcut>();
 
-            foreach (var shortcut in Biota.CharacterPropertiesShortcutBar)
+            foreach (var shortcut in Character.CharacterPropertiesShortcutBar)
                 shortcuts.Add(new Shortcut(shortcut));
 
             return shortcuts;
@@ -99,9 +99,9 @@ namespace ACE.Server.WorldObjects
         {
             // When a shortcut is added on top of an existing item, the client automatically sends the RemoveShortcut command for that existing item first, then will add the new item, and re-add the existing item to the appropriate place.
 
-            var entity = new CharacterPropertiesShortcutBar { ObjectId = Biota.Id, ShortcutBarIndex = shortcut.Index, ShortcutObjectId = shortcut.ObjectId, Object = Biota };
+            var entity = new CharacterPropertiesShortcutBar { CharacterId = Biota.Id, ShortcutBarIndex = shortcut.Index, ShortcutObjectId = shortcut.ObjectId };
 
-            Biota.CharacterPropertiesShortcutBar.Add(entity);
+            Character.CharacterPropertiesShortcutBar.Add(entity);
             ChangesDetected = true;
         }
 
@@ -110,12 +110,11 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionRemoveShortcut(uint index)
         {
-            var entity = Biota.CharacterPropertiesShortcutBar.FirstOrDefault(x => x.ShortcutBarIndex == index);
+            var entity = Character.CharacterPropertiesShortcutBar.FirstOrDefault(x => x.ShortcutBarIndex == index);
 
             if (entity != null)
             {
-                Biota.CharacterPropertiesShortcutBar.Remove(entity);
-                entity.Object = null;
+                Character.CharacterPropertiesShortcutBar.Remove(entity);
 
                 if (ExistsInDatabase && entity.Id != 0)
                     DatabaseManager.Shard.RemoveEntity(entity, null);

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -1,5 +1,6 @@
 using System;
 
+using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameMessages.Messages;
@@ -45,6 +46,8 @@ namespace ACE.Server.WorldObjects
                 if (possession.ChangesDetected)
                     possession.SaveBiotaToDatabase();
             }
+
+            DatabaseManager.Shard.SaveCharacter(Character, null);
 
             #if DEBUG
             if (Session.Player != null && showMsg)

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -105,7 +105,7 @@ namespace ACE.Server.WorldObjects
         {
             var spells = new List<SpellBarPositions>();
 
-            var results = Biota.CharacterPropertiesSpellBar.Where(x => x.SpellBarNumber == barId);
+            var results = Character.CharacterPropertiesSpellBar.Where(x => x.SpellBarNumber == barId);
 
             foreach (var result in results)
             {
@@ -130,15 +130,15 @@ namespace ACE.Server.WorldObjects
                 spellBarPositionId = (uint)(spells.Count + 1);
 
             // We must increment the position of existing spells in the bar that exist on or after this position
-            foreach (var property in Biota.CharacterPropertiesSpellBar)
+            foreach (var property in Character.CharacterPropertiesSpellBar)
             {
                 if (property.SpellBarNumber == spellBarId && property.SpellBarIndex >= spellBarPositionId)
                     property.SpellBarIndex++;
             }
 
-            var entity = new CharacterPropertiesSpellBar { ObjectId = Biota.Id, SpellBarNumber = spellBarId, SpellBarIndex = spellBarPositionId, SpellId = spellId, Object = Biota };
+            var entity = new CharacterPropertiesSpellBar { CharacterId = Biota.Id, SpellBarNumber = spellBarId, SpellBarIndex = spellBarPositionId, SpellId = spellId };
 
-            Biota.CharacterPropertiesSpellBar.Add(entity);
+            Character.CharacterPropertiesSpellBar.Add(entity);
             ChangesDetected = true;
         }
 
@@ -147,12 +147,12 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionRemoveSpellFavorite(uint spellId, uint spellBarId)
         {
-            var entity = Biota.CharacterPropertiesSpellBar.FirstOrDefault(x => x.SpellBarNumber == spellBarId && x.SpellId == spellId);
+            var entity = Character.CharacterPropertiesSpellBar.FirstOrDefault(x => x.SpellBarNumber == spellBarId && x.SpellId == spellId);
 
             if (entity != null)
             {
                 // We must decrement the position of existing spells in the bar that exist after this position
-                foreach (var property in Biota.CharacterPropertiesSpellBar)
+                foreach (var property in Character.CharacterPropertiesSpellBar)
                 {
                     if (property.SpellBarNumber == spellBarId && property.SpellBarIndex > entity.SpellBarIndex)
                     {
@@ -161,8 +161,7 @@ namespace ACE.Server.WorldObjects
                     }
                 }
 
-                Biota.CharacterPropertiesSpellBar.Remove(entity);
-                entity.Object = null;
+                Character.CharacterPropertiesSpellBar.Remove(entity);
 
                 if (ExistsInDatabase && entity.Id != 0)
                     DatabaseManager.Shard.RemoveEntity(entity, null);

--- a/Source/ACE.Server/WorldObjects/Player_Titles.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Titles.cs
@@ -21,7 +21,7 @@ namespace ACE.Server.WorldObjects
 
             var titlebook = new List<uint>();
 
-            foreach (var title in Biota.CharacterPropertiesTitleBook)
+            foreach (var title in Character.CharacterPropertiesTitleBook)
                 titlebook.Add(title.TitleId);
 
             NumCharacterTitles = titlebook.Count();
@@ -31,7 +31,7 @@ namespace ACE.Server.WorldObjects
 
             if (!titlebook.Contains(titleId))
             {
-                Biota.CharacterPropertiesTitleBook.Add(new Database.Models.Shard.CharacterPropertiesTitleBook { ObjectId = Guid.Full, TitleId = titleId });
+                Character.CharacterPropertiesTitleBook.Add(new Database.Models.Shard.CharacterPropertiesTitleBook { CharacterId = Guid.Full, TitleId = titleId });
                 titlebook.Add(titleId);
                 NumCharacterTitles++;
                 sendMsg = true;

--- a/Source/ACE.Server/WorldObjects/Sentinel.cs
+++ b/Source/ACE.Server/WorldObjects/Sentinel.cs
@@ -22,7 +22,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Restore a WorldObject from the database.
         /// </summary>
-        public Sentinel(Biota biota, IEnumerable<Biota> inventory, IEnumerable<Biota> wieldedItems, Session session) : base(biota, inventory, wieldedItems, session)
+        public Sentinel(Biota biota, IEnumerable<Biota> inventory, IEnumerable<Biota> wieldedItems, Character character, Session session) : base(biota, inventory, wieldedItems, character, session)
         {
             SetEphemeralValues();
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -37,7 +37,6 @@ namespace ACE.Server.WorldObjects
         private readonly ReaderWriterLockSlim biotaPropertiesDIDLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim biotaPropertiesEnchantmentLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim biotaPropertiesFloatLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesFriendLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim biotaPropertiesIIDLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim biotaPropertiesIntLock = new ReaderWriterLockSlim();
         private readonly ReaderWriterLockSlim biotaPropertiesInt64Lock = new ReaderWriterLockSlim();
@@ -338,12 +337,6 @@ namespace ACE.Server.WorldObjects
         public void RemoveEnchantment(int spellId)
         {
             if (Biota.TryRemoveEnchantment(spellId, out var entity, biotaPropertiesEnchantmentLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
-        }
-
-        public void RemoveFriend(ObjectGuid friendGuid)
-        {
-            if (Biota.TryRemoveFriend(friendGuid, out var entity, biotaPropertiesFriendLock) && ExistsInDatabase && entity.Id != 0)
                 DatabaseManager.Shard.RemoveEntity(entity, null);
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2018-08-07
+[Mag-nus]
+* Shard schema changed to remove foreign key link between Character and Biota.
+* This also significantly changes the relationship of Session/Player/Character objects.
+
 ### 2018-08-06
 [Mag-nus]
 * Major schema refactoring + changes for World and Shard.


### PR DESCRIPTION
This removes Character as the parent of a Biota, and instead, makes them side by side objects that are owned by Player.

Session no longer owns Character.

Session maintains a list of the Characters for the account.

Session holds a reference to the current Player being used.

Player holds a reference to Biota and Character objects.

What I said in discord:

We have the Player object (our god class).

To put a player in the world, it requires a biota. It doesn't require a character or session.
To manipulate the player, we need a session (but not a character).
To give the player a user interface, we need a character.

The character holds all the user progress of the particular biota it's associated with.

So, a session holds a link to the current player the session is managing.

Player holds a link to the biota and character that represent the player.

The biota represents the player from the worlds pov.
The character represents the player from the users pov.