### PR TITLE
Don't throw warnings on CICMDCommand packets

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -162,6 +162,10 @@ namespace ACE.Server.Managers
                 if (session != null)
                     session.ProcessPacket(packet);
             }
+            else if (packet.Header.Id == 0 && packet.Header.HasFlag(PacketHeaderFlags.CICMDCommand))
+            {
+                // TODO: Not sure what to do with these packets yet
+            }
             else if (sessionMap.Length > packet.Header.Id && loggedInClients.Contains(endPoint))
             {
                 var session = sessionMap[packet.Header.Id];

--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -89,8 +89,7 @@ namespace ACE.Server.Network
                 if (packetLog.IsDebugEnabled)
                 {
                     StringBuilder sb = new StringBuilder();
-                    sb.AppendLine(
-                        $"Received Packet (Len: {data.Length}) [{ipEndpoint.Address}:{ipEndpoint.Port}=>{listenerEndpoint.Address}:{listenerEndpoint.Port}]");
+                    sb.AppendLine($"Received Packet (Len: {data.Length}) [{ipEndpoint.Address}:{ipEndpoint.Port}=>{listenerEndpoint.Address}:{listenerEndpoint.Port}]");
                     sb.AppendLine(data.BuildPacketString());
                     packetLog.Debug(sb.ToString());
                 }

--- a/Source/ACE.Server/Network/PacketHeaderFlags.cs
+++ b/Source/ACE.Server/Network/PacketHeaderFlags.cs
@@ -5,28 +5,28 @@ namespace ACE.Server.Network
     [Flags]
     public enum PacketHeaderFlags : uint  //ACE
     {
-        None = 0x00000000,
-        Retransmission = 0x00000001,
-        EncryptedChecksum = 0x00000002,     // can't be paired with 0x00000001, see FlowQueue::DequeueAck
-        BlobFragments = 0x00000004,
-        ServerSwitch = 0x00000100,          // Server Switch
-        LogonServerAddr = 0x00000200,       // Logon Server Addr
-        EmptyHeader1 = 0x00000400,          // Empty Header 1
-        Referral = 0x00000800,              // Referral
-        RequestRetransmit = 0x00001000,     // Nak
-        RejectRetransmit = 0x00002000,      // Empty Ack
-        AckSequence = 0x00004000,           // Pak
-        Disconnect = 0x00008000,            // Empty Header 2
-        LoginRequest = 0x00010000,          // Login
-        WorldLoginRequest = 0x00020000,     // ULong 1
-        ConnectRequest = 0x00040000,        // Connect
-        ConnectResponse = 0x00080000,       // ULong 2
-        NetError = 0x00100000,              // Net Error
-        NetErrorDisconnect = 0x00200000,    // Net Error Disconnect
-        CICMDCommand = 0x00400000,          // ICmd
-        TimeSync = 0x01000000,              // Time Sync
-        EchoRequest = 0x02000000,           // Echo Request
-        EchoResponse = 0x04000000,          // Echo Response
-        Flow = 0x08000000                   // Flow
+        None                = 0x00000000,
+        Retransmission      = 0x00000001,
+        EncryptedChecksum   = 0x00000002,   // can't be paired with 0x00000001, see FlowQueue::DequeueAck
+        BlobFragments       = 0x00000004,
+        ServerSwitch        = 0x00000100,   // Server Switch
+        LogonServerAddr     = 0x00000200,   // Logon Server Addr
+        EmptyHeader1        = 0x00000400,   // Empty Header 1
+        Referral            = 0x00000800,   // Referral
+        RequestRetransmit   = 0x00001000,   // Nak
+        RejectRetransmit    = 0x00002000,   // Empty Ack
+        AckSequence         = 0x00004000,   // Pak
+        Disconnect          = 0x00008000,   // Empty Header 2
+        LoginRequest        = 0x00010000,   // Login
+        WorldLoginRequest   = 0x00020000,   // ULong 1
+        ConnectRequest      = 0x00040000,   // Connect
+        ConnectResponse     = 0x00080000,   // ULong 2
+        NetError            = 0x00100000,   // Net Error
+        NetErrorDisconnect  = 0x00200000,   // Net Error Disconnect
+        CICMDCommand        = 0x00400000,   // ICmd
+        TimeSync            = 0x01000000,   // Time Sync
+        EchoRequest         = 0x02000000,   // Echo Request
+        EchoResponse        = 0x04000000,   // Echo Response
+        Flow                = 0x08000000    // Flow
     }
 }


### PR DESCRIPTION
CICMDCommand packets always have a Header.Id of 0.

We cannot use the Header.Id as a session index to process these packets. We need to process them separately.

They represent some sort of command.

You can see these in AC Log View. Open a pcap as fragments and search for an ICmd header. They will be all by themselves. I have yet to see them actually contain a payload.