### PR TITLE
ActionChain Cleanup

### DIFF
--- a/Source/ACE.Server/WorldObjects/AdvocateFane.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateFane.cs
@@ -66,8 +66,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Book.cs
+++ b/Source/ACE.Server/WorldObjects/Book.cs
@@ -71,8 +71,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.
@@ -87,11 +86,10 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the player using the item.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item should be in the players possession.
         /// </summary>
-        public override void UseItem(Player player, ActionChain actionChain)
+        public override void UseItem(Player player)
         {
             BookUseHandler(player.Session);
         }

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -60,8 +60,7 @@ namespace ACE.Server.WorldObjects
         //private static readonly MotionState motionStateClosed = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Off));
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -370,8 +370,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Cow.cs
+++ b/Source/ACE.Server/WorldObjects/Cow.cs
@@ -50,8 +50,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -548,8 +548,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -39,11 +39,10 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the player using the item.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item should be in the players possession.
         /// </summary>
-        public override void UseItem(Player player, ActionChain actionChain)
+        public override void UseItem(Player player)
         {
             Player.ConsumableBuffType buffType;
 

--- a/Source/ACE.Server/WorldObjects/Game.cs
+++ b/Source/ACE.Server/WorldObjects/Game.cs
@@ -38,8 +38,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -49,8 +49,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the player using the item.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item should be in the players possession.
         /// 
         /// The OnUse method for this class is to use a contract to add a tracked quest to our quest panel.
@@ -58,7 +57,7 @@ namespace ACE.Server.WorldObjects
         /// and shows our progress for kill tasks as well as any timing information such as when we can repeat the
         /// quest or how much longer we have to complete it in the case of at timed quest.   Og II
         /// </summary>
-        public override void UseItem(Player player, ActionChain actionChain)
+        public override void UseItem(Player player)
         {
             if (UseCreateContractId == null)
             {

--- a/Source/ACE.Server/WorldObjects/Lifestone.cs
+++ b/Source/ACE.Server/WorldObjects/Lifestone.cs
@@ -39,8 +39,7 @@ namespace ACE.Server.WorldObjects
         private static readonly UniversalMotion sanctuary = new UniversalMotion(MotionStance.Standing, new MotionItem(MotionCommand.Sanctuary));
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/PKModifier.cs
+++ b/Source/ACE.Server/WorldObjects/PKModifier.cs
@@ -54,8 +54,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -8,7 +8,6 @@ using ACE.DatLoader.FileTypes;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Network;
@@ -486,81 +485,78 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionPutItemInContainer(ObjectGuid itemGuid, ObjectGuid containerGuid, int placement = 0)
         {
-            new ActionChain(this, () =>
+            bool containerOwnedByPlayer = true;
+
+            Container container;
+
+            if (containerGuid == Guid)
+                container = this; // Destination is main pack
+            else
+                container = (Container)GetInventoryItem(containerGuid); // Destination is side pack
+
+            if (container == null) // Destination is a container in the world, not in our possession
             {
-                bool containerOwnedByPlayer = true;
+                containerOwnedByPlayer = false;
+                container = CurrentLandblock?.GetObject(containerGuid) as Container;
 
-                Container container;
-
-                if (containerGuid == Guid)
-                    container = this; // Destination is main pack
-                else
-                    container = (Container)GetInventoryItem(containerGuid); // Destination is side pack
-
-                if (container == null) // Destination is a container in the world, not in our possession
+                if (container == null) // Container is a container within a container in the world....
                 {
-                    containerOwnedByPlayer = false;
-                    container = CurrentLandblock?.GetObject(containerGuid) as Container;
+                    var lastUsedContainer = CurrentLandblock?.GetObject(lastUsedContainerId) as Container;
 
-                    if (container == null) // Container is a container within a container in the world....
-                    {
-                        var lastUsedContainer = CurrentLandblock?.GetObject(lastUsedContainerId) as Container;
-
-                        if (lastUsedContainer != null && lastUsedContainer.Inventory.TryGetValue(containerGuid, out var value))
-                            container = value as Container;
-                    }
+                    if (lastUsedContainer != null && lastUsedContainer.Inventory.TryGetValue(containerGuid, out var value))
+                        container = value as Container;
                 }
+            }
 
-                if (container == null)
+            if (container == null)
+            {
+                log.Error("Player_Inventory HandleActionPutItemInContainer container not found");
+                return;
+            }
+
+            var item = GetInventoryItem(itemGuid) ?? GetWieldedItem(itemGuid);
+
+            if (item != null)
+            {
+                IsAttuned(itemGuid, out bool isAttuned);
+                if (isAttuned == true && containerOwnedByPlayer == false)
                 {
-                    log.Error("Player_Inventory HandleActionPutItemInContainer container not found");
+                    Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.AttunedItem));
+                    Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
                     return;
                 }
+            }
 
-                var item = GetInventoryItem(itemGuid) ?? GetWieldedItem(itemGuid);
-
-                if (item != null)
+            var corpse = container as Corpse;
+            if (corpse != null)
+            {
+                if (corpse.IsMonster == false)
                 {
-                    IsAttuned(itemGuid, out bool isAttuned);
-                    if (isAttuned == true && containerOwnedByPlayer == false)
-                    {
-                        Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.AttunedItem));
-                        Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, this));
-                        return;
-                    }
-                }
-
-                var corpse = container as Corpse;
-                if (corpse != null)
-                {
-                    if (corpse.IsMonster == false)
-                    {
-                        Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.Dead));
-                        return;
-                    }
-                }
-
-                // Is this something I already have? If not, it has to be a pickup - do the pickup and out.
-                if (item == null)
-                {
-                    // This is a pickup into our main pack.
-                    PickupItemWithNetworking(container, itemGuid, placement, PropertyInstanceId.Container);
+                    Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.Dead));
                     return;
                 }
