### PR TITLE
WorldObject Position Updates

### DIFF
--- a/Source/ACE.DatLoader/BinaryReaderExtensions.cs
+++ b/Source/ACE.DatLoader/BinaryReaderExtensions.cs
@@ -95,6 +95,7 @@ namespace ACE.DatLoader
             }
             return thestring;
         }
+ 
         /// <summary>
         /// Returns a Vector3 object read out as 3 floats, x y z
         /// </summary>

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -111,6 +111,28 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static Dictionary<PositionType, Position> GetPositions(this Biota biota, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                var results = new Dictionary<PositionType, Position>();
+
+                foreach (var value in biota.BiotaPropertiesPosition)
+                {
+                    var position = new Position(value.ObjCellId, value.OriginX, value.OriginY, value.OriginZ, value.AnglesX, value.AnglesY, value.AnglesZ, value.AnglesW);
+
+                    results.Add((PositionType)value.PositionType, position);
+                }
+
+                return results;
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
         public static string GetProperty(this Biota biota, PropertyString property, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterReadLock();

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -598,7 +598,7 @@ namespace ACE.Server.Command.Handlers
                 }
 
                 // Save the position
-                session.Player.SetCharacterPosition(positionType, (Position)playerPosition.Clone());
+                session.Player.SetPosition(positionType, (Position)playerPosition.Clone());
                 // Report changes to client
                 var positionMessage = new GameMessageSystemChat($"Set: {positionType} to Loc: {playerPosition}", ChatMessageType.Broadcast);
                 session.Network.EnqueueSend(positionMessage);

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -402,7 +402,8 @@ namespace ACE.Server.Command.Handlers
                 }
 
                 // If we have the position, teleport the player
