### PR TITLE
Creature GetNewFace fix for enum values

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -98,7 +98,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (!String.IsNullOrEmpty(HeritageGroup))
                 {
-                    HeritageGroup parsed = (HeritageGroup)Enum.Parse(typeof(HeritageGroup), HeritageGroup.Replace("'", ""));
+                    HeritageGroup parsed = (HeritageGroup)Enum.Parse(typeof(HeritageGroup), HeritageGroup.Replace("'", ""), true);
                     if (parsed != 0)
                         Heritage = (int)parsed;
                 }
@@ -108,7 +108,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (!String.IsNullOrEmpty(Sex))
                 {
-                    Gender parsed = (Gender)Enum.Parse(typeof(Gender), Sex);
+                    Gender parsed = (Gender)Enum.Parse(typeof(Gender), Sex, true);
                     if (parsed != 0)
                         Gender = (int)parsed;
                 }


### PR DESCRIPTION
In the world data, some property strings don't have the exact case we have in the enums. Thus, a simple ignoreCase bool is needed.