### PR TITLE
Copy CharacterOptions

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -72,6 +72,15 @@ namespace ACE.Server.WorldObjects
             Session = session;
 
             SetEphemeralValues();
+
+            // THIS IS A TEMPORARY PATCH TO COPY OVER EXISTING CHARACTER OPTIONS FROM THE BIOTA TO THE CHARACTER OBJECT.
+            // This can be removed in time. 2018-09-01 Mag-nus
+            if (Character.CharacterOptions1 == 0 && Character.CharacterOptions2 == 0)
+            {
+                Character.CharacterOptions1 = GetProperty((PropertyInt)9003) ?? 1355064650;
+                Character.CharacterOptions2 = GetProperty((PropertyInt)9004) ?? 34560;
+                CharacterChangesDetected = true;
+            }
         }
 
         public override void InitPhysicsObj()


### PR DESCRIPTION
If the Character.CharacterOptions are 0, this will try to pull the options from the Biota, or set them to default values.

This is a patch to fix the PR979 schema change.