### PR TITLE
Rename CommandHandlers to be more appropriate

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminShardCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminShardCommands.cs
@@ -6,7 +6,7 @@ using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.Command.Handlers
 {
-    public static class ShardCommands
+    public static class AdminShardCommands
     {
         // // commandname parameters
         // [CommandHandler("commandname", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0)]

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -22,7 +22,7 @@ using ACE.Server.WorldObjects.Entity;
 
 namespace ACE.Server.Command.Handlers
 {
-    public static class DebugCommands
+    public static class DeveloperCommands
     {
         // TODO: Replace later with a command to spawn a generator at the player's location
         /*


### PR DESCRIPTION
This is in preparation for some DeveloperDatabaseCommands I plan to add.

The reason for the rename is the command handlers we have are all organized based on AccessLevel. Thus, this just aligns the file/class names to the access level commands it contains.