### PR TITLE
CommandHandlerHelper (Yum!) Added

### DIFF
--- a/Source/ACE.Server/Command/CommandManager.cs
+++ b/Source/ACE.Server/Command/CommandManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+
 using ACE.Entity.Enum;
 using ACE.Server.Network;
 

--- a/Source/ACE.Server/Command/Handlers/AccountCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AccountCommands.cs
@@ -3,7 +3,6 @@ using System;
 using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Server.Network;
-using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -59,13 +58,7 @@ namespace ACE.Server.Command.Handlers
                 }
             }
 
-            if (session == null)
-                Console.WriteLine(message);
-            else
-            {
-                var sysChatMsg = new GameMessageSystemChat(message, ChatMessageType.WorldBroadcast);
-                session.Network.EnqueueSend(sysChatMsg);
-            }
+            CommandHandlerHelper.WriteOutputInfo(session, message, ChatMessageType.WorldBroadcast);
         }
   
         [CommandHandler("accountget", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 1,
@@ -91,19 +84,20 @@ namespace ACE.Server.Command.Handlers
 
             if (accountId == 0)
             {
-                if (session == null)
-                    Console.WriteLine("Account " + accountName + " does not exist.");
-                else
-                    ChatPacket.SendServerMessage(session, "Account " + accountName + " does not exist.", ChatMessageType.Broadcast);
+                CommandHandlerHelper.WriteOutputInfo(session, "Account " + accountName + " does not exist.", ChatMessageType.Broadcast);
                 return;
             }
 
             AccessLevel accessLevel = AccessLevel.Player;
 
             if (parameters.Length > 1)
+            {
                 if (Enum.TryParse(parameters[1], true, out accessLevel))
+                {
                     if (!Enum.IsDefined(typeof(AccessLevel), accessLevel))
                         accessLevel = AccessLevel.Player;
+                }
+            }
 
             string articleAorAN = "a";
             if (accessLevel == AccessLevel.Advocate || accessLevel == AccessLevel.Admin || accessLevel == AccessLevel.Envoy)
@@ -111,19 +105,13 @@ namespace ACE.Server.Command.Handlers
 
             if (accountId == 0)
             {
-                if (session == null)
-                    Console.WriteLine("Account " + accountName + " does not exist.");
-                else
-                    ChatPacket.SendServerMessage(session, "Account " + accountName + " does not exist.", ChatMessageType.Broadcast);
+                CommandHandlerHelper.WriteOutputInfo(session, "Account " + accountName + " does not exist.", ChatMessageType.Broadcast);
                 return;
             }
 
             DatabaseManager.Authentication.UpdateAccountAccessLevel(accountId, accessLevel);
 
-            if (session == null)
-                Console.WriteLine("Account " + accountName + " updated with access rights set as " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".");
-            else
-                ChatPacket.SendServerMessage(session, "Account " + accountName + " updated with access rights set as " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".", ChatMessageType.Broadcast);
+            CommandHandlerHelper.WriteOutputInfo(session, "Account " + accountName + " updated with access rights set as " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".", ChatMessageType.Broadcast);
         }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -20,7 +20,6 @@ using ACE.Server.Entity;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Network;
-using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
 
@@ -207,10 +206,7 @@ namespace ACE.Server.Command.Handlers
             // Did not find a player
             string errorText = "Error locating the player or account to boot.";
             // Send the error to a player or the console
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat(errorText, ChatMessageType.Broadcast));
-            else
-                Console.WriteLine(errorText);
+            CommandHandlerHelper.WriteOutputInfo(session, errorText, ChatMessageType.Broadcast);
         }
 
         // deaf < on / off >
@@ -798,16 +794,8 @@ namespace ACE.Server.Command.Handlers
             String messageUTC = "The current server time in UtcNow is: " + DateTime.UtcNow;
             String messagePY = "The current server time in DerethDateTime is: " + currentPYtime;
 
-            var chatSysMessageUTC = new GameMessageSystemChat(messageUTC, ChatMessageType.WorldBroadcast);
-            var chatSysMessagePY = new GameMessageSystemChat(messagePY, ChatMessageType.WorldBroadcast);
-
-            if (session != null)
-                session.Network.EnqueueSend(chatSysMessageUTC, chatSysMessagePY);
-            else
-            {
-                Console.WriteLine(messageUTC);
-                Console.WriteLine(messagePY);
-            }
+            CommandHandlerHelper.WriteOutputInfo(session, messageUTC, ChatMessageType.Broadcast);
+            CommandHandlerHelper.WriteOutputInfo(session, messagePY, ChatMessageType.WorldBroadcast);
         }
 
         // trophies