+            }
 
-                // Ok, I know my container and I know I must have the item so let's get it.
+            // Is this something I already have? If not, it has to be a pickup - do the pickup and out.
+            if (item == null)
+            {
+                // This is a pickup into our main pack.
+                PickupItemWithNetworking(container, itemGuid, placement, PropertyInstanceId.Container);
+                return;
+            }
 
-                // Was I equiped? If so, lets take care of that and unequip
-                if (item.WielderId != null)
-                {
-                    UnwieldItemWithNetworking(container, item, placement);
-                    item.IsAffecting = false;
-                    return;
-                }
+            // Ok, I know my container and I know I must have the item so let's get it.
 
-                // if were are still here, this needs to do a pack pack or main pack move.
-                MoveItemWithNetworking(item, container, placement);
-            }).EnqueueChain();
+            // Was I equiped? If so, lets take care of that and unequip
+            if (item.WielderId != null)
+            {
+                UnwieldItemWithNetworking(container, item, placement);
+                item.IsAffecting = false;
+                return;
+            }
+
+            // if were are still here, this needs to do a pack pack or main pack move.
+            MoveItemWithNetworking(item, container, placement);
         }
 
         /// <summary>
@@ -576,87 +572,80 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            var actionChain = new ActionChain();
+            // check packs of item.
+            WorldObject item;
 
-            actionChain.AddAction(this, () =>
+            if (!TryRemoveFromInventory(itemGuid, out item))
             {
-                // check packs of item.
-                WorldObject item;
-
-                if (!TryRemoveFromInventory(itemGuid, out item))
+                // check to see if this item is wielded
+                if (TryDequipObject(itemGuid, out item))
                 {
-                    // check to see if this item is wielded
-                    if (TryDequipObject(itemGuid, out item))
-                    {
-                        Children.Remove(Children.Find(s => s.Guid == item.Guid.Full));
+                    Children.Remove(Children.Find(s => s.Guid == item.Guid.Full));
 
-                        //Session.Network.EnqueueSend(
-                        //    new GameMessageSound(Guid, Sound.WieldObject, 1.0f),
-                        //    new GameMessageObjDescEvent(this),
-                        //    new GameMessageUpdateInstanceId(item.Sequences, new ObjectGuid(0), item.Guid, PropertyInstanceId.Wielder));
+                    //Session.Network.EnqueueSend(
+                    //    new GameMessageSound(Guid, Sound.WieldObject, 1.0f),
+                    //    new GameMessageObjDescEvent(this),
+                    //    new GameMessageUpdateInstanceId(item.Sequences, new ObjectGuid(0), item.Guid, PropertyInstanceId.Wielder));
 
-                        EnqueueBroadcast(new GameMessageSound(Guid, Sound.WieldObject, 1.0f),
-                            new GameMessageObjDescEvent(this),
-                            new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Wielder, new ObjectGuid(0)));
-                    }
+                    EnqueueBroadcast(new GameMessageSound(Guid, Sound.WieldObject, 1.0f),
+                        new GameMessageObjDescEvent(this),
+                        new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Wielder, new ObjectGuid(0)));
                 }
+            }
 
-                if (item == null)
-                {
-                    log.Error("Player_Inventory HandleActionDropItem item is null");
-                    return;
-                }
+            if (item == null)
+            {
+                log.Error("Player_Inventory HandleActionDropItem item is null");
+                return;
+            }
 
