### PR TITLE
LandblockMotionQueue removed

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -64,7 +64,6 @@ namespace ACE.Server.Managers
         public static readonly ActionQueue InboundMessageQueue = new ActionQueue();
 
         public static readonly ActionQueue LandblockActionQueue = new ActionQueue();
-        public static readonly ActionQueue LandblockMotionQueue = new ActionQueue();
         public static readonly ActionQueue LandblockBroadcastQueue = new ActionQueue();
 
         public static readonly DelayManager DelayManager = new DelayManager();
@@ -432,10 +431,6 @@ namespace ACE.Server.Managers
                 }
 
                 InboundMessageQueue.RunActions();
-
-                // Process between landblock object motions sequentially
-                // Currently only used for picking items up off a landblock
-                LandblockMotionQueue.RunActions();
 
                 // Now, update actions within landblocks
                 //   This is responsible for updating all "actors" residing within the landblock. 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -222,9 +222,11 @@ namespace ACE.Server.WorldObjects
             if (item != null)
             {
                 itemWasRestingOnLandblock = true;
-                item.NotifyOfEvent(RegenerationType.PickUp);
-                // Queue up an action that wait for the landblock to remove the item. The action that gets queued, when fired, will be run on the landblocks ActionChain, not this players.
-                CurrentLandblock?.QueueItemRemove(pickUpItemChain, itemGuid);
+                pickUpItemChain.AddAction(this, () =>
+                {
+                    if (CurrentLandblock != null && CurrentLandblock.RemoveWorldObjectFromPickup(itemGuid))
+                        item.NotifyOfEvent(RegenerationType.PickUp);
+                });
             }
             else
             {


### PR DESCRIPTION
The purpose of this queue was to make removing items from a landblock thread safe.

The assumption was that a worldObject and the landblock that owns it could be run on two separate threads.

Our initial implentation for multithreaded AC was that any Landblock or WO could be ticking on a completely separate thread.

We've since changed how we plan to multi-thread AC, with the assumption that a WO will be ticked/think on the same thread as it's parent Landblock, and furthermore that any adjacent landblock that has at least 1 player will also tick/think on the same thread.

This makes the design of ACE a lot more simple in the long run, and allows us to remove a lot of instances of excessive thread safety and action chain use.