### PR TITLE
EnchantmentRegistry improvements

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -36,19 +36,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static IList<BiotaPropertiesEnchantmentRegistry> GetEnchantments(this Biota biota, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterReadLock();
-            try
-            {
-                return biota.BiotaPropertiesEnchantmentRegistry.ToList();
-            }
-            finally
-            {
-                rwLock.ExitReadLock();
-            }
-        }
-
         public static double? GetProperty(this Biota biota, PropertyFloat property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();
@@ -195,19 +182,6 @@ namespace ACE.Database.Models.Shard
             finally
             {
                 rwLock.ExitUpgradeableReadLock();
-            }
-        }
-
-        public static void AddEnchantment(this Biota biota, BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterWriteLock();
-            try
-            {
-                biota.BiotaPropertiesEnchantmentRegistry.Add(entity);
-            }
-            finally
-            {
-                rwLock.ExitWriteLock();
             }
         }
 
@@ -468,34 +442,6 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static bool TryRemoveEnchantment(this Biota biota, int spellId, out BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterUpgradeableReadLock();
-            try
-            {
-                entity = biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(x => x.SpellId == spellId);
-                if (entity != null)
-                {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        biota.BiotaPropertiesEnchantmentRegistry.Remove(entity);
-                        entity.Object = null;
-                        return true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
-                }
-                return false;
-            }
-            finally
-            {
-                rwLock.ExitUpgradeableReadLock();
-            }
-        }
-
         public static bool TryRemoveProperty(this Biota biota, PropertyFloat property, out BiotaPropertiesFloat entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -661,6 +607,143 @@ namespace ACE.Database.Models.Shard
             finally
             {
                 rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+
+        public static bool HasEnchantments(this Biota biota, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.Any();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static bool HasEnchantment(this Biota biota, uint spellId, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.Any(e => e.SpellId == spellId);
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static BiotaPropertiesEnchantmentRegistry GetEnchantmentBySpell(this Biota biota, int spellId, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(e => e.SpellId == spellId);
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+
+        }
+
+        public static List<BiotaPropertiesEnchantmentRegistry> GetEnchantments(this Biota biota, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.ToList();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static List<BiotaPropertiesEnchantmentRegistry> GetEnchantmentsByCategory(this Biota biota, ushort spellCategory, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.Where(e => e.SpellCategory == spellCategory).ToList();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static List<BiotaPropertiesEnchantmentRegistry> GetEnchantmentsByStatModType(this Biota biota, uint statModType, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.Where(e => (e.StatModType & statModType) == statModType).ToList();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static void AddEnchantment(this Biota biota, BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterWriteLock();
+            try
+            {
+                biota.BiotaPropertiesEnchantmentRegistry.Add(entity);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        public static bool TryRemoveEnchantment(this Biota biota, int spellId, out BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                entity = biota.BiotaPropertiesEnchantmentRegistry.FirstOrDefault(x => x.SpellId == spellId);
+                if (entity != null)
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        biota.BiotaPropertiesEnchantmentRegistry.Remove(entity);
+                        entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static void RemoveAllEnchantments(this Biota biota, ICollection<int> spellsToExclude, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterWriteLock();
+            try
+            {
+               var enchantments = biota.BiotaPropertiesEnchantmentRegistry.Where(e => !spellsToExclude.Contains(e.SpellId));
+
+                foreach (var enchantment in enchantments)
+                    biota.BiotaPropertiesEnchantmentRegistry.Remove(enchantment);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
             }
         }
 

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
@@ -35,7 +36,18 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        // BiotaPropertiesEnchantmentRegistry
+        public static IList<BiotaPropertiesEnchantmentRegistry> GetEnchantments(this Biota biota, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.BiotaPropertiesEnchantmentRegistry.ToList();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
 
         public static double? GetProperty(this Biota biota, PropertyFloat property, ReaderWriterLockSlim rwLock)
         {
@@ -186,7 +198,18 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        // BiotaPropertiesEnchantmentRegistry
+        public static void AddEnchantment(this Biota biota, BiotaPropertiesEnchantmentRegistry entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterWriteLock();
+            try
+            {
+                biota.BiotaPropertiesEnchantmentRegistry.Add(entity);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
 
         public static void SetProperty(this Biota biota, PropertyFloat property, double value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {

--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -121,10 +121,8 @@ namespace ACE.Server.Managers
 
                             var newEntry = BuildEntry(enchantment.Spell.Id, caster);
                             newEntry.LayerId = enchantment.Layer;
-
                             WorldObject.Biota.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
                             WorldObject.ChangesDetected = true;
-
                             result = StackType.Refresh;
                             break;
                         }
@@ -157,10 +155,8 @@ namespace ACE.Server.Managers
 
                     var newEntry = BuildEntry(enchantment.Spell.Id, caster);
                     newEntry.LayerId = enchantment.Layer;
-
                     WorldObject.Biota.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
                     WorldObject.ChangesDetected = true;
-
                     result = StackType.Surpass;
                 }
             }
@@ -173,11 +169,8 @@ namespace ACE.Server.Managers
         /// </summary>
         public void SendRegistry(BinaryWriter writer)
         {
-            if (Player == null)
-                return;
-
+            if (Player == null) return;
             var enchantmentRegistry = new EnchantmentRegistry(Player);
-
             writer.Write(enchantmentRegistry);
         }
 
@@ -186,11 +179,8 @@ namespace ACE.Server.Managers
         /// </summary>
         public void SendUpdateVitae()
         {
-            if (Player == null)
-                return;
-
+            if (Player == null) return;
             var vitae = new Enchantment(Player, GetVitae());
-
             Player.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(Player.Session, vitae));
         }
 
@@ -199,9 +189,7 @@ namespace ACE.Server.Managers
         /// </summary>
         public float UpdateVitae()
         {
-            if (Player == null)
-                return 0;
-
+            if (Player == null) return 0;
             BiotaPropertiesEnchantmentRegistry vitae;
 
             if (!HasVitae)
@@ -211,7 +199,6 @@ namespace ACE.Server.Managers
                 vitae.EnchantmentCategory = (uint)EnchantmentMask.Vitae;
                 vitae.LayerId = 0;
                 vitae.StatModValue = 1.0f - (float)PropertyManager.GetDouble("vitae_penalty").Item;
-
                 WorldObject.Biota.BiotaPropertiesEnchantmentRegistry.Add(vitae);
                 WorldObject.ChangesDetected = true;
             }
@@ -250,7 +237,6 @@ namespace ACE.Server.Managers
         public float ReduceVitae()
         {
             var vitae = GetVitae();
-
             vitae.StatModValue += 0.01f;
 
             if (Math.Abs(vitae.StatModValue - 1.0f) < PhysicsGlobals.EPSILON)
@@ -439,17 +425,14 @@ namespace ACE.Server.Managers
             var propVitae = PropertyManager.GetDouble("vitae_min").Item;
 
             var maxPenalty = (level - 1) * 3;
-
             if (maxPenalty < 1)
                 maxPenalty = 1;
 
             var globalMax = 100 - (uint)Math.Round(propVitae * 100);
-
             if (maxPenalty > globalMax)
                 maxPenalty = globalMax;
 
             var minVitae = (100 - maxPenalty) / 100.0f;
-
             if (minVitae < propVitae)
                 minVitae = (float)propVitae;
 
@@ -495,7 +478,6 @@ namespace ACE.Server.Managers
             var enchantments = GetEnchantments(EnchantmentTypeFlags.Skill, (uint)skill);
 
             var skillMod = 0;
-
             foreach (var enchantment in enchantments)
                 skillMod += (int)enchantment.StatModValue;
 
@@ -510,7 +492,6 @@ namespace ACE.Server.Managers
             var enchantments = GetEnchantments(EnchantmentTypeFlags.Attribute, (uint)attribute);
 
             var attributeMod = 0;
-
             foreach (var enchantment in enchantments)
                 attributeMod += (int)enchantment.StatModValue;
 
@@ -534,7 +515,6 @@ namespace ACE.Server.Managers
             var enchantments = GetEnchantments(type);
 
             var modifier = 0;
-
             foreach (var enchantment in enchantments)
                 modifier += (int)enchantment.StatModValue;
 
@@ -549,7 +529,6 @@ namespace ACE.Server.Managers
             var enchantments = GetEnchantments(EnchantmentTypeFlags.Additive, (uint)statModKey);
 
             var modifier = 0;
-
             foreach (var enchantment in enchantments)
                 modifier += (int)enchantment.StatModValue;
 
@@ -563,7 +542,6 @@ namespace ACE.Server.Managers
             var enchantments = GetEnchantments(typeFlags, (uint)statModKey);
 
             var modifier = 0.0f;
-
             foreach (var enchantment in enchantments)
                 modifier += enchantment.StatModValue;
 
@@ -579,7 +557,6 @@ namespace ACE.Server.Managers
 
             // multiplicative
             var modifier = 1.0f;
-
             foreach (var enchantment in enchantments)
                 modifier *= enchantment.StatModValue;
 
@@ -592,14 +569,11 @@ namespace ACE.Server.Managers
         public float GetResistanceMod(DamageType damageType)
         {
             var typeFlags = EnchantmentTypeFlags.Float | EnchantmentTypeFlags.SingleStat | EnchantmentTypeFlags.Multiplicative;
-
             var resistance = GetResistanceKey(damageType);
-
             var enchantments = GetEnchantments(typeFlags, (uint)resistance);
 
             // multiplicative
             var modifier = 1.0f;
-
             foreach (var enchantment in enchantments)
                 modifier *= enchantment.StatModValue;
 
@@ -613,14 +587,11 @@ namespace ACE.Server.Managers
         public float GetRegenerationMod(CreatureVital vital)
         {
             var typeFlags = EnchantmentTypeFlags.Float | EnchantmentTypeFlags.SingleStat | EnchantmentTypeFlags.Multiplicative;
-
             var vitalKey = GetVitalKey(vital);
-
             var enchantments = GetEnchantments(typeFlags, (uint)vitalKey);
 
             // multiplicative
             var modifier = 1.0f;
-
             foreach (var enchantment in enchantments)
                 modifier *= enchantment.StatModValue;
 
@@ -758,14 +729,11 @@ namespace ACE.Server.Managers
         public float GetArmorModVsType(DamageType damageType)
         {
             var typeFlags = EnchantmentTypeFlags.Float | EnchantmentTypeFlags.SingleStat | EnchantmentTypeFlags.Additive;
-
             var key = GetImpenBaneKey(damageType);
-
             var enchantments = GetEnchantments(typeFlags, (uint)key);
 
             // additive
             var modifier = 0.0f;
-
             foreach (var enchantment in enchantments)
                 modifier += enchantment.StatModValue;
 
@@ -778,7 +746,6 @@ namespace ACE.Server.Managers
         public List<BiotaPropertiesEnchantmentRegistry> GetEnchantments(MagicSchool magicSchool)
         {
             var spells = new List<BiotaPropertiesEnchantmentRegistry>();
-
             var enchantments = WorldObject.Biota.GetEnchantments(WorldObject.BiotaDatabaseLock);
 
             foreach (var enchantment in enchantments)

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -30,12 +30,6 @@ namespace ACE.Server.WorldObjects
             GetSaveChain(showMsg).EnqueueChain();
         }
 
-        public void SaveDatabase(bool showMsg = true)
-        {
-            var saveChain = GetSaveChain(showMsg);
-            saveChain.EnqueueChain();
-        }
-
         /// <summary>
         /// This will set the LastRequestedDatabaseSave to UtcNow and ChangesDetected to false.<para />
         /// If enqueueSave is set to true, DatabaseManager.Shard.SaveBiota() will be called for the biota.<para />

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -12,7 +12,7 @@ namespace ACE.Server.WorldObjects
         /// This variable is set to true when a change is made, and set to false before a save is requested.<para />
         /// The primary use for this is to trigger save on add/modify/remove of properties.
         /// </summary>
-        public bool ChangesDetected { get; protected set; }
+        public bool ChangesDetected { get; set; }
 
         /// <summary>
         /// This will set the LastRequestedDatabaseSave to UtcNow and ChangesDetected to false.<para />

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -400,13 +400,6 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        public void RemoveEnchantment(int spellId)
-        {
-            if (Biota.TryRemoveEnchantment(spellId, out _, BiotaDatabaseLock))
-                ChangesDetected = true;
-        }
-
-
         // SetPropertiesForWorld, SetPropertiesForContainer, SetPropertiesForVendor
         #region Utility Functions
         internal void SetPropertiesForWorld(WorldObject objectToPlaceInRelationTo)


### PR DESCRIPTION
Thread safety added to EnchantmentManager
Thread safety added to EnchantmentRegistry

The locks are required only when we iterate/insert/remove from the collections. EF accesses these collections on a separate thread and they cannot be modified while being iterated over.

Player save removed from EnchantmentManager. Saving a player should be a function of the player, not the enchantment manager. If we want to save a player on death, we can do that from the player.

Some minor cosmetic code improvements here and there.