### PR TITLE
First round of updates toward new threading model and less ActionChain usage

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -313,7 +313,7 @@ namespace ACE.Server.Command.Handlers
             }
 
             UniversalMotion motion = new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)animationId));
-            session.Player.HandleActionMotion(motion);
+            session.Player.EnqueueBroadcastMotion(motion);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Numerics;
+
+using log4net;
+
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
@@ -24,6 +28,8 @@ namespace ACE.Server.Command.Handlers
 {
     public static class DeveloperCommands
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // TODO: Replace later with a command to spawn a generator at the player's location
         /*
         /// <summary>
@@ -409,16 +415,23 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("loadalllandblocks", AccessLevel.Developer, CommandHandlerFlag.None, "Loads all Landblocks. This is VERY crude. Do NOT use it on a live server!!! It will likely crash the server.")]
         public static void HandleLoadAllLandblocks(Session session, params string[] parameters)
         {
-            session.Network.EnqueueSend(new GameMessageSystemChat("Loading landblocks... This will likely crash the server...", ChatMessageType.System));
+            if (session != null)
+                session.Network.EnqueueSend(new GameMessageSystemChat("Loading landblocks... This will likely crash the server...", ChatMessageType.System));
 
-            //Task.Run(() => // Using Task.Run() seems to halt around the 0x01E# block range.
+            Task.Run(() =>
             {
                 for (int x = 0; x <= 0xFE; x++)
                 {
                     for (int y = 0; y <= 0xFE; y++)
-                        LandblockManager.ForceLoadLandBlock(new LandblockId((byte)x, (byte)y));
+                    {
+                        var blockid = new LandblockId((byte)x, (byte)y);
+                        Stopwatch sw = Stopwatch.StartNew();
+                        LandblockManager.ForceLoadLandBlock(blockid);
+                        sw.Stop();
+                        log.DebugFormat("Loaded Landblock {0:X4} in {1} milliseconds ", blockid.Landblock, sw.ElapsedMilliseconds);
+                    }
                 }
-            }//);
+            });
         }
 
         [CommandHandler("cacheallweenies", AccessLevel.Developer, CommandHandlerFlag.None, "Loads and caches all Weenies. This may take 10+ minutes and is very heavy on the database.")]

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -19,10 +19,6 @@ using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
-using ACE.Server.Network.GameMessages;
-using ACE.Server.Network.GameMessages.Messages;
-using ACE.Server.Network.Motion;
-using ACE.Server.Network.Sequence;
 using ACE.Server.Physics.Common;
 using ACE.Server.WorldObjects;
 
@@ -585,14 +581,6 @@ namespace ACE.Server.Entity
             return inRange;
         }
 
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast a motion.
-        /// </summary>
-        public void EnqueueBroadcastMotion(WorldObject wo, UniversalMotion motion)
-        {
-            wo.EnqueueBroadcast(new GameMessageUpdateMotion(wo.Guid, wo.Sequences.GetCurrentSequence(SequenceType.ObjectInstance), wo.Sequences, motion));
-        }
-        
         // Wrappers so landblocks can be treated as actors and actions
         // FIXME(ddevec): Once cludgy UseTime function removed, I can probably remove the action interface from landblock...?
         public LinkedListNode<IAction> EnqueueAction(IAction actn)

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -65,7 +65,7 @@ namespace ACE.Server.Entity
 
         public LandBlockStatus Status = new LandBlockStatus();
 
-        private NestedActionQueue actionQueue;
+        private readonly NestedActionQueue actionQueue;
 
         public LandblockId Id { get; }
 
@@ -530,72 +530,56 @@ namespace ACE.Server.Entity
             if (!highXInLandblock)
             {
                 if (EastAdjacency != null)
-                {
                     inRange.Add(EastAdjacency);
-                }
             }
 
             // North East
             if (!highXInLandblock && !highYInLandblock)
             {
                 if (NorthEastAdjacency != null)
-                {
                     inRange.Add(NorthEastAdjacency);
-                }
             }
 
             // North
             if (!highYInLandblock)
             {
                 if (NorthAdjacency != null)
-                {
                     inRange.Add(NorthAdjacency);
-                }
             }
 
             // North West
             if (!lowXInLandblock && !highYInLandblock)
             {
                 if (NorthWestAdjacency != null)
-                {
                     inRange.Add(NorthWestAdjacency);
-                }
             }
 
             // West
             if (!lowXInLandblock)
             {
                 if (WestAdjacency != null)
-                {
                     inRange.Add(WestAdjacency);
-                }
             }
 
             // South West
             if (!lowXInLandblock && !lowYInLandblock)
             {
                 if (SouthWestAdjacency != null)
-                {
                     inRange.Add(SouthWestAdjacency);
-                }
             }
 
             // South
             if (!lowYInLandblock)
             {
                 if (SouthAdjacency != null)
-                {
                     inRange.Add(SouthAdjacency);
-                }
             }
 
             // South East
             if (!highXInLandblock && !lowYInLandblock)
             {
                 if (SouthEastAdjacency != null)
-                {
                     inRange.Add(SouthEastAdjacency);
-                }
             }
 
             return inRange;
@@ -606,50 +590,9 @@ namespace ACE.Server.Entity
         /// </summary>
         public void EnqueueBroadcastMotion(WorldObject wo, UniversalMotion motion)
         {
-            wo.EnqueueBroadcast(new GameMessageUpdateMotion(wo.Guid,
-                wo.Sequences.GetCurrentSequence(SequenceType.ObjectInstance), wo.Sequences, motion));
-        }
-
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast a sound.
-        /// </summary>
-        public void EnqueueBroadcastSound(WorldObject wo, Sound sound, float volume = 1.0f)
-        {
-            wo.EnqueueBroadcast(new GameMessageSound(wo.Guid, sound, volume));
+            wo.EnqueueBroadcast(new GameMessageUpdateMotion(wo.Guid, wo.Sequences.GetCurrentSequence(SequenceType.ObjectInstance), wo.Sequences, motion));
         }
         
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast local chat.
-        /// </summary>
-        public void EnqueueBroadcastSystemChat(WorldObject wo, string message, ChatMessageType type)
-        {
-            wo.EnqueueBroadcast(new GameMessageSystemChat(message, type));
-        }
-
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast local chat.
-        /// </summary>
-        public void EnqueueBroadcastLocalChat(WorldObject wo, string message)
-        {
-            wo.EnqueueBroadcast(new GameMessageCreatureMessage(message, wo.Name, wo.Guid.Full, ChatMessageType.Speech));
-        }
-
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast local chat emotes.
-        /// </summary>
-        public void EnqueueBroadcastLocalChatEmote(WorldObject wo, string emote)
-        {
-            wo.EnqueueBroadcast(new GameMessageEmoteText(wo.Guid.Full, wo.Name, emote));
-        }
-
-        /// <summary>
-        /// Convenience wrapper to EnqueueBroadcast to broadcast local soul emotes.
-        /// </summary>
-        public void EnqueueBroadcastLocalChatSoulEmote(WorldObject wo, string emote)
-        {
-            wo.EnqueueBroadcast(new GameMessageSoulEmote(wo.Guid.Full, wo.Name, emote));
-        }
-
         // Wrappers so landblocks can be treated as actors and actions
         // FIXME(ddevec): Once cludgy UseTime function removed, I can probably remove the action interface from landblock...?
         public LinkedListNode<IAction> EnqueueAction(IAction actn)
@@ -883,14 +826,14 @@ namespace ACE.Server.Entity
         {
             if (adjacency == null || adjacencies[adjacency.Value] != landblock)
             {
-                Console.WriteLine($"Landblock({Id}).UnloadAdjacent({adjacency}, {landblock.Id}) couldn't find adjacent landblock");
+                log.Error($"Landblock({Id}).UnloadAdjacent({adjacency}, {landblock.Id}) couldn't find adjacent landblock");
                 return;
             }
             adjacencies[adjacency.Value] = null;
             AdjacenciesLoaded = false;
         }
 
-        public void SaveDB()
+        private void SaveDB()
         {
             var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Numerics;
 using System.Threading;
 
+using log4net;
+
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
@@ -23,8 +25,6 @@ using ACE.Server.Network.Motion;
 using ACE.Server.Network.Sequence;
 using ACE.Server.Physics.Common;
 using ACE.Server.WorldObjects;
-
-using log4net;
 
 using Position = ACE.Entity.Position;
 

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -765,7 +765,7 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.Sound:
-                    targetObject.CurrentLandblock?.EnqueueBroadcastSound(targetObject, (Sound)emoteAction.Sound);
+                    targetObject.EnqueueBroadcast(new GameMessageSound(targetObject.Guid, (Sound)emoteAction.Sound, 1.0f));
                     break;
 
                 case EmoteType.SpendLuminance:

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -538,7 +538,7 @@ namespace ACE.Server.Managers
                                 actionChain.AddDelaySeconds(emoteAction.Delay);
                                 actionChain.AddAction(sourceObject, () =>
                                 {
-                                    sourceObject.DoMotion(startingMotion);
+                                    sourceObject.EnqueueBroadcastMotion(startingMotion);
                                     sourceObject.CurrentMotionState = startingMotion;
                                 });
                             }
@@ -550,7 +550,7 @@ namespace ACE.Server.Managers
                                 actionChain.AddDelaySeconds(emoteAction.Delay);
                                 actionChain.AddAction(sourceObject, () =>
                                 {
-                                    sourceObject.DoMotion(motion);
+                                    sourceObject.EnqueueBroadcastMotion(motion);
                                     sourceObject.CurrentMotionState = motion;
                                 });
                                 actionChain.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(sourceObject.MotionTableId).GetAnimationLength((MotionCommand)emoteAction.Motion));
@@ -558,7 +558,7 @@ namespace ACE.Server.Managers
                                 {
                                     actionChain.AddAction(sourceObject, () =>
                                     {
-                                        sourceObject.DoMotion(startingMotion);
+                                        sourceObject.EnqueueBroadcastMotion(startingMotion);
                                         sourceObject.CurrentMotionState = startingMotion;
                                     });
                                 }
@@ -572,7 +572,7 @@ namespace ACE.Server.Managers
                         actionChain.AddDelaySeconds(emoteAction.Delay);
                         actionChain.AddAction(sourceObject, () =>
                         {
-                            sourceObject.DoMotion(motion);
+                            sourceObject.EnqueueBroadcastMotion(motion);
                             sourceObject.CurrentMotionState = motion;
                         });
                     }

--- a/Source/ACE.Server/Managers/EmoteManagerExample.cs
+++ b/Source/ACE.Server/Managers/EmoteManagerExample.cs
@@ -399,7 +399,7 @@ namespace ACE.Server.Managers
                 case EmoteType.LocalBroadcast:
 
                     text = Replace(emote.Message, WorldObject, target);
-                    WorldObject.CurrentLandblock?.EnqueueBroadcastSystemChat(WorldObject, text, ChatMessageType.Broadcast);
+                    WorldObject.EnqueueBroadcast(new GameMessageSystemChat(text, ChatMessageType.Broadcast));
                     break;
 
                 case EmoteType.LocalSignal:
@@ -484,7 +484,7 @@ namespace ACE.Server.Managers
 
                     text = Replace(emote.Message, WorldObject, target);
                     if (player != null)
-                        player.CurrentLandblock?.EnqueueBroadcastLocalChat(player, text);
+                        player.EnqueueBroadcast(new GameMessageCreatureMessage(text, player.Name, player.Guid.Full, ChatMessageType.Speech));
                     break;
 
                 case EmoteType.SetAltRacialSkills:
@@ -564,7 +564,7 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.Sound:
-                    target.CurrentLandblock?.EnqueueBroadcastSound(target, (Sound)emote.Sound);
+                    target.EnqueueBroadcast(new GameMessageSound(target.Guid, (Sound)emote.Sound, 1.0f));
                     break;
 
                 case EmoteType.SpendLuminance:

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 using log4net;
 
@@ -165,19 +164,14 @@ namespace ACE.Server.Managers
             }
         }
 
+        /// <summary>
+        /// This function is NOT thread safe. Using it will likely result in concurrency issues with WorldManager.UpdateWorld.
+        /// You should only use this for debugging/development purposes.
+        /// </summary>
+        /// <param name="blockid"></param>
         public static void ForceLoadLandBlock(LandblockId blockid)
         {
-            Stopwatch sw = Stopwatch.StartNew();
             GetLandblock(blockid, false);
-            sw.Stop();
-            log.DebugFormat("Loaded Landblock {0:X4} in {1} milliseconds ", blockid.Landblock, sw.ElapsedMilliseconds);
-            Console.WriteLine("Loaded Landblock {0:X4} in {1} milliseconds ", blockid.Landblock, sw.ElapsedMilliseconds);
-        }
-
-        public static void FinishedForceLoading()
-        {
-            log.DebugFormat("Finished Forceloading Landblocks");
-            Console.WriteLine("Finished Forceloading Landblocks");
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -41,7 +41,7 @@ namespace ACE.Server.Managers
             double percentSuccess = 1;
 
             UniversalMotion motion = new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.ClapHands));
-            craftChain.AddAction(player, () => player.HandleActionMotion(motion));
+            craftChain.AddAction(player, () => player.EnqueueBroadcastMotion(motion));
             var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>(player.MotionTableId);
             var craftAnimationLength = motionTable.GetAnimationLength(MotionCommand.ClapHands);
             craftChain.AddDelaySeconds(craftAnimationLength);

--- a/Source/ACE.Server/Managers/ServerManager.cs
+++ b/Source/ACE.Server/Managers/ServerManager.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
+
 using ACE.Common;
+
 using log4net;
 
 namespace ACE.Server.Managers
@@ -81,11 +83,11 @@ namespace ACE.Server.Managers
                     // reset shutdown details
                     string shutdownText = $"The server has canceled the shutdown procedure @ {DateTime.UtcNow} UTC";
                     log.Warn(shutdownText);
+
                     // special text
                     foreach (var player in WorldManager.GetAll())
-                    {
                         player.WorldBroadcast(shutdownText);
-                    }
+
                     // break function
                     return;
                 }
@@ -106,11 +108,10 @@ namespace ACE.Server.Managers
 
             // disabled thread update loop and halt application
             WorldManager.StopWorld();
+
             // wait for world to end
             while (WorldManager.WorldActive)
-            {
-                // no nothing
-            }
+                ; // do nothing
 
             // write exit to console/log
             log.Warn($"Exiting at {DateTime.UtcNow}");

--- a/Source/ACE.Server/Network/GameEvent/GameEventMessage.cs
+++ b/Source/ACE.Server/Network/GameEvent/GameEventMessage.cs
@@ -1,5 +1,5 @@
+
 using ACE.Server.Network.GameMessages;
-using System;
 
 namespace ACE.Server.Network.GameEvent
 {
@@ -14,8 +14,6 @@ namespace ACE.Server.Network.GameEvent
             EventType = eventType;
             Session = session;
 
-            // Force session to not be null -- due to races with player initialization
-            session.WaitForPlayer();
             Writer.WriteGuid(session.Player.Guid);
             var debugMessage = $"GameEventSequence Update - {eventType} - GameEventSequence was {session.GameEventSequence}";
             Writer.Write(session.GameEventSequence++);

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -559,7 +559,7 @@ namespace ACE.Server.Network.Handlers
 
             session.State = SessionState.WorldConnected;
 
-            LandblockManager.PlayerEnterWorld(session, character);
+            WorldManager.PlayerEnterWorld(session, character);
         }
 
 

--- a/Source/ACE.Server/Network/Managers/InboundMessageManager.cs
+++ b/Source/ACE.Server/Network/Managers/InboundMessageManager.cs
@@ -97,7 +97,7 @@ namespace ACE.Server.Network.Managers
                 {
                     if (messageHandlerInfo.Attribute.State == session.State)
                     {
-                        WorldManager.InboundMessageQueue.EnqueueAction(new ActionEventDelegate(() =>
+                        WorldManager.InboundClientMessageQueue.EnqueueAction(new ActionEventDelegate(() =>
                         {
                             messageHandlerInfo.Handler.Invoke(message, session);
                         }));
@@ -114,7 +114,7 @@ namespace ACE.Server.Network.Managers
             {
                 if (actionHandlers.TryGetValue(opcode, out var actionHandlerInfo))
                 {
-                    WorldManager.InboundMessageQueue.EnqueueAction(new ActionEventDelegate(() =>
+                    session.InboundGameActionQueue.EnqueueAction(new ActionEventDelegate(() =>
                     {
                         actionHandlerInfo.Handler.Invoke(message, session);
                     }));

--- a/Source/ACE.Server/WorldObjects/AdvocateFane.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateFane.cs
@@ -5,7 +5,6 @@ using ACE.DatLoader.FileTypes;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Network.GameMessages.Messages;
@@ -83,9 +82,9 @@ namespace ACE.Server.WorldObjects
                     {
                         //error msg here
                         if (UseTargetFailureAnimation.HasValue)
-                            CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
+                            EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
                         else
-                            CurrentLandblock?.EnqueueBroadcastMotion(this, twitch2);
+                            EnqueueBroadcastMotion(twitch2);
 
                         player.SendUseDoneEvent();
                         return;
@@ -98,21 +97,21 @@ namespace ACE.Server.WorldObjects
                         var faneTimer = new ActionChain();
                         var turnToMotion = new UniversalMotion(MotionStance.NonCombat, Location, Guid);
                         turnToMotion.MovementTypes = MovementTypes.TurnToObject;
-                        faneTimer.AddAction(this, () => player.CurrentLandblock?.EnqueueBroadcastMotion(player, turnToMotion));
+                        faneTimer.AddAction(this, () => player.EnqueueBroadcastMotion(turnToMotion));
                         faneTimer.AddDelaySeconds(1);
                         faneTimer.AddAction(player, () =>
                         {
                             if (UseUserAnimation.HasValue)
-                                CurrentLandblock?.EnqueueBroadcastMotion(player, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseUserAnimation)));
+                                player.EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseUserAnimation)));
                             else
-                                CurrentLandblock?.EnqueueBroadcastMotion(player, bowDeep);
+                                player.EnqueueBroadcastMotion(bowDeep);
                         });
                         faneTimer.AddAction(player, () =>
                         {
                             if (UseTargetSuccessAnimation.HasValue)
-                                CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetSuccessAnimation)));
+                                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetSuccessAnimation)));
                             else
-                                CurrentLandblock?.EnqueueBroadcastMotion(this, twitch);
+                                EnqueueBroadcastMotion(twitch);
                         });
                         if (UseTargetSuccessAnimation.HasValue)
                             faneTimer.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength((MotionCommand)UseTargetSuccessAnimation));
@@ -170,9 +169,9 @@ namespace ACE.Server.WorldObjects
                     else
                     {
                         if (UseTargetFailureAnimation.HasValue)
-                            CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
+                            EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
                         else
-                            CurrentLandblock?.EnqueueBroadcastMotion(this, twitch2);
+                            EnqueueBroadcastMotion(twitch2);
 
                         player.SendUseDoneEvent();
                     }

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -6,6 +6,7 @@ using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.Motion;
 using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
 {
@@ -101,7 +102,7 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"The {Name} is locked!"));
-                    CurrentLandblock?.EnqueueBroadcastSound(this, Sound.OpenFailDueToLock);
+                    EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));
                 }
 
                 player.SendUseDoneEvent();

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -86,7 +86,7 @@ namespace ACE.Server.WorldObjects
                         turnToMotion.MovementTypes = MovementTypes.TurnToObject;
 
                         ActionChain turnToTimer = new ActionChain();
-                        turnToTimer.AddAction(this, () => player.CurrentLandblock?.EnqueueBroadcastMotion(player, turnToMotion));
+                        turnToTimer.AddAction(this, () => player.EnqueueBroadcastMotion(turnToMotion));
                         turnToTimer.AddDelaySeconds(1);
                         turnToTimer.AddAction(this, () => Open(player));
                         turnToTimer.EnqueueChain();
@@ -111,13 +111,13 @@ namespace ACE.Server.WorldObjects
 
         protected override void DoOnOpenMotionChanges()
         {
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionOpen);
+            EnqueueBroadcastMotion(motionOpen);
             CurrentMotionState = motionOpen;
         }
 
         protected override void DoOnCloseMotionChanges()
         {
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionClosed);
+            EnqueueBroadcastMotion(motionClosed);
             CurrentMotionState = motionClosed;
         }
 

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -386,7 +386,7 @@ namespace ACE.Server.WorldObjects
                     turnToMotion.MovementTypes = MovementTypes.TurnToObject;
 
                     var turnToTimer = new ActionChain();
-                    turnToTimer.AddAction(this, () => player.CurrentLandblock?.EnqueueBroadcastMotion(player, turnToMotion));
+                    turnToTimer.AddAction(this, () => player.EnqueueBroadcastMotion(turnToMotion));
                     turnToTimer.AddDelaySeconds(1);
                     turnToTimer.AddAction(this, () => Open(player));
                     turnToTimer.EnqueueChain();

--- a/Source/ACE.Server/WorldObjects/Cow.cs
+++ b/Source/ACE.Server/WorldObjects/Cow.cs
@@ -81,7 +81,7 @@ namespace ACE.Server.WorldObjects
         {       
             AllowedActivator = activator.Full;
 
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionTipRight);
+            EnqueueBroadcastMotion(motionTipRight);
             
             // Stamp Cow tipping quest here;
 

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -222,7 +222,7 @@ namespace ACE.Server.WorldObjects
             newMotion.DistanceFrom = 0.60f;
             newMotion.MovementTypes = movementType;
             EnqueueBroadcast(new GameMessageUpdatePosition(this));
-            CurrentLandblock?.EnqueueBroadcastMotion(this, newMotion);
+            EnqueueBroadcastMotion(newMotion);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -8,7 +8,6 @@ using ACE.DatLoader.FileTypes;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
@@ -55,7 +54,7 @@ namespace ACE.Server.WorldObjects
 
             // broadcast death animation
             var motionDeath = new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.Dead));
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionDeath);
+            EnqueueBroadcastMotion(motionDeath);
 
             var dieChain = new ActionChain();
 

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -66,13 +66,13 @@ namespace ACE.Server.WorldObjects
             //motion.TargetGuid = target.Guid;
             CurrentMotionState = motion;
 
-            actionChain.AddAction(this, () => DoMotion(motion));
+            actionChain.AddAction(this, () => EnqueueBroadcastMotion(motion));
             actionChain.AddDelaySeconds(animLength);
 
             actionChain.AddAction(this, () =>
             {
                 motion.MovementData.ForwardCommand = (uint)MotionCommand.Invalid;
-                DoMotion(motion);
+                EnqueueBroadcastMotion(motion);
                 CurrentMotionState = motion;
             });
 

--- a/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
@@ -95,7 +96,7 @@ namespace ACE.Server.WorldObjects
             // send network message to start turning creature
             var turnToMotion = new UniversalMotion(CurrentMotionState.Stance, target.Location, target.Guid);
             turnToMotion.MovementTypes = MovementTypes.TurnToObject;
-            CurrentLandblock?.EnqueueBroadcastMotion(this, turnToMotion);
+            EnqueueBroadcastMotion(turnToMotion);
 
             var angle = GetAngle(target);
             //Console.WriteLine("Angle: " + angle);
@@ -152,7 +153,7 @@ namespace ACE.Server.WorldObjects
             // send network message to start turning creature
             var turnToMotion = new UniversalMotion(CurrentMotionState.Stance, position);
             turnToMotion.MovementTypes = MovementTypes.TurnToHeading;
-            CurrentLandblock?.EnqueueBroadcastMotion(this, turnToMotion);
+            EnqueueBroadcastMotion(turnToMotion);
 
             var angle = GetAngle(position);
             //Console.WriteLine("Angle: " + angle);
@@ -198,7 +199,7 @@ namespace ACE.Server.WorldObjects
 
             var turnToMotion = new UniversalMotion(CurrentMotionState.Stance, target.Location, target.Guid);
             turnToMotion.MovementTypes = MovementTypes.TurnToObject;
-            CurrentLandblock?.EnqueueBroadcastMotion(this, turnToMotion);
+            EnqueueBroadcastMotion(turnToMotion);
 
             CurrentMotionState = turnToMotion;
 
@@ -233,7 +234,7 @@ namespace ACE.Server.WorldObjects
 
             CurrentMotionState = motion;
 
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
         }
 
         /// <summary>
@@ -250,7 +251,7 @@ namespace ACE.Server.WorldObjects
             // todo: use better movement system
             Location = position;
 
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Networking.cs
@@ -203,7 +203,7 @@ namespace ACE.Server.WorldObjects
             actionChain.AddAction(this, () =>
             {
                 CurrentMotionState = motion;
-                DoMotion(motion);
+                EnqueueBroadcastMotion(motion);
             });
 
             var animLength = Physics.Animation.MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, motionCommand);

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -189,7 +189,7 @@ namespace ACE.Server.WorldObjects
                         var player = worldObject as Player;
                         var doorIsLocked = new GameEventCommunicationTransientString(player.Session, "The door is locked!");
                         player.Session.Network.EnqueueSend(doorIsLocked);
-                        CurrentLandblock?.EnqueueBroadcastSound(this, Sound.OpenFailDueToLock);
+                        EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));
                     }
                 }
 

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -5,7 +5,6 @@ using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Network.GameEvent.Events;
@@ -209,7 +208,7 @@ namespace ACE.Server.WorldObjects
             if (CurrentMotionState == motionOpen)
                 return;
 
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionOpen);
+            EnqueueBroadcastMotion(motionOpen);
             CurrentMotionState = motionOpen;
             Ethereal = true;
             IsOpen = true;
@@ -224,7 +223,7 @@ namespace ACE.Server.WorldObjects
             if (CurrentMotionState == motionClosed)
                 return;
 
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionClosed);
+            EnqueueBroadcastMotion(motionClosed);
             CurrentMotionState = motionClosed;
             Ethereal = false;
             IsOpen = false;

--- a/Source/ACE.Server/WorldObjects/GamePiece.cs
+++ b/Source/ACE.Server/WorldObjects/GamePiece.cs
@@ -35,7 +35,7 @@ namespace ACE.Server.WorldObjects
             ActionChain killChain = new ActionChain();
             killChain.AddAction(this, () =>
             {
-                HandleActionMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.Dead)));
+                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.Dead)));
             });
             killChain.AddDelaySeconds(5);
             killChain.AddAction(this, () =>

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -60,7 +60,7 @@ namespace ACE.Server.WorldObjects
             healer.CurrentMotionState = motion;
 
             var actionChain = new ActionChain();
-            actionChain.AddAction(healer, () => healer.DoMotion(motion));
+            actionChain.AddAction(healer, () => healer.EnqueueBroadcastMotion(motion));
             actionChain.AddDelaySeconds(animLength);
             actionChain.AddAction(healer, () =>
             {

--- a/Source/ACE.Server/WorldObjects/Lifestone.cs
+++ b/Source/ACE.Server/WorldObjects/Lifestone.cs
@@ -54,7 +54,7 @@ namespace ACE.Server.WorldObjects
                 sancTimer.AddAction(player, () =>
                 {
                     CurrentLandblock?.EnqueueBroadcastMotion(player, sanctuary);
-                    CurrentLandblock?.EnqueueBroadcastSound(player, Sound.LifestoneOn, 1);
+                    player.EnqueueBroadcast(new GameMessageSound(player.Guid, Sound.LifestoneOn, 1.0f));
                 });
                 sancTimer.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(player.MotionTableId).GetAnimationLength(MotionCommand.Sanctuary));
                 sancTimer.AddAction(player, () =>

--- a/Source/ACE.Server/WorldObjects/Lifestone.cs
+++ b/Source/ACE.Server/WorldObjects/Lifestone.cs
@@ -53,7 +53,7 @@ namespace ACE.Server.WorldObjects
                 ActionChain sancTimer = new ActionChain();
                 sancTimer.AddAction(player, () =>
                 {
-                    CurrentLandblock?.EnqueueBroadcastMotion(player, sanctuary);
+                    player.EnqueueBroadcastMotion(sanctuary);
                     player.EnqueueBroadcast(new GameMessageSound(player.Guid, Sound.LifestoneOn, 1.0f));
                 });
                 sancTimer.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(player.MotionTableId).GetAnimationLength(MotionCommand.Sanctuary));

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -81,7 +81,7 @@ namespace ACE.Server.WorldObjects
                             player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.LockAlreadyUnlocked));
                             break;
                         case UnlockResults.PickLockFailed:
-                            target.CurrentLandblock?.EnqueueBroadcastSound(target, Sound.PicklockFail);
+                            target.EnqueueBroadcast(new GameMessageSound(target.Guid, Sound.PicklockFail, 1.0f));
                             ConsumeUnlocker(player, unlocker);
                             break;
                         case UnlockResults.CannotBePicked:

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -97,8 +97,7 @@ namespace ACE.Server.WorldObjects
             //motion.TargetGuid = target.Guid;
             CurrentMotionState = motion;
 
-            if (CurrentLandblock != null)
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -116,12 +116,11 @@ namespace ACE.Server.WorldObjects
             motion.TargetGuid = target.Guid;
             CurrentMotionState = motion;
 
-            if (CurrentLandblock != null)
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
 
             // play default script? (special attack)
             //if (MotionTable.HasDefaultScript(MotionTableId, maneuver.Motion, maneuver.Style))
-                //EnqueueBroadcast(new GameMessageScript(Guid, (PlayScript)DefaultScriptId));
+            //EnqueueBroadcast(new GameMessageScript(Guid, (PlayScript)DefaultScriptId));
 
             return null;
         }

--- a/Source/ACE.Server/WorldObjects/PKModifier.cs
+++ b/Source/ACE.Server/WorldObjects/PKModifier.cs
@@ -94,14 +94,14 @@ namespace ACE.Server.WorldObjects
                         var switchTimer = new ActionChain();
                         var turnToMotion = new UniversalMotion(MotionStance.NonCombat, Location, Guid);
                         turnToMotion.MovementTypes = MovementTypes.TurnToObject;
-                        switchTimer.AddAction(this, () => player.CurrentLandblock?.EnqueueBroadcastMotion(player, turnToMotion));
+                        switchTimer.AddAction(this, () => player.EnqueueBroadcastMotion(turnToMotion));
                         switchTimer.AddDelaySeconds(1);
                         switchTimer.AddAction(player, () =>
                         {
                             if (UseTargetSuccessAnimation.HasValue)
-                                CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetSuccessAnimation)));
+                                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetSuccessAnimation)));
                             else
-                                CurrentLandblock?.EnqueueBroadcastMotion(this, twitch);
+                                EnqueueBroadcastMotion(twitch);
                         });
                         if (UseTargetSuccessAnimation.HasValue)
                             switchTimer.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength((MotionCommand)UseTargetSuccessAnimation));
@@ -128,7 +128,7 @@ namespace ACE.Server.WorldObjects
                     else
                     {
                         if (UseTargetFailureAnimation.HasValue)
-                            CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
+                            EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetFailureAnimation)));
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(GetProperty(PropertyString.ActivationFailure), ChatMessageType.Broadcast));
                         player.SendUseDoneEvent();
                     }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -850,17 +850,17 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionTalk(string message)
         {
-            CurrentLandblock?.EnqueueBroadcastLocalChat(this, message);
+            EnqueueBroadcast(new GameMessageCreatureMessage(message, Name, Guid.Full, ChatMessageType.Speech));
         }
 
         public void HandleActionEmote(string message)
         {
-            CurrentLandblock?.EnqueueBroadcastLocalChatEmote(this, message);
+            EnqueueBroadcast(new GameMessageEmoteText(Guid.Full, Name, message));
         }
 
         public void HandleActionSoulEmote(string message)
         {
-            CurrentLandblock?.EnqueueBroadcastLocalChatSoulEmote(this, message);
+            EnqueueBroadcast(new GameMessageSoulEmote(Guid.Full, Name, message));
         }
 
         public void HandleActionJump(JumpPack jump)

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -586,7 +586,7 @@ namespace ACE.Server.WorldObjects
             if (!clientSessionTerminatedAbruptly)
             {
                 var logout = new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.LogOut));
-                CurrentLandblock?.EnqueueBroadcastMotion(this, logout);
+                EnqueueBroadcastMotion(logout);
 
                 EnqueueBroadcastPhysicsState();
 
@@ -896,7 +896,7 @@ namespace ACE.Server.WorldObjects
                 };
                 CurrentMotionState = motion;
                 if (CurrentLandblock != null)
-                    CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+                    EnqueueBroadcastMotion(motion);
             }
             Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You're Exhausted!"));
         }
@@ -924,7 +924,7 @@ namespace ACE.Server.WorldObjects
             var soundEvent = new GameMessageSound(Guid, sound, 1.0f);
             var motion = new UniversalMotion(MotionStance.NonCombat, new MotionItem(motionCommand));
 
-            DoMotion(motion);
+            EnqueueBroadcastMotion(motion);
 
             if (buffType == ConsumableBuffType.Spell)
             {
@@ -976,7 +976,7 @@ namespace ACE.Server.WorldObjects
             motionChain.AddDelaySeconds(motionAnimationLength);
 
             // Return to standing position after the animation delay
-            motionChain.AddAction(this, () => DoMotion(new UniversalMotion(MotionStance.NonCombat)));
+            motionChain.AddAction(this, () => EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat)));
             motionChain.EnqueueChain();
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
@@ -48,7 +48,7 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameMessageSystemChat($"{patron.Name} has accepted your oath of Allegiance!", ChatMessageType.Broadcast));
 
             var motion = new UniversalMotion(CurrentMotionState.Stance, new MotionItem(MotionCommand.Kneel));
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
 
             // rebuild allegiance tree structure
             AllegianceManager.OnSwearAllegiance(this);

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -395,7 +395,7 @@ namespace ACE.Server.WorldObjects
                 if (!string.IsNullOrWhiteSpace(hotspot.ActivationTalkString))
                     Session.Network.EnqueueSend(new GameMessageSystemChat(hotspot.ActivationTalkString.Replace("%i", amount.ToString()), ChatMessageType.Craft));
                 if (!(hotspot.Visibility ?? false))
-                    CurrentLandblock?.EnqueueBroadcastSound(hotspot, Sound.TriggerActivated);
+                    hotspot.EnqueueBroadcast(new GameMessageSound(hotspot.Guid, Sound.TriggerActivated, 1.0f));
             }
 
             if (percent >= 0.1f)

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -1,16 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using ACE.Database;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
-using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
-using ACE.Server.Network;
 using ACE.Server.Network.Structure;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
@@ -37,7 +36,7 @@ namespace ACE.Server.WorldObjects
 
             // broadcast death animation
             var deathAnim = new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.Dead));
-            CurrentLandblock?.EnqueueBroadcastMotion(this, deathAnim);
+            EnqueueBroadcastMotion(deathAnim);
 
             // killer death message = last damager
             var killerMsg = lastDamager != null ? " to " + lastDamager.Name : "";
@@ -115,7 +114,7 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(msgHealthUpdate, msgStaminaUpdate, msgManaUpdate);
 
                 // Stand back up
-                DoMotion(new UniversalMotion(MotionStance.NonCombat));
+                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat));
             });
             teleportChain.EnqueueChain();
         }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -612,8 +612,8 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, new ObjectGuid(0)));
 
             // Set drop motion
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
-
+            EnqueueBroadcastMotion(motion);
+            
             // Now wait for Drop Motion to finish -- use ActionChain
             var dropChain = new ActionChain();
 
@@ -626,8 +626,7 @@ namespace ACE.Server.WorldObjects
             // Put item on landblock
             dropChain.AddAction(this, () =>
             {
-                motion = new UniversalMotion(MotionStance.NonCombat);
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat));
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, (float)1.0));
                 Session.Network.EnqueueSend(
                     new GameEventItemServerSaysMoveItem(Session, item),
@@ -1517,7 +1516,7 @@ namespace ACE.Server.WorldObjects
             motion.MovementData.ForwardCommand = (uint)MotionCommand.Pickup;
 
             // Set drop motion
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcastMotion(motion);
 
             // Now wait for Drop Motion to finish -- use ActionChain
             var dropChain = new ActionChain();
@@ -1535,8 +1534,7 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(container, PropertyInt.EncumbranceVal, container.EncumbranceVal ?? 0));
                 Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
 
-                motion = new UniversalMotion(MotionStance.NonCombat);
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+                EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat));
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem, 1.0f));
 
                 Session.Network.EnqueueSend(new GameMessageSetStackSize(stack));

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -53,8 +53,8 @@ namespace ACE.Server.WorldObjects
                     var updateCombatMode = new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat);
                     Session.Network.EnqueueSend(updateCombatMode);
                 }
-                 
-                CurrentLandblock?.EnqueueBroadcastSystemChat(this, $"{Name} is recalling to the lifestone.", ChatMessageType.Recall);
+
+                EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the lifestone.", ChatMessageType.Recall));
                 CurrentLandblock?.EnqueueBroadcastMotion(this, motionLifestoneRecall);
 
                 // Wait for animation
@@ -78,7 +78,7 @@ namespace ACE.Server.WorldObjects
         {
             var updateCombatMode = new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat);
 
-            CurrentLandblock?.EnqueueBroadcastSystemChat(this, $"{Name} is recalling to the marketplace.", ChatMessageType.Recall);
+            EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall));
             Session.Network.EnqueueSend(updateCombatMode); // this should be handled by a different thing, probably a function that forces player into peacemode
             CurrentLandblock?.EnqueueBroadcastMotion(this, motionMarketplaceRecall);
 

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -55,7 +55,7 @@ namespace ACE.Server.WorldObjects
                 }
 
                 EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the lifestone.", ChatMessageType.Recall));
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motionLifestoneRecall);
+                EnqueueBroadcastMotion(motionLifestoneRecall);
 
                 // Wait for animation
                 ActionChain lifestoneChain = new ActionChain();
@@ -80,7 +80,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall));
             Session.Network.EnqueueSend(updateCombatMode); // this should be handled by a different thing, probably a function that forces player into peacemode
-            CurrentLandblock?.EnqueueBroadcastMotion(this, motionMarketplaceRecall);
+            EnqueueBroadcastMotion(motionMarketplaceRecall);
 
             // TODO: (OptimShi): Actual animation length is longer than in retail. 18.4s
             // float mpAnimationLength = MotionTable.GetAnimationLength((uint)MotionTableId, MotionCommand.MarketplaceRecall);

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -557,7 +557,7 @@ namespace ACE.Server.WorldObjects
                     motionWindUp.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                     motionWindUp.MovementData.ForwardCommand = (uint)windUpMotion;
                     motionWindUp.MovementData.ForwardSpeed = 2;
-                    DoMotion(motionWindUp);
+                    EnqueueBroadcastMotion(motionWindUp);
                 });
             }
 
@@ -571,7 +571,7 @@ namespace ACE.Server.WorldObjects
                 motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                 motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
                 motionCastSpell.MovementData.ForwardSpeed = 2;
-                DoMotion(motionCastSpell);
+                EnqueueBroadcastMotion(motionCastSpell);
             });
 
             if (fastCast == 1)
@@ -742,7 +742,7 @@ namespace ACE.Server.WorldObjects
                 var motionReturnToCastStance = new UniversalMotion(MotionStance.Magic);
                 motionReturnToCastStance.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                 motionReturnToCastStance.MovementData.ForwardCommand = (uint)MotionCommand.Invalid;
-                DoMotion(motionReturnToCastStance);
+                EnqueueBroadcastMotion(motionReturnToCastStance);
             });
 
             switch (castingPreCheckStatus)
@@ -854,7 +854,7 @@ namespace ACE.Server.WorldObjects
                     motionWindUp.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                     motionWindUp.MovementData.ForwardCommand = (uint)windUpMotion;
                     motionWindUp.MovementData.ForwardSpeed = 2;
-                    DoMotion(motionWindUp);
+                    EnqueueBroadcastMotion(motionWindUp);
                 });
             }
 
@@ -868,7 +868,7 @@ namespace ACE.Server.WorldObjects
                 motionCastSpell.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                 motionCastSpell.MovementData.ForwardCommand = (uint)spellGesture;
                 motionCastSpell.MovementData.ForwardSpeed = 2;
-                DoMotion(motionCastSpell);
+                EnqueueBroadcastMotion(motionCastSpell);
             });
 
             if (fastCast == 1)
@@ -905,7 +905,7 @@ namespace ACE.Server.WorldObjects
                 var motionReturnToCastStance = new UniversalMotion(MotionStance.Magic);
                 motionReturnToCastStance.MovementData.CurrentStyle = (ushort)((uint)MotionStance.Magic & 0xFFFF);
                 motionReturnToCastStance.MovementData.ForwardCommand = (uint)MotionCommand.Invalid;
-                DoMotion(motionReturnToCastStance);
+                EnqueueBroadcastMotion(motionReturnToCastStance);
             });
 
             switch (castingPreCheckStatus)

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -126,7 +126,7 @@ namespace ACE.Server.WorldObjects
             CurrentMotionState = motion;
 
             var actionChain = new ActionChain();
-            actionChain.AddAction(this, () => DoMotion(motion));
+            actionChain.AddAction(this, () => EnqueueBroadcastMotion(motion));
             actionChain.AddDelaySeconds(animLength);
             actionChain.AddAction(this, () => Session.Network.EnqueueSend(new GameEventAttackDone(Session)));
             actionChain.AddAction(this, () => Session.Network.EnqueueSend(new GameEventCombatCommmenceAttack(Session)));

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -184,7 +184,7 @@ namespace ACE.Server.WorldObjects
             // FIXME(ddevec): May need to de-dupe animation/commands from client -- getting multiple (e.g. wave)
             // FIXME(ddevec): This is the operation that should update our velocity (for physics later)
             newMotion.Commands.AddRange(commands);
-            CurrentLandblock?.EnqueueBroadcastMotion(this, newMotion);
+            EnqueueBroadcastMotion(newMotion);
 
             // TODO: use real motion / animation system from physics
             CurrentMotionCommand = md.ForwardCommand;

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -186,7 +186,7 @@ namespace ACE.Server.WorldObjects
             var actionChain = new ActionChain();
 
             actionChain
-                .AddAction(player, () => player.HandleActionMotion(motionReading))
+                .AddAction(player, () => player.EnqueueBroadcastMotion(motionReading))
                 .AddDelaySeconds(2);
 
             if (success)
@@ -194,7 +194,7 @@ namespace ACE.Server.WorldObjects
                 actionChain.AddAction(player, () =>
                 {
                     player.LearnSpellWithNetworking(SpellId);
-                    player.HandleActionMotion(motionReady);
+                    player.EnqueueBroadcastMotion(motionReady);
                     if (player.TryRemoveFromInventoryWithNetworking(this))
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat("The scroll is destroyed.", ChatMessageType.Magic));
                 });
@@ -205,7 +205,7 @@ namespace ACE.Server.WorldObjects
                     .AddDelaySeconds(2)
                     .AddAction(player, () =>
                     {
-                        player.HandleActionMotion(motionReady);
+                        player.EnqueueBroadcastMotion(motionReady);
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{failReason}", ChatMessageType.Magic));
                     });
             }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -340,7 +340,7 @@ namespace ACE.Server.WorldObjects
                 if (damage == -1)
                     return;
 
-                CurrentLandblock?.EnqueueBroadcastSound(ProjectileSource, Sound.ResistSpell);
+                ProjectileSource.EnqueueBroadcast(new GameMessageSound(ProjectileSource.Guid, Sound.ResistSpell, 1.0f));
 
                 if (player != null)
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{target.Name} resists {spell.Name}", ChatMessageType.Magic));

--- a/Source/ACE.Server/WorldObjects/Switch.cs
+++ b/Source/ACE.Server/WorldObjects/Switch.cs
@@ -9,7 +9,6 @@ using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Network.Motion;
-using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
 {
@@ -102,14 +101,14 @@ namespace ACE.Server.WorldObjects
             var switchTimer = new ActionChain();
             var turnToMotion = new UniversalMotion(MotionStance.NonCombat, Location, Guid);
             turnToMotion.MovementTypes = MovementTypes.TurnToObject;
-            switchTimer.AddAction(this, () => worldObject.CurrentLandblock?.EnqueueBroadcastMotion(worldObject, turnToMotion));
+            switchTimer.AddAction(this, () => worldObject.EnqueueBroadcastMotion(turnToMotion));
             switchTimer.AddDelaySeconds(1);
             switchTimer.AddAction(worldObject, () =>
             {
                 if (UseTargetAnimation.HasValue)
-                    CurrentLandblock?.EnqueueBroadcastMotion(this, new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetAnimation)));
+                    EnqueueBroadcastMotion(new UniversalMotion(MotionStance.NonCombat, new MotionItem((MotionCommand)UseTargetAnimation)));
                 else
-                    CurrentLandblock?.EnqueueBroadcastMotion(this, twitch);
+                    EnqueueBroadcastMotion(twitch);
             });
             if (UseTargetAnimation.HasValue)
                 switchTimer.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength((MotionCommand)UseTargetAnimation));

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -72,7 +72,7 @@ namespace ACE.Server.WorldObjects
 
                 ActionChain turnToTimer = new ActionChain();
                 turnToTimer.AddAction(this, () => LoadInventory());
-                turnToTimer.AddAction(player, () => player.CurrentLandblock?.EnqueueBroadcastMotion(player, turnToMotion));
+                turnToTimer.AddAction(player, () => player.EnqueueBroadcastMotion(turnToMotion));
                 turnToTimer.AddDelaySeconds(1);
                 turnToTimer.AddAction(this, () => ApproachVendor(player));
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -638,18 +638,9 @@ namespace ACE.Server.WorldObjects
             proj.OnCollideEnvironment();
         }
 
-        public void HandleActionMotion(UniversalMotion motion)
+        public void EnqueueBroadcastMotion(UniversalMotion motion)
         {
-            if (CurrentLandblock != null)
-            {
-                DoMotion(motion);
-            }
-        }
-
-        public void DoMotion(UniversalMotion motion)
-        {
-            if (CurrentLandblock != null)
-                CurrentLandblock?.EnqueueBroadcastMotion(this, motion);
+            EnqueueBroadcast(new GameMessageUpdateMotion(Guid, Sequences.GetCurrentSequence(SequenceType.ObjectInstance), Sequences, motion));
         }
 
         public void ApplyVisualEffects(PlayScript effect)


### PR DESCRIPTION
PlayerEnterWorld moved from LandblockManager to WorldManager
PlanerEnterWorld ActionQueue created so that the work isn't done on the returned Database task. This allows the SerializedShard worker to continue doing database work.

GameActions are now enqueued in an ActionQueue for session it came in on. This allows us to remove the nasty Session.WaitForPlayer() loop. This is a major fix that allows the server to continue running smoothly when a new player enters the world.

Sessions now have a Tick and TickInParallel.

Some cosmetic cleanups in ServerManager, WorldManager, LandblockManager and Landblock. This is mainly to make it easier to see the round two of updates to UpdateWorld and Landlbock/WorldObject tick functions.

EnqueueBroadcasts have been removed from Landblock. This is a system we've transitioned away from.