### PR TITLE
Shard Biota Save & Threading Model Rework

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
@@ -10,31 +9,6 @@ namespace ACE.Database.Models.Shard
 {
     public static class BiotaExtensions
     {
-        public static uint? GetAnimationId(this Biota biota, byte index)
-        {
-            return biota.BiotaPropertiesAnimPart.FirstOrDefault(x => x.Index == index)?.AnimationId;
-        }
-
-        public static BiotaPropertiesAttribute GetAttribute(this Biota biota, PropertyAttribute attribute)
-        {
-            return biota.BiotaPropertiesAttribute.FirstOrDefault(x => x.Type == (uint)attribute);
-        }
-
-        public static BiotaPropertiesAttribute2nd GetAttribute2nd(this Biota biota, PropertyAttribute2nd attribute)
-        {
-            return biota.BiotaPropertiesAttribute2nd.FirstOrDefault(x => x.Type == (uint)attribute);
-        }
-
-        public static BiotaPropertiesBodyPart GetBodyPart(this Biota biota, ushort key)
-        {
-            return biota.BiotaPropertiesBodyPart.FirstOrDefault(x => x.Key == key);
-        }
-
-        public static BiotaPropertiesBookPageData GetBookPageData(this Biota biota, uint pageId)
-        {
-            return biota.BiotaPropertiesBookPageData.FirstOrDefault(x => x.PageId == pageId);
-        }
-
         public static bool? GetProperty(this Biota biota, PropertyBool property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -46,11 +20,6 @@ namespace ACE.Database.Models.Shard
             {
                 rwLock.ExitReadLock();
             }
-        }
-
-        public static BiotaPropertiesCreateList GetCreateList(this Biota biota, sbyte destinationType)
-        {
-            return biota.BiotaPropertiesCreateList.FirstOrDefault(x => x.DestinationType == destinationType);
         }
 
         public static uint? GetProperty(this Biota biota, PropertyDataId property, ReaderWriterLockSlim rwLock)
@@ -66,21 +35,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static BiotaPropertiesEmote GetEmote(this Biota biota, uint category)
-        {
-            return biota.BiotaPropertiesEmote.FirstOrDefault(x => x.Category == category);
-        }
-
-        public static IEnumerable<BiotaPropertiesEmote> GetEmotes(this Biota biota, uint category)
-        {
-            return biota.BiotaPropertiesEmote.Where(x => x.Category == category);
-        }
-
-        public static BiotaPropertiesEventFilter GetEventFilter(this Biota biota, int eventId)
-        {
-            return biota.BiotaPropertiesEventFilter.FirstOrDefault(x => x.Event == eventId);
-        }
-
         public static double? GetProperty(this Biota biota, PropertyFloat property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -93,8 +47,6 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitReadLock();
             }
         }
-
-        // BiotaPropertiesGenerator
 
         public static uint? GetProperty(this Biota biota, PropertyInstanceId property, ReaderWriterLockSlim rwLock)
         {
@@ -135,11 +87,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static BiotaPropertiesPalette GetPalette(this Biota biota, uint subPaletteId)
-        {
-            return biota.BiotaPropertiesPalette.FirstOrDefault(x => x.SubPaletteId == subPaletteId);
-        }
-
         public static Position GetPosition(this Biota biota, PositionType positionType, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -158,16 +105,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static BiotaPropertiesSkill GetProperty(this Biota biota, Skill skill)
-        {
-            return biota.BiotaPropertiesSkill.FirstOrDefault(x => x.Type == (uint)skill);
-        }
-
-        public static BiotaPropertiesSpellBook GetSpell(this Biota biota, int spell)
-        {
-            return biota.BiotaPropertiesSpellBook.FirstOrDefault(x => x.Spell == spell);
-        }
-
         public static string GetProperty(this Biota biota, PropertyString property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -179,11 +116,6 @@ namespace ACE.Database.Models.Shard
             {
                 rwLock.ExitReadLock();
             }
-        }
-
-        public static BiotaPropertiesTextureMap GetTextureMap(this Biota biota, byte index)
-        {
-            return biota.BiotaPropertiesTextureMap.FirstOrDefault(x => x.Index == index);
         }
 
 
@@ -272,8 +204,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        // BiotaPropertiesGenerator
-
         public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -358,34 +288,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static void SetProperty(this Biota biota, PropertyString property, string value, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterUpgradeableReadLock();
-            try
-            {
-                var result = biota.BiotaPropertiesString.FirstOrDefault(x => x.Type == (uint) property);
-                if (result != null)
-                    result.Value = value;
-                else
-                {
-                    rwLock.EnterWriteLock();
-                    try
-                    { 
-                        var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesString.Add(entity);
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
-                }
-            }
-            finally
-            {
-                rwLock.ExitUpgradeableReadLock();
-            }
-        }
-
         public static void SetPosition(this Biota biota, PositionType positionType, Position position, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -410,6 +312,34 @@ namespace ACE.Database.Models.Shard
                     { 
                         var entity = new BiotaPropertiesPosition { ObjectId = biota.Id, PositionType = (ushort)positionType, ObjCellId = position.Cell, OriginX = position.PositionX, OriginY = position.PositionY, OriginZ = position.PositionZ, AnglesW = position.RotationW, AnglesX = position.RotationX, AnglesY = position.RotationY, AnglesZ = position.RotationZ, Object = biota };
                         biota.BiotaPropertiesPosition.Add(entity);
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static void SetProperty(this Biota biota, PropertyString property, string value, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                var result = biota.BiotaPropertiesString.FirstOrDefault(x => x.Type == (uint)property);
+                if (result != null)
+                    result.Value = value;
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesString.Add(entity);
                     }
                     finally
                     {
@@ -481,6 +411,34 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static bool TryRemoveEnchantment(this Biota biota, int spellId, out BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                entity = biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(x => x.SpellId == spellId);
+                if (entity != null)
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        biota.BiotaPropertiesEnchantmentRegistry.Remove(entity);
+                        entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static bool TryRemoveProperty(this Biota biota, PropertyFloat property, out BiotaPropertiesFloat entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -508,8 +466,6 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitUpgradeableReadLock();
             }
         }
-
-        // BiotaPropertiesGenerator
 
         public static bool TryRemoveProperty(this Biota biota, PropertyInstanceId property, out BiotaPropertiesIID entity, ReaderWriterLockSlim rwLock)
         {
@@ -635,34 +591,6 @@ namespace ACE.Database.Models.Shard
                     try
                     {
                         biota.BiotaPropertiesString.Remove(entity);
-                        entity.Object = null;
-                        return true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
-                }
-                return false;
-            }
-            finally
-            {
-                rwLock.ExitUpgradeableReadLock();
-            }
-        }
-
-        public static bool TryRemoveEnchantment(this Biota biota, int spellId, out BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterUpgradeableReadLock();
-            try
-            {
-                entity = biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(x => x.SpellId == spellId);
-                if (entity != null)
-                {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        biota.BiotaPropertiesEnchantmentRegistry.Remove(entity);
                         entity.Object = null;
                         return true;
                     }

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -610,5 +610,413 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitUpgradeableReadLock();
             }
         }
+
+
+        public static Biota Clone(this Biota biota)
+        {
+            var result = new Biota();
+
+            result.Id = biota.Id;
+            result.WeenieClassId = biota.WeenieClassId;
+            result.WeenieType = biota.WeenieType;
+            result.PopulatedCollectionFlags = biota.PopulatedCollectionFlags;
+
+            if (biota.BiotaPropertiesBook != null)
+            {
+                result.BiotaPropertiesBook = new BiotaPropertiesBook();
+                result.BiotaPropertiesBook.Id = biota.BiotaPropertiesBook.Id;
+                result.BiotaPropertiesBook.ObjectId = biota.BiotaPropertiesBook.ObjectId;
+                result.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
+                result.BiotaPropertiesBook.MaxNumCharsPerPage = biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+            }
+
+            foreach (var value in biota.BiotaPropertiesAnimPart)
+            {
+                result.BiotaPropertiesAnimPart.Add(new BiotaPropertiesAnimPart
+                {
+                    Id = value.Id,
+                    ObjectId = value.Id,
+                    Index = value.Index,
+                    AnimationId = value.AnimationId,
+                    Order = value.Order,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesAttribute)
+            {
+                result.BiotaPropertiesAttribute.Add(new BiotaPropertiesAttribute
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    InitLevel = value.InitLevel,
+                    LevelFromCP = value.LevelFromCP,
+                    CPSpent = value.CPSpent,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesAttribute2nd)
+            {
+                result.BiotaPropertiesAttribute2nd.Add(new BiotaPropertiesAttribute2nd
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    InitLevel = value.InitLevel,
+                    LevelFromCP = value.LevelFromCP,
+                    CPSpent = value.CPSpent,
+                    CurrentLevel = value.CurrentLevel,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesBodyPart)
+            {
+                result.BiotaPropertiesBodyPart.Add(new BiotaPropertiesBodyPart
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Key = value.Key,
+                    DType = value.DType,
+                    DVal = value.DVal,
+                    DVar = value.DVar,
+                    BaseArmor = value.BaseArmor,
+                    ArmorVsSlash = value.ArmorVsSlash,
+                    ArmorVsPierce = value.ArmorVsPierce,
+                    ArmorVsBludgeon = value.ArmorVsBludgeon,
+                    ArmorVsCold = value.ArmorVsCold,
+                    ArmorVsFire = value.ArmorVsFire,
+                    ArmorVsAcid = value.ArmorVsAcid,
+                    ArmorVsElectric = value.ArmorVsElectric,
+                    ArmorVsNether = value.ArmorVsNether,
+                    BH = value.BH,
+                    HLF = value.HLF,
+                    MLF = value.MLF,
+                    LLF = value.LLF,
+                    HRF = value.HRF,
+                    MRF = value.MRF,
+                    LRF = value.LRF,
+                    HLB = value.HLB,
+                    MLB = value.MLB,
+                    LLB = value.LLB,
+                    HRB = value.HRB,
+                    MRB = value.MRB,
+                    LRB = value.LRB,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesBookPageData)
+            {
+                result.BiotaPropertiesBookPageData.Add(new BiotaPropertiesBookPageData
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    PageId = value.PageId,
+                    AuthorId = value.AuthorId,
+                    AuthorName = value.AuthorName,
+                    AuthorAccount = value.AuthorAccount,
+                    IgnoreAuthor = value.IgnoreAuthor,
+                    PageText = value.PageText,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesBool)
+            {
+                result.BiotaPropertiesBool.Add(new BiotaPropertiesBool
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesCreateList)
+            {
+                result.BiotaPropertiesCreateList.Add(new BiotaPropertiesCreateList
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    DestinationType = value.DestinationType,
+                    WeenieClassId = value.WeenieClassId,
+                    StackSize = value.StackSize,
+                    Palette = value.Palette,
+                    Shade = value.Shade,
+                    TryToBond = value.TryToBond,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesDID)
+            {
+                result.BiotaPropertiesDID.Add(new BiotaPropertiesDID
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+
+            foreach (var value in biota.BiotaPropertiesEmote)
+            {
+                var emote = new BiotaPropertiesEmote
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Category = value.Category,
+                    Probability = value.Probability,
+                    WeenieClassId = value.WeenieClassId,
+                    Style = value.Style,
+                    Substyle = value.Substyle,
+                    Quest = value.Quest,
+                    VendorType = value.VendorType,
+                    MinHealth = value.MinHealth,
+                    MaxHealth = value.MaxHealth,
+                };
+
+                foreach (var value2 in value.BiotaPropertiesEmoteAction)
+                {
+                    var action = new BiotaPropertiesEmoteAction
+                    {
+                        Id = value2.Id,
+                        EmoteId = value2.EmoteId,
+                        Order = value2.Order,
+                        Type = value2.Type,
+                        Delay = value2.Delay,
+                        Extent = value2.Extent,
+                        Motion = value2.Motion,
+                        Message = value2.Message,
+                        TestString = value2.TestString,
+                        Min = value2.Min,
+                        Max = value2.Max,
+                        Min64 = value2.Min64,
+                        Max64 = value2.Max64,
+                        MinDbl = value2.MinDbl,
+                        MaxDbl = value2.MaxDbl,
+                        Stat = value2.Stat,
+                        Display = value2.Display,
+                        Amount = value2.Amount,
+                        Amount64 = value2.Amount64,
+                        HeroXP64 = value2.HeroXP64,
+                        Percent = value2.Percent,
+                        SpellId = value2.SpellId,
+                        WealthRating = value2.WealthRating,
+                        TreasureClass = value2.TreasureClass,
+                        TreasureType = value2.TreasureType,
+                        PScript = value2.PScript,
+                        Sound = value2.Sound,
+                        DestinationType = value2.DestinationType,
+                        WeenieClassId = value2.WeenieClassId,
+                        StackSize = value2.StackSize,
+                        Palette = value2.Palette,
+                        Shade = value2.Shade,
+                        TryToBond = value2.TryToBond,
+                        ObjCellId = value2.ObjCellId,
+                        OriginX = value2.OriginX,
+                        OriginY = value2.OriginY,
+                        OriginZ = value2.OriginZ,
+                        AnglesW = value2.AnglesW,
+                        AnglesX = value2.AnglesX,
+                        AnglesY = value2.AnglesY,
+                        AnglesZ = value2.AnglesZ,
+                    };
+
+                    emote.BiotaPropertiesEmoteAction.Add(action);
+                }
+
+                result.BiotaPropertiesEmote.Add(emote);
+            }
+
+
+            foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
+            {
+                result.BiotaPropertiesEnchantmentRegistry.Add(new BiotaPropertiesEnchantmentRegistry
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    EnchantmentCategory = value.EnchantmentCategory,
+                    SpellId = value.SpellId,
+                    LayerId = value.LayerId,
+                    HasSpellSetId = value.HasSpellSetId,
+                    SpellCategory = value.SpellCategory,
+                    PowerLevel = value.PowerLevel,
+                    StartTime = value.StartTime,
+                    Duration = value.Duration,
+                    CasterObjectId = value.CasterObjectId,
+                    DegradeModifier = value.DegradeModifier,
+                    DegradeLimit = value.DegradeLimit,
+                    LastTimeDegraded = value.LastTimeDegraded,
+                    StatModType = value.StatModType,
+                    StatModKey = value.StatModKey,
+                    StatModValue = value.StatModValue,
+                    SpellSetId = value.SpellSetId,
+                });
+            }
+
+
+            foreach (var value in biota.BiotaPropertiesEventFilter)
+            {
+                result.BiotaPropertiesEventFilter.Add(new BiotaPropertiesEventFilter
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Event = value.Event,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesFloat)
+            {
+                result.BiotaPropertiesFloat.Add(new BiotaPropertiesFloat
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesGenerator)
+            {
+                result.BiotaPropertiesGenerator.Add(new BiotaPropertiesGenerator
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Probability = value.Probability,
+                    WeenieClassId = value.WeenieClassId,
+                    Delay = value.Delay,
+                    InitCreate = value.InitCreate,
+                    MaxCreate = value.MaxCreate,
+                    WhenCreate = value.WhenCreate,
+                    WhereCreate = value.WhereCreate,
+                    StackSize = value.StackSize,
+                    PaletteId = value.PaletteId,
+                    Shade = value.Shade,
+                    ObjCellId = value.ObjCellId,
+                    OriginX = value.OriginX,
+                    OriginY = value.OriginY,
+                    OriginZ = value.OriginZ,
+                    AnglesW = value.AnglesW,
+                    AnglesX = value.AnglesX,
+                    AnglesY = value.AnglesY,
+                    AnglesZ = value.AnglesZ,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesIID)
+            {
+                result.BiotaPropertiesIID.Add(new BiotaPropertiesIID
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesInt)
+            {
+                result.BiotaPropertiesInt.Add(new BiotaPropertiesInt
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesInt64)
+            {
+                result.BiotaPropertiesInt64.Add(new BiotaPropertiesInt64
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesPalette)
+            {
+                result.BiotaPropertiesPalette.Add(new BiotaPropertiesPalette
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    SubPaletteId = value.SubPaletteId,
+                    Offset = value.Offset,
+                    Length = value.Length,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesPosition)
+            {
+                result.BiotaPropertiesPosition.Add(new BiotaPropertiesPosition
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    PositionType = value.PositionType,
+                    ObjCellId = value.ObjCellId,
+                    OriginX = value.OriginX,
+                    OriginY = value.OriginY,
+                    OriginZ = value.OriginZ,
+                    AnglesW = value.AnglesW,
+                    AnglesX = value.AnglesX,
+                    AnglesY = value.AnglesY,
+                    AnglesZ = value.AnglesZ,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesSkill)
+            {
+                result.BiotaPropertiesSkill.Add(new BiotaPropertiesSkill
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    LevelFromPP = value.LevelFromPP,
+                    SAC = value.SAC,
+                    PP = value.PP,
+                    InitLevel = value.InitLevel,
+                    ResistanceAtLastCheck = value.ResistanceAtLastCheck,
+                    LastUsedTime = value.LastUsedTime,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesSpellBook)
+            {
+                result.BiotaPropertiesSpellBook.Add(new BiotaPropertiesSpellBook
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Spell = value.Spell,
+                    Probability = value.Probability,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesString)
+            {
+                result.BiotaPropertiesString.Add(new BiotaPropertiesString
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Type = value.Type,
+                    Value = value.Value,
+                });
+            }
+
+            foreach (var value in biota.BiotaPropertiesTextureMap)
+            {
+                result.BiotaPropertiesTextureMap.Add(new BiotaPropertiesTextureMap
+                {
+                    Id = value.Id,
+                    ObjectId = value.ObjectId,
+                    Index = value.Index,
+                    OldId = value.OldId,
+                    NewId = value.NewId,
+                    Order = value.Order,
+                });
+            }
+
+            return result;
+        }
     }
 }

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -35,6 +35,8 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        // BiotaPropertiesEnchantmentRegistry
+
         public static double? GetProperty(this Biota biota, PropertyFloat property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -175,6 +177,8 @@ namespace ACE.Database.Models.Shard
                 rwLock.ExitUpgradeableReadLock();
             }
         }
+
+        // BiotaPropertiesEnchantmentRegistry
 
         public static void SetProperty(this Biota biota, PropertyFloat property, double value, ReaderWriterLockSlim rwLock)
         {

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -14,7 +14,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterReadLock();
             try
             {
-                return biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint) property)?.Value;
+                return biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint)property)?.Value;
             }
             finally
             {
@@ -127,7 +127,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterUpgradeableReadLock();
             try
             {
-                var result = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint) property);
+                var result = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint)property);
                 if (result != null)
                     result.Value = value;
                 else
@@ -185,7 +185,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterUpgradeableReadLock();
             try
             {
-                var result = biota.BiotaPropertiesFloat.FirstOrDefault(x => x.Type == (ushort) property);
+                var result = biota.BiotaPropertiesFloat.FirstOrDefault(x => x.Type == (ushort)property);
                 if (result != null)
                     result.Value = value;
                 else
@@ -213,7 +213,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterUpgradeableReadLock();
             try
             {
-                var result = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint) property);
+                var result = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint)property);
                 if (result != null)
                     result.Value = value;
                 else
@@ -296,7 +296,7 @@ namespace ACE.Database.Models.Shard
         {
             rwLock.EnterUpgradeableReadLock();
             try
-            { 
+            {
                 var result = biota.BiotaPropertiesPosition.FirstOrDefault(x => x.PositionType == (uint)positionType);
                 if (result != null)
                 {
@@ -313,7 +313,7 @@ namespace ACE.Database.Models.Shard
                 {
                     rwLock.EnterWriteLock();
                     try
-                    { 
+                    {
                         var entity = new BiotaPropertiesPosition { ObjectId = biota.Id, PositionType = (ushort)positionType, ObjCellId = position.Cell, OriginX = position.PositionX, OriginY = position.PositionY, OriginZ = position.PositionZ, AnglesW = position.RotationW, AnglesX = position.RotationX, AnglesY = position.RotationY, AnglesZ = position.RotationZ, Object = biota };
                         biota.BiotaPropertiesPosition.Add(entity);
                     }
@@ -364,7 +364,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterUpgradeableReadLock();
             try
             {
-                entity = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint) property);
+                entity = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint)property);
                 if (entity != null)
                 {
                     rwLock.EnterWriteLock();
@@ -476,7 +476,7 @@ namespace ACE.Database.Models.Shard
             rwLock.EnterUpgradeableReadLock();
             try
             {
-                entity = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint) property);
+                entity = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint)property);
                 if (entity != null)
                 {
                     rwLock.EnterWriteLock();

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -109,7 +109,7 @@ namespace ACE.Database
             return _wrappedDatabase.IsCharacterPlussed(biotaId);
         }
 
-        public void AddCharacter(Biota biota, IEnumerable<Biota> possessions, Character character, Action<bool> callback)
+        public void AddCharacter(Biota biota, IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> possessions, Character character, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -164,7 +164,7 @@ namespace ACE.Database
             }));
         }
 
-        public void SaveBiotas(IEnumerable<Biota> biotas, Action<bool> callback) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
+        public void SaveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -182,7 +182,7 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveBiotas(IEnumerable<Biota> biotas, Action<bool> callback) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
+        public void RemoveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -67,6 +67,19 @@ namespace ACE.Database
         }
 
 
+        public int QueueCount => _queue.Count;
+
+        public void GetCurrentQueueWaitTime(Action<TimeSpan> callback)
+        {
+            var initialCallTime = DateTime.UtcNow;
+
+            _queue.Add(new Task(() =>
+            {
+                callback?.Invoke(DateTime.UtcNow - initialCallTime);
+            }));
+        }
+
+
         public void GetMaxGuidFoundInRange(uint min, uint max, Action<uint> callback)
         {
             _queue.Add(new Task(() =>

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -146,24 +146,6 @@ namespace ACE.Database
         }
 
 
-        public void AddBiota(Biota biota, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.AddBiota(biota);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void AddBiotas(IEnumerable<Biota> biotas, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.AddBiotasInParallel(biotas);
-                callback?.Invoke(result);
-            }));
-        }
-
         public void GetBiota(uint id, Action<Biota> callback)
         {
             _queue.Add(new Task(() =>

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -164,7 +164,7 @@ namespace ACE.Database
             }));
         }
 
-        public void SaveBiotas(IEnumerable<Biota> biotas, Action<bool> callback)
+        public void SaveBiotas(IEnumerable<Biota> biotas, Action<bool> callback) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
         {
             _queue.Add(new Task(() =>
             {
@@ -182,7 +182,7 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveBiotas(IEnumerable<Biota> biotas, Action<bool> callback)
+        public void RemoveBiotas(IEnumerable<Biota> biotas, Action<bool> callback) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
         {
             _queue.Add(new Task(() =>
             {

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -177,12 +177,40 @@ namespace ACE.Database
             }));
         }
 
+        public void SaveBiota(Biota biota, ReaderWriterLockSlim rwLock, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        {
+            var initialCallTime = DateTime.UtcNow;
+
+            _queue.Add(new Task(() =>
+            {
+                var taskStartTime = DateTime.UtcNow;
+                var result = _wrappedDatabase.SaveBiota(biota, rwLock);
+                var taskCompletedTime = DateTime.UtcNow;
+                callback?.Invoke(result);
+                performanceResults?.Invoke(taskStartTime - initialCallTime, taskCompletedTime - taskStartTime);
+            }));
+        }
+
         public void SaveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
                 var result = _wrappedDatabase.SaveBiotasInParallel(biotas);
                 callback?.Invoke(result);
+            }));
+        }
+
+        public void SaveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        {
+            var initialCallTime = DateTime.UtcNow;
+
+            _queue.Add(new Task(() =>
+            {
+                var taskStartTime = DateTime.UtcNow;
+                var result = _wrappedDatabase.SaveBiotasInParallel(biotas);
+                var taskCompletedTime = DateTime.UtcNow;
+                callback?.Invoke(result);
+                performanceResults?.Invoke(taskStartTime - initialCallTime, taskCompletedTime - taskStartTime);
             }));
         }
 
@@ -195,12 +223,40 @@ namespace ACE.Database
             }));
         }
 
+        public void RemoveBiota(Biota biota, ReaderWriterLockSlim rwLock, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        {
+            var initialCallTime = DateTime.UtcNow;
+
+            _queue.Add(new Task(() =>
+            {
+                var taskStartTime = DateTime.UtcNow;
+                var result = _wrappedDatabase.RemoveBiota(biota, rwLock);
+                var taskCompletedTime = DateTime.UtcNow;
+                callback?.Invoke(result);
+                performanceResults?.Invoke(taskStartTime - initialCallTime, taskCompletedTime - taskStartTime);
+            }));
+        }
+
         public void RemoveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
                 var result = _wrappedDatabase.RemoveBiotasInParallel(biotas);
                 callback?.Invoke(result);
+            }));
+        }
+
+        public void RemoveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        {
+            var initialCallTime = DateTime.UtcNow;
+
+            _queue.Add(new Task(() =>
+            {
+                var taskStartTime = DateTime.UtcNow;
+                var result = _wrappedDatabase.RemoveBiotasInParallel(biotas);
+                var taskCompletedTime = DateTime.UtcNow;
+                callback?.Invoke(result);
+                performanceResults?.Invoke(taskStartTime - initialCallTime, taskCompletedTime - taskStartTime);
             }));
         }
 

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -155,11 +155,11 @@ namespace ACE.Database
             }));
         }
 