@@ -1005,10 +993,10 @@ namespace ACE.Server.Command.Handlers
 
             var totalDist2d = Vector2.Distance(new Vector2(globLastSpawnPos.X, globLastSpawnPos.Y), new Vector2(globNewPos.X, globNewPos.Y));
 
-            Console.WriteLine($"Teleporting player to {newPos.Cell:X8} @ {newPos.Pos}");
+            ChatPacket.SendServerMessage(session, $"Teleporting player to {newPos.Cell:X8} @ {newPos.Pos}", ChatMessageType.System);
 
-            Console.WriteLine("2D Distance: " + totalDist2d);
-            Console.WriteLine("3D Distance: " + totalDist);
+            ChatPacket.SendServerMessage(session, "2D Distance: " + totalDist2d, ChatMessageType.System);
+            ChatPacket.SendServerMessage(session, "3D Distance: " + totalDist, ChatMessageType.System);
         }
 
         // ci wclassid (number)
@@ -1522,13 +1510,7 @@ namespace ACE.Server.Command.Handlers
                 else
                     message = $"Rename failed because either there is no character by the name {fixupOldName} currently in the database or the name {fixupNewName} is already taken.";
 
-                if (session == null)
-                    Console.WriteLine(message);
-                else
-                {
-                    var sysChatMsg = new GameMessageSystemChat(message, ChatMessageType.WorldBroadcast);
-                    session.Network.EnqueueSend(sysChatMsg);
-                }
+                CommandHandlerHelper.WriteOutputInfo(session, message, ChatMessageType.WorldBroadcast);
             }));
         }
 
@@ -1754,15 +1736,7 @@ namespace ACE.Server.Command.Handlers
             sb.Append($"Portal.dat has {DatManager.PortalDat.FileCache.Count:N0} files cached of {DatManager.PortalDat.AllFiles.Count:N0} total{'\n'}");
             sb.Append($"Cell.dat has {DatManager.CellDat.FileCache.Count:N0} files cached of {DatManager.CellDat.AllFiles.Count:N0} total{'\n'}");
 
