### PR TITLE
Character gameplay_Options fix

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using ACE.Common.Extensions;
@@ -171,9 +172,14 @@ namespace ACE.Server.Network.GameAction.Actions
 
                 byte[] gameplayOptions = new byte[size];
                 gameplayOptions = message.Payload.ReadBytes(size);
-                session.Player.Character.GameplayOptions = gameplayOptions;
-                session.Player.CharacterChangesDetected = true;
+                session.Player.SetCharacterGameplayOptions(gameplayOptions);
             }
+
+            // This message is also sent when a character logs off.
+            // When this happens, the message is sent AFTER ACE has already processed and saved the character to the database.
+            // To make sure we commit these additional changes (if any), we check to see if the log off requested time has a value.
+            if (session.Player.CharacterChangesDetected && session.LogOffRequestTime != DateTime.MinValue)
+                session.Player.SaveCharacterToDatabase();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -174,12 +174,6 @@ namespace ACE.Server.Network.GameAction.Actions
                 gameplayOptions = message.Payload.ReadBytes(size);
                 session.Player.SetCharacterGameplayOptions(gameplayOptions);
             }
-
-            // This message is also sent when a character logs off.
-            // When this happens, the message is sent AFTER ACE has already processed and saved the character to the database.
-            // To make sure we commit these additional changes (if any), we check to see if the log off requested time has a value.
-            if (session.Player.CharacterChangesDetected && session.LogOffRequestTime != DateTime.MinValue)
-                session.Player.SaveCharacterToDatabase();
         }
     }
 }

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -277,7 +277,7 @@ namespace ACE.Server.Network
         private void SendFinalLogOffMessages()
         {
             // It's possible for a character change to happen from a GameActionSetCharacterOptions message.
-            // This message can be received/procesed by the server AFTER LogOfPlayer has been called.
+            // This message can be received/processed by the server AFTER LogOfPlayer has been called.
             // What that means is, we could end up with Character changes after the Character has been saved from the initial LogOff request.
             // To make sure we commit these additional changes (if any), we check again here
             if (Player.CharacterChangesDetected)

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -45,7 +45,7 @@ namespace ACE.Server.Network
 
 
         private DateTime lastAutoSaveTime;
-        private DateTime logOffRequestTime;
+        public DateTime LogOffRequestTime { get; private set; }
         private DateTime lastAgeIntUpdateTime;
         private DateTime lastSendAgeIntUpdateTime;
 
@@ -128,9 +128,9 @@ namespace ACE.Server.Network
 
             // Live server seemed to take about 6 seconds. 4 seconds is nice because it has smooth animation, and saves the user 2 seconds every logoff
             // This could be made 0 for instant logoffs.
-            if (logOffRequestTime != DateTime.MinValue && logOffRequestTime.AddSeconds(6) <= DateTime.UtcNow)
+            if (LogOffRequestTime != DateTime.MinValue && LogOffRequestTime.AddSeconds(6) <= DateTime.UtcNow)
             {
-                logOffRequestTime = DateTime.MinValue;
+                LogOffRequestTime = DateTime.MinValue;
                 SendFinalLogOffMessages();
             }
 
@@ -271,7 +271,7 @@ namespace ACE.Server.Network
             logoutChain.AddChain(Player.GetLogoutChain());
             logoutChain.EnqueueChain();
 
-            logOffRequestTime = DateTime.UtcNow;
+            LogOffRequestTime = DateTime.UtcNow;
         }
 
         private void SendFinalLogOffMessages()

--- a/Source/ACE.Server/WorldObjects/Player_Character.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Character.cs
@@ -70,14 +70,44 @@ namespace ACE.Server.WorldObjects
 
         public void SetCharacterOptions1(int value)
         {
-            Character.CharacterOptions1 = value;
-            CharacterChangesDetected = true;
+            CharacterDatabaseLock.EnterWriteLock();
+            try
+            {
+                Character.CharacterOptions1 = value;
+                CharacterChangesDetected = true;
+            }
+            finally
+            {
+                CharacterDatabaseLock.ExitWriteLock();
+            }
         }
 
         public void SetCharacterOptions2(int value)
         {
-            Character.CharacterOptions2 = value;
-            CharacterChangesDetected = true;
+            CharacterDatabaseLock.EnterWriteLock();
+            try
+            {
+                Character.CharacterOptions2 = value;
+                CharacterChangesDetected = true;
+            }
+            finally
+            {
+                CharacterDatabaseLock.ExitWriteLock();
+            }
+        }
+
+        public void SetCharacterGameplayOptions(byte[] value)
+        {
+            CharacterDatabaseLock.EnterWriteLock();
+            try
+            {
+                Character.GameplayOptions = value;
+                CharacterChangesDetected = true;
+            }
+            finally
+            {
+                CharacterDatabaseLock.ExitWriteLock();
+            }
         }
 
 


### PR DESCRIPTION
This has two fixes.

1) ACE logoff code runs before the final GameActionSetCharacterOption event from the client. Because of this order of operations, any changed options weren't being saved to the character on logoff.

2) Character was being modified while it was being saved by EF. This caused some change tracking mismatches.

I mentioned before, but there are still a few lingering places that need this type of locking. It's another thing on my todo list.