### PR TITLE
Packets log level to separate configurable value via log4net.config file.

### DIFF
--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Managers
             var start = DateTime.UtcNow;
             DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
             {
-                log.Info("GetPlayerBiotas took " + (DateTime.UtcNow - start).TotalMilliseconds + " ms"); // This can be removed after EF performance is at the desired level.
+                log.Debug($"GetPlayerBiotas for {character.Name} took {(DateTime.UtcNow - start).TotalMilliseconds} ms");
                 Player player;
 
                 if (biotas.Player.WeenieType == (int)WeenieType.Admin)

--- a/Source/ACE.Server/Network/ClientPacket.cs
+++ b/Source/ACE.Server/Network/ClientPacket.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+
 using log4net;
 
 namespace ACE.Server.Network
@@ -7,6 +8,8 @@ namespace ACE.Server.Network
     public class ClientPacket : Packet
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog packetLog = LogManager.GetLogger(System.Reflection.Assembly.GetEntryAssembly(), "Packets");
+
         public BinaryReader Payload { get; private set; }
         public PacketHeaderOptional HeaderOptional { get; private set; }
         public bool IsValid { get; private set; } = false;
@@ -60,7 +63,7 @@ namespace ACE.Server.Network
             uint payloadChecksum = HeaderOptional.CalculateHash32() + fragmentChecksum;
 
             uint finalChecksum = Header.CalculateHash32() + (payloadChecksum ^ issacXor);
-            log.DebugFormat("Checksum is calculated as {0} and is {1} in header", finalChecksum, Header.Checksum);
+            packetLog.DebugFormat("Checksum is calculated as {0} and is {1} in header", finalChecksum, Header.Checksum);
             return finalChecksum == Header.Checksum;
         }
     }

--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -2,7 +2,9 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+
 using ACE.Server.Managers;
+
 using log4net;
 
 namespace ACE.Server.Network
@@ -11,6 +13,7 @@ namespace ACE.Server.Network
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private static readonly ILog packetLog = LogManager.GetLogger(System.Reflection.Assembly.GetEntryAssembly(), "Packets");
+
         public Socket Socket { get; private set; }
 
         private IPEndPoint listenerEndpoint;

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -25,6 +25,7 @@ namespace ACE.Server.Network.Handlers
         public const int DefaultAuthTimeout = 15;
 
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog packetLog = LogManager.GetLogger(System.Reflection.Assembly.GetEntryAssembly(), "Packets");
 
         public static void HandleLoginRequest(ClientPacket packet, Session session)
         {
@@ -67,7 +68,7 @@ namespace ACE.Server.Network.Handlers
 
         private static void AccountSelectCallback(Account account, Session session, PacketInboundLoginRequest loginRequest)
         {
-            log.DebugFormat("ConnectRequest TS: {0}", session.Network.ConnectionData.ServerTime);
+            packetLog.DebugFormat("ConnectRequest TS: {0}", session.Network.ConnectionData.ServerTime);
             var connectRequest = new PacketOutboundConnectRequest(session.Network.ConnectionData.ServerTime, 0, session.Network.ClientId, ISAAC.ServerSeed, ISAAC.ClientSeed);
 
             session.Network.EnqueueSend(connectRequest);

--- a/Source/ACE.Server/Network/MessageFragment.cs
+++ b/Source/ACE.Server/Network/MessageFragment.cs
@@ -1,13 +1,16 @@
-using ACE.Server.Network.GameMessages;
-using log4net;
 using System;
 using System.IO;
+
+using ACE.Server.Network.GameMessages;
+
+using log4net;
 
 namespace ACE.Server.Network
 {
     internal class MessageFragment
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly ILog packetLog = LogManager.GetLogger(System.Reflection.Assembly.GetEntryAssembly(), "Packets");
 
         public GameMessage Message { get; private set; }
 
@@ -45,7 +48,7 @@ namespace ACE.Server.Network
             Index = 0;
             if (Count == 1)
                 TailSent = true;
-            log.DebugFormat("Sequence {0}, count {1}, DataRemaining {2}", sequence, Count, DataRemaining);
+            packetLog.DebugFormat("Sequence {0}, count {1}, DataRemaining {2}", sequence, Count, DataRemaining);
         }
 
         public ServerPacketFragment GetTailFragment()
@@ -62,7 +65,7 @@ namespace ACE.Server.Network
 
         private ServerPacketFragment CreateServerFragment(ushort index)
         {
-            log.DebugFormat("Creating ServerFragment for index {0}", index);
+            packetLog.DebugFormat("Creating ServerFragment for index {0}", index);
             if (index >= Count)
                 throw new ArgumentOutOfRangeException("index", index, "Passed index is greater then computed count");
 
@@ -94,7 +97,7 @@ namespace ACE.Server.Network
             fragment.Header.Queue = (ushort)Message.Group;
 
             DataRemaining -= dataToSend;
-            log.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);
+            packetLog.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);
             return fragment;
         }
     }

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -4,9 +4,7 @@ using System.Threading;
 
 using ACE.Database;
 using ACE.Database.Models.Shard;
-using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
-using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
 {
@@ -17,17 +15,17 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Gets the ActionChain to save a character
         /// </summary>
-        public ActionChain GetSaveChain(bool showMsg = true)
+        public ActionChain GetSaveChain()
         {
-            return new ActionChain(this, () => SavePlayer(showMsg));
+            return new ActionChain(this, SavePlayer);
         }
 
         /// <summary>
         /// Creates and Enqueues an ActionChain to save a character
         /// </summary>
-        public void EnqueueSaveChain(bool showMsg = true)
+        public void EnqueueSaveChain()
         {
-            GetSaveChain(showMsg).EnqueueChain();
+            GetSaveChain().EnqueueChain();
         }
 
         /// <summary>
@@ -48,7 +46,7 @@ namespace ACE.Server.WorldObjects
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.<para />
         /// Will also save any possessions that are marked with ChangesDetected.
         /// </summary>
-        private void SavePlayer(bool showMsg = true)
+        private void SavePlayer()
         {
             DatabaseManager.Shard.SaveCharacter(Character, null);
 
@@ -70,13 +68,7 @@ namespace ACE.Server.WorldObjects
 
             var requestedTime = DateTime.UtcNow;
 
-            DatabaseManager.Shard.SaveBiotas(biotas, result =>
-            {
-                #if DEBUG
-                if (Session.Player != null && showMsg)
-                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request.", ChatMessageType.Broadcast));
-                #endif
-            });
+            DatabaseManager.Shard.SaveBiotas(biotas, result => log.Debug($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds} ms to process the request."));
         }
     }
 }

--- a/Source/ACE.Server/log4net.config
+++ b/Source/ACE.Server/log4net.config
@@ -17,6 +17,9 @@
     </layout>
     <threshold value="ALL" />
   </appender>
+  <logger name="Packets">
+    <level value="INFO" />
+  </logger> 
   <root>
     <level value="ALL" />
     <appender-ref ref="Console" />


### PR DESCRIPTION
Using the DEBUG log level was basically useless due to all the packet level spam.

Now, you can keep packets at the log level of INFO and the main log setting at DEBUG. This will allow you to see common debug messages but not the actual packet data.