-                item.SetPropertiesForWorld(this);
+            item.SetPropertiesForWorld(this);
 
-                // It's important that we save an item after it's been removed from inventory.
-                // We want to avoid the scenario where the server crashes and a player has too many items.
-                item.SaveBiotaToDatabase();
+            // It's important that we save an item after it's been removed from inventory.
+            // We want to avoid the scenario where the server crashes and a player has too many items.
+            item.SaveBiotaToDatabase();
 
-                var motion = new UniversalMotion(MotionStance.Standing);
-                motion.MovementData.ForwardCommand = (uint)MotionCommand.Pickup;
-                Session.Network.EnqueueSend(new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, new ObjectGuid(0)));
+            var motion = new UniversalMotion(MotionStance.Standing);
+            motion.MovementData.ForwardCommand = (uint)MotionCommand.Pickup;
+            Session.Network.EnqueueSend(new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, new ObjectGuid(0)));
 
-                // Set drop motion
+            // Set drop motion
+            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+
+            // Now wait for Drop Motion to finish -- use ActionChain
+            var dropChain = new ActionChain();
+
+            // Wait for drop animation
+            var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId);
+            var pickupAnimationLength = motionTable.GetAnimationLength(MotionCommand.Pickup);
+            dropChain.AddDelaySeconds(pickupAnimationLength);
+
+            // Play drop sound
+            // Put item on landblock
+            dropChain.AddAction(this, () =>
+            {
+                motion = new UniversalMotion(MotionStance.Standing);
                 CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+                EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, (float)1.0));
+                Session.Network.EnqueueSend(
+                    new GameEventItemServerSaysMoveItem(Session, item),
+                    new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, new ObjectGuid(0)),
+                    new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
 
-                // Now wait for Drop Motion to finish -- use ActionChain
-                var dropChain = new ActionChain();
-
-                // Wait for drop animation
-                var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId);
-                var pickupAnimationLength = motionTable.GetAnimationLength(MotionCommand.Pickup);
-                dropChain.AddDelaySeconds(pickupAnimationLength);
-
-                // Play drop sound
-                // Put item on landblock
-                dropChain.AddAction(this, () =>
-                {
-                    motion = new UniversalMotion(MotionStance.Standing);
-                    CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
-                    EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, (float)1.0));
-                    Session.Network.EnqueueSend(
-                        new GameEventItemServerSaysMoveItem(Session, item),
-                        new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, new ObjectGuid(0)),
-                        new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
-
-                    if (item.WeenieType == WeenieType.Coin)
-                        UpdateCoinValue();
+                if (item.WeenieType == WeenieType.Coin)
+                    UpdateCoinValue();
 
                     // This is the sequence magic - adds back into 3d space seem to be treated like teleport.
                     item.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
-                    item.Sequences.GetNextSequence(SequenceType.ObjectVector);
+                item.Sequences.GetNextSequence(SequenceType.ObjectVector);
 
-                    CurrentLandblock?.AddWorldObject(item);
+                CurrentLandblock?.AddWorldObject(item);
 
                     //Session.Network.EnqueueSend(new GameMessageUpdateObject(item));
                     EnqueueBroadcast(new GameMessageUpdatePosition(item));
-                });
-
-                actionChain.AddChain(dropChain);
             });
 
-            actionChain.EnqueueChain();
+            dropChain.EnqueueChain();
         }
 
         /// <summary>
@@ -695,32 +684,28 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionGetAndWieldItem(uint itemId, int wieldLocation)
         {
-            new ActionChain(this, () =>
+            var itemGuid = new ObjectGuid(itemId);
+
+            // handle inventory item -> weapon/shield slot
+            var item = GetInventoryItem(itemGuid);
+            if (item != null)
             {
-                var itemGuid = new ObjectGuid(itemId);
+                var result = TryWieldItem(item, wieldLocation);
+                return;
+            }
 
-                // handle inventory item -> weapon/shield slot
-                var item = GetInventoryItem(itemGuid);
-                if (item != null)
-                {
-                    var result = TryWieldItem(item, wieldLocation);
-                    return;
-                }
+            // handle 1 wielded slot -> the other wielded slot
+            // (weapon swap)
+            var wieldedItem = GetWieldedItem(itemGuid);
+            if (wieldedItem != null)
+            {
+                var result = TryWieldItem(wieldedItem, wieldLocation);
+                return;
+            }
 
-                // handle 1 wielded slot -> the other wielded slot
-                // (weapon swap)
-                var wieldedItem = GetWieldedItem(itemGuid);
-                if (wieldedItem != null)
-                {
-                    var result = TryWieldItem(wieldedItem, wieldLocation);
-                    return;
-                }
-
-                // We don't have possession of the item so we must pick it up.
-                // should this be wielding the item afterwards?
-                PickupItemWithNetworking(this, itemGuid, wieldLocation, PropertyInstanceId.Wielder);
-
-            }).EnqueueChain();
+            // We don't have possession of the item so we must pick it up.
+            // should this be wielding the item afterwards?
+            PickupItemWithNetworking(this, itemGuid, wieldLocation, PropertyInstanceId.Wielder);
         }
 
         public bool TryWieldItem(WorldObject item, int wieldLocation)