-            if (session == null)
-            {
-                Console.WriteLine(sb);
-            }
-            else
-            {
-                session.Network.EnqueueSend(new GameMessageSystemChat("", ChatMessageType.System));
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{sb}", ChatMessageType.System));
-            }
+            CommandHandlerHelper.WriteOutputInfo(session, $"{sb}");
         }
 
         [CommandHandler("modifybool", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a bool", "modifybool (string) (bool)")]
@@ -1772,17 +1746,11 @@ namespace ACE.Server.Command.Handlers
             {
                 var boolVal = bool.Parse(paramters[1]);
                 PropertyManager.ModifyBool(paramters[0], boolVal);
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Bool property successfully updated!", ChatMessageType.System));
-                else
-                    Console.WriteLine("Bool property successfully updated!");
+                CommandHandlerHelper.WriteOutputInfo(session, "Bool property successfully updated!");
             }
             catch (Exception)
             {
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Please input a valid bool", ChatMessageType.Help));
-                else
-                    Console.WriteLine("Please input a valid bool");
+                CommandHandlerHelper.WriteOutputInfo(session, "Please input a valid bool", ChatMessageType.Help);
             }
         }
 
@@ -1790,10 +1758,7 @@ namespace ACE.Server.Command.Handlers
         public static void HandleFetchServerBoolProperty(Session session, params string[] paramters)
         {
             var boolVal = PropertyManager.GetBool(paramters[0], cacheFallback: false);
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{paramters[0]} - {boolVal.Description ?? "No Description"}: {boolVal.Item}", ChatMessageType.System));
-            else
-                Console.WriteLine($"{paramters[0]} - {boolVal.Description ?? "No Description"}: {boolVal.Item}");
+            CommandHandlerHelper.WriteOutputInfo(session, $"{paramters[0]} - {boolVal.Description ?? "No Description"}: {boolVal.Item}");
         }
 
         [CommandHandler("modifylong", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a long", "modifylong (string) (long)")]
@@ -1803,17 +1768,11 @@ namespace ACE.Server.Command.Handlers
             {
                 var intVal = int.Parse(paramters[1]);
                 PropertyManager.ModifyLong(paramters[0], intVal);
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Long property successfully updated!", ChatMessageType.System));
-                else
-                    Console.WriteLine("Long property successfully updated!");
+                CommandHandlerHelper.WriteOutputInfo(session, "Long property successfully updated!");
             }
             catch (Exception)
             {
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Please input a valid long", ChatMessageType.Help));
-                else
-                    Console.WriteLine("Please input a valid long");
+                CommandHandlerHelper.WriteOutputInfo(session, "Please input a valid long", ChatMessageType.Help);
             }
         }
 
@@ -1821,10 +1780,7 @@ namespace ACE.Server.Command.Handlers
         public static void HandleFetchServerLongProperty(Session session, params string[] paramters)
         {
             var intVal = PropertyManager.GetLong(paramters[0], cacheFallback: false);
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{paramters[0]} - {intVal.Description ?? "No Description"}: {intVal.Item}", ChatMessageType.System));
-            else
-                Console.WriteLine($"{paramters[0]} - {intVal.Description ?? "No Description"}: {intVal.Item}");
+            CommandHandlerHelper.WriteOutputInfo(session, $"{paramters[0]} - {intVal.Description ?? "No Description"}: {intVal.Item}");
         }
 
         [CommandHandler("modifydouble", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a double", "modifyfloat (string) (double)")]
@@ -1834,16 +1790,11 @@ namespace ACE.Server.Command.Handlers
             {
                 var floatVal = float.Parse(paramters[1]);
                 PropertyManager.ModifyDouble(paramters[0], floatVal);
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Double property successfully updated!", ChatMessageType.System));
-                else
-                    Console.WriteLine("Double property successfully updated!");
-            } catch (Exception)
+                CommandHandlerHelper.WriteOutputInfo(session, "Double property successfully updated!");
+            }
+            catch (Exception)
             {
-                if (session != null)
-                    session.Network.EnqueueSend(new GameMessageSystemChat("Please input a valid double", ChatMessageType.Help));
-                else
-                    Console.WriteLine("Please input a valid double");
+                CommandHandlerHelper.WriteOutputInfo(session, "Please input a valid double", ChatMessageType.Help);
             }
         }
 
@@ -1851,30 +1802,21 @@ namespace ACE.Server.Command.Handlers
         public static void HandleFetchServerFloatProperty(Session session, params string[] paramters)
         {
             var floatVal = PropertyManager.GetDouble(paramters[0], cacheFallback: false);
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{paramters[0]} - {floatVal.Description ?? "No Description"}: {floatVal.Item}", ChatMessageType.System));
-            else
-                Console.WriteLine($"{paramters[0]} - {floatVal.Description ?? "No Description"}: {floatVal.Item}");
+            CommandHandlerHelper.WriteOutputInfo(session, $"{paramters[0]} - {floatVal.Description ?? "No Description"}: {floatVal.Item}");
         }
 
         [CommandHandler("modifystring", AccessLevel.Admin, CommandHandlerFlag.None, 2, "Modifies a server property that is a string", "modifystring (string) (string)")]
         public static void HandleModifyServerStringProperty(Session session, params string[] parameters)
         {
             PropertyManager.ModifyString(parameters[0], parameters[1]);
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat("String property successfully updated!", ChatMessageType.System));
-            else
-                Console.WriteLine("String property successfully updated!");
+            CommandHandlerHelper.WriteOutputInfo(session, "String property successfully updated!");
         }
 
         [CommandHandler("fetchstring", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Fetches a server property that is a string", "fetchstring (string)")]
         public static void HandleFetchServerStringProperty(Session session, params string[] parameters)
         {
             var stringVal = PropertyManager.GetString(parameters[0], cacheFallback: false);
-            if (session != null)
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{parameters[0]} - {stringVal.Description ?? "No Description"}: {stringVal.Item}", ChatMessageType.System));
-            else
-                Console.WriteLine($"{parameters[0]} - {stringVal.Description ?? "No Description"}: {stringVal.Item}");
+            CommandHandlerHelper.WriteOutputInfo(session, $"{parameters[0]} - {stringVal.Description ?? "No Description"}: {stringVal.Item}");
         }
 
         [CommandHandler("modifypropertydesc", AccessLevel.Admin, CommandHandlerFlag.None, 3, "Modifies a server property's description", "modifypropertydesc <STRING|BOOL|DOUBLE|LONG> (string) (string)")]
@@ -1896,17 +1838,11 @@ namespace ACE.Server.Command.Handlers
                     PropertyManager.ModifyLongDescription(parameters[1], parameters[2]);
                     break;
                 default:
-                    if (isSession)
-                        session.Network.EnqueueSend(new GameMessageSystemChat("Please pick from STRING, BOOL, DOUBLE, or LONG", ChatMessageType.Help));
-                    else
-                        Console.WriteLine("Please pick from STRING, BOOL, DOUBLE, or LONG");
+                    CommandHandlerHelper.WriteOutputInfo(session, "Please pick from STRING, BOOL, DOUBLE, or LONG", ChatMessageType.Help);
                     return;
             }
 
-            if (isSession)
-                session.Network.EnqueueSend(new GameMessageSystemChat("Successfully updated property description!", ChatMessageType.Help));
-            else
-                Console.WriteLine("Successfully updated property description!");
+            CommandHandlerHelper.WriteOutputInfo(session, "Successfully updated property description!", ChatMessageType.Help);
         }
 
         [CommandHandler("resyncproperties", AccessLevel.Admin, CommandHandlerFlag.None, -1,

--- a/Source/ACE.Server/Command/Handlers/AdminShardCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminShardCommands.cs
@@ -1,4 +1,7 @@
 using System;
+
+using log4net;
+
 using ACE.Entity.Enum;
 using ACE.Server.Managers;
 using ACE.Server.Network;
@@ -8,13 +11,15 @@ namespace ACE.Server.Command.Handlers
 {
     public static class AdminShardCommands
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // // commandname parameters
         // [CommandHandler("commandname", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0)]
         // public static void HandleHelp(Session session, params string[] parameters)
         // {
         //     //TODO: output
         // }
-   
+
         /// <summary>
         /// Cancels an in-progress shutdown event.
         /// </summary>
@@ -48,11 +53,11 @@ namespace ACE.Server.Command.Handlers
                     ServerManager.SetShutdownInterval(Convert.ToUInt32(newShutdownInterval));
 
                     // message the admin
-                    ChatPacket.SendServerMessage(session, $"Shutdown Interval (seconds to shutdown server) has been set to {ServerManager.ShutdownInterval}.", ChatMessageType.Broadcast);
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Shutdown Interval (seconds to shutdown server) has been set to {ServerManager.ShutdownInterval}.", ChatMessageType.Broadcast);
                     return;
                 }
             }
-            ChatPacket.SendServerMessage(session, "Usage: /change-shutdown-interval <00000>", ChatMessageType.Broadcast);
+            CommandHandlerHelper.WriteOutputInfo(session, "Usage: /change-shutdown-interval <00000>", ChatMessageType.Broadcast);
         }
 
         /// <summary>
@@ -100,11 +105,11 @@ namespace ACE.Server.Command.Handlers
             shutdownText += $"{shutdownInitiator} initiated a complete server shutdown @ {DateTime.UtcNow} UTC";
 
             // output to console (log in the future)
-            Console.WriteLine(shutdownText);
-            Console.WriteLine(timeRemaining);
+            log.Info(shutdownText);
+            log.Info(timeRemaining);
 
             if (adminShutdownText.Length > 0)
-                Console.WriteLine("Admin message: " + adminShutdownText);
+                log.Info("Admin message: " + adminShutdownText);
 
             // send a message to each player that the server will go down in x interval
             foreach (var player in WorldManager.GetAll())

--- a/Source/ACE.Server/Command/Handlers/CharacterCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/CharacterCommands.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+
 using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Server.Network;
@@ -31,17 +32,11 @@ namespace ACE.Server.Command.Handlers
                     if (accessLevel == AccessLevel.Advocate || accessLevel == AccessLevel.Admin || accessLevel == AccessLevel.Envoy)
                         articleAorAN = "an";
 
-                    if (session == null)
-                        Console.WriteLine("Character " + characterName + " has been made " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".");
-                    else
-                        ChatPacket.SendServerMessage(session, "Character " + characterName + " has been made " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".", ChatMessageType.Broadcast);
+                    CommandHandlerHelper.WriteOutputInfo(session, "Character " + characterName + " has been made " + articleAorAN + " " + Enum.GetName(typeof(AccessLevel), accessLevel) + ".", ChatMessageType.Broadcast);
                 }
                 else
                 {
-                    if (session == null)
-                        Console.WriteLine("There is no character by the name of " + characterName + " found in the database. Has it been deleted?");
-                    else
-                        ChatPacket.SendServerMessage(session, "There is no character by the name of " + characterName + " found in the database. Has it been deleted?", ChatMessageType.Broadcast);
+                    CommandHandlerHelper.WriteOutputInfo(session, "There is no character by the name of " + characterName + " found in the database. Has it been deleted?", ChatMessageType.Broadcast);
                 }
             }));
         }

