### PR TITLE
 Adding weapon speed mod

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -282,7 +282,7 @@ namespace ACE.Server.WorldObjects
             var maxAttackSpeed = 2.0;
 
             var divisor = 1.0 - (quickness / 300.0) + (weaponSpeed / 150.0);
-            if (divisor < 0)
+            if (divisor <= 0)
                 return (float)maxAttackSpeed;
 
             var animSpeed = (float)Math.Clamp((1.0 / divisor), minAttackSpeed, maxAttackSpeed);

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -275,26 +275,34 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public float GetAnimSpeed()
         {
-            // Weapon swing animation speed caps at ~180 quickness. But I'm not certain as to the exact formula.
             var quickness = GetCreatureAttribute(PropertyAttribute.Quickness).Current;
             var weaponSpeed = GetWeaponSpeed(this);
 
-            var minAttackSpeed = 0.8f;
-            var maxAttackSpeed = 2.25f;
+            var minAttackSpeed = 0.5;
+            var maxAttackSpeed = 2.0;
 
-            //var minAttackSpeed = 1.0f;
-            //var maxAttackSpeed = 2.0f;
+            var divisor = 1.0 - (quickness / 300.0) + (weaponSpeed / 150.0);
+            if (divisor < 0)
+                return (float)maxAttackSpeed;
 
-            var creatureSpeed = 120 - ((int)quickness - 60) / 2; // we reach 0 creatureSpeed at 300 quickness
+            var animSpeed = (float)Math.Clamp((1.0 / divisor), minAttackSpeed, maxAttackSpeed);
+
+            return animSpeed;
+
+            // GDL bounds - feels fun, but might not be accurate
+
+            // Weapon swing animation speed caps at ~180 quickness. But I'm not certain as to the exact formula.
+            //var minAttackSpeed = 0.8f;
+            //var maxAttackSpeed = 2.25f;
+
+            /*var creatureSpeed = 120 - ((int)quickness - 60) / 2; // we reach 0 creatureSpeed at 300 quickness
             creatureSpeed = Math.Max(0, creatureSpeed);          // do not go below 0
 
             var attackTime = (creatureSpeed + weaponSpeed) / 2;  // our attack time is the average between our speed and the speed of our weapon.
 
             var animSpeed = maxAttackSpeed - (attackTime * (1.0f / 70.0f));
 
-            animSpeed = Math.Clamp(animSpeed, minAttackSpeed, maxAttackSpeed);
-
-            return animSpeed;
+            animSpeed = Math.Clamp(animSpeed, minAttackSpeed, maxAttackSpeed);*/
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -269,6 +269,9 @@ namespace ACE.Server.WorldObjects
                 return 1.0f;
         }
 
+        private static double MinAttackSpeed = 0.5;
+        private static double MaxAttackSpeed = 2.0;
+
         /// <summary>
         /// Returns the animation speed for an attack,
         /// based on the current quickness and weapon speed
@@ -278,31 +281,13 @@ namespace ACE.Server.WorldObjects
             var quickness = GetCreatureAttribute(PropertyAttribute.Quickness).Current;
             var weaponSpeed = GetWeaponSpeed(this);
 
-            var minAttackSpeed = 0.5;
-            var maxAttackSpeed = 2.0;
-
             var divisor = 1.0 - (quickness / 300.0) + (weaponSpeed / 150.0);
             if (divisor <= 0)
-                return (float)maxAttackSpeed;
+                return (float)MaxAttackSpeed;
 
-            var animSpeed = (float)Math.Clamp((1.0 / divisor), minAttackSpeed, maxAttackSpeed);
+            var animSpeed = (float)Math.Clamp((1.0 / divisor), MinAttackSpeed, MaxAttackSpeed);
 
             return animSpeed;