-        public void SaveBiota(Biota biota, Action<bool> callback)
+        public void SaveBiota(Biota biota, ReaderWriterLockSlim rwLock, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
-                var result = _wrappedDatabase.SaveBiota(biota);
+                var result = _wrappedDatabase.SaveBiota(biota, rwLock);
                 callback?.Invoke(result);
             }));
         }
@@ -173,11 +173,11 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveBiota(Biota biota, Action<bool> callback)
+        public void RemoveBiota(Biota biota, ReaderWriterLockSlim rwLock, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
-                var result = _wrappedDatabase.RemoveBiota(biota);
+                var result = _wrappedDatabase.RemoveBiota(biota, rwLock);
                 callback?.Invoke(result);
             }));
         }
@@ -193,97 +193,6 @@ namespace ACE.Database
 
 
         public void RemoveEntity(object entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-
-        public void RemoveEntity(BiotaPropertiesBool entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesDID entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesEnchantmentRegistry entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesFloat entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesIID entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesInt entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesInt64 entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesPosition entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesSpellBook entity, Action<bool> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var result = _wrappedDatabase.RemoveEntity(entity);
-                callback?.Invoke(result);
-            }));
-        }
-
-        public void RemoveEntity(BiotaPropertiesString entity, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -375,6 +375,8 @@ namespace ACE.Database
         {
             using (var context = new ShardDbContext())
             {
+                var existingBiota = GetBiota(context, biota.Id);
+
                 rwLock.EnterWriteLock();
                 try
                 {
@@ -386,8 +388,6 @@ namespace ACE.Database
                     // Manually setting the properties like we do below is the best case scenario for performance. However, it also has risks.
                     // If we add columns to the schema and forget to add those changes here, changes to the biota may not propegate to the database.
                     // Mag-nus 2018-08-18
-
-                    var existingBiota = GetBiota(context, biota.Id);
 
                     if (existingBiota == null)
                     {

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -356,47 +356,52 @@ namespace ACE.Database
             return result;
         }
 
+        private static Biota GetBiota(ShardDbContext context, uint id)
+        {
+            var biota = context.Biota
+            .FirstOrDefault(r => r.Id == id);
+
+            if (biota == null)
+                return null;
+
+            PopulatedCollectionFlags populatedCollectionFlags = (PopulatedCollectionFlags)biota.PopulatedCollectionFlags;
+
+            // todo: There are gains to be had here if we can conditionally perform mulitple .Include (.Where) statements in a single query.
+            // todo: Until I figure out how to do that, this is still pretty good. Mag-nus 2018-08-10
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAnimPart)) biota.BiotaPropertiesAnimPart = context.BiotaPropertiesAnimPart.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAttribute)) biota.BiotaPropertiesAttribute = context.BiotaPropertiesAttribute.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAttribute2nd)) biota.BiotaPropertiesAttribute2nd = context.BiotaPropertiesAttribute2nd.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBodyPart)) biota.BiotaPropertiesBodyPart = context.BiotaPropertiesBodyPart.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBook)) biota.BiotaPropertiesBook = context.BiotaPropertiesBook.FirstOrDefault(r => r.ObjectId == biota.Id);
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBookPageData)) biota.BiotaPropertiesBookPageData = context.BiotaPropertiesBookPageData.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBool)) biota.BiotaPropertiesBool = context.BiotaPropertiesBool.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesCreateList)) biota.BiotaPropertiesCreateList = context.BiotaPropertiesCreateList.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesDID)) biota.BiotaPropertiesDID = context.BiotaPropertiesDID.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEmote)) biota.BiotaPropertiesEmote = context.BiotaPropertiesEmote.Include(r => r.BiotaPropertiesEmoteAction).Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry)) biota.BiotaPropertiesEnchantmentRegistry = context.BiotaPropertiesEnchantmentRegistry.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEventFilter)) biota.BiotaPropertiesEventFilter = context.BiotaPropertiesEventFilter.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesFloat)) biota.BiotaPropertiesFloat = context.BiotaPropertiesFloat.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesGenerator)) biota.BiotaPropertiesGenerator = context.BiotaPropertiesGenerator.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesIID)) biota.BiotaPropertiesIID = context.BiotaPropertiesIID.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesInt)) biota.BiotaPropertiesInt = context.BiotaPropertiesInt.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesInt64)) biota.BiotaPropertiesInt64 = context.BiotaPropertiesInt64.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesPalette)) biota.BiotaPropertiesPalette = context.BiotaPropertiesPalette.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesPosition)) biota.BiotaPropertiesPosition = context.BiotaPropertiesPosition.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesSkill)) biota.BiotaPropertiesSkill = context.BiotaPropertiesSkill.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesSpellBook)) biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesString)) biota.BiotaPropertiesString = context.BiotaPropertiesString.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesTextureMap)) biota.BiotaPropertiesTextureMap = context.BiotaPropertiesTextureMap.Where(r => r.ObjectId == biota.Id).ToList();
+
+            return biota;
+        }
+
         public Biota GetBiota(uint id)
         {
             using (var context = new ShardDbContext())
             {
                 context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
 
-                var biota = context.Biota
-                .FirstOrDefault(r => r.Id == id);
-
-                if (biota == null)
-                    return null;
-
-                PopulatedCollectionFlags populatedCollectionFlags = (PopulatedCollectionFlags)biota.PopulatedCollectionFlags;
-
-                // todo: There are gains to be had here if we can conditionally perform mulitple .Include (.Where) statements in a single query.
-                // todo: Until I figure out how to do that, this is still pretty good. Mag-nus 2018-08-10
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAnimPart)) biota.BiotaPropertiesAnimPart = context.BiotaPropertiesAnimPart.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAttribute)) biota.BiotaPropertiesAttribute = context.BiotaPropertiesAttribute.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesAttribute2nd)) biota.BiotaPropertiesAttribute2nd = context.BiotaPropertiesAttribute2nd.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBodyPart)) biota.BiotaPropertiesBodyPart = context.BiotaPropertiesBodyPart.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBook)) biota.BiotaPropertiesBook = context.BiotaPropertiesBook.FirstOrDefault(r => r.ObjectId == biota.Id);
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBookPageData)) biota.BiotaPropertiesBookPageData = context.BiotaPropertiesBookPageData.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesBool)) biota.BiotaPropertiesBool = context.BiotaPropertiesBool.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesCreateList)) biota.BiotaPropertiesCreateList = context.BiotaPropertiesCreateList.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesDID)) biota.BiotaPropertiesDID = context.BiotaPropertiesDID.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEmote)) biota.BiotaPropertiesEmote = context.BiotaPropertiesEmote.Include(r => r.BiotaPropertiesEmoteAction).Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry)) biota.BiotaPropertiesEnchantmentRegistry = context.BiotaPropertiesEnchantmentRegistry.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesEventFilter)) biota.BiotaPropertiesEventFilter = context.BiotaPropertiesEventFilter.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesFloat)) biota.BiotaPropertiesFloat = context.BiotaPropertiesFloat.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesGenerator)) biota.BiotaPropertiesGenerator = context.BiotaPropertiesGenerator.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesIID)) biota.BiotaPropertiesIID = context.BiotaPropertiesIID.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesInt)) biota.BiotaPropertiesInt = context.BiotaPropertiesInt.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesInt64)) biota.BiotaPropertiesInt64 = context.BiotaPropertiesInt64.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesPalette)) biota.BiotaPropertiesPalette = context.BiotaPropertiesPalette.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesPosition)) biota.BiotaPropertiesPosition = context.BiotaPropertiesPosition.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesSkill)) biota.BiotaPropertiesSkill = context.BiotaPropertiesSkill.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesSpellBook)) biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesString)) biota.BiotaPropertiesString = context.BiotaPropertiesString.Where(r => r.ObjectId == biota.Id).ToList();
-                if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesTextureMap)) biota.BiotaPropertiesTextureMap = context.BiotaPropertiesTextureMap.Where(r => r.ObjectId == biota.Id).ToList();
-
-                return biota;
+                return GetBiota(context, id);
             }
         }
 