--- a/Source/ACE.Server/Command/Handlers/CommandHandlerHelper.cs
+++ b/Source/ACE.Server/Command/Handlers/CommandHandlerHelper.cs
@@ -1,0 +1,45 @@
+
+using log4net;
+
+using ACE.Entity.Enum;
+using ACE.Server.Network;
+
+namespace ACE.Server.Command.Handlers
+{
+    internal static class CommandHandlerHelper
+    {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// This will determine where a command handler should output to, the console or a client session.<para />
+        /// If the session is null, the output will be sent to the console. If the session is not null, and the session.Player is in the world, it will be sent to the session.<para />
+        /// Messages sent to the console will be sent using log.Info()
+        /// </summary>
+        public static void WriteOutputInfo(Session session, string output, ChatMessageType chatMessageType = ChatMessageType.System)
+        {
+            if (session != null)
+            {
+                if (session.State == Network.Enum.SessionState.WorldConnected && session.Player != null)
+                    ChatPacket.SendServerMessage(session, output, chatMessageType);
+            }
+            else
+                log.Info(output);
+        }
+
+        /// <summary>
+        /// This will determine where a command handler should output to, the console or a client session.<para />
+        /// If the session is null, the output will be sent to the console. If the session is not null, and the session.Player is in the world, it will be sent to the session.<para />
+        /// Messages sent to the console will be sent using log.Debug()
+        /// </summary>
+        public static void WriteOutputDebug(Session session, string output, ChatMessageType chatMessageType = ChatMessageType.System)
+        {
+            if (session != null)
+            {
+                if (session.State == Network.Enum.SessionState.WorldConnected && session.Player != null)
+                    ChatPacket.SendServerMessage(session, output, chatMessageType);
+            }
+            else
+                log.Debug(output);
+        }
+    }
+}

