### PR TITLE
Revised pass at secure trade

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionOpenTradeNegotiations.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionOpenTradeNegotiations.cs
@@ -14,10 +14,10 @@ namespace ACE.Server.Network.GameAction.Actions
 
             if (targetsession != null)
             {
-                session.Player.HandleActionOpenTradeNegotiations(session, tradePartner);
-
                 //Open the trade window for the trade partner
-                targetsession.Player.HandleActionOpenTradeNegotiations(targetsession, session.Player.Guid);
+                if (session.Player.HandleActionOpenTradeNegotiations(session, tradePartner, true))
+                    //Trade partner met all criteria to initiate trade, open their window
+                    targetsession.Player.HandleActionOpenTradeNegotiations(targetsession, session.Player.Guid);
             }
         }
     }

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventDeclineTrade.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventDeclineTrade.cs
@@ -1,0 +1,13 @@
+using ACE.Entity;
+
+namespace ACE.Server.Network.GameEvent.Events
+{
+    public class GameEventDeclineTrade : GameEventMessage
+    {
+        public GameEventDeclineTrade(Session session, ObjectGuid whoDeclined)
+            : base(GameEventType.DeclineTrade, GameMessageGroup.UIQueue, session)
+        {
+            Writer.WriteGuid(whoDeclined);
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventTradeFailure.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventTradeFailure.cs
@@ -1,13 +1,15 @@
 using ACE.Entity;
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventTradeFailure : GameEventMessage
     {
-        public GameEventTradeFailure(Session session, ObjectGuid item)
+        public GameEventTradeFailure(Session session, ObjectGuid item, WeenieError reason)
             : base(GameEventType.TradeFailure, GameMessageGroup.UIQueue, session)
         {
             Writer.WriteGuid(item);
+            Writer.Write((uint)reason);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -92,7 +92,10 @@ namespace ACE.Server.WorldObjects
 
             var player = this as Player;
             if (player != null)
+            {
+                player.HandleActionTradeSwitchToCombatMode(player.Session);
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.Melee));
+            }
 
             //Console.WriteLine("HandleSwitchToMeleeCombatMode() - animLength: " + animLength);
             return animLength;
@@ -114,7 +117,10 @@ namespace ACE.Server.WorldObjects
 
             var player = this as Player;
             if (player != null)
+            {
+                player.HandleActionTradeSwitchToCombatMode(player.Session);
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.Magic));
+            }
 
             //Console.WriteLine("HandleSwitchToMagicCombatMode() - animLength: " + animLength);
             return animLength;
@@ -143,8 +149,10 @@ namespace ACE.Server.WorldObjects
 
             var player = this as Player;
             if (player != null)
+            {
+                player.HandleActionTradeSwitchToCombatMode(player.Session);
                 player.Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.Missile));
-
+            }
             //Console.WriteLine("HandleSwitchToMissileCombatMode() - animLength: " + animLength);
             return animLength;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Trade.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Trade.cs
@@ -10,27 +10,75 @@ namespace ACE.Server.WorldObjects
     partial class Player
     {
         public List<ObjectGuid> ItemsInTradeWindow = new List<ObjectGuid>();
-        private bool TradeAccepted = false;
+        private bool TradeAccepted { get; set; } = false;
+        private bool IsTrading = false;
         public ObjectGuid TradePartner;
 
-        public void HandleActionOpenTradeNegotiations(Session session, ObjectGuid tradePartner)
+        public bool HandleActionOpenTradeNegotiations(Session session, ObjectGuid tradePartner, bool initiator = false)
         {
-            session.Player.ItemsInTradeWindow.Clear();
-
             session.Player.TradePartner = tradePartner;
 
             var targetsession = WorldManager.Find(session.Player.TradePartner);
+            var target = CurrentLandblock?.GetObject(tradePartner);
 
-            session.Network.EnqueueSend(new GameEventRegisterTrade(session, session.Player.Guid, tradePartner));
+            //Check to see if partner is not allowing trades
+            if ((initiator) && (targetsession.Player.GetCharacterOption(CharacterOption.IgnoreAllTradeRequests)))
+            {
+                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeIgnoringRequests));
+                return false;
+            }
+
+            //Check to see if either party is already part of an in process trade session
+            if ((session.Player.IsTrading) || (targetsession.Player.IsTrading))
+            {
+                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeAlreadyTrading));
+                return false;
+            }
+
+            //Check to see if either party is in combat mode
+            if ((session.Player.CombatMode != CombatMode.NonCombat) || (targetsession.Player.CombatMode != CombatMode.NonCombat))
+            {
+                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeNonCombatMode));
+                return false;
+            }
+
+            //Check to see if trade partner is in range, if so, rotate and move to
+            var valid = false;
+            bool ret = CurrentLandblock != null ? !CurrentLandblock.WithinUseRadius(session.Player, tradePartner, out valid) : false;
+
+            if (valid)
+            {
+                session.Player.ItemsInTradeWindow.Clear();
+
+                session.Player.Rotate(target);
+                session.Player.MoveTo(target);
+
+                session.Network.EnqueueSend(new GameEventRegisterTrade(session, session.Player.Guid, tradePartner));
+
+                if (!initiator)
+                {
+                    session.Player.IsTrading = true;
+                    targetsession.Player.IsTrading = true;
+                }
+                
+                return true;
+            }
+            else
+            {
+                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeMaxDistanceExceeded));
+                return false;
+            }
         }
 
