### PR TITLE
Spell range check update, correct ring spell projectile destruction and a couple of small fixes.

### DIFF
--- a/Source/ACE.Entity/Enum/SpellBitfield.cs
+++ b/Source/ACE.Entity/Enum/SpellBitfield.cs
@@ -21,6 +21,7 @@ namespace ACE.Entity.Enum
         FellowshipSpell                 = 0x2000,
         FastCast                        = 0x4000,
         IndoorLongRange                 = 0x8000,
-        DamageOverTime                  = 0x10000
+        DamageOverTime                  = 0x10000,
+        UNKNOWN                         = 0x20000
     }
 }

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -38,6 +38,10 @@ namespace ACE.Server.WorldObjects.Entity
             set => biotaPropertiesSkill.PP = value;
         }
 
+        /// <summary>
+        /// Total skill level due to
+        /// directly raising the skill
+        /// </summary>
         public ushort Ranks
         {
             get => biotaPropertiesSkill.LevelFromPP;

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -45,6 +45,18 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// Returns the magic skill level used for spell range checks.
+        /// (initial points + points due to directly raising the skill)
+        /// </summary>
+        /// <returns></returns>
+        public uint GetMagicSkillForRangeCheck()
+        {
+            var currentSpell = GetCurrentSpell();
+            var skill = GetCreatureSkill((MagicSchool)currentSpell.School);
+            return skill.InitLevel + skill.Ranks;
+        }
+
+        /// <summary>
         /// Returns the sum of all probabilities from monster's spell_book
         /// </summary>
         public float GetSpellProbability()
@@ -123,7 +135,7 @@ namespace ACE.Server.WorldObjects
             var spellBase = GetCurrentSpellBase();
             var spell = GetCurrentSpell();
 
-            var targetSelf = spellBase.Name.Contains("Self");   // better way?
+            var targetSelf = (spellBase.Bitfield & (uint)SpellBitfield.SelfTargeted) == 1;
             var target = targetSelf ? this : AttackTarget;
 
             var player = AttackTarget as Player;
@@ -190,7 +202,7 @@ namespace ACE.Server.WorldObjects
         public float GetSpellMaxRange()
         {
             var spell = GetCurrentSpellBase();
-            var skill = GetMagicSkill();
+            var skill = GetMagicSkillForRangeCheck();
 
             var maxRange = spell.BaseRangeConstant + skill * spell.BaseRangeMod;
             if (maxRange == 0.0f)

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -418,8 +418,8 @@ namespace ACE.Server.WorldObjects
 
                     if (distanceTo > spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod)
                     {
-                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicTargetOutOfRange),
-                            new GameMessageSystemChat($"{target.Name} is out of range!", ChatMessageType.Magic));
+                        player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None),
+                            new GameMessageSystemChat($"Target is out of range!", ChatMessageType.Magic));
                         player.IsBusy = false;
                         return;
                     }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -30,6 +30,9 @@ namespace ACE.Server.WorldObjects
         public float PlayscriptIntensity { get; set; }
         public ProjectileSpellType SpellType { get; set; }
 
+        public ACE.Entity.Position SpawnPos;
+        public SpellBase SpellBase;
+
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
         /// </summary>
@@ -64,7 +67,7 @@ namespace ACE.Server.WorldObjects
             SpellId = spellId;
 
             SpellType = GetProjectileSpellType(spellId);
-            var spell = DatManager.PortalDat.SpellTable.Spells[SpellId];
+            SpellBase = DatManager.PortalDat.SpellTable.Spells[SpellId];
 
             // Runtime changes to default state
             ReportCollisions = true;
@@ -80,7 +83,7 @@ namespace ACE.Server.WorldObjects
             {
                 PhysicsObj.DefaultScript = ACE.Entity.Enum.PlayScript.ProjectileCollision;
                 PhysicsObj.DefaultScriptIntensity = 1.0f;
-                var spellLevel = CalculateSpellLevel(spell);
+                var spellLevel = CalculateSpellLevel(SpellBase);
                 PlayscriptIntensity = GetProjectileScriptIntensity(SpellType, spellLevel);
             }
 
@@ -98,7 +101,7 @@ namespace ACE.Server.WorldObjects
             if (SpellType == ProjectileSpellType.Ring)
             {
                 ScriptedCollision = false;
-                var spellLevel = CalculateSpellLevel(spell);
+                var spellLevel = CalculateSpellLevel(SpellBase);
                 PlayscriptIntensity = GetProjectileScriptIntensity(SpellType, spellLevel);
             }
 
@@ -202,7 +205,7 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        private void ProjectileImpact()
+        public void ProjectileImpact()
         {
             SpellTable spellTable = DatManager.PortalDat.SpellTable;
             SpellBase spell = spellTable.Spells[spellId];

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1057,6 +1057,7 @@ namespace ACE.Server.WorldObjects
             spellProjectile.ProjectileSource = this;
             spellProjectile.ProjectileTarget = target;
             spellProjectile.SetProjectilePhysicsState(spellProjectile.ProjectileTarget, useGravity);
+            spellProjectile.SpawnPos = new Position(spellProjectile.Location);
 
             return spellProjectile;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -1145,7 +1145,19 @@ namespace ACE.Server.WorldObjects
             //var dist = Vector3.Distance(ProjectileTarget.Location.Pos, newPos);
             //Console.WriteLine("Dist: " + dist);
             //Console.WriteLine("Velocity: " + PhysicsObj.Velocity);
-
+            var spellProjectile = this as SpellProjectile;
+            if (spellProjectile != null && spellProjectile.SpellType == SpellProjectile.ProjectileSpellType.Ring)
+            {
+                var dist = Vector3.Distance(spellProjectile.SpawnPos.ToGlobal(), Location.ToGlobal());
+                var maxRange = spellProjectile.SpellBase.BaseRangeConstant;
+                //Console.WriteLine("Max range: " + maxRange);
+                if (dist > maxRange)
+                {
+                    PhysicsObj.set_active(false);
+                    spellProjectile.ProjectileImpact();
+                    return false;
+                }
+            }
             return landblockUpdate;
         }
 

--- a/Source/ACE.Server/starterGear.json
+++ b/Source/ACE.Server/starterGear.json
@@ -300,7 +300,7 @@
                     "specializedOnly": "false"
                 },
                 {
-                    "spellId": "118",
+                    "spellId": "18",
                     "name": "Invulnerability Self I",
                     "specializedOnly": "false"
                 },


### PR DESCRIPTION
This PR includes:
1. Ring spell projectiles should now properly explode at their max range. Thanks to @gmriggs for the code.
2. Changed magic range check calculation to match the client code.
3. Added an unknown spell bitfield flag.
4. Fixed a typo with a Creature Magic starter spell.
5. Changed the out of range message for magic to match the retail message.