@@ -1292,45 +1277,42 @@ namespace ACE.Server.WorldObjects
         /// <param name="inscriptionText">This is our inscription</param>
         public void HandleActionSetInscription(ObjectGuid itemGuid, string inscriptionText)
         {
-            new ActionChain(this, () =>
+            var item = GetInventoryItem(itemGuid) ?? GetWieldedItem(itemGuid);
+
+            if (item == null)
             {
-                var item = GetInventoryItem(itemGuid) ?? GetWieldedItem(itemGuid);
+                log.Error("Player_Inventory HandleActionSetInscription failed");
+                return;
+            }
 
-                if (item == null)
+            if (item.Inscribable == true && item.ScribeName != "prewritten")
+            {
+                if (item.ScribeName != null && item.ScribeName != Name)
                 {
-                    log.Error("Player_Inventory HandleActionSetInscription failed");
-                    return;
-                }
-
-                if (item.Inscribable == true && item.ScribeName != "prewritten")
-                {
-                    if (item.ScribeName != null && item.ScribeName != Name)
-                    {
-                        ChatPacket.SendServerMessage(Session, "Only the original scribe may alter this without the use of an uninscription stone.", ChatMessageType.Broadcast);
-                    }
-                    else
-                    {
-                        if (inscriptionText != "")
-                        {
-                            item.Inscription = inscriptionText;
-                            item.ScribeName = Name;
-                            item.ScribeAccount = Session.Account;
-                            Session.Network.EnqueueSend(new GameEventInscriptionResponse(Session, item.Guid.Full, item.Inscription, item.ScribeName, item.ScribeAccount));
-                        }
-                        else
-                        {
-                            item.Inscription = null;
-                            item.ScribeName = null;
-                            item.ScribeAccount = null;
-                        }
-                    }
+                    ChatPacket.SendServerMessage(Session, "Only the original scribe may alter this without the use of an uninscription stone.", ChatMessageType.Broadcast);
                 }
                 else
                 {
-                    // Send some cool you cannot inscribe that item message. Not sure how that was handled live, I could not find a pcap of a failed inscription. Og II
-                    ChatPacket.SendServerMessage(Session, "Target item cannot be inscribed.", ChatMessageType.System);
+                    if (inscriptionText != "")
+                    {
+                        item.Inscription = inscriptionText;
+                        item.ScribeName = Name;
+                        item.ScribeAccount = Session.Account;
+                        Session.Network.EnqueueSend(new GameEventInscriptionResponse(Session, item.Guid.Full, item.Inscription, item.ScribeName, item.ScribeAccount));
+                    }
+                    else
+                    {
+                        item.Inscription = null;
+                        item.ScribeName = null;
+                        item.ScribeAccount = null;
+                    }
                 }
-            }).EnqueueChain();
+            }
+            else
+            {
+                // Send some cool you cannot inscribe that item message. Not sure how that was handled live, I could not find a pcap of a failed inscription. Og II
+                ChatPacket.SendServerMessage(Session, "Target item cannot be inscribed.", ChatMessageType.System);
+            }
         }
 
 
@@ -1413,65 +1395,62 @@ namespace ACE.Server.WorldObjects
         /// <param name="amount">The amount of the stack we are spliting from that we are moving to a new stack.</param>
         public void HandleActionStackableSplitToContainer(uint stackId, uint containerId, int placementPosition, ushort amount)
         {
-            new ActionChain(this, () =>
+            Container container;
+            if (containerId == Guid.Full)
+                container = this;
+            else
+                container = GetInventoryItem(new ObjectGuid(containerId)) as Container;
+
+            if (container == null)
             {
-                Container container;
-                if (containerId == Guid.Full)
-                    container = this;
-                else
-                    container = GetInventoryItem(new ObjectGuid(containerId)) as Container;
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer container not found");
+                return;
+            }
 
-                if (container == null)
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer container not found");
-                    return;
-                }
+            var stack = container.GetInventoryItem(new ObjectGuid(stackId));
 
-                var stack = container.GetInventoryItem(new ObjectGuid(stackId));
+            if (stack == null)
+            {
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not found");
+                return;
+            }
 
-                if (stack == null)
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not found");
-                    return;
-                }
+            if (stack.Value == null || stack.StackSize < amount || stack.StackSize == 0)
+            {
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not large enough for amount");
+                return;
+            }
 
