### PR TITLE
Fix connection failures on initial account auto create session.

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -25,9 +25,13 @@ namespace ACE.Server.Command.Handlers
             var accessLevel = defaultAccessLevel;
 
             if (parameters.Length > 2)
+            {
                 if (Enum.TryParse(parameters[2], true, out accessLevel))
+                {
                     if (!Enum.IsDefined(typeof(AccessLevel), accessLevel))
                         accessLevel = defaultAccessLevel;
+                }
+            }
 
             string articleAorAN = "a";
             if (accessLevel == AccessLevel.Advocate || accessLevel == AccessLevel.Admin || accessLevel == AccessLevel.Envoy)
@@ -49,7 +53,7 @@ namespace ACE.Server.Command.Handlers
 
                     message = ("Account successfully created for " + account.AccountName + " (" + account.AccountId + ") with access rights as " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".");
                 }
-                catch// (MySqlException) Uncomment this after we remove the MySql.Data reference
+                catch
                 {
                     message = "Account already exists. Try a new name.";
                 }

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -155,12 +155,20 @@ namespace ACE.Server.Managers
 
         public static void ProcessPacket(ClientPacket packet, IPEndPoint endPoint)
         {
-            if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest) && !loggedInClients.Contains(endPoint) && loggedInClients.Count < ConfigManager.Config.Server.Network.MaximumAllowedSessions)
+            if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
             {
-                log.DebugFormat("Login Request from {0}", endPoint);
-                var session = FindOrCreateSession(endPoint);
-                if (session != null)
-                    session.ProcessPacket(packet);
+                if (!loggedInClients.Contains(endPoint) && loggedInClients.Count >= ConfigManager.Config.Server.Network.MaximumAllowedSessions)
+                {
+                    log.InfoFormat("Login Request from {0} rejected. Server full.", endPoint);
+                    // TODO can we send a message back to the client indicating we're full?
+                }
+                else
+                {
+                    log.DebugFormat("Login Request from {0}", endPoint);
+                    var session = FindOrCreateSession(endPoint);
+                    if (session != null)
+                        session.ProcessPacket(packet);
+                }
             }
             else if (packet.Header.Id == 0 && packet.Header.HasFlag(PacketHeaderFlags.CICMDCommand))
             {

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -9,7 +9,6 @@ using ACE.Common.Cryptography;
 using ACE.Database;
 using ACE.Database.Models.Auth;
 using ACE.Entity.Enum;
-using ACE.Server.Command.Handlers;
 using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
@@ -44,11 +43,15 @@ namespace ACE.Server.Network.Handlers
                 {
                     if (ConfigManager.Config.Server.Accounts.AllowAutoAccountCreation)
                     {
-                        log.Info($"Auto creating account for: {loginRequest.Account}");
                         // no account, dynamically create one
-                        string[] parameters = new string[] { loginRequest.Account, loginRequest.Password };
-                        AccountCommands.HandleAccountCreate(session, parameters);
-                        account = DatabaseManager.Authentication.GetAccountByName(loginRequest.Account);
+                        log.Info($"Auto creating account for: {loginRequest.Account}");
+
+                        var accessLevel = (AccessLevel)ConfigManager.Config.Server.Accounts.DefaultAccessLevel;
+
+                        if (!System.Enum.IsDefined(typeof(AccessLevel), accessLevel))
+                            accessLevel = AccessLevel.Player;
+
+                        account = DatabaseManager.Authentication.CreateAccount(loginRequest.Account.ToLower(), loginRequest.Password, accessLevel);
                     }
                 }
             }


### PR DESCRIPTION
Because AuthenticationHandler was passing the connection session to AccountCommand to do the account creation, AccountCommand would then try to send a status message to the session.

This would corrupt the clients session because the client wasn't ready to accept such messages.

The simple fix would have been to change this:
AccountCommands.HandleAccountCreate(session, parameters);
to this:
AccountCommands.HandleAccountCreate(null, parameters);

However, I don't like that a very vital piece of code, AuthenticationHandler was using a client input parser to do the actual work, AccountCommand.

Now, AuthenticationHandler does the work that it needs locally.