--- a/Source/ACE.Server/Command/Handlers/ConsoleCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/ConsoleCommands.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
-using ACE.Entity;
 using ACE.Entity.Enum;
-using ACE.Server.Managers;
 using ACE.Server.Network;
 
 namespace ACE.Server.Command.Handlers

--- a/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
@@ -11,11 +11,11 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("databasequeueinfo", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Show database queue information.")]
         public static void HandleDatabaseQueueInfo(Session session, params string[] parameters)
         {
-            ChatPacket.SendServerMessage(session, $"Current database queue count: {DatabaseManager.Shard.QueueCount}", ChatMessageType.System);
+            CommandHandlerHelper.WriteOutputInfo(session, $"Current database queue count: {DatabaseManager.Shard.QueueCount}");
 
             DatabaseManager.Shard.GetCurrentQueueWaitTime(result =>
             {
-                ChatPacket.SendServerMessage(session, $"Current database queue wait time: {result.TotalMilliseconds:N0} ms", ChatMessageType.System);
+                CommandHandlerHelper.WriteOutputInfo(session, $"Current database queue wait time: {result.TotalMilliseconds:N0} ms");
             });
         }
 

--- a/Source/ACE.Server/Command/Handlers/HelpCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/HelpCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.Entity.Enum;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages.Messages;

--- a/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
+++ b/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
@@ -38,7 +38,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
         private void Run(Session session, int biotasPerTest)
         {
-            ChatPacket.SendServerMessage(session, $"Starting Shard Database Performance Tests.\nBiotas per test: {biotasPerTest}\nThis may take several minutes to complete...\nCurrent database queue count: {DatabaseManager.Shard.QueueCount}", ChatMessageType.System);
+            CommandHandlerHelper.WriteOutputInfo(session, $"Starting Shard Database Performance Tests.\nBiotas per test: {biotasPerTest}\nThis may take several minutes to complete...\nCurrent database queue count: {DatabaseManager.Shard.QueueCount}");
 
 
             // Get the current queue wait time
@@ -46,7 +46,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
             DatabaseManager.Shard.GetCurrentQueueWaitTime(result =>
             {
-                ChatPacket.SendServerMessage(session, $"Current database queue wait time: {result.TotalMilliseconds:N0} ms", ChatMessageType.System);
+                CommandHandlerHelper.WriteOutputInfo(session, $"Current database queue wait time: {result.TotalMilliseconds:N0} ms");
                 responseReceived = true;
             });
 
@@ -95,7 +95,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
 
             // Update biotasPerTest biotas individually
-            if (SessionIsStillInWorld(session))
+            if (session == null || SessionIsStillInWorld(session))
             {
                 ModifyBiotas(biotas);
 
@@ -161,7 +161,7 @@ namespace ACE.Server.Command.Handlers.Processors
             ReportResult(session, "individual remove", biotasPerTest, (endTime - startTime), initialQueueWaitTime, totalQueryExecutionTime, trueResults, falseResults);
 
 
-            if (!SessionIsStillInWorld(session))
+            if (session != null && !SessionIsStillInWorld(session))
                 return;
 
             // Generate Bulk WorldObjects
@@ -203,7 +203,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
 
             // Update biotasPerTest biotas in bulk
-            if (SessionIsStillInWorld(session))
+            if (session == null || SessionIsStillInWorld(session))
             {
                 ModifyBiotas(biotas);
 
@@ -263,10 +263,10 @@ namespace ACE.Server.Command.Handlers.Processors
             ReportResult(session, "bulk remove", biotasPerTest, (endTime - startTime), initialQueueWaitTime, totalQueryExecutionTime, trueResults, falseResults);
 
 
-            if (!SessionIsStillInWorld(session))
+            if (session != null && !SessionIsStillInWorld(session))
                 return;
 
-            ChatPacket.SendServerMessage(session, "Database Performance Tests Completed", ChatMessageType.System);
+            CommandHandlerHelper.WriteOutputInfo(session, "Database Performance Tests Completed");
         }
 
         private static void ModifyBiotas(ICollection<(Biota biota, ReaderWriterLockSlim rwLock)> biotas)
@@ -340,10 +340,10 @@ namespace ACE.Server.Command.Handlers.Processors
 
         private static void ReportResult(Session session, string testDescription, int biotasPerTest, TimeSpan duration, TimeSpan queueWaitTime, TimeSpan totalQueryExecutionTime, long trueResults, long falseResults)
         {
-            if (!SessionIsStillInWorld(session))
+            if (session != null && !SessionIsStillInWorld(session))
                 return;
 
-            ChatPacket.SendServerMessage(session, $"{biotasPerTest} {testDescription.PadRight(17)} Duration: {duration.TotalSeconds.ToString("N1").PadLeft(5)} s. Queue Wait Time: {queueWaitTime.TotalMilliseconds.ToString("N0").PadLeft(3)} ms. Average Execution Time: {(totalQueryExecutionTime.TotalMilliseconds / biotasPerTest).ToString("N0").PadLeft(3)} ms. Success/Fail: {trueResults}/{falseResults}.", ChatMessageType.System);
+            CommandHandlerHelper.WriteOutputInfo(session, $"{biotasPerTest} {testDescription.PadRight(17)} Duration: {duration.TotalSeconds.ToString("N1").PadLeft(5)} s. Queue Wait Time: {queueWaitTime.TotalMilliseconds.ToString("N0").PadLeft(3)} ms. Average Execution Time: {(totalQueryExecutionTime.TotalMilliseconds / biotasPerTest).ToString("N0").PadLeft(3)} ms. Success/Fail: {trueResults}/{falseResults}.", ChatMessageType.System);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -375,7 +375,7 @@ namespace ACE.Server.WorldObjects
                     if (wo != null)
                         wo.Examine(Session);
                     else
-                        Console.WriteLine("${Name} tried to appraise object {examinationId:X8}, couldn't find it");
+                        log.Warn("${Name} tried to appraise object {examinationId:X8}, couldn't find it");
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -165,7 +165,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (!UnwieldItemWithNetworking(this, item))
                 {
-                    Console.WriteLine($"Player_Inventory.TryRemoveItemWithNetworking: couldn't unwield item from {Name} ({item.Name})");
+                    log.Warn($"Player_Inventory.TryRemoveItemWithNetworking: couldn't unwield item from {Name} ({item.Name})");
                     return false;
                 }
             }


### PR DESCRIPTION
There were a ton of commands that worked both on the console, and from a player session.

These commands had conditions like the following to determine if the output should be sent to the console or to the sesion:
if (session != null)
 sendToSession()
else
 SendToConsole()

CommandHandlerHelper cleans up this.

In addition, there were places in the code that were doing Console.WriteLine that should have been using the logger instead.