-                if (stack.Value == null || stack.StackSize < amount || stack.StackSize == 0)
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not large enough for amount");
-                    return;
-                }
+            // Ok we are in business
+            stack.StackSize -= amount;
+            stack.EncumbranceVal = (stack.StackUnitEncumbrance ?? 0) * (stack.StackSize ?? 1);
+            stack.Value = (stack.StackUnitValue ?? 0) * (stack.StackSize ?? 1);
 
-                // Ok we are in business
-                stack.StackSize -= amount;
-                stack.EncumbranceVal = (stack.StackUnitEncumbrance ?? 0) * (stack.StackSize ?? 1);
-                stack.Value = (stack.StackUnitValue ?? 0) * (stack.StackSize ?? 1);
+            var newStack = WorldObjectFactory.CreateNewWorldObject(stack.WeenieClassId);
+            newStack.StackSize = amount;
+            newStack.EncumbranceVal = (newStack.StackUnitEncumbrance ?? 0) * (newStack.StackSize ?? 1);
+            newStack.Value = (newStack.StackUnitValue ?? 0) * (newStack.StackSize ?? 1);
 
-                var newStack = WorldObjectFactory.CreateNewWorldObject(stack.WeenieClassId);
-                newStack.StackSize = amount;
-                newStack.EncumbranceVal = (newStack.StackUnitEncumbrance ?? 0) * (newStack.StackSize ?? 1);
-                newStack.Value = (newStack.StackUnitValue ?? 0) * (newStack.StackSize ?? 1);
+            if (!container.TryAddToInventory(newStack, placementPosition, true))
+            {
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer TryAddToInventory failed");
+                return;
+            }
 
-                if (!container.TryAddToInventory(newStack, placementPosition, true))
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer TryAddToInventory failed");
-                    return;
-                }
+            /* todo this needs to be fixed. There are many scenarios here, to/from main pack, to/from side pack, to/from landscape container.
+            if (container.Guid.Full == stack.ContainerId)
+            {
+                // We subtract the new stack from our main values because TryAddToInventory will end up readding them.
+                EncumbranceVal -= newStack.EncumbranceVal;
+                Value -= newStack.Value;
+                // todo CoinValue .. would only apply if we're going to/from landscape container
+            }*/
 
-                /* todo this needs to be fixed. There are many scenarios here, to/from main pack, to/from side pack, to/from landscape container.
-                if (container.Guid.Full == stack.ContainerId)
-                {
-                    // We subtract the new stack from our main values because TryAddToInventory will end up readding them.
-                    EncumbranceVal -= newStack.EncumbranceVal;
-                    Value -= newStack.Value;
-                    // todo CoinValue .. would only apply if we're going to/from landscape container
-                }*/
-
-                // todo i'm not sure if this is right? Should it be a landblock broadcast if we're splitting items on our own person?
-                // todo Probably only landblock if the container exists on the landscape, but even then... i don't think so
-                EnqueueBroadcast(new GameEventItemServerSaysContainId(Session, newStack, container),
-                    new GameMessageSetStackSize(stack),
-                    new GameMessageCreateObject(newStack));
-            }).EnqueueChain();
+            // todo i'm not sure if this is right? Should it be a landblock broadcast if we're splitting items on our own person?
+            // todo Probably only landblock if the container exists on the landscape, but even then... i don't think so
+            EnqueueBroadcast(new GameEventItemServerSaysContainId(Session, newStack, container),
+                new GameMessageSetStackSize(stack),
+                new GameMessageCreateObject(newStack));
         }
 
         /// <summary>