@@ -406,7 +411,517 @@ namespace ACE.Database
             {
                 SetBiotaPopulatedCollections(biota);
 
-                context.Biota.Update(biota);
+                var existingBiota = GetBiota(context, biota.Id);
+
+                if (existingBiota == null)
+                {
+                    context.Biota.Add(biota);
+                }
+                else
+                {
+                    context.Entry(existingBiota).CurrentValues.SetValues(biota);
+
+                    foreach (var value in biota.BiotaPropertiesAnimPart)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesAnimPart.Add(value);
+                        else
+                        {
+                            existingValue.Index = value.Index;
+                            existingValue.AnimationId = value.AnimationId;
+                            existingValue.Order = value.Order;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesAnimPart)
+                    {
+                        if (!biota.BiotaPropertiesAnimPart.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesAnimPart.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesAttribute)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesAttribute.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.InitLevel = value.InitLevel;
+                            existingValue.LevelFromCP = value.LevelFromCP;
+                            existingValue.CPSpent = value.CPSpent;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesAttribute)
+                    {
+                        if (!biota.BiotaPropertiesAttribute.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesAttribute.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesAttribute2nd)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesAttribute2nd.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.InitLevel = value.InitLevel;
+                            existingValue.LevelFromCP = value.LevelFromCP;
+                            existingValue.CPSpent = value.CPSpent;
+                            existingValue.CurrentLevel = value.CurrentLevel;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesAttribute2nd)
+                    {
+                        if (!biota.BiotaPropertiesAttribute2nd.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesAttribute2nd.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesBodyPart)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesBodyPart.Add(value);
+                        else
+                        {
+                            existingValue.Key = value.Key;
+                            existingValue.DType = value.DType;
+                            existingValue.DVal = value.DVal;
+                            existingValue.DVar = value.DVar;
+                            existingValue.BaseArmor = value.BaseArmor;
+                            existingValue.ArmorVsSlash = value.ArmorVsSlash;
+                            existingValue.ArmorVsPierce = value.ArmorVsPierce;
+                            existingValue.ArmorVsBludgeon = value.ArmorVsBludgeon;
+                            existingValue.ArmorVsCold = value.ArmorVsCold;
+                            existingValue.ArmorVsFire = value.ArmorVsFire;
+                            existingValue.ArmorVsAcid = value.ArmorVsAcid;
+                            existingValue.ArmorVsElectric = value.ArmorVsElectric;
+                            existingValue.ArmorVsNether = value.ArmorVsNether;
+                            existingValue.BH = value.BH;
+                            existingValue.HLF = value.HLF;
+                            existingValue.MLF = value.MLF;
+                            existingValue.LLF = value.LLF;
+                            existingValue.HRF = value.HRF;
+                            existingValue.MRF = value.MRF;
+                            existingValue.LRF = value.LRF;
+                            existingValue.HLB = value.HLB;
+                            existingValue.MLB = value.MLB;
+                            existingValue.LLB = value.LLB;
+                            existingValue.HRB = value.HRB;
+                            existingValue.MRB = value.MRB;
+                            existingValue.LRB = value.LRB;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesBodyPart)
+                    {
+                        if (!biota.BiotaPropertiesBodyPart.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesBodyPart.Remove(value);
+                    }
+
+                    if (biota.BiotaPropertiesBook != null)
+                    {
+                        if (existingBiota.BiotaPropertiesBook == null)
+                            existingBiota.BiotaPropertiesBook = new BiotaPropertiesBook();
+
+                        existingBiota.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
+                        existingBiota.BiotaPropertiesBook.MaxNumCharsPerPage = biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+                    }
+                    else
+                    {
+                        if (existingBiota.BiotaPropertiesBook != null)
+                            ; // todo remove the old one
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesBookPageData)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesBookPageData.Add(value);
+                        else
+                        {
+                            existingValue.PageId = value.PageId;
+                            existingValue.AuthorId = value.AuthorId;
+                            existingValue.AuthorName = value.AuthorName;
+                            existingValue.AuthorAccount = value.AuthorAccount;
+                            existingValue.IgnoreAuthor = value.IgnoreAuthor;
+                            existingValue.PageText = value.PageText;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesBookPageData)
+                    {
+                        if (!biota.BiotaPropertiesBookPageData.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesBookPageData.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesBool)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesBool.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesBool.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesBool)
+                    {
+                        if (!biota.BiotaPropertiesBool.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesBool.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesCreateList)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesCreateList.Add(value);
+                        else
+                        {
+                            existingValue.DestinationType = value.DestinationType;
+                            existingValue.WeenieClassId = value.WeenieClassId;
+                            existingValue.StackSize = value.StackSize;
+                            existingValue.Palette = value.Palette;
+                            existingValue.Shade = value.Shade;
+                            existingValue.TryToBond = value.TryToBond;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesCreateList)
+                    {
+                        if (!biota.BiotaPropertiesCreateList.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesCreateList.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesDID)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesDID.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesDID.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesDID)
+                    {
+                        if (!biota.BiotaPropertiesDID.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesDID.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesEmote)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesEmote.Add(value);
+                        else
+                        {
+                            existingValue.Category = value.Category;
+                            existingValue.Probability = value.Probability;
+                            existingValue.WeenieClassId = value.WeenieClassId;
+                            existingValue.Style = value.Style;
+                            existingValue.Substyle = value.Substyle;
+                            existingValue.Quest = value.Quest;
+                            existingValue.VendorType = value.VendorType;
+                            existingValue.MinHealth = value.MinHealth;
+                            existingValue.MaxHealth = value.MaxHealth;
+                        }
+
+                        // todo BiotaPropertiesEmoteAction
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesEmote)
+                    {
+                        if (!biota.BiotaPropertiesEmote.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesEmote.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesEnchantmentRegistry.Add(value);
+                        else
+                        {
+                            existingValue.EnchantmentCategory = value.EnchantmentCategory;
+                            existingValue.SpellId = value.SpellId;
+                            existingValue.LayerId = value.LayerId;
+                            existingValue.HasSpellSetId = value.HasSpellSetId;
+                            existingValue.SpellCategory = value.SpellCategory;
+                            existingValue.PowerLevel = value.PowerLevel;
+                            existingValue.StartTime = value.StartTime;
+                            existingValue.Duration = value.Duration;
+                            existingValue.CasterObjectId = value.CasterObjectId;
+                            existingValue.DegradeModifier = value.DegradeModifier;
+                            existingValue.DegradeLimit = value.DegradeLimit;
+                            existingValue.LastTimeDegraded = value.LastTimeDegraded;
+                            existingValue.StatModType = value.StatModType;
+                            existingValue.StatModKey = value.StatModKey;
+                            existingValue.StatModValue = value.StatModValue;
+                            existingValue.SpellSetId = value.SpellSetId;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesEnchantmentRegistry)
+                    {
+                        if (!biota.BiotaPropertiesEnchantmentRegistry.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesEnchantmentRegistry.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesEventFilter)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesEventFilter.Add(value);
+                        else
+                        {
+                            existingValue.Event = value.Event;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesEventFilter)
+                    {
+                        if (!biota.BiotaPropertiesEventFilter.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesEventFilter.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesFloat)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesFloat.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesFloat)
+                    {
+                        if (!biota.BiotaPropertiesFloat.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesFloat.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesGenerator)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesGenerator.Add(value);
+                        else
+                        {
+                            existingValue.Probability = value.Probability;
+                            existingValue.WeenieClassId = value.WeenieClassId;
+                            existingValue.Delay = value.Delay;
+                            existingValue.InitCreate = value.InitCreate;
+                            existingValue.MaxCreate = value.MaxCreate;
+                            existingValue.WhenCreate = value.WhenCreate;
+                            existingValue.WhereCreate = value.WhereCreate;
+                            existingValue.StackSize = value.StackSize;
+                            existingValue.PaletteId = value.PaletteId;
+                            existingValue.Shade = value.Shade;
+                            existingValue.ObjCellId = value.ObjCellId;
+                            existingValue.OriginX = value.OriginX;
+                            existingValue.OriginY = value.OriginY;
+                            existingValue.OriginZ = value.OriginZ;
+                            existingValue.AnglesW = value.AnglesW;
+                            existingValue.AnglesX = value.AnglesX;
+                            existingValue.AnglesY = value.AnglesY;
+                            existingValue.AnglesZ = value.AnglesZ;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesGenerator)
+                    {
+                        if (!biota.BiotaPropertiesGenerator.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesGenerator.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesIID)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesIID.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesIID.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesIID)
+                    {
+                        if (!biota.BiotaPropertiesIID.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesIID.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesInt)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesInt.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesInt.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesInt)
+                    {
+                        if (!biota.BiotaPropertiesInt.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesInt.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesInt64)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesInt64.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesInt64)
+                    {
+                        if (!biota.BiotaPropertiesInt64.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesInt64.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesPalette)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesPalette.Add(value);
+                        else
+                        {
+                            existingValue.SubPaletteId = value.SubPaletteId;
+                            existingValue.Offset = value.Offset;
+                            existingValue.Length = value.Length;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesPalette)
+                    {
+                        if (!biota.BiotaPropertiesPalette.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesPalette.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesPosition)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesPosition.Add(value);
+                        else
+                        {
+                            existingValue.PositionType = value.PositionType;
+                            existingValue.ObjCellId = value.ObjCellId;
+                            existingValue.OriginX = value.OriginX;
+                            existingValue.OriginY = value.OriginY;
+                            existingValue.OriginZ = value.OriginZ;
+                            existingValue.AnglesW = value.AnglesW;
+                            existingValue.AnglesX = value.AnglesX;
+                            existingValue.AnglesY = value.AnglesY;
+                            existingValue.AnglesZ = value.AnglesZ;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesPosition)
+                    {
+                        if (!biota.BiotaPropertiesPosition.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesPosition.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesSkill)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesSkill.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.LevelFromPP = value.LevelFromPP;
+                            existingValue.SAC = value.SAC;
+                            existingValue.PP = value.PP;
+                            existingValue.InitLevel = value.InitLevel;
+                            existingValue.ResistanceAtLastCheck = value.ResistanceAtLastCheck;
+                            existingValue.LastUsedTime = value.LastUsedTime;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesSkill)
+                    {
+                        if (!biota.BiotaPropertiesSkill.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesSkill.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesSpellBook)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesSpellBook.Add(value);
+                        else
+                        {
+                            existingValue.Spell = value.Spell;
+                            existingValue.Probability = value.Probability;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesSpellBook)
+                    {
+                        if (!biota.BiotaPropertiesSpellBook.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesSpellBook.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesString)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesString.Add(value);
+                        else
+                        {
+                            existingValue.Type = value.Type;
+                            existingValue.Value = value.Value;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesString)
+                    {
+                        if (!biota.BiotaPropertiesString.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesString.Remove(value);
+                    }
+
+                    foreach (var value in biota.BiotaPropertiesTextureMap)
+                    {
+                        var existingValue = existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
+
+                        if (existingValue == null)
+                            existingBiota.BiotaPropertiesTextureMap.Add(value);
+                        else
+                        {
+                            existingValue.Index = value.Index;
+                            existingValue.OldId = value.OldId;
+                            existingValue.NewId = value.NewId;
+                            existingValue.Order = value.Order;
+                        }
+                    }
+                    foreach (var value in existingBiota.BiotaPropertiesTextureMap)
+                    {
+                        if (!biota.BiotaPropertiesTextureMap.Any(p => p.Id == value.Id))
+                            context.BiotaPropertiesTextureMap.Remove(value);
+                    }
+                }
 
                 try
                 {

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -163,7 +163,7 @@ namespace ACE.Database
             }
         }
 
-        public bool AddCharacterInParallel(Biota biota, IEnumerable<Biota> possessions, Character character)
+        public bool AddCharacterInParallel(Biota biota, IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> possessions, Character character)
         {
             if (!SaveBiota(biota, new ReaderWriterLockSlim()))
                 return false; // Biota save failed which mean Character fails.
@@ -974,13 +974,13 @@ namespace ACE.Database
             }
         }
 
-        public bool SaveBiotasInParallel(IEnumerable<Biota> biotas) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
+        public bool SaveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas)
         {
             var result = true;
 
             Parallel.ForEach(biotas, biota =>
             {
-                if (!SaveBiota(biota, new ReaderWriterLockSlim()))
+                if (!SaveBiota(biota.biota, biota.rwLock))
                     result = false;
             });
 
@@ -1015,13 +1015,13 @@ namespace ACE.Database
             }
         }
 
-        public bool RemoveBiotasInParallel(IEnumerable<Biota> biotas) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
+        public bool RemoveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas)
         {
             var result = true;
 
             Parallel.ForEach(biotas, biota =>
             {
-                if (!RemoveBiota(biota, new ReaderWriterLockSlim()))
+                if (!RemoveBiota(biota.biota, biota.rwLock))
                     result = false;
             });
 

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -325,7 +325,7 @@ namespace ACE.Database
         private static Biota GetBiota(ShardDbContext context, uint id)
         {
             var biota = context.Biota
-            .FirstOrDefault(r => r.Id == id);
+                .FirstOrDefault(r => r.Id == id);
 
             if (biota == null)
                 return null;
@@ -991,6 +991,13 @@ namespace ACE.Database
         {
             using (var context = new ShardDbContext())
             {
+                var existingBiota = context.Biota
+                    .AsNoTracking()
+                    .FirstOrDefault(r => r.Id == biota.Id);
+
+                if (existingBiota == null)
+                    return true;
+
                 rwLock.EnterWriteLock();
                 try
                 {

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -399,7 +399,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAnimPart)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesAnimPart existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAnimPart.Add(value);
@@ -418,7 +418,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAttribute)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesAttribute existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAttribute.Add(value);
@@ -438,7 +438,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAttribute2nd)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesAttribute2nd existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAttribute2nd.Add(value);
@@ -459,7 +459,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesBodyPart)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesBodyPart existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesBodyPart.Add(value);
@@ -517,7 +517,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesBookPageData)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesBookPageData existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesBookPageData.Add(value);
@@ -539,7 +539,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesBool)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesBool.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesBool existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesBool.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesBool.Add(value);
@@ -557,7 +557,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesCreateList)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesCreateList existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesCreateList.Add(value);
@@ -579,7 +579,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesDID)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesDID.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesDID existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesDID.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesDID.Add(value);
@@ -597,7 +597,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEmote)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesEmote existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEmote.Add(value);
@@ -615,7 +615,7 @@ namespace ACE.Database
 
                                 foreach (var value2 in value.BiotaPropertiesEmoteAction)
                                 {
-                                    var existingValue2 = existingValue.BiotaPropertiesEmoteAction.FirstOrDefault(r => r.Id == value2.Id);
+                                    BiotaPropertiesEmoteAction existingValue2 = (value2.Id == 0 ? null : existingValue.BiotaPropertiesEmoteAction.FirstOrDefault(r => r.Id == value2.Id));
 
                                     if (existingValue2 == null)
                                         existingValue.BiotaPropertiesEmoteAction.Add(value2);
@@ -678,7 +678,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesEnchantmentRegistry existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEnchantmentRegistry.Add(value);
@@ -710,7 +710,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEventFilter)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesEventFilter existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEventFilter.Add(value);
@@ -727,7 +727,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesFloat)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesFloat existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesFloat.Add(value);
@@ -745,7 +745,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesGenerator)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesGenerator existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesGenerator.Add(value);
@@ -779,7 +779,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesIID)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesIID.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesIID existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesIID.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesIID.Add(value);
@@ -797,7 +797,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesInt)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesInt.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesInt existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesInt.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesInt.Add(value);
@@ -815,7 +815,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesInt64)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesInt64 existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesInt64.Add(value);
@@ -833,7 +833,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesPalette)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesPalette existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesPalette.Add(value);
@@ -852,7 +852,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesPosition)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesPosition existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesPosition.Add(value);
@@ -877,7 +877,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesSkill)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesSkill existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesSkill.Add(value);
@@ -900,7 +900,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesSpellBook)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesSpellBook existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesSpellBook.Add(value);
@@ -918,7 +918,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesString)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesString existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesString.Add(value);
@@ -936,7 +936,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesTextureMap)
                         {
-                            var existingValue = existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
+                            BiotaPropertiesTextureMap existingValue = (value.Id == 0 ? null : existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id));
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesTextureMap.Add(value);

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -165,7 +165,7 @@ namespace ACE.Database
 
         public bool AddCharacterInParallel(Biota biota, IEnumerable<Biota> possessions, Character character)
         {
-            if (!SaveBiota(biota))
+            if (!SaveBiota(biota, new ReaderWriterLockSlim()))
                 return false; // Biota save failed which mean Character fails.
 
             if (!SaveBiotasInParallel(possessions))
@@ -371,534 +371,590 @@ namespace ACE.Database
             }
         }
 
