### PR TITLE
Threading improvement for WorldManager

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -463,11 +463,8 @@ namespace ACE.Server.Managers
 
                 // Removes sessions in the NetworkTimeout state, incuding sessions that have reached a timeout limit.
                 var deadSessions = sessions.FindAll(s => s.State == Network.Enum.SessionState.NetworkTimeout);
-                if (deadSessions.Count > 0)
-                {
-                    foreach (var session in deadSessions)
-                        RemoveSession(session);
-                }
+                foreach (var session in deadSessions)
+                    RemoveSession(session);
 
                 Thread.Sleep(1);
 

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -464,7 +464,10 @@ namespace ACE.Server.Managers
                 // Removes sessions in the NetworkTimeout state, incuding sessions that have reached a timeout limit.
                 var deadSessions = sessions.FindAll(s => s.State == Network.Enum.SessionState.NetworkTimeout);
                 if (deadSessions.Count > 0)
-                    Parallel.ForEach(deadSessions, RemoveSession);
+                {
+                    foreach (var session in deadSessions)
+                        RemoveSession(session);
+                }
 
                 Thread.Sleep(1);
 


### PR DESCRIPTION
Very simple functions should not be parallelized. It will actually be slower to do so.

In addition, it's unlikely there will be so many network sessions timed out in a single tick that would even require them to be parallelized.