@@ -1482,90 +1461,83 @@ namespace ACE.Server.WorldObjects
         /// <param name="amount">The amount of the stack we are spliting from that we are moving to a new stack.</param>
         public void HandleActionStackableSplitTo3D(uint stackId, uint amount)
         {
-            var actionChain = new ActionChain();
+            var stack = GetInventoryItem(new ObjectGuid(stackId), out var container);
 
-            actionChain.AddAction(this, () =>
+            if (stack == null)
             {
-                var stack = GetInventoryItem(new ObjectGuid(stackId), out var container);
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not found");
+                return;
+            }
 
-                if (stack == null)
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not found");
-                    return;
-                }
+            if (stack.Value == null || stack.StackSize < amount || stack.StackSize == 0)
+            {
+                log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not large enough for amount");
+                return;
+            }
 
-                if (stack.Value == null || stack.StackSize < amount || stack.StackSize == 0)
-                {
-                    log.Error("Player_Inventory HandleActionStackableSplitToContainer stack not large enough for amount");
-                    return;
-                }
+            // Ok we are in business
+            stack.StackSize -= (ushort)amount;
+            stack.EncumbranceVal = (stack.StackUnitEncumbrance ?? 0) * (stack.StackSize ?? 1);
+            stack.Value = (stack.StackUnitValue ?? 0) * (stack.StackSize ?? 1);
 
-                // Ok we are in business
-                stack.StackSize -= (ushort)amount;
-                stack.EncumbranceVal = (stack.StackUnitEncumbrance ?? 0) * (stack.StackSize ?? 1);
-                stack.Value = (stack.StackUnitValue ?? 0) * (stack.StackSize ?? 1);
+            var newStack = WorldObjectFactory.CreateNewWorldObject(stack.WeenieClassId);
+            newStack.StackSize = (ushort)amount;
+            newStack.EncumbranceVal = (newStack.StackUnitEncumbrance ?? 0) * (newStack.StackSize ?? 1);
+            newStack.Value = (newStack.StackUnitValue ?? 0) * (newStack.StackSize ?? 1);
 
-                var newStack = WorldObjectFactory.CreateNewWorldObject(stack.WeenieClassId);
-                newStack.StackSize = (ushort)amount;
-                newStack.EncumbranceVal = (newStack.StackUnitEncumbrance ?? 0) * (newStack.StackSize ?? 1);
-                newStack.Value = (newStack.StackUnitValue ?? 0) * (newStack.StackSize ?? 1);
+            newStack.SetPropertiesForWorld(this);
 
-                newStack.SetPropertiesForWorld(this);
+            container.EncumbranceVal -= newStack.EncumbranceVal;
+            container.Value -= newStack.Value;
 
-                container.EncumbranceVal -= newStack.EncumbranceVal;
-                container.Value -= newStack.Value;
+            if (container != this)
+            {
+                EncumbranceVal -= newStack.EncumbranceVal;
+                Value -= newStack.Value;
+            }
 
+            var motion = new UniversalMotion(MotionStance.Standing);
+            motion.MovementData.ForwardCommand = (uint)MotionCommand.Pickup;
+
+            // Set drop motion
+            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+
+            // Now wait for Drop Motion to finish -- use ActionChain
+            var dropChain = new ActionChain();
+
+            // Wait for drop animation
+            var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId);
+            var pickupAnimationLength = motionTable.GetAnimationLength(MotionCommand.Pickup);
+            dropChain.AddDelaySeconds(pickupAnimationLength);
+
+            // Play drop sound
+            // Put item on landblock
+            dropChain.AddAction(this, () =>
+            {
                 if (container != this)
-                {
-                    EncumbranceVal -= newStack.EncumbranceVal;
-                    Value -= newStack.Value;
-                }
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(container, PropertyInt.EncumbranceVal, container.EncumbranceVal ?? 0));
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
 
-                var motion = new UniversalMotion(MotionStance.Standing);
-                motion.MovementData.ForwardCommand = (uint)MotionCommand.Pickup;
-
-                // Set drop motion
+                motion = new UniversalMotion(MotionStance.Standing);
                 CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+                EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, 1.0f));
 
-                // Now wait for Drop Motion to finish -- use ActionChain
-                var dropChain = new ActionChain();
+                Session.Network.EnqueueSend(new GameMessageSetStackSize(stack));
 
-                // Wait for drop animation
-                var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId);
-                var pickupAnimationLength = motionTable.GetAnimationLength(MotionCommand.Pickup);
-                dropChain.AddDelaySeconds(pickupAnimationLength);
-
-                // Play drop sound
-                // Put item on landblock
-                dropChain.AddAction(this, () =>
-                {
-                    if (container != this)
-                        Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(container, PropertyInt.EncumbranceVal, container.EncumbranceVal ?? 0));
-                    Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
-
-                    motion = new UniversalMotion(MotionStance.Standing);
-                    CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
-                    EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, 1.0f));
-
-                    Session.Network.EnqueueSend(new GameMessageSetStackSize(stack));
-
-                    if (newStack.WeenieType == WeenieType.Coin)
-                        UpdateCoinValue();
+                if (newStack.WeenieType == WeenieType.Coin)
+                    UpdateCoinValue();
 
                     // This is the sequence magic - adds back into 3d space seem to be treated like teleport.
                     newStack.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