-        public bool SaveBiota(Biota biota)
+        public bool SaveBiota(Biota biota, ReaderWriterLockSlim rwLock)
         {
             using (var context = new ShardDbContext())
             {
-                SetBiotaPopulatedCollections(biota);
-
-                var existingBiota = GetBiota(context, biota.Id);
-
-                if (existingBiota == null)
+                rwLock.EnterWriteLock();
+                try
                 {
-                    context.Biota.Add(biota);
-                }
-                else
-                {
-                    context.Entry(existingBiota).CurrentValues.SetValues(biota);
+                    SetBiotaPopulatedCollections(biota);
 
-                    foreach (var value in biota.BiotaPropertiesAnimPart)
+                    // This pattern is described here: https://docs.microsoft.com/en-us/ef/core/saving/disconnected-entities
+                    // You'll notice though that we're not using the recommended: context.Entry(existingEntry).CurrentValues.SetValues(newEntry);
+                    // It is EXTREMLY slow. 4x or more slower. I suspect because it uses reflection to find the properties that the object contains
+                    // Manually setting the properties like we do below is the best case scenario for performance. However, it also has risks.
+                    // If we add columns to the schema and forget to add those changes here, changes to the biota may not propegate to the database.
+                    // Mag-nus 2018-08-18
+
+                    var existingBiota = GetBiota(context, biota.Id);
+
+                    if (existingBiota == null)
                     {
-                        var existingValue = existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesAnimPart.Add(value);
-                        else
-                        {
-                            existingValue.Index = value.Index;
-                            existingValue.AnimationId = value.AnimationId;
-                            existingValue.Order = value.Order;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesAnimPart)
-                    {
-                        if (!biota.BiotaPropertiesAnimPart.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesAnimPart.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesAttribute)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesAttribute.Add(value);
-                        else
-                        {
-                            existingValue.Type = value.Type;
-                            existingValue.InitLevel = value.InitLevel;
-                            existingValue.LevelFromCP = value.LevelFromCP;
-                            existingValue.CPSpent = value.CPSpent;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesAttribute)
-                    {
-                        if (!biota.BiotaPropertiesAttribute.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesAttribute.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesAttribute2nd)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesAttribute2nd.Add(value);
-                        else
-                        {
-                            existingValue.Type = value.Type;
-                            existingValue.InitLevel = value.InitLevel;
-                            existingValue.LevelFromCP = value.LevelFromCP;
-                            existingValue.CPSpent = value.CPSpent;
-                            existingValue.CurrentLevel = value.CurrentLevel;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesAttribute2nd)
-                    {
-                        if (!biota.BiotaPropertiesAttribute2nd.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesAttribute2nd.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesBodyPart)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesBodyPart.Add(value);
-                        else
-                        {
-                            existingValue.Key = value.Key;
-                            existingValue.DType = value.DType;
-                            existingValue.DVal = value.DVal;
-                            existingValue.DVar = value.DVar;
-                            existingValue.BaseArmor = value.BaseArmor;
-                            existingValue.ArmorVsSlash = value.ArmorVsSlash;
-                            existingValue.ArmorVsPierce = value.ArmorVsPierce;
-                            existingValue.ArmorVsBludgeon = value.ArmorVsBludgeon;
-                            existingValue.ArmorVsCold = value.ArmorVsCold;
-                            existingValue.ArmorVsFire = value.ArmorVsFire;
-                            existingValue.ArmorVsAcid = value.ArmorVsAcid;
-                            existingValue.ArmorVsElectric = value.ArmorVsElectric;
-                            existingValue.ArmorVsNether = value.ArmorVsNether;
-                            existingValue.BH = value.BH;
-                            existingValue.HLF = value.HLF;
-                            existingValue.MLF = value.MLF;
-                            existingValue.LLF = value.LLF;
-                            existingValue.HRF = value.HRF;
-                            existingValue.MRF = value.MRF;
-                            existingValue.LRF = value.LRF;
-                            existingValue.HLB = value.HLB;
-                            existingValue.MLB = value.MLB;
-                            existingValue.LLB = value.LLB;
-                            existingValue.HRB = value.HRB;
-                            existingValue.MRB = value.MRB;
-                            existingValue.LRB = value.LRB;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesBodyPart)
-                    {
-                        if (!biota.BiotaPropertiesBodyPart.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesBodyPart.Remove(value);
-                    }
-
-                    if (biota.BiotaPropertiesBook != null)
-                    {
-                        if (existingBiota.BiotaPropertiesBook == null)
-                            existingBiota.BiotaPropertiesBook = new BiotaPropertiesBook();
-
-                        existingBiota.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
-                        existingBiota.BiotaPropertiesBook.MaxNumCharsPerPage = biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+                        context.Biota.Add(biota);
                     }
                     else
                     {
-                        if (existingBiota.BiotaPropertiesBook != null)
-                            ; // todo remove the old one
-                    }
+                        context.Entry(existingBiota).CurrentValues.SetValues(biota);
 
-                    foreach (var value in biota.BiotaPropertiesBookPageData)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesBookPageData.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesAnimPart)
                         {
-                            existingValue.PageId = value.PageId;
-                            existingValue.AuthorId = value.AuthorId;
-                            existingValue.AuthorName = value.AuthorName;
-                            existingValue.AuthorAccount = value.AuthorAccount;
-                            existingValue.IgnoreAuthor = value.IgnoreAuthor;
-                            existingValue.PageText = value.PageText;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesBookPageData)
-                    {
-                        if (!biota.BiotaPropertiesBookPageData.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesBookPageData.Remove(value);
-                    }
+                            var existingValue =
+                                existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
 
-                    foreach (var value in biota.BiotaPropertiesBool)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesBool.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesBool.Add(value);
-                        else
-                        {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesBool)
-                    {
-                        if (!biota.BiotaPropertiesBool.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesBool.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesCreateList)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesCreateList.Add(value);
-                        else
-                        {
-                            existingValue.DestinationType = value.DestinationType;
-                            existingValue.WeenieClassId = value.WeenieClassId;
-                            existingValue.StackSize = value.StackSize;
-                            existingValue.Palette = value.Palette;
-                            existingValue.Shade = value.Shade;
-                            existingValue.TryToBond = value.TryToBond;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesCreateList)
-                    {
-                        if (!biota.BiotaPropertiesCreateList.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesCreateList.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesDID)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesDID.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesDID.Add(value);
-                        else
-                        {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
-                        }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesDID)
-                    {
-                        if (!biota.BiotaPropertiesDID.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesDID.Remove(value);
-                    }
-
-                    foreach (var value in biota.BiotaPropertiesEmote)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesEmote.Add(value);
-                        else
-                        {
-                            existingValue.Category = value.Category;
-                            existingValue.Probability = value.Probability;
-                            existingValue.WeenieClassId = value.WeenieClassId;
-                            existingValue.Style = value.Style;
-                            existingValue.Substyle = value.Substyle;
-                            existingValue.Quest = value.Quest;
-                            existingValue.VendorType = value.VendorType;
-                            existingValue.MinHealth = value.MinHealth;
-                            existingValue.MaxHealth = value.MaxHealth;
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesAnimPart.Add(value);
+                            else
+                            {
+                                existingValue.Index = value.Index;
+                                existingValue.AnimationId = value.AnimationId;
+                                existingValue.Order = value.Order;
+                            }
                         }
 
-                        // todo BiotaPropertiesEmoteAction
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesEmote)
-                    {
-                        if (!biota.BiotaPropertiesEmote.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesEmote.Remove(value);
-                    }
+                        foreach (var value in existingBiota.BiotaPropertiesAnimPart)
+                        {
+                            if (!biota.BiotaPropertiesAnimPart.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesAnimPart.Remove(value);
+                        }
 
-                    foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
+                        foreach (var value in biota.BiotaPropertiesAttribute)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
 
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesEnchantmentRegistry.Add(value);
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesAttribute.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.InitLevel = value.InitLevel;
+                                existingValue.LevelFromCP = value.LevelFromCP;
+                                existingValue.CPSpent = value.CPSpent;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesAttribute)
+                        {
+                            if (!biota.BiotaPropertiesAttribute.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesAttribute.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesAttribute2nd)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesAttribute2nd.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.InitLevel = value.InitLevel;
+                                existingValue.LevelFromCP = value.LevelFromCP;
+                                existingValue.CPSpent = value.CPSpent;
+                                existingValue.CurrentLevel = value.CurrentLevel;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesAttribute2nd)
+                        {
+                            if (!biota.BiotaPropertiesAttribute2nd.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesAttribute2nd.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesBodyPart)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesBodyPart.Add(value);
+                            else
+                            {
+                                existingValue.Key = value.Key;
+                                existingValue.DType = value.DType;
+                                existingValue.DVal = value.DVal;
+                                existingValue.DVar = value.DVar;
+                                existingValue.BaseArmor = value.BaseArmor;
+                                existingValue.ArmorVsSlash = value.ArmorVsSlash;
+                                existingValue.ArmorVsPierce = value.ArmorVsPierce;
+                                existingValue.ArmorVsBludgeon = value.ArmorVsBludgeon;
+                                existingValue.ArmorVsCold = value.ArmorVsCold;
+                                existingValue.ArmorVsFire = value.ArmorVsFire;
+                                existingValue.ArmorVsAcid = value.ArmorVsAcid;
+                                existingValue.ArmorVsElectric = value.ArmorVsElectric;
+                                existingValue.ArmorVsNether = value.ArmorVsNether;
+                                existingValue.BH = value.BH;
+                                existingValue.HLF = value.HLF;
+                                existingValue.MLF = value.MLF;
+                                existingValue.LLF = value.LLF;
+                                existingValue.HRF = value.HRF;
+                                existingValue.MRF = value.MRF;
+                                existingValue.LRF = value.LRF;
+                                existingValue.HLB = value.HLB;
+                                existingValue.MLB = value.MLB;
+                                existingValue.LLB = value.LLB;
+                                existingValue.HRB = value.HRB;
+                                existingValue.MRB = value.MRB;
+                                existingValue.LRB = value.LRB;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesBodyPart)
+                        {
+                            if (!biota.BiotaPropertiesBodyPart.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesBodyPart.Remove(value);
+                        }
+
+                        if (biota.BiotaPropertiesBook != null)
+                        {
+                            if (existingBiota.BiotaPropertiesBook == null)
+                                existingBiota.BiotaPropertiesBook = new BiotaPropertiesBook();
+
+                            existingBiota.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
+                            existingBiota.BiotaPropertiesBook.MaxNumCharsPerPage =
+                                biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+                        }
                         else
                         {
-                            existingValue.EnchantmentCategory = value.EnchantmentCategory;
-                            existingValue.SpellId = value.SpellId;
-                            existingValue.LayerId = value.LayerId;
-                            existingValue.HasSpellSetId = value.HasSpellSetId;
-                            existingValue.SpellCategory = value.SpellCategory;
-                            existingValue.PowerLevel = value.PowerLevel;
-                            existingValue.StartTime = value.StartTime;
-                            existingValue.Duration = value.Duration;
-                            existingValue.CasterObjectId = value.CasterObjectId;
-                            existingValue.DegradeModifier = value.DegradeModifier;
-                            existingValue.DegradeLimit = value.DegradeLimit;
-                            existingValue.LastTimeDegraded = value.LastTimeDegraded;
-                            existingValue.StatModType = value.StatModType;
-                            existingValue.StatModKey = value.StatModKey;
-                            existingValue.StatModValue = value.StatModValue;
-                            existingValue.SpellSetId = value.SpellSetId;
+                            if (existingBiota.BiotaPropertiesBook != null)
+                                ; // todo remove the old one
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesEnchantmentRegistry)
-                    {
-                        if (!biota.BiotaPropertiesEnchantmentRegistry.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesEnchantmentRegistry.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesEventFilter)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesEventFilter.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesBookPageData)
                         {
-                            existingValue.Event = value.Event;
+                            var existingValue =
+                                existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesBookPageData.Add(value);
+                            else
+                            {
+                                existingValue.PageId = value.PageId;
+                                existingValue.AuthorId = value.AuthorId;
+                                existingValue.AuthorName = value.AuthorName;
+                                existingValue.AuthorAccount = value.AuthorAccount;
+                                existingValue.IgnoreAuthor = value.IgnoreAuthor;
+                                existingValue.PageText = value.PageText;
+                            }
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesEventFilter)
-                    {
-                        if (!biota.BiotaPropertiesEventFilter.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesEventFilter.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesFloat)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesFloat.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesBookPageData)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
+                            if (!biota.BiotaPropertiesBookPageData.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesBookPageData.Remove(value);
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesFloat)
-                    {
-                        if (!biota.BiotaPropertiesFloat.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesFloat.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesGenerator)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesGenerator.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesBool)
                         {
-                            existingValue.Probability = value.Probability;
-                            existingValue.WeenieClassId = value.WeenieClassId;
-                            existingValue.Delay = value.Delay;
-                            existingValue.InitCreate = value.InitCreate;
-                            existingValue.MaxCreate = value.MaxCreate;
-                            existingValue.WhenCreate = value.WhenCreate;
-                            existingValue.WhereCreate = value.WhereCreate;
-                            existingValue.StackSize = value.StackSize;
-                            existingValue.PaletteId = value.PaletteId;
-                            existingValue.Shade = value.Shade;
-                            existingValue.ObjCellId = value.ObjCellId;
-                            existingValue.OriginX = value.OriginX;
-                            existingValue.OriginY = value.OriginY;
-                            existingValue.OriginZ = value.OriginZ;
-                            existingValue.AnglesW = value.AnglesW;
-                            existingValue.AnglesX = value.AnglesX;
-                            existingValue.AnglesY = value.AnglesY;
-                            existingValue.AnglesZ = value.AnglesZ;
+                            var existingValue = existingBiota.BiotaPropertiesBool.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesBool.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesGenerator)
-                    {
-                        if (!biota.BiotaPropertiesGenerator.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesGenerator.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesIID)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesIID.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesIID.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesBool)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
+                            if (!biota.BiotaPropertiesBool.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesBool.Remove(value);
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesIID)
-                    {
-                        if (!biota.BiotaPropertiesIID.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesIID.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesInt)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesInt.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesInt.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesCreateList)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
+                            var existingValue =
+                                existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesCreateList.Add(value);
+                            else
+                            {
+                                existingValue.DestinationType = value.DestinationType;
+                                existingValue.WeenieClassId = value.WeenieClassId;
+                                existingValue.StackSize = value.StackSize;
+                                existingValue.Palette = value.Palette;
+                                existingValue.Shade = value.Shade;
+                                existingValue.TryToBond = value.TryToBond;
+                            }
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesInt)
-                    {
-                        if (!biota.BiotaPropertiesInt.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesInt.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesInt64)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesInt64.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesCreateList)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
+                            if (!biota.BiotaPropertiesCreateList.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesCreateList.Remove(value);
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesInt64)
-                    {
-                        if (!biota.BiotaPropertiesInt64.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesInt64.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesPalette)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesPalette.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesDID)
                         {
-                            existingValue.SubPaletteId = value.SubPaletteId;
-                            existingValue.Offset = value.Offset;
-                            existingValue.Length = value.Length;
+                            var existingValue = existingBiota.BiotaPropertiesDID.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesDID.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesPalette)
-                    {
-                        if (!biota.BiotaPropertiesPalette.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesPalette.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesPosition)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesPosition.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesDID)
                         {
-                            existingValue.PositionType = value.PositionType;
-                            existingValue.ObjCellId = value.ObjCellId;
-                            existingValue.OriginX = value.OriginX;
-                            existingValue.OriginY = value.OriginY;
-                            existingValue.OriginZ = value.OriginZ;
-                            existingValue.AnglesW = value.AnglesW;
-                            existingValue.AnglesX = value.AnglesX;
-                            existingValue.AnglesY = value.AnglesY;
-                            existingValue.AnglesZ = value.AnglesZ;
+                            if (!biota.BiotaPropertiesDID.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesDID.Remove(value);
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesPosition)
-                    {
-                        if (!biota.BiotaPropertiesPosition.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesPosition.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesSkill)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesSkill.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesEmote)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.LevelFromPP = value.LevelFromPP;
-                            existingValue.SAC = value.SAC;
-                            existingValue.PP = value.PP;
-                            existingValue.InitLevel = value.InitLevel;
-                            existingValue.ResistanceAtLastCheck = value.ResistanceAtLastCheck;
-                            existingValue.LastUsedTime = value.LastUsedTime;
+                            var existingValue =
+                                existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesEmote.Add(value);
+                            else
+                            {
+                                existingValue.Category = value.Category;
+                                existingValue.Probability = value.Probability;
+                                existingValue.WeenieClassId = value.WeenieClassId;
+                                existingValue.Style = value.Style;
+                                existingValue.Substyle = value.Substyle;
+                                existingValue.Quest = value.Quest;
+                                existingValue.VendorType = value.VendorType;
+                                existingValue.MinHealth = value.MinHealth;
+                                existingValue.MaxHealth = value.MaxHealth;
+                            }
+
+                            // todo BiotaPropertiesEmoteAction
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesSkill)
-                    {
-                        if (!biota.BiotaPropertiesSkill.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesSkill.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesSpellBook)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesSpellBook.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesEmote)
                         {
-                            existingValue.Spell = value.Spell;
-                            existingValue.Probability = value.Probability;
+                            if (!biota.BiotaPropertiesEmote.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesEmote.Remove(value);
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesSpellBook)
-                    {
-                        if (!biota.BiotaPropertiesSpellBook.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesSpellBook.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesString)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesString.Add(value);
-                        else
+                        foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
                         {
-                            existingValue.Type = value.Type;
-                            existingValue.Value = value.Value;
+                            var existingValue =
+                                existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesEnchantmentRegistry.Add(value);
+                            else
+                            {
+                                existingValue.EnchantmentCategory = value.EnchantmentCategory;
+                                existingValue.SpellId = value.SpellId;
+                                existingValue.LayerId = value.LayerId;
+                                existingValue.HasSpellSetId = value.HasSpellSetId;
+                                existingValue.SpellCategory = value.SpellCategory;
+                                existingValue.PowerLevel = value.PowerLevel;
+                                existingValue.StartTime = value.StartTime;
+                                existingValue.Duration = value.Duration;
+                                existingValue.CasterObjectId = value.CasterObjectId;
+                                existingValue.DegradeModifier = value.DegradeModifier;
+                                existingValue.DegradeLimit = value.DegradeLimit;
+                                existingValue.LastTimeDegraded = value.LastTimeDegraded;
+                                existingValue.StatModType = value.StatModType;
+                                existingValue.StatModKey = value.StatModKey;
+                                existingValue.StatModValue = value.StatModValue;
+                                existingValue.SpellSetId = value.SpellSetId;
+                            }
                         }
-                    }
-                    foreach (var value in existingBiota.BiotaPropertiesString)
-                    {
-                        if (!biota.BiotaPropertiesString.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesString.Remove(value);
-                    }
 
-                    foreach (var value in biota.BiotaPropertiesTextureMap)
-                    {
-                        var existingValue = existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
-
-                        if (existingValue == null)
-                            existingBiota.BiotaPropertiesTextureMap.Add(value);
-                        else
+                        foreach (var value in existingBiota.BiotaPropertiesEnchantmentRegistry)
                         {
-                            existingValue.Index = value.Index;
-                            existingValue.OldId = value.OldId;
-                            existingValue.NewId = value.NewId;
-                            existingValue.Order = value.Order;
+                            if (!biota.BiotaPropertiesEnchantmentRegistry.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesEnchantmentRegistry.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesEventFilter)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesEventFilter.Add(value);
+                            else
+                            {
+                                existingValue.Event = value.Event;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesEventFilter)
+                        {
+                            if (!biota.BiotaPropertiesEventFilter.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesEventFilter.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesFloat)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesFloat.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesFloat)
+                        {
+                            if (!biota.BiotaPropertiesFloat.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesFloat.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesGenerator)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesGenerator.Add(value);
+                            else
+                            {
+                                existingValue.Probability = value.Probability;
+                                existingValue.WeenieClassId = value.WeenieClassId;
+                                existingValue.Delay = value.Delay;
+                                existingValue.InitCreate = value.InitCreate;
+                                existingValue.MaxCreate = value.MaxCreate;
+                                existingValue.WhenCreate = value.WhenCreate;
+                                existingValue.WhereCreate = value.WhereCreate;
+                                existingValue.StackSize = value.StackSize;
+                                existingValue.PaletteId = value.PaletteId;
+                                existingValue.Shade = value.Shade;
+                                existingValue.ObjCellId = value.ObjCellId;
+                                existingValue.OriginX = value.OriginX;
+                                existingValue.OriginY = value.OriginY;
+                                existingValue.OriginZ = value.OriginZ;
+                                existingValue.AnglesW = value.AnglesW;
+                                existingValue.AnglesX = value.AnglesX;
+                                existingValue.AnglesY = value.AnglesY;
+                                existingValue.AnglesZ = value.AnglesZ;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesGenerator)
+                        {
+                            if (!biota.BiotaPropertiesGenerator.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesGenerator.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesIID)
+                        {
+                            var existingValue = existingBiota.BiotaPropertiesIID.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesIID.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesIID)
+                        {
+                            if (!biota.BiotaPropertiesIID.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesIID.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesInt)
+                        {
+                            var existingValue = existingBiota.BiotaPropertiesInt.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesInt.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesInt)
+                        {
+                            if (!biota.BiotaPropertiesInt.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesInt.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesInt64)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesInt64.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesInt64)
+                        {
+                            if (!biota.BiotaPropertiesInt64.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesInt64.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesPalette)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesPalette.Add(value);
+                            else
+                            {
+                                existingValue.SubPaletteId = value.SubPaletteId;
+                                existingValue.Offset = value.Offset;
+                                existingValue.Length = value.Length;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesPalette)
+                        {
+                            if (!biota.BiotaPropertiesPalette.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesPalette.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesPosition)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesPosition.Add(value);
+                            else
+                            {
+                                existingValue.PositionType = value.PositionType;
+                                existingValue.ObjCellId = value.ObjCellId;
+                                existingValue.OriginX = value.OriginX;
+                                existingValue.OriginY = value.OriginY;
+                                existingValue.OriginZ = value.OriginZ;
+                                existingValue.AnglesW = value.AnglesW;
+                                existingValue.AnglesX = value.AnglesX;
+                                existingValue.AnglesY = value.AnglesY;
+                                existingValue.AnglesZ = value.AnglesZ;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesPosition)
+                        {
+                            if (!biota.BiotaPropertiesPosition.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesPosition.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesSkill)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesSkill.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.LevelFromPP = value.LevelFromPP;
+                                existingValue.SAC = value.SAC;
+                                existingValue.PP = value.PP;
+                                existingValue.InitLevel = value.InitLevel;
+                                existingValue.ResistanceAtLastCheck = value.ResistanceAtLastCheck;
+                                existingValue.LastUsedTime = value.LastUsedTime;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesSkill)
+                        {
+                            if (!biota.BiotaPropertiesSkill.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesSkill.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesSpellBook)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesSpellBook.Add(value);
+                            else
+                            {
+                                existingValue.Spell = value.Spell;
+                                existingValue.Probability = value.Probability;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesSpellBook)
+                        {
+                            if (!biota.BiotaPropertiesSpellBook.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesSpellBook.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesString)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesString.Add(value);
+                            else
+                            {
+                                existingValue.Type = value.Type;
+                                existingValue.Value = value.Value;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesString)
+                        {
+                            if (!biota.BiotaPropertiesString.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesString.Remove(value);
+                        }
+
+                        foreach (var value in biota.BiotaPropertiesTextureMap)
+                        {
+                            var existingValue =
+                                existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
+
+                            if (existingValue == null)
+                                existingBiota.BiotaPropertiesTextureMap.Add(value);
+                            else
+                            {
+                                existingValue.Index = value.Index;
+                                existingValue.OldId = value.OldId;
+                                existingValue.NewId = value.NewId;
+                                existingValue.Order = value.Order;
+                            }
+                        }
+
+                        foreach (var value in existingBiota.BiotaPropertiesTextureMap)
+                        {
+                            if (!biota.BiotaPropertiesTextureMap.Any(p => p.Id == value.Id))
+                                context.BiotaPropertiesTextureMap.Remove(value);
                         }
                     }
-                    foreach (var value in existingBiota.BiotaPropertiesTextureMap)
+
+                    try
                     {
-                        if (!biota.BiotaPropertiesTextureMap.Any(p => p.Id == value.Id))
-                            context.BiotaPropertiesTextureMap.Remove(value);
+                        context.SaveChanges();
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Character name might be in use or some other fault
+                        log.Error($"SaveBiota failed with exception: {ex}");
+                        return false;
                     }
                 }
-
-                try
+                finally
                 {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"SaveBiota failed with exception: {ex}");
-                    return false;
+                    rwLock.ExitWriteLock();
                 }
             }
         }
@@ -909,29 +965,37 @@ namespace ACE.Database
 
             Parallel.ForEach(biotas, biota =>
             {
-                if (!SaveBiota(biota))
+                if (!SaveBiota(biota, new ReaderWriterLockSlim()))
                     result = false;
             });
 
             return result;
         }
 
-        public bool RemoveBiota(Biota biota)
+        public bool RemoveBiota(Biota biota, ReaderWriterLockSlim rwLock)
         {
             using (var context = new ShardDbContext())
             {
-                context.Biota.Remove(biota);
-
+                rwLock.EnterWriteLock();
                 try
                 {
-                    context.SaveChanges();
-                    return true;
+                    context.Biota.Remove(biota);
+
+                    try
+                    {
+                        context.SaveChanges();
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Character name might be in use or some other fault
+                        log.Error($"RemoveBiota failed with exception: {ex}");
+                        return false;
+                    }
                 }
-                catch (Exception ex)
+                finally
                 {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveBiota failed with exception: {ex}");
-                    return false;
+                    rwLock.ExitWriteLock();
                 }
             }
         }
@@ -942,7 +1006,7 @@ namespace ACE.Database
 
             Parallel.ForEach(biotas, biota =>
             {
-                if (!RemoveBiota(biota))
+                if (!RemoveBiota(biota, new ReaderWriterLockSlim()))
                     result = false;
             });
 
@@ -955,166 +1019,6 @@ namespace ACE.Database
             using (var context = new ShardDbContext())
             {
                 context.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesBool entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesBool.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesDID entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesDID.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesEnchantmentRegistry entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesEnchantmentRegistry.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesFloat entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesFloat.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesIID entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesIID.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesInt entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesInt.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesInt64 entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesInt64.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesPosition entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesPosition.Remove(entity);
 
                 try
                 {
@@ -1155,46 +1059,6 @@ namespace ACE.Database
             using (var context = new ShardDbContext())
             {
                 context.CharacterPropertiesSpellBar.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesSpellBook entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesSpellBook.Remove(entity);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    // Character name might be in use or some other fault
-                    log.Error($"RemoveEntity failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool RemoveEntity(BiotaPropertiesString entity)
-        {
-            using (var context = new ShardDbContext())
-            {
-                context.BiotaPropertiesString.Remove(entity);
 
                 try
                 {

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -165,10 +165,10 @@ namespace ACE.Database
 
         public bool AddCharacterInParallel(Biota biota, IEnumerable<Biota> possessions, Character character)
         {
-            if (!AddBiota(biota))
+            if (!SaveBiota(biota))
                 return false; // Biota save failed which mean Character fails.
 
-            if (!AddBiotasInParallel(possessions))
+            if (!SaveBiotasInParallel(possessions))
                 return false;
 
             using (var context = new ShardDbContext())
@@ -320,40 +320,6 @@ namespace ACE.Database
             if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
 
             biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
-        }
-
-        public bool AddBiota(Biota biota)
-        {
-            using (var context = new ShardDbContext())
-            {
-                SetBiotaPopulatedCollections(biota);
-
-                context.Biota.Add(biota);
-
-                try
-                {
-                    context.SaveChanges();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    log.Error($"AddBiota failed with exception: {ex}");
-                    return false;
-                }
-            }
-        }
-
-        public bool AddBiotasInParallel(IEnumerable<Biota> biotas)
-        {
-            var result = true;
-
-            Parallel.ForEach(biotas, biota =>
-            {
-                if (!AddBiota(biota))
-                    result = false;
-            });
-
-            return result;
         }
 
         private static Biota GetBiota(ShardDbContext context, uint id)

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -399,8 +399,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAnimPart)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesAnimPart.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAnimPart.Add(value);
@@ -411,7 +410,6 @@ namespace ACE.Database
                                 existingValue.Order = value.Order;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesAnimPart)
                         {
                             if (!biota.BiotaPropertiesAnimPart.Any(p => p.Id == value.Id))
@@ -420,8 +418,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAttribute)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesAttribute.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAttribute.Add(value);
@@ -433,7 +430,6 @@ namespace ACE.Database
                                 existingValue.CPSpent = value.CPSpent;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesAttribute)
                         {
                             if (!biota.BiotaPropertiesAttribute.Any(p => p.Id == value.Id))
@@ -442,8 +438,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesAttribute2nd)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesAttribute2nd.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesAttribute2nd.Add(value);
@@ -456,7 +451,6 @@ namespace ACE.Database
                                 existingValue.CurrentLevel = value.CurrentLevel;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesAttribute2nd)
                         {
                             if (!biota.BiotaPropertiesAttribute2nd.Any(p => p.Id == value.Id))
@@ -465,8 +459,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesBodyPart)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesBodyPart.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesBodyPart.Add(value);
@@ -500,7 +493,6 @@ namespace ACE.Database
                                 existingValue.LRB = value.LRB;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesBodyPart)
                         {
                             if (!biota.BiotaPropertiesBodyPart.Any(p => p.Id == value.Id))
@@ -510,22 +502,22 @@ namespace ACE.Database
                         if (biota.BiotaPropertiesBook != null)
                         {
                             if (existingBiota.BiotaPropertiesBook == null)
-                                existingBiota.BiotaPropertiesBook = new BiotaPropertiesBook();
-
-                            existingBiota.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
-                            existingBiota.BiotaPropertiesBook.MaxNumCharsPerPage =
-                                biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+                                existingBiota.BiotaPropertiesBook = biota.BiotaPropertiesBook;
+                            else
+                            {
+                                existingBiota.BiotaPropertiesBook.MaxNumPages = biota.BiotaPropertiesBook.MaxNumPages;
+                                existingBiota.BiotaPropertiesBook.MaxNumCharsPerPage = biota.BiotaPropertiesBook.MaxNumCharsPerPage;
+                            }
                         }
                         else
                         {
                             if (existingBiota.BiotaPropertiesBook != null)
-                                ; // todo remove the old one
+                                context.BiotaPropertiesBook.Remove(existingBiota.BiotaPropertiesBook);
                         }
 
                         foreach (var value in biota.BiotaPropertiesBookPageData)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesBookPageData.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesBookPageData.Add(value);
@@ -539,7 +531,6 @@ namespace ACE.Database
                                 existingValue.PageText = value.PageText;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesBookPageData)
                         {
                             if (!biota.BiotaPropertiesBookPageData.Any(p => p.Id == value.Id))
@@ -558,7 +549,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesBool)
                         {
                             if (!biota.BiotaPropertiesBool.Any(p => p.Id == value.Id))
@@ -567,8 +557,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesCreateList)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesCreateList.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesCreateList.Add(value);
@@ -582,7 +571,6 @@ namespace ACE.Database
                                 existingValue.TryToBond = value.TryToBond;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesCreateList)
                         {
                             if (!biota.BiotaPropertiesCreateList.Any(p => p.Id == value.Id))
@@ -601,7 +589,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesDID)
                         {
                             if (!biota.BiotaPropertiesDID.Any(p => p.Id == value.Id))
@@ -610,8 +597,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEmote)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesEmote.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEmote.Add(value);
@@ -626,11 +612,64 @@ namespace ACE.Database
                                 existingValue.VendorType = value.VendorType;
                                 existingValue.MinHealth = value.MinHealth;
                                 existingValue.MaxHealth = value.MaxHealth;
+
+                                foreach (var value2 in value.BiotaPropertiesEmoteAction)
+                                {
+                                    var existingValue2 = existingValue.BiotaPropertiesEmoteAction.FirstOrDefault(r => r.Id == value2.Id);
+
+                                    if (existingValue2 == null)
+                                        existingValue.BiotaPropertiesEmoteAction.Add(value2);
+                                    else
+                                    {
+                                        existingValue2.EmoteId = value2.EmoteId;
+                                        existingValue2.Order = value2.Order;
+                                        existingValue2.Type = value2.Type;
+                                        existingValue2.Delay = value2.Delay;
+                                        existingValue2.Extent = value2.Extent;
+                                        existingValue2.Motion = value2.Motion;
+                                        existingValue2.Message = value2.Message;
+                                        existingValue2.TestString = value2.TestString;
+                                        existingValue2.Min = value2.Min;
+                                        existingValue2.Max = value2.Max;
+                                        existingValue2.Min64 = value2.Min64;
+                                        existingValue2.Max64 = value2.Max64;
+                                        existingValue2.MinDbl = value2.MinDbl;
+                                        existingValue2.MaxDbl = value2.MaxDbl;
+                                        existingValue2.Stat = value2.Stat;
+                                        existingValue2.Display = value2.Display;
+                                        existingValue2.Amount = value2.Amount;
+                                        existingValue2.Amount64 = value2.Amount64;
+                                        existingValue2.HeroXP64 = value2.HeroXP64;
+                                        existingValue2.Percent = value2.Percent;
+                                        existingValue2.SpellId = value2.SpellId;
+                                        existingValue2.WealthRating = value2.WealthRating;
+                                        existingValue2.TreasureClass = value2.TreasureClass;
+                                        existingValue2.TreasureType = value2.TreasureType;
+                                        existingValue2.PScript = value2.PScript;
+                                        existingValue2.Sound = value2.Sound;
+                                        existingValue2.DestinationType = value2.DestinationType;
+                                        existingValue2.WeenieClassId = value2.WeenieClassId;
+                                        existingValue2.StackSize = value2.StackSize;
+                                        existingValue2.Palette = value2.Palette;
+                                        existingValue2.Shade = value2.Shade;
+                                        existingValue2.TryToBond = value2.TryToBond;
+                                        existingValue2.ObjCellId = value2.ObjCellId;
+                                        existingValue2.OriginX = value2.OriginX;
+                                        existingValue2.OriginY = value2.OriginY;
+                                        existingValue2.OriginZ = value2.OriginZ;
+                                        existingValue2.AnglesW = value2.AnglesW;
+                                        existingValue2.AnglesX = value2.AnglesX;
+                                        existingValue2.AnglesY = value2.AnglesY;
+                                        existingValue2.AnglesZ = value2.AnglesZ;
+                                    }
+                                }
+                                foreach (var value2 in value.BiotaPropertiesEmoteAction)
+                                {
+                                    if (!existingValue.BiotaPropertiesEmoteAction.Any(p => p.Id == value2.Id))
+                                        context.BiotaPropertiesEmoteAction.Remove(value2);
+                                }
                             }
-
-                            // todo BiotaPropertiesEmoteAction
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesEmote)
                         {
                             if (!biota.BiotaPropertiesEmote.Any(p => p.Id == value.Id))
@@ -639,8 +678,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEnchantmentRegistry)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEnchantmentRegistry.Add(value);
@@ -664,7 +702,6 @@ namespace ACE.Database
                                 existingValue.SpellSetId = value.SpellSetId;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesEnchantmentRegistry)
                         {
                             if (!biota.BiotaPropertiesEnchantmentRegistry.Any(p => p.Id == value.Id))
@@ -673,8 +710,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesEventFilter)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesEventFilter.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesEventFilter.Add(value);
@@ -683,7 +719,6 @@ namespace ACE.Database
                                 existingValue.Event = value.Event;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesEventFilter)
                         {
                             if (!biota.BiotaPropertiesEventFilter.Any(p => p.Id == value.Id))
@@ -692,8 +727,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesFloat)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesFloat.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesFloat.Add(value);
@@ -703,7 +737,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesFloat)
                         {
                             if (!biota.BiotaPropertiesFloat.Any(p => p.Id == value.Id))
@@ -712,8 +745,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesGenerator)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesGenerator.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesGenerator.Add(value);
@@ -739,7 +771,6 @@ namespace ACE.Database
                                 existingValue.AnglesZ = value.AnglesZ;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesGenerator)
                         {
                             if (!biota.BiotaPropertiesGenerator.Any(p => p.Id == value.Id))
@@ -758,7 +789,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesIID)
                         {
                             if (!biota.BiotaPropertiesIID.Any(p => p.Id == value.Id))
@@ -777,7 +807,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesInt)
                         {
                             if (!biota.BiotaPropertiesInt.Any(p => p.Id == value.Id))
@@ -786,8 +815,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesInt64)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesInt64.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesInt64.Add(value);
@@ -797,7 +825,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesInt64)
                         {
                             if (!biota.BiotaPropertiesInt64.Any(p => p.Id == value.Id))
@@ -806,8 +833,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesPalette)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesPalette.Add(value);
@@ -818,7 +844,6 @@ namespace ACE.Database
                                 existingValue.Length = value.Length;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesPalette)
                         {
                             if (!biota.BiotaPropertiesPalette.Any(p => p.Id == value.Id))
@@ -827,8 +852,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesPosition)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesPosition.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesPosition.Add(value);
@@ -845,7 +869,6 @@ namespace ACE.Database
                                 existingValue.AnglesZ = value.AnglesZ;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesPosition)
                         {
                             if (!biota.BiotaPropertiesPosition.Any(p => p.Id == value.Id))
@@ -854,8 +877,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesSkill)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesSkill.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesSkill.Add(value);
@@ -870,7 +892,6 @@ namespace ACE.Database
                                 existingValue.LastUsedTime = value.LastUsedTime;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesSkill)
                         {
                             if (!biota.BiotaPropertiesSkill.Any(p => p.Id == value.Id))
@@ -879,8 +900,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesSpellBook)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesSpellBook.Add(value);
@@ -890,7 +910,6 @@ namespace ACE.Database
                                 existingValue.Probability = value.Probability;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesSpellBook)
                         {
                             if (!biota.BiotaPropertiesSpellBook.Any(p => p.Id == value.Id))
@@ -899,8 +918,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesString)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesString.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesString.Add(value);
@@ -910,7 +928,6 @@ namespace ACE.Database
                                 existingValue.Value = value.Value;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesString)
                         {
                             if (!biota.BiotaPropertiesString.Any(p => p.Id == value.Id))
@@ -919,8 +936,7 @@ namespace ACE.Database
 
                         foreach (var value in biota.BiotaPropertiesTextureMap)
                         {
-                            var existingValue =
-                                existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
+                            var existingValue = existingBiota.BiotaPropertiesTextureMap.FirstOrDefault(r => r.Id == value.Id);
 
                             if (existingValue == null)
                                 existingBiota.BiotaPropertiesTextureMap.Add(value);
@@ -932,7 +948,6 @@ namespace ACE.Database
                                 existingValue.Order = value.Order;
                             }
                         }
-
                         foreach (var value in existingBiota.BiotaPropertiesTextureMap)
                         {
                             if (!biota.BiotaPropertiesTextureMap.Any(p => p.Id == value.Id))
@@ -959,7 +974,7 @@ namespace ACE.Database
             }
         }
 
-        public bool SaveBiotasInParallel(IEnumerable<Biota> biotas)
+        public bool SaveBiotasInParallel(IEnumerable<Biota> biotas) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
         {
             var result = true;
 
@@ -1000,7 +1015,7 @@ namespace ACE.Database
             }
         }
 
-        public bool RemoveBiotasInParallel(IEnumerable<Biota> biotas)
+        public bool RemoveBiotasInParallel(IEnumerable<Biota> biotas) // // todo make Biotas an IEnumerable<Tuple<Biota, ReadWriterLockSlim>>
         {
             var result = true;
 
@@ -1106,7 +1121,7 @@ namespace ACE.Database
                     {
                         inventory.Add(biota);
 
-                        if (includedNestedItems && biota.WeenieType == (int) WeenieType.Container)
+                        if (includedNestedItems && biota.WeenieType == (int)WeenieType.Container)
                         {
                             var subItems = GetInventoryInParallel(biota.Id, false);
 

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Numerics;
 using System.Text;
+using System.Threading;
 
 using log4net;
 
@@ -1452,9 +1453,9 @@ namespace ACE.Server.Command.Handlers
             }
 
             var possessions = player.GetAllPossessions();
-            var possessedBiotas = new Collection<Biota>();
+            var possessedBiotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
             foreach (var possession in possessions)
-                possessedBiotas.Add(possession.Biota);
+                possessedBiotas.Add((possession.Biota, possession.BiotaDatabaseLock));
 
             DatabaseManager.Shard.AddCharacter(player.Biota, possessedBiotas, player.Character, null);
 

--- a/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Command.Handlers
 {
     public static class DeveloperDatabaseCommands
     {
-        [CommandHandler("databasequeueinfo", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Show database queue information.")]
+        [CommandHandler("databasequeueinfo", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Show database queue information.")]
         public static void HandleDatabaseQueueInfo(Session session, params string[] parameters)
         {
             ChatPacket.SendServerMessage(session, $"Current database queue count: {DatabaseManager.Shard.QueueCount}", ChatMessageType.System);
@@ -19,7 +19,7 @@ namespace ACE.Server.Command.Handlers
             });
         }
 
-        [CommandHandler("databaseperftest", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Test server/database performance.", "biotasPerTest\n" + "optional parameter biotasPerTest if omitted 1000")]
+        [CommandHandler("databaseperftest", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Test server/database performance.", "biotasPerTest\n" + "optional parameter biotasPerTest if omitted 1000")]
         public static void HandleDatabasePerfTest(Session session, params string[] parameters)
         {
             int biotasPerTest = DatabasePerfTest.DefaultBiotasTestCount;

--- a/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
@@ -1,4 +1,5 @@
 
+using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Server.Command.Handlers.Processors;
 using ACE.Server.Network;
@@ -7,6 +8,17 @@ namespace ACE.Server.Command.Handlers
 {
     public static class DeveloperDatabaseCommands
     {
+        [CommandHandler("databasequeueinfo", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Show database queue information.")]
+        public static void HandleDatabaseQueueInfo(Session session, params string[] parameters)
+        {
+            ChatPacket.SendServerMessage(session, $"Current database queue count: {DatabaseManager.Shard.QueueCount}", ChatMessageType.System);
+
+            DatabaseManager.Shard.GetCurrentQueueWaitTime(result =>
+            {
+                ChatPacket.SendServerMessage(session, $"Current database queue wait time: {result.TotalMilliseconds:N0} ms", ChatMessageType.System);
+            });
+        }
+
         [CommandHandler("databaseperftest", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Test server/database performance.", "biotasPerTest\n" + "optional parameter biotasPerTest if omitted 1000")]
         public static void HandleDatabasePerfTest(Session session, params string[] parameters)
         {

--- a/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
+++ b/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
@@ -40,6 +40,8 @@ namespace ACE.Server.Command.Handlers.Processors
         {
             ChatPacket.SendServerMessage(session, $"Starting Database Performance Tests.\nBiotas per test: {biotasPerTest}\nThis may take several minutes to complete...", ChatMessageType.System);
 
+            var rwLock = new ReaderWriterLockSlim();
+
 
             // Generate Individual WorldObjects
             var biotas = new Collection<Biota>();
@@ -58,7 +60,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
             foreach (var biota in biotas)
             {
-                DatabaseManager.Shard.SaveBiota(biota, result =>
+                DatabaseManager.Shard.SaveBiota(biota, rwLock, result =>
                 {
                     if (result)
                         Interlocked.Increment(ref trueResults);
@@ -85,7 +87,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
                 foreach (var biota in biotas)
                 {
-                    DatabaseManager.Shard.SaveBiota(biota, result =>
+                    DatabaseManager.Shard.SaveBiota(biota, rwLock, result =>
                     {
                         if (result)
                             Interlocked.Increment(ref trueResults);
@@ -110,7 +112,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
             foreach (var biota in biotas)
             {
-                DatabaseManager.Shard.RemoveBiota(biota, result =>
+                DatabaseManager.Shard.RemoveBiota(biota, rwLock, result =>
                 {
                     if (result)
                         Interlocked.Increment(ref trueResults);

--- a/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
+++ b/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
@@ -58,7 +58,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
             foreach (var biota in biotas)
             {
-                DatabaseManager.Shard.AddBiota(biota, result =>
+                DatabaseManager.Shard.SaveBiota(biota, result =>
                 {
                     if (result)
                         Interlocked.Increment(ref trueResults);
@@ -144,7 +144,7 @@ namespace ACE.Server.Command.Handlers.Processors
             falseResults = 0;
             startTime = DateTime.UtcNow;
 
-            DatabaseManager.Shard.AddBiotas(biotas, result =>
+            DatabaseManager.Shard.SaveBiotas(biotas, result =>
             {
                 if (result)
                     Interlocked.Increment(ref trueResults);
@@ -238,7 +238,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
 
                 // Remove the last record
-                /*if (biota.BiotaPropertiesInt.Count > 0)
+                if (biota.BiotaPropertiesInt.Count > 0)
                     biota.BiotaPropertiesInt.Remove(biota.BiotaPropertiesInt.Last());
 
                 if (biota.BiotaPropertiesInt64.Count > 0)
@@ -261,19 +261,19 @@ namespace ACE.Server.Command.Handlers.Processors
 
 
                 // Add a new record
-                biota.BiotaPropertiesInt.Add(new BiotaPropertiesInt { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesInt.Add(new BiotaPropertiesInt { ObjectId = biota.Id, Type = ushort.MaxValue, Value = 0, Object = biota });
 
-                biota.BiotaPropertiesInt64.Add(new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesInt64.Add(new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = ushort.MaxValue, Value = 0, Object = biota });
 
-                biota.BiotaPropertiesIID.Add(new BiotaPropertiesIID { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesIID.Add(new BiotaPropertiesIID { ObjectId = biota.Id, Type = ushort.MaxValue, Value = 0, Object = biota });
 
-                biota.BiotaPropertiesDID.Add(new BiotaPropertiesDID { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesDID.Add(new BiotaPropertiesDID { ObjectId = biota.Id, Type = ushort.MaxValue, Value = 0, Object = biota });
 
-                biota.BiotaPropertiesFloat.Add(new BiotaPropertiesFloat { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesFloat.Add(new BiotaPropertiesFloat { ObjectId = biota.Id, Type = ushort.MaxValue, Value = 0, Object = biota });
 
-                biota.BiotaPropertiesBool.Add(new BiotaPropertiesBool { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });
+                biota.BiotaPropertiesBool.Add(new BiotaPropertiesBool { ObjectId = biota.Id, Type = ushort.MaxValue, Value = false, Object = biota });
 
-                biota.BiotaPropertiesString.Add(new BiotaPropertiesString { ObjectId = biota.Id, Type = ushort.MaxValue, Object = biota });*/
+                biota.BiotaPropertiesString.Add(new BiotaPropertiesString { ObjectId = biota.Id, Type = ushort.MaxValue, Value = "", Object = biota });
             }
         }
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
-using System.Threading.Tasks;
 
 using ACE.Database;
 using ACE.Database.Models.Shard;
@@ -951,8 +951,14 @@ namespace ACE.Server.Entity
 
         public void SaveDB()
         {
-            // only updates corpses atm
-            var biotas = worldObjects.Values.Where(wo => wo is Corpse && (wo as Corpse).IsMonster == false).Select(wo => wo.Biota).ToList();
+            var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
+
+            foreach (var wo in worldObjects.Values)
+            {
+                // only updates corpses atm
+                if (wo is Corpse corpse && !corpse.IsMonster)
+                    biotas.Add((corpse.Biota, corpse.BiotaDatabaseLock));
+            }
 
             DatabaseManager.Shard.SaveBiotas(biotas, result => { });
         }

--- a/Source/ACE.Server/Managers/EmoteManagerExample.cs
+++ b/Source/ACE.Server/Managers/EmoteManagerExample.cs
@@ -1,5 +1,6 @@
 using System;
-using ACE.Database.Models.Shard;
+using System.Linq;
+
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -702,7 +703,7 @@ namespace ACE.Server.Managers
 
         public void InqCategory(EmoteCategory categoryId, Emote emote)
         {
-            var category = WorldObject.Biota.GetEmotes((uint)categoryId);
+            var category = WorldObject.Biota.BiotaPropertiesEmote.Where(x => x.Category == (uint)categoryId);
             if (category == null) return;
             foreach (var entry in category)
             {
@@ -741,7 +742,7 @@ namespace ACE.Server.Managers
 
         public void InqPropertyInner(Emote emote, bool inRange)
         {
-            var category = WorldObject.Biota.GetEmotes(inRange ? (uint)EmoteCategory.TestSuccess : (uint)EmoteCategory.TestFailure);
+            var category = WorldObject.Biota.BiotaPropertiesEmote.Where(x => x.Category == (inRange ? (uint)EmoteCategory.TestSuccess : (uint)EmoteCategory.TestFailure));
             if (category == null) return;
             foreach (var entry in category)
             {

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 
 using log4net;
 
@@ -384,9 +385,9 @@ namespace ACE.Server.Network.Handlers
                 player.Sanctuary = player.Location;
 
                 var possessions = player.GetAllPossessions();
-                var possessedBiotas = new Collection<Biota>();
+                var possessedBiotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
                 foreach (var possession in possessions)
-                    possessedBiotas.Add(possession.Biota);
+                    possessedBiotas.Add((possession.Biota, possession.BiotaDatabaseLock));
 
                 // We must await here -- 
                 DatabaseManager.Shard.AddCharacter(player.Biota, possessedBiotas, player.Character, saveSuccess =>

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -261,6 +261,7 @@ namespace ACE.Server.Network
         {
             playerWaitLock.EnterWriteLock();
             Player = player;
+            lastAutoSaveTime = DateTime.UtcNow;
             // NOTE(ddevec): Once again -- no reader-writer lock and Monitor support in c# -- ventring frustration now --  asa;gklkfj;kl
             //  -- This should be a rare operation, so we don't really care about the stupid double locking, as long as its done right for no deadlocks
             lock (playerSync)

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -28,10 +28,6 @@ namespace ACE.Server.WorldObjects
         public Container(Weenie weenie, ObjectGuid guid) : base(weenie, guid)
         {
             SetEphemeralValues();
-
-            // A player has their possessions passed via the ctor. All other world objects must load their own inventory
-            if (!(this is Player) && !(new ObjectGuid(ContainerId ?? 0).IsPlayer()))
-                DatabaseManager.Shard.GetInventory(guid.Full, false, SortBiotasIntoInventory);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -112,7 +112,7 @@ namespace ACE.Server.WorldObjects
                 // http://asheron.wikia.com/wiki/Item_Decay
 
                 if (!IsMonster)
-                    DatabaseManager.Shard.RemoveBiota(Biota, result => { });
+                    DatabaseManager.Shard.RemoveBiota(Biota, BiotaDatabaseLock, result => { });
 
                 Destroy();
                 return;

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -22,12 +24,12 @@ namespace ACE.Server.WorldObjects.Entity
             this.creature = creature;
             Attribute = attribute;
 
-            biotaPropertiesAttribute = creature.Biota.GetAttribute(Attribute);
+            biotaPropertiesAttribute = creature.Biota.BiotaPropertiesAttribute.FirstOrDefault(x => x.Type == (uint)Attribute);
 
             if (biotaPropertiesAttribute == null)
             {
-                creature.Biota.BiotaPropertiesAttribute.Add(new BiotaPropertiesAttribute {ObjectId = creature.Biota.Id, Type = (ushort)Attribute });
-                biotaPropertiesAttribute = creature.Biota.GetAttribute(Attribute);
+                biotaPropertiesAttribute = new BiotaPropertiesAttribute { ObjectId = creature.Biota.Id, Type = (ushort)Attribute };
+                creature.Biota.BiotaPropertiesAttribute.Add(biotaPropertiesAttribute);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
@@ -18,7 +19,7 @@ namespace ACE.Server.WorldObjects.Entity
             this.creature = creature;
             Skill = skill;
 
-            biotaPropertiesSkill = creature.Biota.GetProperty(skill);
+            biotaPropertiesSkill = creature.Biota.BiotaPropertiesSkill.FirstOrDefault(x => x.Type == (uint)skill);
         }
 
         public SkillAdvancementClass AdvancementClass

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
@@ -24,12 +25,12 @@ namespace ACE.Server.WorldObjects.Entity
             this.creature = creature;
             Vital = vital;
 
-            biotaPropertiesAttribute2nd = creature.Biota.GetAttribute2nd(Vital);
+            biotaPropertiesAttribute2nd = creature.Biota.BiotaPropertiesAttribute2nd.FirstOrDefault(x => x.Type == (uint)Vital);
 
             if (biotaPropertiesAttribute2nd == null)
             {
-                creature.Biota.BiotaPropertiesAttribute2nd.Add(new BiotaPropertiesAttribute2nd { ObjectId = creature.Biota.Id, Type = (ushort)Vital });
-                biotaPropertiesAttribute2nd = creature.Biota.GetAttribute2nd(Vital);
+                biotaPropertiesAttribute2nd = new BiotaPropertiesAttribute2nd { ObjectId = creature.Biota.Id, Type = (ushort)Vital };
+                creature.Biota.BiotaPropertiesAttribute2nd.Add(biotaPropertiesAttribute2nd);
             }
 
             switch (Vital)

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -526,7 +526,7 @@ namespace ACE.Server.WorldObjects
             }
 
             // remove friend in DB
-            if (Character.TryRemoveFriend(friendId, out var entity) && ExistsInDatabase && entity.Id != 0)
+            if (Character.TryRemoveFriend(friendId, out var entity) && entity.Id != 0)
                 DatabaseManager.Shard.RemoveEntity(entity, null);
 
             // send network message

--- a/Source/ACE.Server/WorldObjects/Player_Client.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Client.cs
@@ -116,7 +116,7 @@ namespace ACE.Server.WorldObjects
             {
                 Character.CharacterPropertiesShortcutBar.Remove(entity);
 
-                if (ExistsInDatabase && entity.Id != 0)
+                if (entity.Id != 0)
                     DatabaseManager.Shard.RemoveEntity(entity, null);
             }
         }

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.ObjectModel;
+using System.Threading;
 
 using ACE.Database;
+using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameMessages.Messages;
@@ -34,33 +37,52 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// This will set the LastRequestedDatabaseSave to UtcNow and ChangesDetected to false.<para />
+        /// If enqueueSave is set to true, DatabaseManager.Shard.SaveBiota() will be called for the biota.<para />
+        /// Set enqueueSave to false if you want to perform all the normal routines for a save but not the actual save. This is useful if you're going to collect biotas in bulk for bulk saving.
+        /// </summary>
+        public override void SaveBiotaToDatabase(bool enqueueSave = true)
+        {
+            // Save the current position to persistent storage, only during the server update interval
+            SetPhysicalCharacterPosition();
+
+            base.SaveBiotaToDatabase(enqueueSave);
+        }
+
+        /// <summary>
         /// Internal save character functionality<para  />
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.<para />
         /// Will also save any possessions that are marked with ChangesDetected.
         /// </summary>
         private void SavePlayer(bool showMsg = true)
         {
-            LastRequestedDatabaseSave = DateTime.UtcNow;
+            DatabaseManager.Shard.SaveCharacter(Character, null);
 
-            // Save the current position to persistent storage, only during the server update interval
-            SetPhysicalCharacterPosition();
+            var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
 
-            SaveBiotaToDatabase();
+            SaveBiotaToDatabase(false);
+            biotas.Add((Biota, BiotaDatabaseLock));
 
             var allPosessions = GetAllPossessions();
 
             foreach (var possession in allPosessions)
             {
                 if (possession.ChangesDetected)
-                    possession.SaveBiotaToDatabase();
+                {
+                    possession.SaveBiotaToDatabase(false);
+                    biotas.Add((possession.Biota, possession.BiotaDatabaseLock));
+                }
             }
 
-            DatabaseManager.Shard.SaveCharacter(Character, null);
+            var requestedTime = DateTime.UtcNow;
 
-            #if DEBUG
-            if (Session.Player != null && showMsg)
-                Session.Network.EnqueueSend(new GameMessageSystemChat($"{Session.Player.Name} has been saved.", ChatMessageType.Broadcast));
-            #endif
+            DatabaseManager.Shard.SaveBiotas(biotas, result =>
+            {
+                #if DEBUG
+                if (Session.Player != null && showMsg)
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request.", ChatMessageType.Broadcast));
+                #endif
+            });
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -88,9 +88,7 @@ namespace ACE.Server.WorldObjects
 
                 Biota.BiotaPropertiesSpellBook.Remove(entity);
                 entity.Object = null;
-
-                if (ExistsInDatabase && entity.Id != 0)
-                    DatabaseManager.Shard.RemoveEntity(entity, null);
+                ChangesDetected = true;
 
                 GameEventMagicRemoveSpellId removeSpellEvent = new GameEventMagicRemoveSpellId(Session, spellId);
                 Session.Network.EnqueueSend(removeSpellEvent);
@@ -163,7 +161,7 @@ namespace ACE.Server.WorldObjects
 
                 Character.CharacterPropertiesSpellBar.Remove(entity);
 
-                if (ExistsInDatabase && entity.Id != 0)
+                if (entity.Id != 0)
                     DatabaseManager.Shard.RemoveEntity(entity, null);
             }
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -92,9 +92,6 @@ namespace ACE.Server.WorldObjects
         {
             Biota = biota;
 
-            ExistsInDatabase = true;
-            LastRequestedDatabaseSave = DateTime.UtcNow;
-
             SetEphemeralValues();
         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -14,20 +14,32 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool ChangesDetected { get; protected set; }
 
-        public void SaveBiotaToDatabase()
+        /// <summary>
+        /// This will set the LastRequestedDatabaseSave to UtcNow and ChangesDetected to false.<para />
+        /// If enqueueSave is set to true, DatabaseManager.Shard.SaveBiota() will be called for the biota.<para />
+        /// Set enqueueSave to false if you want to perform all the normal routines for a save but not the actual save. This is useful if you're going to collect biotas in bulk for bulk saving.
+        /// </summary>
+        public virtual void SaveBiotaToDatabase(bool enqueueSave = true)
         {
             LastRequestedDatabaseSave = DateTime.UtcNow;
             ChangesDetected = false;
 
-            DatabaseManager.Shard.SaveBiota(Biota, BiotaDatabaseLock, null);
+            if (enqueueSave)
+                DatabaseManager.Shard.SaveBiota(Biota, BiotaDatabaseLock, null);
         }
 
-        public void RemoveBiotaFromDatabase()
+        /// <summary>
+        /// This will set the LastRequestedDatabaseSave to MinValue and ChangesDetected to true.<para />
+        /// If enqueueRemove is set to true, DatabaseManager.Shard.RemoveBiota() will be called for the biota.<para />
+        /// Set enqueueRemove to false if you want to perform all the normal routines for a remove but not the actual removal. This is useful if you're going to collect biotas in bulk for bulk removing.
+        /// </summary>
+        public void RemoveBiotaFromDatabase(bool enqueueRemove = true)
         {
             LastRequestedDatabaseSave = DateTime.MinValue;
             ChangesDetected = true;
 
-            DatabaseManager.Shard.RemoveBiota(Biota, BiotaDatabaseLock, null);
+            if (enqueueRemove)
+                DatabaseManager.Shard.RemoveBiota(Biota, BiotaDatabaseLock, null);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -24,7 +24,7 @@ namespace ACE.Server.WorldObjects
             // That way no database operations are lost between the time we tried to save and the time we actually saved.
             ExistsInDatabase = true;
 
-            DatabaseManager.Shard.AddBiota(Biota, result =>
+            DatabaseManager.Shard.SaveBiota(Biota, result =>
             {
                 if (result)
                     ChangesDetected = false;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -6,62 +6,28 @@ namespace ACE.Server.WorldObjects
 {
     partial class WorldObject
     {
-        protected bool ExistsInDatabase { get; private set; }
-
         public DateTime LastRequestedDatabaseSave { get; protected set; }
 
         /// <summary>
-        /// This variable is set to true when a change is made, and set to false after a save completed.<para />
-        /// If you are removing an entity from a local property collection, and the database, you do not need to set this to true.<para />
-        /// The primary use for this is to trigger save on add/modify of properties.
+        /// This variable is set to true when a change is made, and set to false before a save is requested.<para />
+        /// The primary use for this is to trigger save on add/modify/remove of properties.
         /// </summary>
         public bool ChangesDetected { get; protected set; }
-
-        private void AddBiotaToDatabase()
-        {
-            // We assume the add will be successful
-            // By setting this first, it allows other threads to queue up entity remove operations after this save operation completes
-            // That way no database operations are lost between the time we tried to save and the time we actually saved.
-            ExistsInDatabase = true;
-
-            DatabaseManager.Shard.SaveBiota(Biota, result =>
-            {
-                if (result)
-                    ChangesDetected = false;
-                else
-                    // Uh oh, something went wrong...
-                    ExistsInDatabase = false;
-            });
-        }
 
         public void SaveBiotaToDatabase()
         {
             LastRequestedDatabaseSave = DateTime.UtcNow;
+            ChangesDetected = false;
 
-            if (!ExistsInDatabase)
-            {
-                AddBiotaToDatabase();
-                return;
-            }
-
-            DatabaseManager.Shard.SaveBiota(Biota, result =>
-            {
-                if (result)
-                    ChangesDetected = false;
-                else
-                    // Uh oh, something went wrong...
-                    ExistsInDatabase = false;
-            });
+            DatabaseManager.Shard.SaveBiota(Biota, BiotaDatabaseLock, null);
         }
 
         public void RemoveBiotaFromDatabase()
         {
-            if (ExistsInDatabase && Biota.Id != 0)
-            {
-                ExistsInDatabase = false;
-                LastRequestedDatabaseSave = DateTime.MinValue;
-                DatabaseManager.Shard.RemoveBiota(Biota, null);
-            }
+            LastRequestedDatabaseSave = DateTime.MinValue;
+            ChangesDetected = true;
+
+            DatabaseManager.Shard.RemoveBiota(Biota, BiotaDatabaseLock, null);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -477,8 +477,8 @@ namespace ACE.Server.WorldObjects
                     GeneratorQueue.Clear();
                     GeneratorProfilesActive.Clear();
 
-                    InitGeneratedObjects = Biota.GetProperty(PropertyInt.InitGeneratedObjects, biotaPropertiesIntLock);
-                    MaxGeneratedObjects = Biota.GetProperty(PropertyInt.MaxGeneratedObjects, biotaPropertiesIntLock);
+                    InitGeneratedObjects = GetProperty(PropertyInt.InitGeneratedObjects);
+                    MaxGeneratedObjects = GetProperty(PropertyInt.MaxGeneratedObjects);
                 }
                 else
                 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -44,7 +44,7 @@ namespace ACE.Server.WorldObjects
         /// The critical thing is that the collections are not added to or removed from while Entity Framework is iterating over them.<para />
         /// Mag-nus 2018-08-19
         /// </summary>
-        protected readonly ReaderWriterLockSlim BiotaDatabaseLock = new ReaderWriterLockSlim();
+        public readonly ReaderWriterLockSlim BiotaDatabaseLock = new ReaderWriterLockSlim();
 
         #region GetProperty Functions
         public bool? GetProperty(PropertyBool property) { if (EphemeralPropertyBools.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -37,7 +37,9 @@ namespace ACE.Server.WorldObjects
         /// However, it's only a requirement to do this for properties/collections that will be modified after the initial biota has been created.<para />
         /// There are several properties/collections of the biota that are simply duplicates of the original weenie and are never changed. You wouldn't need to use this lock to read those collections.<para />
         /// <para />
-        /// For absolute maximum performance, if you're willing to assume (and risk) that a biota in the database will not be modified outside of ACE while ACE is running with a reference to that biota,<para />
+        /// For absolute maximum performance, if you're willing to assume (and risk) the following:<para />
+        ///  - that the biota in the database will not be modified (in a way that adds or removes properties) outside of ACE while ACE is running with a reference to that biota<para />
+        ///  - that the biota will only be read/modified by a single thread in ACE<para />
         /// You can remove the lock usage for any Get/GetAll Property functions. You would simply use it for Set/Remove Property functions because each of these could end up adding/removing to the collections.<para />
         /// The critical thing is that the collections are not added to or removed from while Entity Framework is iterating over them.<para />
         /// Mag-nus 2018-08-19

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -32,26 +32,21 @@ namespace ACE.Server.WorldObjects
         public Dictionary<PropertyInt64, long?> EphemeralPropertyInt64s = new Dictionary<PropertyInt64, long?>();
         public Dictionary<PropertyString, string> EphemeralPropertyStrings = new Dictionary<PropertyString, string>();
 
-        #region Property Locks
-        private readonly ReaderWriterLockSlim biotaPropertiesBoolLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesDIDLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesEnchantmentLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesFloatLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesIIDLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesIntLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesInt64Lock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesPositionLock = new ReaderWriterLockSlim();
-        private readonly ReaderWriterLockSlim biotaPropertiesStringLock = new ReaderWriterLockSlim();
-        #endregion
+        /// <summary>
+        /// Best practice says you should use this lock any time you read/write the Biota.<para />
+        /// However, it's only a requirement to do this for properties/collections that will be modified after the initial biota has been created.<para />
+        /// There are several properties/collections of the biota that are simply duplicates of the original weenie and are never changed. You wouldn't need to use this lock to read those collections.
+        /// </summary>
+        protected readonly ReaderWriterLockSlim BiotaDatabaseLock = new ReaderWriterLockSlim();
 
         #region GetProperty Functions
-        public bool? GetProperty(PropertyBool property) { if (EphemeralPropertyBools.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesBoolLock); }
-        public uint? GetProperty(PropertyDataId property) { if (EphemeralPropertyDataIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesDIDLock); }
-        public double? GetProperty(PropertyFloat property) { if (EphemeralPropertyFloats.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesFloatLock); }
-        public uint? GetProperty(PropertyInstanceId property) { if (EphemeralPropertyInstanceIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesIIDLock); }
-        public int? GetProperty(PropertyInt property) { if (EphemeralPropertyInts.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesIntLock); }
-        public long? GetProperty(PropertyInt64 property) { if (EphemeralPropertyInt64s.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesInt64Lock); }
-        public string GetProperty(PropertyString property) { if (EphemeralPropertyStrings.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, biotaPropertiesStringLock); }
+        public bool? GetProperty(PropertyBool property) { if (EphemeralPropertyBools.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public uint? GetProperty(PropertyDataId property) { if (EphemeralPropertyDataIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public double? GetProperty(PropertyFloat property) { if (EphemeralPropertyFloats.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public uint? GetProperty(PropertyInstanceId property) { if (EphemeralPropertyInstanceIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public int? GetProperty(PropertyInt property) { if (EphemeralPropertyInts.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public long? GetProperty(PropertyInt64 property) { if (EphemeralPropertyInt64s.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public string GetProperty(PropertyString property) { if (EphemeralPropertyStrings.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
         #endregion
 
         #region SetProperty Functions
@@ -61,7 +56,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyBools[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesBoolLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -71,7 +66,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyDataIds[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesDIDLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -81,7 +76,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyFloats[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesFloatLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -91,7 +86,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyInstanceIds[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesIIDLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -101,7 +96,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyInts[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesIntLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -111,7 +106,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyInt64s[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesInt64Lock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -121,7 +116,7 @@ namespace ACE.Server.WorldObjects
                 EphemeralPropertyStrings[property] = value;
             else
             {
-                Biota.SetProperty(property, value, biotaPropertiesStringLock);
+                Biota.SetProperty(property, value, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -132,50 +127,50 @@ namespace ACE.Server.WorldObjects
         {
             if (EphemeralPropertyBools.ContainsKey(property))
                 EphemeralPropertyBools[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesBoolLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyDataId property)
         {
             if (EphemeralPropertyDataIds.ContainsKey(property))
                 EphemeralPropertyDataIds[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesDIDLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyFloat property)
         {
             if (EphemeralPropertyFloats.ContainsKey(property))
                 EphemeralPropertyFloats[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesFloatLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyInstanceId property)
         {
             if (EphemeralPropertyInstanceIds.ContainsKey(property))
                 EphemeralPropertyInstanceIds[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesIIDLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyInt property)
         {
             if (EphemeralPropertyInts.ContainsKey(property))
                 EphemeralPropertyInts[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesIntLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyInt64 property)
         {
             if (EphemeralPropertyInt64s.ContainsKey(property))
                 EphemeralPropertyInt64s[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesInt64Lock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         public void RemoveProperty(PropertyString property)
         {
             if (EphemeralPropertyStrings.ContainsKey(property))
                 EphemeralPropertyStrings[property] = null;
-            else if (Biota.TryRemoveProperty(property, out var entity, biotaPropertiesStringLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
         #endregion
 
@@ -184,8 +179,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyBool, bool>();
 
-            foreach (var property in Biota.BiotaPropertiesBool)
-                results[(PropertyBool)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesBool)
+                    results[(PropertyBool)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyBools)
                 if (property.Value.HasValue)
@@ -198,8 +201,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyDataId, uint>();
 
-            foreach (var property in Biota.BiotaPropertiesDID)
-                results[(PropertyDataId)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesDID)
+                    results[(PropertyDataId)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyDataIds)
                 if (property.Value.HasValue)
@@ -212,8 +223,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyFloat, double>();
 
-            foreach (var property in Biota.BiotaPropertiesFloat)
-                results[(PropertyFloat)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesFloat)
+                    results[(PropertyFloat)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyFloats)
                 if (property.Value.HasValue)
@@ -226,8 +245,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyInstanceId, uint>();
 
-            foreach (var property in Biota.BiotaPropertiesIID)
-                results[(PropertyInstanceId)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesIID)
+                    results[(PropertyInstanceId)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyInstanceIds)
                 if (property.Value.HasValue)
@@ -240,8 +267,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyInt, int>();
 
-            foreach (var property in Biota.BiotaPropertiesInt)
-                results[(PropertyInt)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesInt)
+                    results[(PropertyInt)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyInts)
                 if (property.Value.HasValue)
@@ -254,8 +289,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyInt64, long>();
 
-            foreach (var property in Biota.BiotaPropertiesInt64)
-                results[(PropertyInt64)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesInt64)
+                    results[(PropertyInt64)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyInt64s)
                 if (property.Value.HasValue)
@@ -268,8 +311,16 @@ namespace ACE.Server.WorldObjects
         {
             var results = new Dictionary<PropertyString, string>();
 
-            foreach (var property in Biota.BiotaPropertiesString)
-                results[(PropertyString)property.Type] = property.Value;
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                foreach (var property in Biota.BiotaPropertiesString)
+                    results[(PropertyString)property.Type] = property.Value;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
 
             foreach (var property in EphemeralPropertyStrings)
                 if (property.Value != null)
@@ -294,7 +345,7 @@ namespace ACE.Server.WorldObjects
 
             if (!success)
             {
-                var result = Biota.GetPosition(positionType, biotaPropertiesPositionLock);
+                var result = Biota.GetPosition(positionType, BiotaDatabaseLock);
 
                 if (result != null)
                     Positions.TryAdd(positionType, result);
@@ -320,7 +371,7 @@ namespace ACE.Server.WorldObjects
                 else
                     Positions[positionType] = position;
 
-                Biota.SetPosition(positionType, position, biotaPropertiesPositionLock);
+                Biota.SetPosition(positionType, position, BiotaDatabaseLock);
                 ChangesDetected = true;
             }
         }
@@ -329,15 +380,15 @@ namespace ACE.Server.WorldObjects
         {
             Positions.Remove(positionType);
 
-            if (Biota.TryRemovePosition(positionType, out var entity, biotaPropertiesPositionLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            if (Biota.TryRemovePosition(positionType, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
 
 
         public void RemoveEnchantment(int spellId)
         {
-            if (Biota.TryRemoveEnchantment(spellId, out var entity, biotaPropertiesEnchantmentLock) && ExistsInDatabase && entity.Id != 0)
-                DatabaseManager.Shard.RemoveEntity(entity, null);
+            if (Biota.TryRemoveEnchantment(spellId, out _, BiotaDatabaseLock))
+                ChangesDetected = true;
         }
 
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -35,7 +35,12 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Best practice says you should use this lock any time you read/write the Biota.<para />
         /// However, it's only a requirement to do this for properties/collections that will be modified after the initial biota has been created.<para />
-        /// There are several properties/collections of the biota that are simply duplicates of the original weenie and are never changed. You wouldn't need to use this lock to read those collections.
+        /// There are several properties/collections of the biota that are simply duplicates of the original weenie and are never changed. You wouldn't need to use this lock to read those collections.<para />
+        /// <para />
+        /// For absolute maximum performance, if you're willing to assume (and risk) that a biota in the database will not be modified outside of ACE while ACE is running with a reference to that biota,<para />
+        /// You can remove the lock usage for any Get/GetAll Property functions. You would simply use it for Set/Remove Property functions because each of these could end up adding/removing to the collections.<para />
+        /// The critical thing is that the collections are not added to or removed from while Entity Framework is iterating over them.<para />
+        /// Mag-nus 2018-08-19
         /// </summary>
         protected readonly ReaderWriterLockSlim BiotaDatabaseLock = new ReaderWriterLockSlim();
 


### PR DESCRIPTION
This is a major change on how Biotas are added/saved to shard.

The AddBiota function is no more. Now, to add or save a biota, the same function is used, SaveBiota.

SaveBiota will pull (in full) the existing biota (if it exists) from the database. It will do a full diff between the new biota to save and the existing biota. It will copy over any differences, add any new rows, and delete from the database any rows that have been removed.

In addition, a ReadWriterLockSlim is passed to the Save/Remove functions in the database. This is necessary to prevent collection modification from the server while Entity Framework is processing the object.

There are still some bugs I need to fix.
BiotaPropertiesEnchantmentRegistry needs to be accessed through this new model for thread safety.
Character also needs to be converted to this new model for thread safety
_Save/Remove InParallel functions need to have ReadWriterLockSlims passed for each biota._ -Completed

The new model offers thread safety, and is much more performant.
The existing model would submit a database request every time a new record was removed from any biota collection. This was required because our biota is detached from the context. On an active server, this would hammer the database.

The new model offers a true X minute save for a biota where only the changed properties are submitted to the database via an sql statement.

This could use playtesting.