### PR TITLE
Fix serialization of the critical hit field.

### DIFF
--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventAttackerNotification.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventAttackerNotification.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Network.GameEvent.Events
             Writer.Write((uint)damageType);
             Writer.Write((double)percent);
             Writer.Write(damage);
-            Writer.Write(Convert.ToUInt16(criticalHit));
+            Writer.Write(Convert.ToUInt32(criticalHit));
             Writer.Write((UInt64)attackConditions);
         }
     }


### PR DESCRIPTION
This fixes the serialization of the AttackerNotification message. Critical hit messages will now be displayed properly in the client.