-                    newStack.Sequences.GetNextSequence(SequenceType.ObjectVector);
+                newStack.Sequences.GetNextSequence(SequenceType.ObjectVector);
 
-                    CurrentLandblock?.AddWorldObject(newStack);
+                CurrentLandblock?.AddWorldObject(newStack);
 
                     //Session.Network.EnqueueSend(new GameMessageUpdateObject(item));
                     EnqueueBroadcast(new GameMessageUpdatePosition(newStack));
-                });
-
-                actionChain.AddChain(dropChain);
             });
 
-            actionChain.EnqueueChain();
+            dropChain.EnqueueChain();
         }
 
         /// <summary>
@@ -1576,50 +1548,47 @@ namespace ACE.Server.WorldObjects
         /// <param name="amount">How many are we merging fromGuid into the toGuid</param>
         public void HandleActionStackableMerge(ObjectGuid mergeFromGuid, ObjectGuid mergeToGuid, int amount)
         {
-            new ActionChain(this, () =>
+            // is this something I already have? If not, it has to be a pickup - do the pickup and out.
+            if (!HasInventoryItem(mergeFromGuid))
             {
-                // is this something I already have? If not, it has to be a pickup - do the pickup and out.
-                if (!HasInventoryItem(mergeFromGuid))
-                {
-                    // This is a pickup into our main pack.
-                    HandleActionPutItemInContainer(mergeFromGuid, Guid);
-                    return;
-                }
+                // This is a pickup into our main pack.
+                HandleActionPutItemInContainer(mergeFromGuid, Guid);
+                return;
+            }
 
-                var fromItem = GetInventoryItem(mergeFromGuid);
-                var toItem = GetInventoryItem(mergeToGuid);
-                var missileAmmo = toItem.ItemType == ItemType.MissileWeapon;
+            var fromItem = GetInventoryItem(mergeFromGuid);
+            var toItem = GetInventoryItem(mergeToGuid);
+            var missileAmmo = toItem.ItemType == ItemType.MissileWeapon;
 
-                if (fromItem == null || toItem == null)
-                    return;
+            if (fromItem == null || toItem == null)
+                return;
 
-                // Check to see if we are trying to merge into a full stack. If so, nothing to do here.
-                // Check this and see if I need to call UpdateToStack to clear the action with an amount of 0 Og II
-                if (toItem.MaxStackSize == toItem.StackSize)
-                    return;
+            // Check to see if we are trying to merge into a full stack. If so, nothing to do here.
+            // Check this and see if I need to call UpdateToStack to clear the action with an amount of 0 Og II
+            if (toItem.MaxStackSize == toItem.StackSize)
+                return;
 
-                if (toItem.MaxStackSize >= (ushort)((toItem.StackSize ?? 0) + amount))
-                {
-                    // The toItem has enoguh capacity to take the full amount
-                    UpdateToStack(fromItem, toItem, amount, missileAmmo);
+            if (toItem.MaxStackSize >= (ushort)((toItem.StackSize ?? 0) + amount))
+            {
+                // The toItem has enoguh capacity to take the full amount
+                UpdateToStack(fromItem, toItem, amount, missileAmmo);
 
-                    // Ok did we merge it all? If so, let's remove the item.
-                    if (fromItem.StackSize == amount)
-                        TryRemoveFromInventoryWithNetworking(fromItem, true);
-                    else
-                        UpdateFromStack(fromItem, amount);
-                }
+                // Ok did we merge it all? If so, let's remove the item.
+                if (fromItem.StackSize == amount)
+                    TryRemoveFromInventoryWithNetworking(fromItem, true);
                 else
-                {
-                    // The toItem does not have enough capacity to take the full amount. Just add what we can and adjust both.
-                    Debug.Assert(toItem.MaxStackSize != null, "toWo.MaxStackSize != null");
+                    UpdateFromStack(fromItem, amount);
+            }
+            else
+            {
+                // The toItem does not have enough capacity to take the full amount. Just add what we can and adjust both.
+                Debug.Assert(toItem.MaxStackSize != null, "toWo.MaxStackSize != null");
 
-                    var amtToFill = (toItem.MaxStackSize ?? 0) - (toItem.StackSize ?? 0);
+                var amtToFill = (toItem.MaxStackSize ?? 0) - (toItem.StackSize ?? 0);
 
-                    UpdateToStack(fromItem, toItem, amtToFill, missileAmmo);
-                    UpdateFromStack(toItem, amtToFill);
-                }
-            }).EnqueueChain();
+                UpdateToStack(fromItem, toItem, amtToFill, missileAmmo);
+                UpdateFromStack(toItem, amtToFill);
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -2,7 +2,6 @@
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
 using ACE.Entity.Enum;
-using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -63,19 +62,16 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionMagicRemoveSpellId(uint spellId)
         {
-            new ActionChain(this, () =>
+            if (!Biota.TryRemoveKnownSpell((int)spellId, out _, BiotaDatabaseLock))
             {
-                if (!Biota.TryRemoveKnownSpell((int)spellId, out _, BiotaDatabaseLock))
-                {
-                    log.Error("Invalid spellId passed to Player.RemoveSpellFromSpellBook");
-                    return;
-                }
+                log.Error("Invalid spellId passed to Player.RemoveSpellFromSpellBook");
+                return;
+            }
 
-                ChangesDetected = true;
+            ChangesDetected = true;
 
-                GameEventMagicRemoveSpellId removeSpellEvent = new GameEventMagicRemoveSpellId(Session, spellId);
-                Session.Network.EnqueueSend(removeSpellEvent);
-            }).EnqueueChain();
+            GameEventMagicRemoveSpellId removeSpellEvent = new GameEventMagicRemoveSpellId(Session, spellId);
+            Session.Network.EnqueueSend(removeSpellEvent);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -317,8 +317,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -153,11 +153,10 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the player using the item.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item should be in the players possession.
         /// </summary>
-        public override void UseItem(Player player, ActionChain actionChain)
+        public override void UseItem(Player player)
         {
             bool success = true;
             string failReason = "You are unable to read the scroll.";
@@ -183,6 +182,8 @@ namespace ACE.Server.WorldObjects
                 success = false;
                 failReason = "You already know the spell inscribed upon this scroll.";
             }
+
+            var actionChain = new ActionChain();
 
             actionChain
                 .AddAction(player, () => player.HandleActionMotion(motionReading))
@@ -211,6 +212,8 @@ namespace ACE.Server.WorldObjects
 
             actionChain
                 .AddAction(player, () => player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session)));
