### PR TITLE
Skill redistribution functionality

### DIFF
--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -103,6 +103,8 @@ namespace ACE.Server.Factories
                     return new SlumLord(weenie, guid);
                 case WeenieType.HousePortal:
                     return new WorldObjects.HousePortal(weenie, guid);
+                case WeenieType.SkillAlterationDevice:
+                    return new WorldObjects.SkillAlterationDevice(weenie, guid);
                 default:
                     return new GenericObject(weenie, guid);
             }
@@ -192,6 +194,8 @@ namespace ACE.Server.Factories
                     return new SlumLord(biota);
                 case WeenieType.HousePortal:
                     return new WorldObjects.HousePortal(biota);
+                case WeenieType.SkillAlterationDevice:
+                    return new WorldObjects.SkillAlterationDevice(biota);
                 default:
                     return new GenericObject(biota);
             }

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -112,9 +112,14 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Sets the skill to untrained status
         /// </summary>
-        public bool UntrainSkill(Skill skill, int creditsSpent)
+        public bool UntrainSkill(Skill skill, int creditsSpent, bool skillIsHeritageSkill = false)
         {
             var cs = GetCreatureSkill(skill);
+
+            if (cs == null)
+            {
+                return false;
+            }
 
             if (cs.AdvancementClass != SkillAdvancementClass.Trained && cs.AdvancementClass != SkillAdvancementClass.Specialized)
             {
@@ -124,12 +129,47 @@ namespace ACE.Server.WorldObjects
                 return true;
             }
 
-            if (cs.AdvancementClass == SkillAdvancementClass.Trained)
+            if (cs.AdvancementClass == SkillAdvancementClass.Trained) 
             {
-                cs.AdvancementClass = SkillAdvancementClass.Untrained;
+                //Perform refund of XP and credits
+                RefundXP(cs.ExperienceSpent);
+
+                if (!skillIsHeritageSkill)
+                {
+                    cs.AdvancementClass = SkillAdvancementClass.Untrained;
+                    AvailableSkillCredits += creditsSpent;
+                }
+                
                 cs.Ranks = 0;
                 cs.ExperienceSpent = 0;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Lowers skill from Specialized to Trained and returns both skill credits and invested XP
+        /// </summary>
+        public bool UnspecializeSkill(Skill skill, int creditsSpent)
+        {
+            var cs = GetCreatureSkill(skill);
+
+            if(cs == null)
+            {
+                return false;
+            }
+
+            if (cs.AdvancementClass == SkillAdvancementClass.Specialized)
+            {
+                //Perform refund of XP and credits
+                RefundXP(cs.ExperienceSpent);
                 AvailableSkillCredits += creditsSpent;
+
+                cs.AdvancementClass = SkillAdvancementClass.Trained;
+                cs.ExperienceSpent = 0;
+                cs.Ranks = 0;
+
                 return true;
             }
 

--- a/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
+++ b/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
@@ -1,0 +1,81 @@
+using ACE.Database.Models.Shard;
+using ACE.Database.Models.World;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Network;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.Network.Motion;
+using System;
+
+namespace ACE.Server.WorldObjects
+{
+    public class SkillAlterationDevice : WorldObject
+    {
+        public SkillAlterationType TypeOfAlteration { get; set; }
+        public Skill SkillToBeAltered { get; set; }
+
+        public enum SkillAlterationType
+        {
+            Undef = 0,
+            Specialize = 1,
+            Lower = 2,
+        }
+
+        /// <summary>
+        /// A new biota be created taking all of its values from weenie.
+        /// </summary>
+        public SkillAlterationDevice(Weenie weenie, ObjectGuid guid) : base(weenie, guid)
+        {
+            SetEphemeralValues();
+        }
+
+        /// <summary>
+        /// Restore a WorldObject from the database.
+        /// </summary>
+        public SkillAlterationDevice(Biota biota) : base(biota)
+        {
+            SetEphemeralValues();
+        }
+
+        private void SetEphemeralValues()
+        {
+            //Copy values to properties
+            TypeOfAlteration = (SkillAlterationType)(GetProperty(PropertyInt.TypeOfAlteration) ?? 1);
+            SkillToBeAltered = (Skill)(GetProperty(PropertyInt.SkillToBeAltered) ?? 0);
+        }
+
+        /// <summary>
+        /// This is raised by Player.HandleActionUseItem.<para />
+        /// The item should be in the players possession.
+        /// </summary>
+        public override void UseItem(Player player)
+        {
+            Console.WriteLine("In SkillAlterationDevice.UseItem()");
+
+            switch (TypeOfAlteration)
+            {
+                case SkillAlterationType.Specialize:
+                    var currentSkill = player.GetCreatureSkill(SkillToBeAltered);
+                    if (currentSkill.AdvancementClass == SkillAdvancementClass.Specialized)
+                    {
+
+                    }
+                    break;
+                case SkillAlterationType.Lower:
+
+                    break;
+                default:
+#if DEBUG
+                    Console.WriteLine("Undefined or unspecified TypeOfAlteration reached");
+#endif
+
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YouFailToAlterSkill));
+                    break;
+            }
+
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -34,8 +34,9 @@ namespace ACE.Server.WorldObjects
         public virtual void UseItem(Player player)
         {
             // Do Nothing by default
+
 #if DEBUG
-            var message = $"Default UseItem reached, this object ({Name}) not programmed yet.";
+            var message = $"Default UseItem reached, this object ({Name}) of type ({WeenieType}) not programmed yet."; 
             player.Session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.System));
             log.Error(message);
 #endif


### PR DESCRIPTION
This PR implements basic skill redistribution functionality as required by the Skill Redistribution Quest (http://asheron.wikia.com/wiki/Attribute_and_Skill_Redistribution)

The dungeon works based on previous Emote work accomplished by others.

It appears that our database does not spawn the "Wardens" as described in the quest outline above.

In order to test the functionality you will have to spawn the appropriate Enlightenment/Forgetfulness gems through the /ci developer command. Here is a listing of the Weenie IDs for those gems (https://github.com/ACEmulator/ACE-World-16PY/tree/master/Database/3-Core/9%20WeenieDefaults/SQL/SkillAlterationDevice/GEM)

This PR should take into account most or all of the following scenarios:
 - Advancing a trained skill to a specialized skill
 - Demoting a specialized skill to a trained skill with both skill credit and invested XP refunds
 - Demoting a trained skill to an untrained skill with both skill credit and invested XP refunds
 - Prevents specializing a skill if doing so would exceed the 70+ credit specialization limit in retail
 - Prevents demoting a skill if an equipped item used the skill to be demoted

This PR does not:
 - Account for quest limits imposed by this quest in retail (should honestly be part of the emote functionality anyways)
 - Does not spawn the missing "Wardens" in the Inner Sanctum dungeon(s)