-        public void HandleActionCloseTradeNegotiations(Session session)
+        public void HandleActionCloseTradeNegotiations(Session session, EndTradeReason endTradeReason = EndTradeReason.Normal)
         {
+            session.Player.IsTrading = false;
             session.Player.TradeAccepted = false;
             session.Player.ItemsInTradeWindow.Clear();
             session.Player.TradePartner = new ObjectGuid(0);
 
-            session.Network.EnqueueSend(new GameEventCloseTrade(session, EndTradeReason.Normal));
+            session.Network.EnqueueSend(new GameEventCloseTrade(session, endTradeReason));
+            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeClosed));
         }
 
         public void HandleActionAddToTrade(Session session, ObjectGuid item, uint tradeWindowSlotNumber)
@@ -61,7 +109,8 @@ namespace ACE.Server.WorldObjects
                 }
                 else
                 {
-                    session.Network.EnqueueSend(new GameEventTradeFailure(session, item));
+                    session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "You cannot trade that!"));
+                    session.Network.EnqueueSend(new GameEventTradeFailure(session, item, WeenieError.AttunedItem));
                 }
             }
         }
@@ -80,14 +129,23 @@ namespace ACE.Server.WorldObjects
 
             session.Network.EnqueueSend(new GameEventAcceptTrade(session, whoAccepted));
 
+            if (whoAccepted == session.Player.Guid)
+                session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "You have accepted the offer"));
+
             var targetsession = WorldManager.Find(session.Player.TradePartner);
 
             if (targetsession != null)
             {
                 targetsession.Network.EnqueueSend(new GameEventAcceptTrade(targetsession, whoAccepted));
 
+                if (whoAccepted == session.Player.Guid)
+                    targetsession.Network.EnqueueSend(new GameEventCommunicationTransientString(targetsession, $"({session.Player.Name}) has accepted the offer"));
+
                 if ((session.Player.TradeAccepted) && (targetsession.Player.TradeAccepted))
                 {
+                    session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "The items are being traded"));
+                    targetsession.Network.EnqueueSend(new GameEventCommunicationTransientString(targetsession, "The items are being traded"));
+
                     foreach (ObjectGuid itemGuid in session.Player.ItemsInTradeWindow)
                     {
                         WorldObject wo = GetInventoryItem(itemGuid);
@@ -117,8 +175,8 @@ namespace ACE.Server.WorldObjects
                     session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeComplete));
                     targetsession.Network.EnqueueSend(new GameEventWeenieError(targetsession, WeenieError.TradeComplete));
 
-                    session.Player.HandleActionResetTrade(session,session.Player.Guid);
-                    targetsession.Player.HandleActionResetTrade(targetsession, session.Player.Guid);
+                    session.Player.HandleActionResetTrade(session, new ObjectGuid(0));
+                    targetsession.Player.HandleActionResetTrade(targetsession, new ObjectGuid(0));
 
                     session.Player.EnqueueSaveChain();
                     targetsession.Player.EnqueueSaveChain();
@@ -130,13 +188,32 @@ namespace ACE.Server.WorldObjects
         {
             session.Player.TradeAccepted = false;
 
-            session.Network.EnqueueSend(new GameEventClearTradeAcceptance(session));
-
+            session.Network.EnqueueSend(new GameEventDeclineTrade(session,session.Player.Guid));
+            session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "Trade confirmation failed"));
+            
             var targetsession = WorldManager.Find(session.Player.TradePartner);
 
             if (targetsession != null)
             {
-                targetsession.Network.EnqueueSend(new GameEventClearTradeAcceptance(targetsession));
+                targetsession.Network.EnqueueSend(new GameEventDeclineTrade(targetsession, session.Player.Guid));
+                targetsession.Network.EnqueueSend(new GameEventCommunicationTransientString(targetsession, "Trade confirmation failed"));
+            }
+        }
+
+        public void HandleActionTradeSwitchToCombatMode(Session session)
+        {
+            if (session.Player.CombatMode != CombatMode.NonCombat)
+            {
+                var targetsession = WorldManager.Find(session.Player.TradePartner);
+
+                session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeNonCombatMode));
+                session.Player.HandleActionCloseTradeNegotiations(session, EndTradeReason.EnteredCombat);
+
+                if (targetsession !=null)
+                {
+                    targetsession.Network.EnqueueSend(new GameEventWeenieError(targetsession, WeenieError.TradeNonCombatMode));
+                    targetsession.Player.HandleActionCloseTradeNegotiations(targetsession, EndTradeReason.EnteredCombat);
+                }
             }
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 # ACEmulator Change Log
+### 2018-09-09
+[mcreedjr]
+* Revised pass at secure trade
+  - Added motion commands for turn to and approach
+  - Added check for in progress trade session
+  - Matched interactions more closely with retail PCAPs
+
 ### 2018-09-03
 [mcreedjr]
 * Initial pass at secure trade


### PR DESCRIPTION
This is an update to my previous PR where basic secure trade functionality was implemented.

This PR does the following:
 - Verifies that trade partner is in range
 - Honors ignore all trade requests character option
 - Does not initiate when either party is in combat mode
 - Adds a few messages based on what I saw in retail PCAPs
 - Implemented GameEventDeclineTrade per PCAPs
 - Implements turn to when approaching trade partner

Probably a few other minor tweaks. Again, sorry for all of the open and closing PR noise. Git and I are often not friends.