+
+            actionChain.EnqueueChain();
         }
 
         //public override void SerializeIdentifyObjectResponse(BinaryWriter writer, bool success, IdentifyResponseFlags flags = IdentifyResponseFlags.None)

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -55,8 +55,7 @@ namespace ACE.Server.WorldObjects
 
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -642,11 +642,8 @@ namespace ACE.Server.WorldObjects
 
         public void ApplyVisualEffects(PlayScript effect)
         {
-            // new ActionChain(this, () => PlayParticleEffect(effect, Guid)).EnqueueChain();
             if (CurrentLandblock != null)
-            {
                 PlayParticleEffect(effect, Guid);
-            }
         }
 
         // plays particle effect like spell casting or bleed etc..

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -1,11 +1,8 @@
 
-using ACE.Database;
-using ACE.DatLoader;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
-using ACE.Server.Network.Structure;
 
 namespace ACE.Server.WorldObjects
 {
@@ -23,11 +20,10 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the player using the item.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item should be in the players possession.
         /// </summary>
-        public virtual void UseItem(Player player, ActionChain actionChain)
+        public virtual void UseItem(Player player)
         {
             // Do Nothing by default
 #if DEBUG
@@ -40,8 +36,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// This is raised by Player.HandleActionUseItem, and is wrapped in ActionChain.<para />
-        /// The actor of the ActionChain is the item being used.<para />
+        /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
         /// If the item was outside of range, the player will have been commanded to move using DoMoveTo before ActOnUse is called.<para />
         /// When this is called, it should be assumed that the player is within range.
@@ -49,9 +44,8 @@ namespace ACE.Server.WorldObjects
         public virtual void ActOnUse(WorldObject worldObject)
         {
             // Do Nothing by default
-            if (worldObject is Player)
+            if (worldObject is Player player)
             {
-                var player = worldObject as Player;
 #if DEBUG
                 var message = $"Default ActOnUse reached, this object ({Name}) not programmed yet.";
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.System));


### PR DESCRIPTION
This removes the unecessary ActionChains that were wrapping many of the HandleActionGameEvent functions.

ActionChains should only be used to enqueue work with delays, or, explicitly queue work for another WO that absolutely must be run on the landblock thread that owns the WO. (very rare, if any cases?)

We do not need to worry about out of order operations with HandleActionGameEvents. These handlers are enqueued when they are received on the network threads. They are then executed in a single thread in our UpdateWorld loop. This pattern is unlikely to change, and allows us to make the assumption that code executed from any HandleAction function (and not from an action chain) does not need to worry about thread safety, as it is the only thread modifying the world.

Parallelization will be added for Physics and Landblocks.Tick() at a future date.