### PR TITLE
ActionChain AddDelaySeconds cleanup

### DIFF
--- a/Source/ACE.Server/Entity/Actions/ActionChain.cs
+++ b/Source/ACE.Server/Entity/Actions/ActionChain.cs
@@ -127,7 +127,7 @@ namespace ACE.Server.Entity.Actions
                 return this;
             }
 
-            AddAction(WorldManager.DelayManager, new DelayAction(WorldManager.SecondsToTicks(timeInSeconds)));
+            AddAction(WorldManager.DelayManager, new DelayAction(timeInSeconds));
 
             return this;
         }

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -578,10 +578,5 @@ namespace ACE.Server.Managers
 
             return newPosition;
         }
-
-        public static double SecondsToTicks(double elapsedTimeSeconds)
-        {
-            return elapsedTimeSeconds;
-        }
     }
 }


### PR DESCRIPTION
WorldManager SecondsToTicks wasn't implemented correctly and simply returned the same value.

This was added long time ago. It likely had a purpose that doesn't exist anymore.