### PR TITLE
Fixed bug where excess WeenieError.TradeCancelled was sent

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Trade.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Trade.cs
@@ -202,7 +202,7 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionTradeSwitchToCombatMode(Session session)
         {
-            if (session.Player.CombatMode != CombatMode.NonCombat)
+            if ((session.Player.CombatMode != CombatMode.NonCombat) && (session.Player.IsTrading))
             {
                 var targetsession = WorldManager.Find(session.Player.TradePartner);
 


### PR DESCRIPTION
Fixed a bug @gmriggs found where where an erroneous WeenieError.TradeCancelled was sent to client when a character entered combat mode, whether or not the character was trading.