### PR TITLE
Session connecting log level improvements

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -196,7 +196,7 @@ namespace ACE.Server.Managers
                         {
                             if (sessionMap[i] == null)
                             {
-                                log.InfoFormat("Creating new session for {0} with id {1}", endPoint, i);
+                                log.DebugFormat("Creating new session for {0} with id {1}", endPoint, i);
                                 session = new Session(endPoint, i, ServerId);
                                 sessions.Add(session);
                                 sessionMap[i] = session;
@@ -235,7 +235,7 @@ namespace ACE.Server.Managers
             sessionLock.EnterWriteLock();
             try
             {
-                log.InfoFormat("Removing session for {0} with id {1}", session.EndPoint, session.Network.ClientId);
+                log.DebugFormat("Removing session for {0} with id {1}", session.EndPoint, session.Network.ClientId);
                 if (sessions.Contains(session))
                     sessions.Remove(session);
                 if (sessionMap[session.Network.ClientId] == session)
@@ -534,7 +534,10 @@ namespace ACE.Server.Managers
                     var deadSessions = sessions.FindAll(s => s.State == Network.Enum.SessionState.NetworkTimeout);
 
                     foreach (var session in deadSessions)
+                    {
+                        log.Info($"client {session.Account} dropped");
                         RemoveSession(session);
+                    }
                 }
                 finally
                 {

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -55,12 +55,12 @@ namespace ACE.Server.Network.Handlers
 
             try
             {
-                log.Info($"new client connected: {loginRequest.Account}. setting session properties");
+                log.Debug($"new client connected: {loginRequest.Account}. setting session properties");
                 AccountSelectCallback(account, session, loginRequest);
             }
             catch (Exception ex)
             {
-                log.Info("Error in HandleLoginRequest trying to find the account.", ex);
+                log.Error("Error in HandleLoginRequest trying to find the account.", ex);
                 AccountSelectCallback(null, session, null);
             }
         }

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -338,7 +338,7 @@ namespace ACE.Server.Network
             // In our current implimenation we handle all roles in this one server.
             if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
             {
-                packetLog.Info($"[{session.LoggingIdentifier}] LoginRequest");
+                packetLog.Debug($"[{session.LoggingIdentifier}] LoginRequest");
                 AuthenticationHandler.HandleLoginRequest(packet, session);
                 return;
             }

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -89,6 +89,8 @@ namespace ACE.Server.Network
                 Player.HandleActionLogout(true);
             }
 
+            log.Info($"client {Account} disconnected");
+
             WorldManager.RemoveSession(this);
         }
 


### PR DESCRIPTION
The info log level shouldn't be too verbose. Info sould just have 1 record for a connect and disconnect.

The other debugging messages have been moved to the Debug log level.