### PR TITLE
Network fatal exception recovery

### DIFF
--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -62,6 +62,7 @@ namespace ACE.Server.Network
             catch (Exception exception)
             {
                 log.FatalFormat("Network Socket has thrown: {0}", exception.Message);
+                Listen();
             }
         }
 

--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -59,10 +59,14 @@ namespace ACE.Server.Network
                 EndPoint clientEndPoint = new IPEndPoint(listeningHost, 0);
                 Socket.BeginReceiveFrom(buffer, 0, buffer.Length, SocketFlags.None, ref clientEndPoint, OnDataReceieve, Socket);
             }
+            catch (SocketException socketException)
+            {
+                log.DebugFormat("Network Socket has thrown: {0} {1}", socketException.ErrorCode, socketException.Message);
+                Listen();
+            }
             catch (Exception exception)
             {
                 log.FatalFormat("Network Socket has thrown: {0}", exception.Message);
-                Listen();
             }
         }
 


### PR DESCRIPTION
This patch recovers from fatal network errors, such as 'FATAL: Network Socket has thrown: An existing connection was forcibly closed by the remote host' which seems to be thrown often from ThwargLauncher connections

The ConnectionListener.Listen() function starts receiving data from a socket, calling OnDataReceive. At the end of OnDataReceive, the Listen() function is called again to resume listening for the next request

If an exception is thrown in Listen(), the exception handler needs to call Listen() again to recover gracefully and to start listening for the next request.