### PR TITLE
Fix the picking up of open and in use packs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -492,7 +492,7 @@ namespace ACE.Server.WorldObjects
             bool containerOwnedByPlayer = true;
 
             Container container;
-
+            
             if (containerGuid == Guid)
                 container = this; // Destination is main pack
             else
@@ -519,7 +519,7 @@ namespace ACE.Server.WorldObjects
             }
 
             var item = GetInventoryItem(itemGuid) ?? GetWieldedItem(itemGuid);
-
+                        
             if (item != null)
             {
                 IsAttuned(itemGuid, out bool isAttuned);
@@ -544,6 +544,34 @@ namespace ACE.Server.WorldObjects
             // Is this something I already have? If not, it has to be a pickup - do the pickup and out.
             if (item == null)
             {
+                var itemToPickup = CurrentLandblock?.GetObject(itemGuid);
+
+                if (itemToPickup != null)
+                {
+                    //Checking to see if item to pick is an container itself
+                    if (itemToPickup.WeenieType == WeenieType.Container)
+                    {
+                        //Check to see if the container is open
+                        if (itemToPickup.IsOpen ?? false)
+                        {
+                            var containerToPickup = CurrentLandblock?.GetObject(itemGuid) as Container;
+
+                            if (containerToPickup.Viewer == Session.Player.Guid.Full)
+                            {
+                                //We're the one that has it open. Close it before picking it up
+                                containerToPickup.Close(Session.Player);
+                            }
+                            else
+                            {
+                                //We're not who has it open. Can't pick up something someone else is viewing!
+                                Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(Session, WeenieErrorWithString.The_IsCurrentlyInUse, itemToPickup.Name));
+                                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.Stuck));
+                                return;
+                            }
+                        }
+                    }
+                }
+
                 // This is a pickup into our main pack.
                 PickupItemWithNetworking(container, itemGuid, placement, PropertyInstanceId.Container);
                 return;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -564,6 +564,9 @@ namespace ACE.Server.WorldObjects
                             else
                             {
                                 //We're not who has it open. Can't pick up something someone else is viewing!
+
+                                //TODO: These messages are what I remember of retail. I was unable to confirm or deny with PCAPs
+                                //TODO: This will likley need revisited at some point to align with retail
                                 Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(Session, WeenieErrorWithString.The_IsCurrentlyInUse, itemToPickup.Name));
                                 Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.Stuck));
                                 return;

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
  - Prevent players from picking up containers on the landscape that are being viewed by other players
  - Resolve bug where picking up an open pack caused it to remain locked and unusable
 
+[mcreedjr]
+* Revised pass at secure trade
+  - Added motion commands for turn to and approach
+  - Added check for in progress trade session
+  - Matched interactions more closely with retail PCAPs
+
 ### 2018-09-03
 [mcreedjr]
 * Initial pass at secure trade

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
  - Prevent players from picking up containers on the landscape that are being viewed by other players
  - Resolve bug where picking up an open pack caused it to remain locked and unusable
 
+ ### 2018-09-09
 [mcreedjr]
 * Revised pass at secure trade
   - Added motion commands for turn to and approach

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # ACEmulator Change Log
+### 2018-09-11
+* Resolve issue 866
+ - Prevent players from picking up containers on the landscape that are being viewed by other players
+ - Resolve bug where picking up an open pack caused it to remain locked and unusable
+
 ### 2018-09-03
 [mcreedjr]
 * Initial pass at secure trade


### PR DESCRIPTION
This PR should address both concerns raised by @OptimShi as noted in issue #866.

The messages returned when a user attempts to place pack being viewed by another user were what I remembered of retail. I couldn't find anything in PCAPs to support what I remembered. I'm open to suggestions if those messages should be something else. I'd be happy to update with the consensus.