-                if (session.Player.Positions.ContainsKey(positionType))
+                var position = session.Player.GetPosition(positionType);
+                if (position != null)
                 {
                     session.Player.TeleToPosition(positionType);
                     var positionMessage = new GameMessageSystemChat($"Recalling to {positionType}", ChatMessageType.Broadcast);

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -635,7 +635,7 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("listpositions", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Displays all available saved character positions from the database.", "@listpositions")]
         public static void HandleListPositions(Session session, params string[] parameters)
         {
-            var posDict = session.Player.Positions;
+            var posDict = session.Player.GetPositions();
             string message = "Saved character positions:\n";
 
             foreach (var posPair in posDict)

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -647,7 +647,7 @@ namespace ACE.Server.Command.Handlers
         }
 
         /// <summary>
-        /// Debug command to save the player's current location as sepecific position type.
+        /// Debug command to save the player's current location as specific position type.
         /// </summary>
         [CommandHandler("setposition", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Saves the supplied character position type to the database.", "uint 1-27\n" + "@setposition 1")]
         public static void HandleSetPosition(Session session, params string[] parameters)

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -667,7 +667,7 @@ namespace ACE.Server.Command.Handlers
                         Position playerPosition = (Position)session.Player.Location.Clone();
 
                         // Save the position
-                        session.Player.SetCharacterPosition(positionType, playerPosition);
+                        session.Player.SetPosition(positionType, playerPosition);
 
                         // Report changes to client
                         var positionMessage = new GameMessageSystemChat($"Set: {positionType} to Loc: {playerPosition}", ChatMessageType.Broadcast);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -474,19 +474,6 @@ namespace ACE.Server.WorldObjects
 
  
         /// <summary>
-        /// Saves a CharacterPosition to the character position dictionary
-        /// </summary>
-        public void SetCharacterPosition(PositionType type, Position newPosition)
-        {
-            // todo: is this really needed?
-            // reset the landblock id
-            if (newPosition.LandblockId.Landblock == 0 && newPosition.Cell > 0)
-                newPosition.LandblockId = new LandblockId(newPosition.Cell);
-
-            SetPosition(type, newPosition);
-        }
-
-        /// <summary>
         /// Returns false if the player has chosen to Appear Offline.  Otherwise it will return their actual online status.
         /// </summary>
         public bool GetVirtualOnlineStatus()

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -474,26 +474,16 @@ namespace ACE.Server.WorldObjects
 
  
         /// <summary>
-        /// Set the currently position of the character, to later save in the database.
-        /// </summary>
-        public void SetPhysicalCharacterPosition()
-        {
-            // Saves the current player position after converting from a Position Object, to a CharacterPosition object
-            SetCharacterPosition(PositionType.Location, Location);
-        }
-
-        /// <summary>
         /// Saves a CharacterPosition to the character position dictionary
         /// </summary>
         public void SetCharacterPosition(PositionType type, Position newPosition)
         {
+            // todo: is this really needed?
             // reset the landblock id
             if (newPosition.LandblockId.Landblock == 0 && newPosition.Cell > 0)
-            {
                 newPosition.LandblockId = new LandblockId(newPosition.Cell);
-            }
 
-            Positions[type] = newPosition;
+            SetPosition(type, newPosition);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -96,18 +96,5 @@ namespace ACE.Server.WorldObjects
 
             DatabaseManager.Shard.SaveCharacter(Character, CharacterDatabaseLock, null);
         }
-
-        /// <summary>
-        /// This will set the LastRequestedDatabaseSave to UtcNow and ChangesDetected to false.<para />
-        /// If enqueueSave is set to true, DatabaseManager.Shard.SaveBiota() will be called for the biota.<para />
-        /// Set enqueueSave to false if you want to perform all the normal routines for a save but not the actual save. This is useful if you're going to collect biotas in bulk for bulk saving.
-        /// </summary>
-        public override void SaveBiotaToDatabase(bool enqueueSave = true)
-        {
-            // Save the current position to persistent storage, only during the server update interval
-            SetPhysicalCharacterPosition();
-
-            base.SaveBiotaToDatabase(enqueueSave);
-        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -1,4 +1,5 @@
 using System;
+
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.DatLoader;
@@ -7,7 +8,6 @@ using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;
-using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Motion;
@@ -21,14 +21,15 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Teleports the player to position
         /// </summary>
-        /// <param name="position">PositionType to be teleported to</param>
+        /// <param name="positionType">PositionType to be teleported to</param>
         /// <returns>true on success (position is set) false otherwise</returns>
-        public bool TeleToPosition(PositionType position)
+        public bool TeleToPosition(PositionType positionType)
         {
-            if (Positions.ContainsKey(position))
+            var position = GetPosition(positionType);
+
+            if (position != null)
             {
-                Position dest = Positions[position];
-                Teleport(dest);
+                Teleport(position);
                 return true;
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 
 using ACE.Database;
+using ACE.Database.Models.Shard;
 
 namespace ACE.Server.WorldObjects
 {
@@ -38,6 +39,10 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual void SaveBiotaToDatabase(bool enqueueSave = true)
         {
+            // Make sure all of our positions in the biota are up to date with our current cached values.
+            foreach (var kvp in positionCache)
+                Biota.SetPosition(kvp.Key, kvp.Value, BiotaDatabaseLock, out _);
+
             LastRequestedDatabaseSave = DateTime.UtcNow;
             ChangesDetected = false;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -667,7 +667,7 @@ namespace ACE.Server.WorldObjects
                         switch (spell.MetaSpellId)
                         {
                             case 2645: // Portal Recall
-                                if (!player.Positions.ContainsKey(PositionType.LastPortal))
+                                if (player.GetPosition(PositionType.LastPortal) == null)
                                 {
                                     // You must link to a portal to recall it!
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToPortalToRecall));
@@ -676,7 +676,7 @@ namespace ACE.Server.WorldObjects
                                     recall = PositionType.LastPortal;
                                 break;
                             case 1635: // Lifestone Recall
-                                if (!player.Positions.ContainsKey(PositionType.LinkedLifestone))
+                                if (player.GetPosition(PositionType.LinkedLifestone) == null)
                                 {
                                     // You must link to a lifestone to recall it!
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToLifestoneToRecall));
@@ -685,7 +685,7 @@ namespace ACE.Server.WorldObjects
                                     recall = PositionType.LinkedLifestone;
                                 break;
                             case 48: // Primary Portal Recall
-                                if (!player.Positions.ContainsKey(PositionType.LinkedPortalOne))
+                                if (player.GetPosition(PositionType.LinkedPortalOne) == null)
                                 {
                                     // You must link to a portal to recall it!
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToPortalToRecall));
@@ -694,7 +694,7 @@ namespace ACE.Server.WorldObjects
                                     recall = PositionType.LinkedPortalOne;
                                 break;
                             case 2647: // Secondary Portal Recall
-                                if (!player.Positions.ContainsKey(PositionType.LinkedPortalTwo))
+                                if (player.GetPosition(PositionType.LinkedPortalTwo) == null)
                                 {
                                     // You must link to a portal to recall it!
                                     player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustLinkToPortalToRecall));

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -433,18 +433,6 @@ namespace ACE.Server.WorldObjects
 
 
         // ========================================
-        // =========== Model Properties ===========
-        // ========================================
-        // used in SerializeModelData()
-        [Obsolete]
-        private readonly List<ModelPalette> modelPalettes = new List<ModelPalette>();
-        [Obsolete]
-        private readonly List<ModelTexture> modelTextures = new List<ModelTexture>();
-        [Obsolete]
-        private readonly List<Model> models = new List<Model>();
-
-
-        // ========================================
         // ======== Physics Desc Properties =======
         // ========================================
         // used in CalculatedPhysicsDescriptionFlag()

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -773,7 +773,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Persistent boolean value that tracks whether an equipped item is affecting (the item's spells are in effect and its mana is burning) or not.
         /// </summary>
-        public virtual bool? IsAffecting
+        public bool? IsAffecting
         {
             get => GetProperty(PropertyBool.IsAffecting);
             set
@@ -851,7 +851,7 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.MaxStructure); else SetProperty(PropertyInt.MaxStructure, value.Value); }
         }
 
-        public virtual ushort? StackSize
+        public ushort? StackSize
         {
             get => (ushort?)GetProperty(PropertyInt.StackSize);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.StackSize); else SetProperty(PropertyInt.StackSize, value.Value); }
@@ -1894,13 +1894,13 @@ namespace ACE.Server.WorldObjects
         //    set { SetProperty(PropertyInt.AvailableCharacter, value); }
         //}
 
-        public virtual int? StackUnitValue
+        public int? StackUnitValue
         {
             get => GetProperty(PropertyInt.StackUnitValue);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.StackUnitValue); else SetProperty(PropertyInt.StackUnitValue, value.Value); }
         }
 
-        public virtual int? StackUnitEncumbrance
+        public int? StackUnitEncumbrance
         {
             get => GetProperty(PropertyInt.StackUnitEncumbrance);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.StackUnitEncumbrance); else SetProperty(PropertyInt.StackUnitEncumbrance, value.Value); }
@@ -2163,7 +2163,7 @@ namespace ACE.Server.WorldObjects
         // ========================================
         //= ======== Position Properties ==========
         // ========================================
-        public virtual Position Location
+        public Position Location
         {
             get => GetPosition(PositionType.Location);
             set => SetPosition(PositionType.Location, value);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -365,6 +365,14 @@ namespace ACE.Server.WorldObjects
             return new Dictionary<PositionType, Position>(positionCache);
         }
 
+        /// <summary>
+        /// !!! VERY IMPORTANT NOTE REGARDING SetPosition !!!<para />
+        /// Position objects are reference types. Lets say you want to create a new object and give it the location of a player,
+        /// If you do LandscapeItem.SetPosition(PositionType.Location, Player.Location), you've now set the Location position
+        /// for both the player and the LandscapeItem to the same exact object. Modifying one will affect the other.<para />
+        /// The proper way to would be: LandscapeItem.SetPosition(PositionType.Location, (Position)Player.Location.Clone())<para />
+        /// Any time you want to set a position of a different PositionType, or, positions between WorldObjects, you should use the above Clone method.
+        /// </summary>
         public void SetPosition(PositionType positionType, Position position)
         {
             if (position == null)


### PR DESCRIPTION
WorldObject.Positions was misused. The code has been cleaned up so that Position access passes through the Get/Set/Remove functions.

Furthermore, on save, we make sure that the positions in the biota have the latest up to date values from the cache.

We must do this because we don't wrap Positions like we do attributes/skills/vitals.


Also added a very important note regarding use of SetPosition:
        /// !!! VERY IMPORTANT NOTE REGARDING SetPosition !!!<para />
        /// Position objects are reference types. Lets say you want to create a new object and give it the location of a player,
        /// If you do LandscapeItem.SetPosition(PositionType.Location, Player.Location), you've now set the Location position
        /// for both the player and the LandscapeItem to the same exact object. Modifying one will affect the other.<para />
        /// The proper way to would be: LandscapeItem.SetPosition(PositionType.Location, (Position)Player.Location.Clone())<para />
        /// Any time you want to set a position of a different PositionType, or, positions between WorldObjects, you should use the above Clone method.