### PR TITLE
PropertyManager Database Cleanup

### DIFF
--- a/Source/ACE.Database/DatabaseManager.cs
+++ b/Source/ACE.Database/DatabaseManager.cs
@@ -15,20 +15,23 @@ namespace ACE.Database
 
         public static SerializedShardDatabase Shard { get; private set; }
 
+        public static ShardConfigDatabase ShardConfig { get; } = new ShardConfigDatabase();
+
         public static void Initialize(bool autoRetry = true)
         {
             Authentication.Exists(true);
+
             World.Exists(true);
+
+            var playerWeenieLoadTest = World.GetCachedWeenie("human");
+            if (playerWeenieLoadTest == null)
+                log.Fatal("Database does not contain the weenie for human (1). Characters cannot be created or logged into until the missing weenie is restored.");
 
             var shardDb = new ShardDatabase();
             serializedShardDb = new SerializedShardDatabase(shardDb);
             Shard = serializedShardDb;
 
             shardDb.Exists(true);
-
-            var playerWeenieLoadTest = World.GetCachedWeenie("human");
-            if (playerWeenieLoadTest == null)
-                log.Fatal($"Database does not contain the weenie for human (1). Characters cannot be created or logged into until the missing weenie is restored.");
         }
 
         public static void Start()

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -1,13 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Microsoft.EntityFrameworkCore;
-
-using log4net;
 
 using ACE.Database.Entity;
 using ACE.Database.Models.Shard;
@@ -22,8 +17,6 @@ namespace ACE.Database
         private readonly BlockingCollection<Task> _queue = new BlockingCollection<Task>();
 
         private Thread _workerThread;
-
-        public readonly ShardPropertyTables Config = new ShardPropertyTables();
 
         internal SerializedShardDatabase(ShardDatabase shardDatabase)
         {
@@ -421,191 +414,6 @@ namespace ACE.Database
         public void SetCharacterAccessLevelByName(string name, AccessLevel accessLevel, Action<uint> callback)
         {
             throw new NotImplementedException();
-        }
-    }
-
-    public class ShardPropertyTables
-    {
-        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        public void AddBool(string key, bool value, string description = "")
-        {
-            var stat = new ConfigPropertiesBoolean
-            {
-                Key = key,
-                Value = value,
-                Description = description
-            };
-
-            using (var context = new ShardDbContext())
-            {
-                context.ConfigPropertiesBoolean.Add(stat);
-
-                context.SaveChanges();
-            }
-        }
-
-        public void ModifyBool(ConfigPropertiesBoolean stat)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.Entry(stat).State = EntityState.Modified;
-
-                context.SaveChanges();
-            }
-        }
-
-        public ConfigPropertiesBoolean GetBool(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesBoolean.AsNoTracking().FirstOrDefault(r => r.Key == key);
-        }
-
-        public bool BoolExists(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesBoolean.Any(r => r.Key == key);
-        }
-
-        public void AddLong(string key, long value, string description = "")
-        {
-            var stat = new ConfigPropertiesLong
-            {
-                Key = key,
-                Value = value,
-                Description = description
-            };
-
-            using (var context = new ShardDbContext())
-            {
-                context.ConfigPropertiesLong.Add(stat);
-
-                context.SaveChanges();
-            }
-        }
-
-        public void ModifyLong(ConfigPropertiesLong stat)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.Entry(stat).State = EntityState.Modified;
-
-                context.SaveChanges();
-            }
-        }
-
-        public ConfigPropertiesLong GetLong(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesLong.AsNoTracking().FirstOrDefault(r => r.Key == key);
-        }
-
-        public bool LongExists(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesLong.Any(r => r.Key == key);
-        }
-
-        public void AddDouble(string key, double value, string description = "")
-        {
-            var stat = new ConfigPropertiesDouble
-            {
-                Key = key,
-                Value = value,
-                Description = description
-            };
-
-            using (var context = new ShardDbContext())
-            {
-                context.ConfigPropertiesDouble.Add(stat);
-
-                context.SaveChanges();
-            }
-        }
-
-        public void ModifyDouble(ConfigPropertiesDouble stat)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.Entry(stat).State = EntityState.Modified;
-
-                context.SaveChanges();
-            }
-        }
-
-        public ConfigPropertiesDouble GetDouble(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesDouble.AsNoTracking().FirstOrDefault(r => r.Key == key);
-        }
-
-        public bool DoubleExists(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesDouble.Any(r => r.Key == key);
-        }
-
-        public void AddString(string key, string value, string description = "")
-        {
-            var stat = new ConfigPropertiesString
-            {
-                Key = key,
-                Value = value,
-                Description = description
-            };
-
-            using (var context = new ShardDbContext())
-            {
-                context.ConfigPropertiesString.Add(stat);
-
-                context.SaveChanges();
-            }
-        }
-
-        public void ModifyString(ConfigPropertiesString stat)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.Entry(stat).State = EntityState.Modified;
-
-                context.SaveChanges();
-            }
-        }
-
-        public ConfigPropertiesString GetString(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesString.AsNoTracking().FirstOrDefault(r => r.Key == key);
-        }
-
-        public bool StringExists(string key)
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesString.Any(r => r.Key == key);
-        }
-
-        public List<ConfigPropertiesBoolean> GetAllBools()
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesBoolean.AsNoTracking().ToList();
-        }
-
-        public List<ConfigPropertiesLong> GetAllLongs()
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesLong.AsNoTracking().ToList();
-        }
-
-        public List<ConfigPropertiesDouble> GetAllDoubles()
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesDouble.AsNoTracking().ToList();
-        }
-
-        public List<ConfigPropertiesString> GetAllStrings()
-        {
-            using (var context = new ShardDbContext())
-                return context.ConfigPropertiesString.AsNoTracking().ToList();
         }
     }
 }

