### PR TITLE
Add alwaysshowwelcome config property

### DIFF
--- a/Database/Updates/Shard/AddAlwaysShowWelcomeProperty.sql
+++ b/Database/Updates/Shard/AddAlwaysShowWelcomeProperty.sql
@@ -1,0 +1,8 @@
+/*
+SQLyog Community v13.0.0 (64 bit)
+MySQL - 10.2.6-MariaDB 
+*********************************************************************
+*/
+/*!40101 SET NAMES utf8 */;
+
+insert into `config_properties_boolean` (`key`, `value`, `description`) values('alwaysshowwelcome',0,'Determines whether or not the Welcome message is shown at each logon');

--- a/Database/Updates/Shard/updates.txt
+++ b/Database/Updates/Shard/updates.txt
@@ -1,3 +1,7 @@
+08/19/2018
+---------
+ - Added `alwaysshowwelcome` key to `config_properties_boolean` table
+
 08/10/2018
 ---------
 - Added `populated_collection_flags` to `biota` table.

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -72,7 +72,7 @@ namespace ACE.Server.Managers
 
                 string msg = "To begin your training, speak to the Society Greeter. Walk up to the Society Greeter using the 'W' key, then double-click on her to initiate a conversation.";
 
-                if (player.TotalLogins <= 1)
+                if ((player.TotalLogins <= 1) || ((bool)PropertyManager.GetBool("alwaysshowwelcome").Item == true))
                     session.Network.EnqueueSend(new GameEventPopupString(session, $"{welcomeHeader}\n{msg}"));
 
                 var location = player.GetPosition(PositionType.Location);

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # ACEmulator Change Log
+### 2018-08-19
+[mcreedjr]
+* Added alwaysshowwelcome Boolean config property
+
 ### 2018-08-12
 [OptimShi]
 * Added handling of Bool.NpcLooksLikeObject to the AppraiseInfo event.


### PR DESCRIPTION
I'd like to propose the addition of this property. On the test server I've spun up, I'm communicating server build information in the Welcome message, and I'd like the ability to force the Welcome message to be shown at each logon, and not just the first logon. The option will default to off.