-
-            // GDL bounds - feels fun, but might not be accurate
-
-            // Weapon swing animation speed caps at ~180 quickness. But I'm not certain as to the exact formula.
-            //var minAttackSpeed = 0.8f;
-            //var maxAttackSpeed = 2.25f;
-
-            /*var creatureSpeed = 120 - ((int)quickness - 60) / 2; // we reach 0 creatureSpeed at 300 quickness
-            creatureSpeed = Math.Max(0, creatureSpeed);          // do not go below 0
-
-            var attackTime = (creatureSpeed + weaponSpeed) / 2;  // our attack time is the average between our speed and the speed of our weapon.
-
-            var animSpeed = maxAttackSpeed - (attackTime * (1.0f / 70.0f));
-
-            animSpeed = Math.Clamp(animSpeed, minAttackSpeed, maxAttackSpeed);*/
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -270,6 +270,34 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// Returns the animation speed for an attack,
+        /// based on the current quickness and weapon speed
+        /// </summary>
+        public float GetAnimSpeed()
+        {
+            // Weapon swing animation speed caps at ~180 quickness. But I'm not certain as to the exact formula.
+            var quickness = GetCreatureAttribute(PropertyAttribute.Quickness).Current;
+            var weaponSpeed = GetWeaponSpeed(this);
+
+            var minAttackSpeed = 0.8f;
+            var maxAttackSpeed = 2.25f;
+
+            //var minAttackSpeed = 1.0f;
+            //var maxAttackSpeed = 2.0f;
+
+            var creatureSpeed = 120 - ((int)quickness - 60) / 2; // we reach 0 creatureSpeed at 300 quickness
+            creatureSpeed = Math.Max(0, creatureSpeed);          // do not go below 0
+
+            var attackTime = (creatureSpeed + weaponSpeed) / 2;  // our attack time is the average between our speed and the speed of our weapon.
+
+            var animSpeed = maxAttackSpeed - (attackTime * (1.0f / 70.0f));
+
+            animSpeed = Math.Clamp(animSpeed, minAttackSpeed, maxAttackSpeed);
+
+            return animSpeed;
+        }
+
+        /// <summary>
         /// Returns the current attack height as an enumerable string
         /// </summary>
         public string GetAttackHeight()

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -106,8 +106,10 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public ActionChain DoSwingMotion(WorldObject target, CombatManeuver maneuver, out float animLength)
         {
-            var swingAnimation = new MotionItem(maneuver.Motion, 1.25f);
-            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, maneuver.Motion, null, 1.25f);
+            var animSpeed = GetAnimSpeed();
+
+            var swingAnimation = new MotionItem(maneuver.Motion, animSpeed);
+            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, maneuver.Motion, null, animSpeed);
 
             var motion = new UniversalMotion(CurrentMotionState.Stance, swingAnimation);
             motion.MovementData.CurrentStyle = (uint)CurrentMotionState.Stance;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -708,7 +708,7 @@ namespace ACE.Server.WorldObjects
             if (wo != null)
                 EnqueueBroadcast(new GameMessageObjDescEvent(wo));
             else
-                log.Debug($"Error - requested object description for an item I do not know about - {item.Full:X}");
+                log.Warn($"HandleActionForceObjDescSend() - couldn't find inventory item {item}");
         }
 
         protected override void SendUpdatePosition(bool forcePos = false)

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -708,7 +708,7 @@ namespace ACE.Server.WorldObjects
             if (wo != null)
                 EnqueueBroadcast(new GameMessageObjDescEvent(wo));
             else
-                log.Warn($"HandleActionForceObjDescSend() - couldn't find inventory item {item}");
+                log.Debug($"HandleActionForceObjDescSend() - couldn't find inventory item {item}");
         }
 
         protected override void SendUpdatePosition(bool forcePos = false)

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -113,8 +113,10 @@ namespace ACE.Server.WorldObjects
         public ActionChain DoSwingMotion(WorldObject target, out float animLength)
         {
             // FIXME: proper swing animation speeds
+            var baseSpeed = GetAnimSpeed();
             var animSpeedMod = IsDualWieldAttack ? 1.2f : 1.0f;     // dual wield swing animation 20% faster
-            var animSpeed = 1.25f * animSpeedMod;
+            var animSpeed = baseSpeed * animSpeedMod;
+
             var swingAnimation = new MotionItem(GetSwingAnimation(), animSpeed);
             animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, swingAnimation.Motion, null, animSpeed);
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -4,6 +4,7 @@ using ACE.Database.Models.Shard;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Physics.Common;
@@ -212,7 +213,7 @@ namespace ACE.Server.WorldObjects
                     continue;
                 }
 