--- a/Source/ACE.Database/ShardConfigDatabase.cs
+++ b/Source/ACE.Database/ShardConfigDatabase.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.EntityFrameworkCore;
+
+using ACE.Database.Models.Shard;
+
+namespace ACE.Database
+{
+    public class ShardConfigDatabase
+    {
+        public bool BoolExists(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesBoolean.Any(r => r.Key == key);
+        }
+
+        public bool DoubleExists(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesDouble.Any(r => r.Key == key);
+        }
+
+        public bool LongExists(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesLong.Any(r => r.Key == key);
+        }
+
+        public bool StringExists(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesString.Any(r => r.Key == key);
+        }
+
+
+        public void AddBool(string key, bool value, string description = null)
+        {
+            var stat = new ConfigPropertiesBoolean
+            {
+                Key = key,
+                Value = value,
+                Description = description
+            };
+
+            using (var context = new ShardDbContext())
+            {
+                context.ConfigPropertiesBoolean.Add(stat);
+
+                context.SaveChanges();
+            }
+        }
+
+        public void AddLong(string key, long value, string description = null)
+        {
+            var stat = new ConfigPropertiesLong
+            {
+                Key = key,
+                Value = value,
+                Description = description
+            };
+
+            using (var context = new ShardDbContext())
+            {
+                context.ConfigPropertiesLong.Add(stat);
+
+                context.SaveChanges();
+            }
+        }
+
+        public void AddDouble(string key, double value, string description = null)
+        {
+            var stat = new ConfigPropertiesDouble
+            {
+                Key = key,
+                Value = value,
+                Description = description
+            };
+
+            using (var context = new ShardDbContext())
+            {
+                context.ConfigPropertiesDouble.Add(stat);
+
+                context.SaveChanges();
+            }
+        }
+
+        public void AddString(string key, string value, string description = null)
+        {
+            var stat = new ConfigPropertiesString
+            {
+                Key = key,
+                Value = value,
+                Description = description
+            };
+
+            using (var context = new ShardDbContext())
+            {
+                context.ConfigPropertiesString.Add(stat);
+
+                context.SaveChanges();
+            }
+        }
+
+
+        public ConfigPropertiesBoolean GetBool(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesBoolean.AsNoTracking().FirstOrDefault(r => r.Key == key);
+        }
+
+        public ConfigPropertiesLong GetLong(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesLong.AsNoTracking().FirstOrDefault(r => r.Key == key);
+        }
+
+        public ConfigPropertiesDouble GetDouble(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesDouble.AsNoTracking().FirstOrDefault(r => r.Key == key);
+        }
+
+        public ConfigPropertiesString GetString(string key)
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesString.AsNoTracking().FirstOrDefault(r => r.Key == key);
+        }
+
+
+        public List<ConfigPropertiesBoolean> GetAllBools()
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesBoolean.AsNoTracking().ToList();
+        }
+
+        public List<ConfigPropertiesLong> GetAllLongs()
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesLong.AsNoTracking().ToList();
+        }
+
+        public List<ConfigPropertiesDouble> GetAllDoubles()
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesDouble.AsNoTracking().ToList();
+        }
+
+        public List<ConfigPropertiesString> GetAllStrings()
+        {
+            using (var context = new ShardDbContext())
+                return context.ConfigPropertiesString.AsNoTracking().ToList();
+        }
+
+
+        public void SaveBool(ConfigPropertiesBoolean stat)
+        {
+            using (var context = new ShardDbContext())
+            {
+                context.Entry(stat).State = EntityState.Modified;
+
+                context.SaveChanges();
+            }
+        }
+
+        public void SaveLong(ConfigPropertiesLong stat)
+        {
+            using (var context = new ShardDbContext())
+            {
+                context.Entry(stat).State = EntityState.Modified;
+
+                context.SaveChanges();
+            }
+        }
+
+        public void SaveDouble(ConfigPropertiesDouble stat)
+        {
+            using (var context = new ShardDbContext())
+            {
+                context.Entry(stat).State = EntityState.Modified;
+
+                context.SaveChanges();
+            }
+        }
+
+        public void SaveString(ConfigPropertiesString stat)
+        {
+            using (var context = new ShardDbContext())
+            {
+                context.Entry(stat).State = EntityState.Modified;
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1717,8 +1717,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("modifybool", AccessLevel.Admin, CommandHandlerFlag.None, 2,
-            "Modifies a server property that is a bool", "modifybool (string) (bool)")]
+        [CommandHandler("modifybool", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a bool", "modifybool (string) (bool)")]
         public static void HandleModifyServerBoolProperty(Session session, params string[] paramters)
         {
             try
@@ -1739,8 +1738,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("fetchbool", AccessLevel.Admin, CommandHandlerFlag.None, 1,
-            "Fetches a server property that is a bool", "fetchbool (string)")]
+        [CommandHandler("fetchbool", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Fetches a server property that is a bool", "fetchbool (string)")]
         public static void HandleFetchServerBoolProperty(Session session, params string[] paramters)
         {
             var boolVal = PropertyManager.GetBool(paramters[0], cacheFallback: false);
@@ -1750,8 +1748,7 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine($"{paramters[0]} - {boolVal.Description ?? "No Description"}: {boolVal.Item}");
         }
 
-        [CommandHandler("modifylong", AccessLevel.Admin, CommandHandlerFlag.None, 2,
-            "Modifies a server property that is a long", "modifylong (string) (long)")]
+        [CommandHandler("modifylong", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a long", "modifylong (string) (long)")]
         public static void HandleModifyServerLongProperty(Session session, params string[] paramters)
         {
             try
@@ -1772,8 +1769,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("fetchlong", AccessLevel.Admin, CommandHandlerFlag.None, 1,
-            "Fetches a server property that is a long", "fetchlong (string)")]
+        [CommandHandler("fetchlong", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Fetches a server property that is a long", "fetchlong (string)")]
         public static void HandleFetchServerLongProperty(Session session, params string[] paramters)
         {
             var intVal = PropertyManager.GetLong(paramters[0], cacheFallback: false);
@@ -1783,8 +1779,7 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine($"{paramters[0]} - {intVal.Description ?? "No Description"}: {intVal.Item}");
         }
 
-        [CommandHandler("modifydouble", AccessLevel.Admin, CommandHandlerFlag.None, 2,
-            "Modifies a server property that is a double", "modifyfloat (string) (double)")]
+        [CommandHandler("modifydouble", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a double", "modifyfloat (string) (double)")]
         public static void HandleModifyServerFloatProperty(Session session, params string[] paramters)
         {
             try
@@ -1804,8 +1799,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("fetchdouble", AccessLevel.Admin, CommandHandlerFlag.None, 1,
-            "Fetches a server property that is a double", "fetchdouble (string)")]
+        [CommandHandler("fetchdouble", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Fetches a server property that is a double", "fetchdouble (string)")]
         public static void HandleFetchServerFloatProperty(Session session, params string[] paramters)
         {
             var floatVal = PropertyManager.GetDouble(paramters[0], cacheFallback: false);
@@ -1815,8 +1809,7 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine($"{paramters[0]} - {floatVal.Description ?? "No Description"}: {floatVal.Item}");
         }
 
-        [CommandHandler("modifystring", AccessLevel.Admin, CommandHandlerFlag.None, 2,
-            "Modifies a server property that is a string", "modifystring (string) (string)")]
+        [CommandHandler("modifystring", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a string", "modifystring (string) (string)")]
         public static void HandleModifyServerStringProperty(Session session, params string[] parameters)
         {
             PropertyManager.ModifyString(parameters[0], parameters[1]);
@@ -1826,8 +1819,7 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine("String property successfully updated!");
         }
 
-        [CommandHandler("fetchstring", AccessLevel.Admin, CommandHandlerFlag.None, 1,
-            "Fetches a server property that is a string", "fetchstring (string)")]
+        [CommandHandler("fetchstring", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Fetches a server property that is a string", "fetchstring (string)")]
         public static void HandleFetchServerStringProperty(Session session, params string[] parameters)
         {
             var stringVal = PropertyManager.GetString(parameters[0], cacheFallback: false);
@@ -1837,12 +1829,12 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine($"{parameters[0]} - {stringVal.Description ?? "No Description"}: {stringVal.Item}");
         }
 
-        [CommandHandler("modifypropertydesc", AccessLevel.Admin, CommandHandlerFlag.None, 3,
-            "Modifies a server property's description", "modifypropertydesc <STRING|BOOL|DOUBLE|LONG> (string) (string)")]
+        [CommandHandler("modifypropertydesc", AccessLevel.Admin, CommandHandlerFlag.None, 3, "Modifies a server property's description", "modifypropertydesc <STRING|BOOL|DOUBLE|LONG> (string) (string)")]
         public static void HandleModifyPropertyDescription(Session session, params string[] parameters)
         {
             var isSession = session != null;
-            switch (parameters[0]) {
+            switch (parameters[0])
+            {
                 case "STRING":
                     PropertyManager.ModifyStringDescription(parameters[1], parameters[2]);
                     break;
@@ -1857,24 +1849,16 @@ namespace ACE.Server.Command.Handlers
                     break;
                 default:
                     if (isSession)
-                    {
                         session.Network.EnqueueSend(new GameMessageSystemChat("Please pick from STRING, BOOL, DOUBLE, or LONG", ChatMessageType.Help));
-                    }
                     else
-                    {
                         Console.WriteLine("Please pick from STRING, BOOL, DOUBLE, or LONG");
-                    }
                     return;
             }
 
             if (isSession)
-            {
                 session.Network.EnqueueSend(new GameMessageSystemChat("Successfully updated property description!", ChatMessageType.Help));
-            }
             else
-            {
                 Console.WriteLine("Successfully updated property description!");
-            }
         }
 
         [CommandHandler("resyncproperties", AccessLevel.Admin, CommandHandlerFlag.None, -1,


### PR DESCRIPTION
Previously, PropertyManager used SerializedShardDatabase to wrap it's database calls.

This didn't make much sense because SerializedShardDatabase was basically just a wrapper that serialized calls to ShardDatabase.

So, instead, we now have a ShardConfigDatabase class as well that is held by DatabaseManager. This holds the property/config specific funcitons for the shard.

In addition, there were a couple bugs fixed in PropertyManager where a function migt have been GetLong() when it should have been GetDouble(), etc...