### PR TITLE
Player giving items to other players fix

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -870,11 +870,11 @@ namespace ACE.Server.Managers
                     {
                         actionChain.AddDelaySeconds(emoteAction.Delay);
                         var pos = new Position(creature.Location.Cell, creature.Location.PositionX, creature.Location.PositionY, creature.Location.PositionZ, emoteAction.AnglesX ?? 0, emoteAction.AnglesY ?? 0, emoteAction.AnglesZ ?? 0, emoteAction.AnglesW ?? 0);
-                        var rotateTime = 0.0f;
                         actionChain.AddAction(creature, () =>
                         {
-                            rotateTime = creature.TurnTo(pos);
+                            creature.TurnTo(pos);
                         });
+                        var rotateTime = creature.GetRotateDelay(pos);
                         actionChain.AddDelaySeconds(rotateTime);
                     }
                     break;
@@ -884,11 +884,11 @@ namespace ACE.Server.Managers
                     if (creature != null && targetCreature != null)
                     {
                         actionChain.AddDelaySeconds(emoteAction.Delay);
-                        var rotateTime = 0.0f;
                         actionChain.AddAction(creature, () =>
                         {
-                            rotateTime = creature.Rotate(targetCreature);
+                            creature.Rotate(targetCreature);
                         });
+                        var rotateTime = creature.GetRotateDelay(targetCreature);
                         actionChain.AddDelaySeconds(rotateTime);
                     }
                     break;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1169,9 +1169,6 @@ namespace ACE.Server.WorldObjects
                                 UpdateCoinValue();
                         }
 
-                        // It's important that we save an item after it's changed owners.
-                        item.SaveBiotaToDatabase();
-
                         Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
                         Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));
                         Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem, 1));

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1169,6 +1169,9 @@ namespace ACE.Server.WorldObjects
                                 UpdateCoinValue();
                         }
 
+                        // It's important that we save an item after it's changed owners.
+                        item.SaveBiotaToDatabase();
+
                         Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
                         Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));
                         Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem, 1));

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1218,8 +1218,8 @@ namespace ACE.Server.WorldObjects
 
             TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
 
-            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));
             Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));
             Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem, 1));
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1144,6 +1144,8 @@ namespace ACE.Server.WorldObjects
                     {
                         target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{player.Name} gives you {item.Name}.", ChatMessageType.Broadcast));
                         target.Session.Network.EnqueueSend(new GameMessageSound(target.Guid, Sound.ReceiveItem, 1));
+
+                        item.SaveBiotaToDatabase();
                     });
                 }
             }
@@ -1199,8 +1201,6 @@ namespace ACE.Server.WorldObjects
                 new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, container.Guid),
                 new GameMessageCreateObject(item),
                 new GameEventItemServerSaysContainId(Session, item, container));
-
-            item.SaveBiotaToDatabase();
 
             return true;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -317,7 +317,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool Teleporting { get; set; } = false;
 
-        public bool HandleReceive(WorldObject item, uint amount, WorldObject receiver, WorldObject giver, ActionChain chain)
+        public bool HandleNPCReceiveItem(WorldObject item, WorldObject receiver, WorldObject giver, ActionChain chain)
         {
             if (chain == null) chain = new ActionChain();
 


### PR DESCRIPTION
-Implement unsecure ability, ie. without Trade_ protocols, to give items to other players, given the status of their "Let Other Players Give You Items" CharacterOption

-Bug fix by gmriggs in EmoteManager.cs for EmoteType.Turn and EmoteType.TurnToTarget