-                //Console.WriteLine($"Generator({Name} - {Location.Cell:X8}) spawned {wo.Name}");
+                //Console.WriteLine($"Generator({Name} - {Location.Cell:X8}) spawned {wo.Name} - {(RegenLocationType)profile.WhereCreate}");
 
                 switch ((RegenLocationType)profile.WhereCreate)
                 {
@@ -246,6 +247,7 @@ namespace ACE.Server.WorldObjects
                             newPos.Z = LScape.get_landblock(wo.Location.Cell).GetZ(newPos);
                         }
                         wo.Location.SetPosition(newPos);
+                        wo.Location.LandblockId = new LandblockId(wo.Location.GetCell());
                         break;
 
                     // generator is a container, spawns in inventory

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -1293,7 +1293,12 @@ namespace ACE.Server.WorldObjects
                 self.EnqueueAction(new ActionEventDelegate(() => delegateAction(self)));
 
             foreach (var player in PhysicsObj.ObjMaint.VoyeurTable.Values.Select(v => v.WeenieObj.WorldObject as Player))
+            {
+                if ((Visibility ?? false) && !player.Adminvision)
+                    continue;
+
                 player.EnqueueAction(new ActionEventDelegate(() => delegateAction(player)));
+            }
         }
 
         /// <summary>
@@ -1315,6 +1320,9 @@ namespace ACE.Server.WorldObjects
                 if (isDungeon && Location.Landblock != player.Location.Landblock)
                     continue;
 
+                if ((Visibility ?? false) && !player.Adminvision)
+                    continue;
+
                 var dist = Vector3.Distance(Location.ToGlobal(), player.Location.ToGlobal());
                 if (dist <= range)
                     player.Session.Network.EnqueueSend(msg);
@@ -1333,7 +1341,12 @@ namespace ACE.Server.WorldObjects
                 self.Session.Network.EnqueueSend(msgs);
 
             foreach (var player in PhysicsObj.ObjMaint.VoyeurTable.Values.Select(v => v.WeenieObj.WorldObject as Player))
+            {
+                if ((Visibility ?? false) && !player.Adminvision)
+                    continue;
+
                 player.Session.Network.EnqueueSend(msgs);
+            }
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -10,6 +10,7 @@ namespace ACE.Server.WorldObjects
         const float defaultMagicCritFrequency = 0.02f;
         const float defaultCritMultiplier = 0.0f;
         const float defaultBonusModifier = 1.0f;
+        const uint defaultSpeed = 40;   // TODO: find default speed
 
         /// <summary>
         /// Returns the primary weapon equipped by a player
@@ -26,6 +27,21 @@ namespace ACE.Server.WorldObjects
                 weapon = wielder.GetEquippedWand();
 
             return weapon;
+        }
+
+        /// <summary>
+        /// Returns the weapon speed, with enchantments factored in
+        /// </summary>
+        public static uint GetWeaponSpeed(Creature wielder)
+        {
+            WorldObject weapon = GetWeapon(wielder as Player);
+
+            if (weapon == null)
+                return defaultSpeed;
+
+            var baseSpeed = weapon.GetProperty(PropertyInt.WeaponTime) ?? (int)defaultSpeed;
+            var speedMod = wielder != null ? wielder.EnchantmentManager.GetWeaponSpeedMod() : 0;
+            return (uint)Math.Max(0, baseSpeed + speedMod);
         }
 
         /// <summary>


### PR DESCRIPTION
This patch adjusts the attack animation speed for Players and monsters to match the quickness / weapon speed / enchantments for melee weapons

- Fixed a bug with indoor scatter generators not getting the new cell
- Fixed an issue with invisible objects broadcasting to players