### PR TITLE
Added NpcLooksLikeObject usage in AppraiseInfo

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -111,6 +111,7 @@ namespace ACE.Entity.Enum.Properties
         IgnorePortalRestrictions         = 80,
         RequiresBackpackSlot             = 81,
         DontTurnOrMoveWhenGiving         = 82,
+        [ServerOnly]
         NpcLooksLikeObject               = 83,
         IgnoreCloIcons                   = 84,
         AppraisalHasAllowedWielder       = 85,

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -56,6 +56,9 @@ namespace ACE.Server.Network.Structure
 
         public ArmorLevel ArmorLevels;
 
+        // This helps ensure the item will identify properly. Some "items" are technically "Creatures".
+        private bool NPCLooksLikeObject; 
+
         /// <summary>
         /// Construct all of the info required for appraising any WorldObject
         /// </summary>
@@ -73,8 +76,14 @@ namespace ACE.Server.Network.Structure
             BuildProperties(wo, wielder);
             BuildSpells(wo);
 
+            // Help us make sure the item identify properly
+            if(wo.GetProperty(PropertyBool.NpcLooksLikeObject) == true)
+                NPCLooksLikeObject = true;
+            else
+                NPCLooksLikeObject = false;
+
             // armor / clothing / shield
-            var isShield = wo.CombatUse != null && wo.CombatUse == CombatUse.Shield;
+                var isShield = wo.CombatUse != null && wo.CombatUse == CombatUse.Shield;
             if (wo is Clothing || isShield)
                 BuildArmor(wo);
 
@@ -261,31 +270,31 @@ namespace ACE.Server.Network.Structure
                 Flags |= IdentifyResponseFlags.IntStatsTable;
             if (PropertiesInt64.Count > 0)
                 Flags |= IdentifyResponseFlags.Int64StatsTable;
-            if (PropertiesBool.Count > 0)
+            if (PropertiesBool.Count > 0 && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.BoolStatsTable;
-            if (PropertiesFloat.Count > 0)
+            if (PropertiesFloat.Count > 0 && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.FloatStatsTable;
             if (PropertiesString.Count > 0)
                 Flags |= IdentifyResponseFlags.StringStatsTable;
-            if (PropertiesDID.Count > 0)
+            if (PropertiesDID.Count > 0 && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.DidStatsTable;
             if (SpellBook.Count > 0)
                 Flags |= IdentifyResponseFlags.SpellBook;
-            if (ArmorProfile != null)
+            if (ArmorProfile != null && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.ArmorProfile;
-            if (CreatureProfile != null)
+            if (CreatureProfile != null && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.CreatureProfile;
-            if (WeaponProfile != null)
+            if (WeaponProfile != null && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.WeaponProfile;
             if (HookProfile != null)
                 Flags |= IdentifyResponseFlags.HookProfile;
-            if (ArmorHighlight != 0)
+            if (ArmorHighlight != 0 && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.ArmorEnchantmentBitfield;
-            if (WeaponHighlight != 0)
+            if (WeaponHighlight != 0 && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.WeaponEnchantmentBitfield;
             if (ResistHighlight != 0)
                 Flags |= IdentifyResponseFlags.ResistEnchantmentBitfield;
-            if (ArmorLevels != null)
+            if (ArmorLevels != null && !NPCLooksLikeObject)
                 Flags |= IdentifyResponseFlags.ArmorLevels;
         }
     }

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -77,13 +77,10 @@ namespace ACE.Server.Network.Structure
             BuildSpells(wo);
 
             // Help us make sure the item identify properly
-            if(wo.GetProperty(PropertyBool.NpcLooksLikeObject) == true)
-                NPCLooksLikeObject = true;
-            else
-                NPCLooksLikeObject = false;
+            NPCLooksLikeObject = wo.GetProperty(PropertyBool.NpcLooksLikeObject) ?? false;
 
             // armor / clothing / shield
-                var isShield = wo.CombatUse != null && wo.CombatUse == CombatUse.Shield;
+            var isShield = wo.CombatUse != null && wo.CombatUse == CombatUse.Shield;
             if (wo is Clothing || isShield)
                 BuildArmor(wo);
 
@@ -270,31 +267,34 @@ namespace ACE.Server.Network.Structure
                 Flags |= IdentifyResponseFlags.IntStatsTable;
             if (PropertiesInt64.Count > 0)
                 Flags |= IdentifyResponseFlags.Int64StatsTable;
-            if (PropertiesBool.Count > 0 && !NPCLooksLikeObject)
+            if (SpellBook.Count > 0)
+                Flags |= IdentifyResponseFlags.SpellBook;
+            if (ResistHighlight != 0)
+                Flags |= IdentifyResponseFlags.ResistEnchantmentBitfield;
+            
+			if (NPCLooksLikeObject) return;
+				
+			if (PropertiesBool.Count > 0)
                 Flags |= IdentifyResponseFlags.BoolStatsTable;
-            if (PropertiesFloat.Count > 0 && !NPCLooksLikeObject)
+            if (PropertiesFloat.Count > 0)
                 Flags |= IdentifyResponseFlags.FloatStatsTable;
             if (PropertiesString.Count > 0)
                 Flags |= IdentifyResponseFlags.StringStatsTable;
-            if (PropertiesDID.Count > 0 && !NPCLooksLikeObject)
+            if (PropertiesDID.Count > 0)
                 Flags |= IdentifyResponseFlags.DidStatsTable;
-            if (SpellBook.Count > 0)
-                Flags |= IdentifyResponseFlags.SpellBook;
-            if (ArmorProfile != null && !NPCLooksLikeObject)
+            if (ArmorProfile != null)
                 Flags |= IdentifyResponseFlags.ArmorProfile;
-            if (CreatureProfile != null && !NPCLooksLikeObject)
+            if (CreatureProfile != null)
                 Flags |= IdentifyResponseFlags.CreatureProfile;
-            if (WeaponProfile != null && !NPCLooksLikeObject)
+            if (WeaponProfile != null)
                 Flags |= IdentifyResponseFlags.WeaponProfile;
             if (HookProfile != null)
                 Flags |= IdentifyResponseFlags.HookProfile;
-            if (ArmorHighlight != 0 && !NPCLooksLikeObject)
+            if (ArmorHighlight != 0)
                 Flags |= IdentifyResponseFlags.ArmorEnchantmentBitfield;
-            if (WeaponHighlight != 0 && !NPCLooksLikeObject)
+            if (WeaponHighlight != 0)
                 Flags |= IdentifyResponseFlags.WeaponEnchantmentBitfield;
-            if (ResistHighlight != 0)
-                Flags |= IdentifyResponseFlags.ResistEnchantmentBitfield;
-            if (ArmorLevels != null && !NPCLooksLikeObject)
+            if (ArmorLevels != null)
                 Flags |= IdentifyResponseFlags.ArmorLevels;
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # ACEmulator Change Log
+### 2018-08-12
+[OptimShi]
+* Added handling of Bool.NpcLooksLikeObject to the AppraiseInfo event.
+
 ### 2018-08-11
 [mcreedjr]
 * Added missing comma in updated ShardBase.sql to allow creation of updated Shard DB after Mag-nus' previous PR


### PR DESCRIPTION
Test: @create 28973
Portrait of Asheron Realaidain

Even though the item is a technically creature (Int.ItemType = 16), it should ID as a regular object.

Examine should continue to work for creatures, NPCs, other objects as expected.