### PR TITLE
Improved monster timing / server animation sync

### DIFF
--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -118,13 +118,14 @@ namespace ACE.Entity
             var dy = Convert.ToSingle(Math.Cos(heading) * distanceInFront);
 
             // move the Z slightly up and let gravity pull it down.  just makes things easier.
+            var bumpHeight = 0.0f;
             if (rotate180)
             {
                 var rotate = new Quaternion(0, 0, qz, qw) * Quaternion.CreateFromYawPitchRoll(0, 0, (float)Math.PI);
-                return new Position(LandblockId.Raw, PositionX + dx, PositionY + dy, PositionZ + 0.5f, 0f, 0f, rotate.Z, rotate.W);
+                return new Position(LandblockId.Raw, PositionX + dx, PositionY + dy, PositionZ + bumpHeight, 0f, 0f, rotate.Z, rotate.W);
             }
             else
-                return new Position(LandblockId.Raw, PositionX + dx, PositionY + dy, PositionZ + 0.5f, 0f, 0f, qz, qw);
+                return new Position(LandblockId.Raw, PositionX + dx, PositionY + dy, PositionZ + bumpHeight, 0f, 0f, qz, qw);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1199,6 +1199,25 @@ namespace ACE.Server.Command.Handlers
             Console.WriteLine("Visible: " + visible);
         }
 
+        public static WorldObject GetLastAppraisedObject(Session session)
+        {
+            // get the wo emotemanager for the last appraised object
+            var targetID = session.Player.CurrentAppraisalTarget;
+            if (targetID == null)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "ERROR: no appraisal target");
+                return null;
+            }
+            var targetGuid = new ObjectGuid(targetID.Value);
+            var target = session.Player.CurrentLandblock?.GetObject(targetGuid);
+            if (target == null)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "ERROR: couldn't find " + targetGuid);
+                return null;
+            }
+            return target;
+        }
+
         [CommandHandler("debugemote", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Debugs a hardcoded emote for the last appraised object", "debugemote")]
         public static void HandleDebugEmote(Session session, params string[] parameters)
         {
@@ -1238,6 +1257,25 @@ namespace ACE.Server.Command.Handlers
             CommandHandlerHelper.WriteOutputInfo(session, $"Moving {target.Name} from {target.Location.LandblockId} {currentPos.Pos} to {newPos.LandblockId} {newPos.Pos}");
 
             target.EmoteManager.ExecuteEmote(emote, action, actionChain, target, target);
+        }
+
+        /// <summary>
+        /// Returns the distance to the last appraised object
+        /// </summary>
+        [CommandHandler("dist", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Returns the distance to the last appraised object")]
+        public static void HandleTeleportDist(Session session, params string[] parameters)
+        {
+            var obj = GetLastAppraisedObject(session);
+            if (obj == null) return;
+
+            var sourcePos = session.Player.Location.ToGlobal();
+            var targetPos = obj.Location.ToGlobal();
+
+            var dist = Vector3.Distance(sourcePos, targetPos);
+            var dist2d = Vector2.Distance(new Vector2(sourcePos.X, sourcePos.Y), new Vector2(targetPos.X, targetPos.Y));
+
+            Console.WriteLine("Dist: " + dist);
+            Console.WriteLine("2D Dist: " + dist2d);
         }
     }
 }

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -554,7 +554,12 @@ namespace ACE.Server.Managers
                                 actionChain.AddAction(sourceObject, () =>
                                 {
                                     //Console.WriteLine($"{sourceObject.Name} running motion {(MotionStance)emote.Style}, {(MotionCommand)emoteAction.Motion}");
-                                    sourceObject.ExecuteMotion(motion);
+
+                                    float? maxRange = ClientMaxAnimRange;
+                                    if (MotionQueue.Contains((MotionCommand)emoteAction.Motion))
+                                        maxRange = null;
+
+                                    sourceObject.ExecuteMotion(motion, true, maxRange);
                                 });
                                 actionChain.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(sourceObject.MotionTableId).GetAnimationLength((MotionCommand)emoteAction.Motion));
                                 if (motion.Commands[0].Motion != MotionCommand.Sleeping && motion.Commands[0].Motion != MotionCommand.Sitting) // this feels like it can be handled better, somehow?
@@ -936,6 +941,22 @@ namespace ACE.Server.Managers
                     break;
             }
         }
+
+        /// <summary>
+        /// The maximum animation range of the client
+        /// Motions broadcast outside of this range will be automatically queued by client
+        /// </summary>
+        public static float ClientMaxAnimRange = 96.0f;
+
+        /// <summary>
+        /// The client automatically queues animations that are broadcast outside of 96.0f range
+        /// Normally we exclude these emotes from being broadcast outside this range,
+        /// but for certain emotes (like monsters going to sleep) we want to always broadcast / enqueue
+        /// </summary>
+        public static HashSet<MotionCommand> MotionQueue = new HashSet<MotionCommand>()
+        {
+            MotionCommand.Sleeping
+        };
 
         public void InqCategory(EmoteCategory categoryId, BiotaPropertiesEmoteAction emoteAction, WorldObject sourceObject, WorldObject targetObject, ActionChain actionChain, bool useRNG = false)
         {

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -45,7 +45,7 @@ namespace ACE.Server.Managers
             var emoteType = (EmoteType)emoteAction.Type;
 
             //if (emoteType != EmoteType.Motion && emoteType != EmoteType.Turn && emoteType != EmoteType.Move)
-                //Console.WriteLine($"ExecuteEmote({emoteType})");
+                //Console.WriteLine($"{WorldObject.Name}.ExecuteEmote({emoteType})");
 
             var text = emoteAction.Message;
 
@@ -541,8 +541,8 @@ namespace ACE.Server.Managers
                                 actionChain.AddDelaySeconds(emoteAction.Delay);
                                 actionChain.AddAction(sourceObject, () =>
                                 {
-                                    sourceObject.EnqueueBroadcastMotion(startingMotion);
-                                    sourceObject.CurrentMotionState = startingMotion;
+                                    //Console.WriteLine($"{sourceObject.Name} running starting motion {(MotionStance)emote.Style}, {(MotionCommand)emote.Substyle}");
+                                    sourceObject.ExecuteMotion(startingMotion);
                                 });
                             }
                         }
@@ -553,16 +553,16 @@ namespace ACE.Server.Managers
                                 actionChain.AddDelaySeconds(emoteAction.Delay);
                                 actionChain.AddAction(sourceObject, () =>
                                 {
-                                    sourceObject.EnqueueBroadcastMotion(motion);
-                                    sourceObject.CurrentMotionState = motion;
+                                    //Console.WriteLine($"{sourceObject.Name} running motion {(MotionStance)emote.Style}, {(MotionCommand)emoteAction.Motion}");
+                                    sourceObject.ExecuteMotion(motion);
                                 });
                                 actionChain.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(sourceObject.MotionTableId).GetAnimationLength((MotionCommand)emoteAction.Motion));
                                 if (motion.Commands[0].Motion != MotionCommand.Sleeping && motion.Commands[0].Motion != MotionCommand.Sitting) // this feels like it can be handled better, somehow?
                                 {
                                     actionChain.AddAction(sourceObject, () =>
                                     {
-                                        sourceObject.EnqueueBroadcastMotion(startingMotion);
-                                        sourceObject.CurrentMotionState = startingMotion;
+                                        //Console.WriteLine($"{sourceObject.Name} running starting motion again {(MotionStance)emote.Style}, {(MotionCommand)emote.Substyle}");
+                                        sourceObject.ExecuteMotion(startingMotion);
                                     });
                                 }
                             }
@@ -575,8 +575,8 @@ namespace ACE.Server.Managers
                         actionChain.AddDelaySeconds(emoteAction.Delay);
                         actionChain.AddAction(sourceObject, () =>
                         {
-                            sourceObject.EnqueueBroadcastMotion(motion);
-                            sourceObject.CurrentMotionState = motion;
+                            //Console.WriteLine($"{sourceObject.Name} running motion (block 2) {(MotionStance)emote.Style}, {(MotionCommand)emoteAction.Motion}");
+                            sourceObject.ExecuteMotion(motion);
                         });
                     }
 

--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -452,7 +452,13 @@ namespace ACE.Server.Physics.Animation
             }
         }
 
-        public static float GetAnimationLength(uint motionTableId, MotionStance stance, MotionCommand motion, MotionCommand? currentMotion = null, float speed = 1.0f)
+        public static float GetAnimationLength(uint motionTableId, MotionStance stance, MotionCommand motion, float speed = 1.0f)
+        {
+            var motionTable = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(motionTableId);
+            return motionTable.GetAnimationLength(stance, motion, null) / speed;
+        }
+
+        public static float GetAnimationLength(uint motionTableId, MotionStance stance, MotionCommand currentMotion, MotionCommand motion, float speed = 1.0f)
         {
             var motionTable = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(motionTableId);
             return motionTable.GetAnimationLength(stance, motion, currentMotion) / speed;

--- a/Source/ACE.Server/Physics/Managers/MoveToManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MoveToManager.cs
@@ -357,6 +357,8 @@ namespace ACE.Server.Physics.Animation
 
         public void BeginMoveForward()
         {
+            //Console.WriteLine("BeginMoveForward");
+
             if (PhysicsObj == null)
             {
                 CancelMoveTo(WeenieError.NoPhysicsObject);
@@ -536,8 +538,8 @@ namespace ACE.Server.Physics.Animation
 
             var movementParams = new MovementParameters();
             movementParams.CancelMoveTo = false;
-            //movementParams.Speed = MovementParams.Speed;    // only for turning, too fast?
-            movementParams.Speed = 1.0f;    // commented out before?
+            movementParams.Speed = MovementParams.Speed;    // only for turning, too fast?
+            //movementParams.Speed = 1.0f;    // commented out before?
             movementParams.HoldKeyToApply = MovementParams.HoldKeyToApply;
 
             var result = _DoMotion(motionID, movementParams);

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -3752,6 +3752,9 @@ namespace ACE.Server.Physics
             if (forcePos)
                 set_current_pos(RequestPos);
 
+            // temp for players
+            CachedVelocity = Vector3.Zero;
+
             UpdateTime = PhysicsTimer.CurrentTime;
         }
 

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -3721,11 +3721,11 @@ namespace ACE.Server.Physics
             //Console.WriteLine("deltaTime: " + deltaTime);
 
             // commented out for debugging
-            /*if (deltaTime > PhysicsGlobals.HugeQuantum)
+            if (deltaTime > PhysicsGlobals.HugeQuantum)
             {
-                UpdateTime = Timer.CurrentTime;   // consume time?
+                UpdateTime = PhysicsTimer.CurrentTime;   // consume time?
                 return false;
-            }*/
+            }
 
             while (deltaTime > PhysicsGlobals.MaxQuantum)
             {
@@ -3751,6 +3751,8 @@ namespace ACE.Server.Physics
 
             if (forcePos)
                 set_current_pos(RequestPos);
+
+            UpdateTime = PhysicsTimer.CurrentTime;
         }
 
         public void update_position()

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -527,7 +527,7 @@ namespace ACE.Server.WorldObjects
 
         private void GenerateContainList()
         {
-            foreach(var item in Biota.BiotaPropertiesCreateList.Where(x => x.DestinationType == (sbyte)DestinationType.Contain || x.DestinationType == (sbyte)DestinationType.ContainTreasure))
+            foreach (var item in Biota.BiotaPropertiesCreateList.Where(x => x.DestinationType == (sbyte)DestinationType.Contain || x.DestinationType == (sbyte)DestinationType.ContainTreasure))
             {
                 var wo = WorldObjectFactory.CreateNewWorldObject(item.WeenieClassId);
 

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -85,8 +85,11 @@ namespace ACE.Server.WorldObjects
 
             Value = null; // Creatures don't have value. By setting this to null, it effectively disables the Value property. (Adding/Subtracting from null results in null)
 
-            CurrentMotionState = new UniversalMotion(MotionStance.NonCombat);
+            //CurrentMotionState = new UniversalMotion(MotionStance.NonCombat);     // breaks emotes?
             //CurrentMotionState.MovementData.ForwardCommand = (uint)MotionCommand.Ready;   // already the default?
+
+            //CurrentMotionState = new UniversalMotion(MotionStance.NonCombat, new MotionItem(MotionCommand.Ready));
+            CurrentMotionState = new UniversalMotion(MotionStance.Invalid, new MotionItem(MotionCommand.Invalid));
         }
 
         public void GenerateNewFace()

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -85,7 +85,8 @@ namespace ACE.Server.WorldObjects
 
             Value = null; // Creatures don't have value. By setting this to null, it effectively disables the Value property. (Adding/Subtracting from null results in null)
 
-            CurrentMotionState = new UniversalMotion(MotionStance.Invalid, new MotionItem(MotionCommand.Invalid));
+            CurrentMotionState = new UniversalMotion(MotionStance.NonCombat);
+            //CurrentMotionState.MovementData.ForwardCommand = (uint)MotionCommand.Ready;   // already the default?
         }
 
         public void GenerateNewFace()

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -80,7 +80,7 @@ namespace ACE.Server.WorldObjects
                 GenerateWieldList();
                 GenerateWieldedTreasure();
 
-                EquipWieldedTreasure();
+                EquipInventoryItems();
             }
 
             Value = null; // Creatures don't have value. By setting this to null, it effectively disables the Value property. (Adding/Subtracting from null results in null)

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -100,7 +100,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public float SwitchCombatStyles()
         {
-            if (CurrentMotionState.Stance == MotionStance.NonCombat)
+            if (CurrentMotionState.Stance == MotionStance.NonCombat || CurrentMotionState.Stance == MotionStance.Invalid)
                 return 0.0f;
 
             var combatStance = GetCombatStance();

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -261,10 +261,9 @@ namespace ACE.Server.WorldObjects
             item.Location = Location;
         }
 
-
         public void GenerateWieldList()
         {
-            foreach (var item in Biota.BiotaPropertiesCreateList.Where(x => x.DestinationType == (int)DestinationType.Wield || x.DestinationType == (int)DestinationType.WieldTreasure))
+            foreach (var item in Biota.BiotaPropertiesCreateList.Where(x => x.DestinationType == (int) DestinationType.Wield || x.DestinationType == (int) DestinationType.WieldTreasure))
             {
                 var wo = WorldObjectFactory.CreateNewWorldObject(item.WeenieClassId);
 
@@ -277,7 +276,7 @@ namespace ACE.Server.WorldObjects
                         wo.Shade = item.Shade;
 
                     if (wo.ValidLocations != null)
-                        TryEquipObject(wo, (int)wo.ValidLocations.Value);
+                        TryEquipObject(wo, (int) wo.ValidLocations.Value);
                 }
             }
         }
@@ -343,7 +342,18 @@ namespace ACE.Server.WorldObjects
                 wo.Shade = item.Shade;
 
             if (item.StackSize > 0)
-                wo.StackSize = (ushort)item.StackSize; // todo: stack_Size_Variance rng
+            {
+                var stackSize = item.StackSize;
+
+                var hasVariance = item.StackSizeVariance > 0;
+                if (hasVariance)
+                {
+                    var minStack = (int)Math.Round(item.StackSize * item.StackSizeVariance);
+                    var maxStack = item.StackSize;
+                    stackSize = Physics.Common.Random.RollDice(minStack, maxStack);
+                }
+                wo.StackSize = (ushort)stackSize;
+            }
 
             return TryAddToInventory(wo);
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
@@ -193,8 +193,11 @@ namespace ACE.Server.WorldObjects
         /// It is mostly a duplicate of Rotate(), and should be refactored eventually...
         /// It sets CurrentMotionState and AttackTarget here
         /// </summary>
-        public float TurnTo(WorldObject target)
+        public float TurnTo(WorldObject target, bool debug = false)
         {
+            if (DebugMove)
+                Console.WriteLine($"{Name}.TurnTo({target.Name})");
+
             if (this is Player) return 0.0f;
 
             var turnToMotion = new UniversalMotion(CurrentMotionState.Stance, target.Location, target.Guid);
@@ -205,7 +208,8 @@ namespace ACE.Server.WorldObjects
 
             AttackTarget = target;
             var rotateDelay = EstimateTurnTo();
-            //Console.WriteLine("TurnTime = " + turnTime);
+            if (debug)
+                Console.WriteLine("TurnTime = " + rotateDelay);
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(rotateDelay);
             actionChain.AddAction(this, () =>
@@ -213,7 +217,8 @@ namespace ACE.Server.WorldObjects
                 // fix me: in progress turn
                 //var targetDir = GetDirection(Location.ToGlobal(), target.Location.ToGlobal());
                 //Location.Rotate(targetDir);
-                //Console.WriteLine("Finished turning - " + turnTime + "s");
+                if (debug)
+                    Console.WriteLine("Finished turning - " + rotateDelay + "s");
             });
             actionChain.EnqueueChain();
             return rotateDelay;
@@ -224,6 +229,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void MoveTo(WorldObject target, float runRate = 1.0f)
         {
+            if (DebugMove)
+                Console.WriteLine($"{Name}.MoveTo({target.Name}, {runRate})");
+
             if (this is Player) return;
 
             var motion = new UniversalMotion(CurrentMotionState.Stance, target.Location, target.Guid);

--- a/Source/ACE.Server/WorldObjects/Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Monster.cs
@@ -1,10 +1,4 @@
 using System;
-using ACE.Database;
-using ACE.Database.Models.World;
-using ACE.Entity;
-using ACE.Entity.Enum;
-using ACE.Entity.Enum.Properties;
-using ACE.Server.Factories;
 
 namespace ACE.Server.WorldObjects
 {
@@ -29,7 +23,7 @@ namespace ACE.Server.WorldObjects
             Awake
         };
 
-        public void EquipWieldedTreasure(bool weaponsOnly = false)
+        public void EquipInventoryItems(bool weaponsOnly = false)
         {
             var items = weaponsOnly ? SelectWieldedWeapons() : SelectWieldedTreasure();
             if (items != null)

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -40,9 +40,7 @@ namespace ACE.Server.WorldObjects
         {
             MonsterState = State.Awake;
             IsAwake = true;
-            var stanceTime = DoAttackStance();
-            //Console.WriteLine("StanceTime: " + stanceTime);
-            NextAttackTime = DateTime.UtcNow.AddSeconds(stanceTime + 1.0f);
+            DoAttackStance();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -107,11 +107,13 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Switch to attack stance
         /// </summary>
-        public float DoAttackStance()
+        public void DoAttackStance()
         {
             var combatMode = IsRanged ? CombatMode.Missile : CombatMode.Melee;
 
-            return SetCombatMode(combatMode);
+            var stanceTime = SetCombatMode(combatMode);
+
+            NextAttackTime = DateTime.UtcNow.AddSeconds(stanceTime + 1.0f);
         }
 
         public float GetMaxRange()

--- a/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
-using ACE.Server.Factories;
 using ACE.Server.Physics.Extensions;
 
 namespace ACE.Server.WorldObjects
@@ -148,6 +147,8 @@ namespace ACE.Server.WorldObjects
 
         public List<WorldObject> SelectWieldedWeapons()
         {
+            //Console.WriteLine($"{Name}.SelectWieldedWeapons()");
+
             var meleeWeapons = GetInventoryItemsOfTypeWeenieType(WeenieType.MeleeWeapon);
             var missileWeapons = GetInventoryItemsOfTypeWeenieType(WeenieType.MissileLauncher);
             var missiles = GetInventoryItemsOfTypeWeenieType(WeenieType.Missile);
@@ -155,6 +156,7 @@ namespace ACE.Server.WorldObjects
             var ammo = GetInventoryItemsOfTypeWeenieType(WeenieType.Ammunition);
 
             var allWeapons = meleeWeapons.Concat(missileWeapons).ToList();
+            //var allWeapons = missileWeapons;
 
             if (allWeapons.Count == 0) return new List<WorldObject>();
 

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using ACE.Database.Models.Shard;
+using ACE.DatLoader;
 using ACE.DatLoader.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -18,7 +19,9 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The delay between melee attacks (todo: find actual value)
         /// </summary>
-        public static readonly float MeleeDelay = 2.0f;
+        public static readonly float MeleeDelay = 1.5f;
+        public static readonly float MeleeDelayMin = 0.5f;
+        public static readonly float MeleeDelayMax = 2.0f;
 
         /// <summary>
         /// Returns TRUE if creature can perform a melee attack
@@ -39,7 +42,11 @@ namespace ACE.Server.WorldObjects
 
             // choose a random combat maneuver
             var maneuver = GetCombatManeuver();
-            if (maneuver == null) return 0.0f;
+            if (maneuver == null)
+            {
+                Console.WriteLine($"Combat maneuver null! Stance {CurrentMotionState.Stance}, MotionTable {MotionTableId:X8}");
+                return 0.0f;
+            }
 
             AttackHeight = maneuver.AttackHeight;
 
@@ -50,7 +57,7 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.stick_to_object(AttackTarget.PhysicsObj.ID);
 
             var actionChain = new ActionChain();
-            actionChain.AddDelaySeconds(animLength / 2.0f);
+            actionChain.AddDelaySeconds(animLength / 3.0f);     // TODO: get attack frame?
             actionChain.AddAction(this, () =>
             {
                 if (AttackTarget == null) return;
@@ -76,7 +83,8 @@ namespace ACE.Server.WorldObjects
             actionChain.EnqueueChain();
 
             // TODO: figure out exact speed / delay formula
-            NextAttackTime = DateTime.UtcNow.AddSeconds(animLength + MeleeDelay);
+            var meleeDelay = Physics.Common.Random.RollDice(MeleeDelayMin, MeleeDelayMax);
+            NextAttackTime = DateTime.UtcNow.AddSeconds(animLength + meleeDelay);
             return animLength;
         }
 
@@ -87,15 +95,36 @@ namespace ACE.Server.WorldObjects
         {
             //ShowCombatTable();
 
+            // for some reason, the combat maneuvers table can return stance motions that don't exist in the motion table
+            // ie. skeletons (combat maneuvers table 0x30000000, motion table 0x09000025)
+            // for sword combat, they have double and triple strikes (dagger / two-handed only?)
+
             var stanceManeuvers = CombatTable.CMT.Where(m => m.Style == (MotionCommand)CurrentMotionState.Stance).ToList();
 
             if (stanceManeuvers.Count == 0)
                 return null;
 
-            var rng = Physics.Common.Random.RollDice(0, stanceManeuvers.Count - 1);
-            //Console.WriteLine("Selecting combat maneuver #" + rng);
+            var motionTable = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(MotionTableId);
+            if (motionTable == null)
+                return null;
 
-            return stanceManeuvers[rng];
+            var stanceKey = (uint)CurrentMotionState.Stance << 16 | ((uint)MotionCommand.Ready & 0xFFFFF);
+            motionTable.Links.TryGetValue(stanceKey, out var motions);
+            if (motions == null)
+                return null;
+
+            while (true)    // limiter?
+            {
+                var rng = Physics.Common.Random.RollDice(0, stanceManeuvers.Count - 1);
+                //Console.WriteLine("Selecting combat maneuver #" + rng);
+
+                var combatManeuver = stanceManeuvers[rng];
+
+                // ensure combat maneuver exists for this monster's motion table
+                motions.TryGetValue((uint)combatManeuver.Motion, out var motionData);
+                if (motionData != null)
+                    return combatManeuver;
+            };
         }
 
         /// <summary>
@@ -114,12 +143,12 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Perform the melee attack swing animation
         /// </summary>
-        public ActionChain DoSwingMotion(WorldObject target, CombatManeuver maneuver, out float animLength)
+        public void DoSwingMotion(WorldObject target, CombatManeuver maneuver, out float animLength)
         {
             var animSpeed = GetAnimSpeed();
 
             var swingAnimation = new MotionItem(maneuver.Motion, animSpeed);
-            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, maneuver.Motion, null, animSpeed);
+            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, maneuver.Motion, animSpeed);
 
             var motion = new UniversalMotion(CurrentMotionState.Stance, swingAnimation);
             motion.MovementData.CurrentStyle = (uint)CurrentMotionState.Stance;
@@ -129,12 +158,6 @@ namespace ACE.Server.WorldObjects
             CurrentMotionState = motion;
 
             EnqueueBroadcastMotion(motion);
-
-            // play default script? (special attack)
-            //if (MotionTable.HasDefaultScript(MotionTableId, maneuver.Motion, maneuver.Style))
-            //EnqueueBroadcast(new GameMessageScript(Guid, (PlayScript)DefaultScriptId));
-
-            return null;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -1,5 +1,4 @@
 using System;
-
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
@@ -13,7 +12,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The delay between missile attacks (todo: find actual value)
         /// </summary>
-        public static readonly float MissileDelay = 2.0f;
+        public static readonly float MissileDelay = 1.0f;
 
         /// <summary>
         /// Returns TRUE if monster has physical ranged attacks
@@ -39,8 +38,8 @@ namespace ACE.Server.WorldObjects
 
             // simulate accuracy bar / allow client rotate to fully complete
             var actionChain = new ActionChain();
-            IsTurning = true;
-            actionChain.AddDelaySeconds(0.5f);
+            //IsTurning = true;
+            //actionChain.AddDelaySeconds(0.5f);
 
             // do missile attack
             actionChain.AddAction(this, LaunchMissile);
@@ -52,13 +51,20 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void LaunchMissile()
         {
-            IsTurning = false;
+            //IsTurning = false;
 
             var weapon = GetEquippedMissileWeapon();
             if (weapon == null || AttackTarget == null) return;
 
             var ammo = weapon.IsAmmoLauncher ? GetEquippedAmmo() : weapon;
             if (ammo == null) return;
+
+            // ensure direct line of sight
+            /*if (!IsDirectVisible(AttackTarget))
+            {
+                NextAttackTime = DateTime.UtcNow.AddSeconds(1.0f);
+                return;
+            }*/
 
             // should this be called each launch?
             AttackHeight = ChooseAttackHeight();
@@ -84,13 +90,21 @@ namespace ACE.Server.WorldObjects
                 UpdateAmmoAfterLaunch(ammo);
             });
 
+            // will ammo be depleted?
+            if (ammo.StackSize == 1)
+            {
+                actionChain.EnqueueChain();
+                NextAttackTime = DateTime.UtcNow.AddSeconds(launchTime + MissileDelay);
+                return;
+            }
+
             // reload animation
             var reloadTime = EnqueueMotion(actionChain, MotionCommand.Reload);
             //Console.WriteLine("ReloadTime: " + reloadTime);
 
             // reset for next projectile
             EnqueueMotion(actionChain, MotionCommand.Ready);
-            var linkTime = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready, MotionCommand.Reload);
+            var linkTime = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Reload, MotionCommand.Ready);
             //Console.WriteLine("LinkTime: " + linkTime);
 
             actionChain.AddAction(this, () => EnqueueBroadcast(new GameMessageParentEvent(this, ammo, (int)ACE.Entity.Enum.ParentLocation.RightHand,
@@ -100,10 +114,7 @@ namespace ACE.Server.WorldObjects
 
             var timeOffset = launchTime + reloadTime + linkTime;
 
-            if (timeOffset < MissileDelay)
-                timeOffset = MissileDelay;
-
-            NextAttackTime = DateTime.UtcNow.AddSeconds(timeOffset);
+            NextAttackTime = DateTime.UtcNow.AddSeconds(timeOffset + MissileDelay);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -60,11 +60,11 @@ namespace ACE.Server.WorldObjects
             if (ammo == null) return;
 
             // ensure direct line of sight
-            /*if (!IsDirectVisible(AttackTarget))
+            if (!IsDirectVisible(AttackTarget))
             {
                 NextAttackTime = DateTime.UtcNow.AddSeconds(1.0f);
                 return;
-            }*/
+            }
 
             // should this be called each launch?
             AttackHeight = ChooseAttackHeight();

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -42,14 +42,14 @@ namespace ACE.Server.WorldObjects
                 if (ammo == null)
                 {
                     TryDequipObject(weapon.Guid);
-                    EquipWieldedTreasure(true);
+                    EquipInventoryItems(true);
                     DoAttackStance();
                     CurrentAttack = null;
                 }
             }
             if (weapon == null && CurrentAttack != null && CurrentAttack == AttackType.Missile)
             {
-                EquipWieldedTreasure(true);
+                EquipInventoryItems(true);
                 DoAttackStance();
                 CurrentAttack = null;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -827,7 +827,17 @@ namespace ACE.Server.WorldObjects
                 }
             }
             else
+            {
                 Session.Network.EnqueueSend(msgWieldItem, sound);
+
+                // new ammo becomes visible
+                // FIXME: can't get this to work without breaking client
+                // existing functionality also broken while swapping multiple arrows in missile combat mode
+                /*if (CombatMode == CombatMode.Missile)
+                {
+                    EnqueueBroadcast(new GameMessageParentEvent(this, item, (int)ACE.Entity.Enum.ParentLocation.RightHand, (int)ACE.Entity.Enum.Placement.RightHandCombat));
+                }*/
+            }
 
             return true;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -416,11 +416,10 @@ namespace ACE.Server.WorldObjects
                 new GameEventItemServerSaysContainId(Session, item, container),
                 new GameMessageObjDescEvent(this));
 
-            if ((oldLocation != EquipMask.MissileWeapon && oldLocation != EquipMask.Held && oldLocation != EquipMask.MeleeWeapon) || ((CombatMode & CombatMode.CombatCombat) == 0))
+            if (CombatMode == CombatMode.NonCombat || (oldLocation != EquipMask.MeleeWeapon && oldLocation != EquipMask.MissileWeapon && oldLocation != EquipMask.Held && oldLocation != EquipMask.Shield))
                 return true;
 
-            HandleSwitchToPeaceMode();
-            HandleSwitchToMeleeCombatMode();
+            SetCombatMode(CombatMode.Melee);
             return true;
         }
 
@@ -526,6 +525,8 @@ namespace ACE.Server.WorldObjects
                         
             if (item != null)
             {
+                //Console.WriteLine($"HandleActionPutItemInContainer({item.Name})");
+
                 IsAttuned(itemGuid, out bool isAttuned);
                 if (isAttuned == true && containerOwnedByPlayer == false)
                 {
@@ -730,6 +731,8 @@ namespace ACE.Server.WorldObjects
             var item = GetInventoryItem(itemGuid);
             if (item != null)
             {
+                //Console.WriteLine($"HandleActionGetAndWieldItem({item.Name})");
+
                 var result = TryWieldItem(item, wieldLocation);
                 return;
             }
@@ -804,6 +807,7 @@ namespace ACE.Server.WorldObjects
 
                 SetChild(item, wieldLocation, out var placementId, out var childLocation);
 
+                // TODO: wait for HandleQueueStance() here?
                 EnqueueBroadcast(new GameMessageParentEvent(this, item, childLocation, placementId), msgWieldItem, sound, updateContainer, updateWielder, updateWieldLoc);
 
                 if (CombatMode == CombatMode.NonCombat || CombatMode == CombatMode.Undef)

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -120,7 +120,7 @@ namespace ACE.Server.WorldObjects
             var animSpeed = baseSpeed * animSpeedMod;
 
             var swingAnimation = new MotionItem(GetSwingAnimation(), animSpeed);
-            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, swingAnimation.Motion, null, animSpeed);
+            animLength = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, swingAnimation.Motion, animSpeed);
 
             var motion = new UniversalMotion(CurrentMotionState.Stance, swingAnimation);
             motion.MovementData.CurrentStyle = (uint)CurrentMotionState.Stance;

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -114,7 +114,7 @@ namespace ACE.Server.WorldObjects
 
             // reset for next projectile
             EnqueueMotion(actionChain, MotionCommand.Ready);
-            var linkTime = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready, MotionCommand.Reload);
+            var linkTime = MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Reload, MotionCommand.Ready);
             //var cycleTime = MotionTable.GetCycleLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready);
 
             actionChain.AddAction(this, () => EnqueueBroadcast(new GameMessageParentEvent(this, ammo, (int)ACE.Entity.Enum.ParentLocation.RightHand,

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -109,6 +109,18 @@ namespace ACE.Server.WorldObjects
                 UpdateAmmoAfterLaunch(ammo);
             });
 
+            // ammo remaining?
+            if (ammo.StackSize == 1)
+            {
+                actionChain.AddAction(this, () =>
+                {
+                    SetCombatMode(CombatMode.NonCombat);
+                });
+
+                actionChain.EnqueueChain();
+                return;
+            }
+
             // reload animation
             var reloadTime = EnqueueMotion(actionChain, MotionCommand.Reload);
 
@@ -144,6 +156,11 @@ namespace ACE.Server.WorldObjects
 
             actionChain.EnqueueChain();
         }
+
+        // TODO: the damage pipeline currently uses the creature ammo instead of the projectile
+        // for calculating damage. when the last arrow is launched, the player ammo will be null
+        // give projectiles an owner, and have the damage pipeline take the actual damage source object
+        // (ie. the arrow-in-flight, or a melee weapon)
 
         public override float GetAimHeight(WorldObject target)
         {

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -103,22 +103,26 @@ namespace ACE.Server.WorldObjects
         public void TrackEquippedObjects(Creature creature, bool remove = false)
         {
             foreach (var wieldedItem in creature.EquippedObjects.Values)
-            {
-                var selectable = (wieldedItem.ValidLocations.Value & EquipMask.Selectable) != 0;
-                var missileCombat = creature.CombatMode == CombatMode.Missile && (wieldedItem.ValidLocations.Value & EquipMask.MissileAmmo) != 0;
+                TrackEquippedObject(creature, wieldedItem, remove);
+        }
 
-                if (!selectable && !missileCombat)
-                    continue;
+        public void TrackEquippedObject(Creature creature, WorldObject wieldedItem, bool remove = false)
+        {
+            //Console.WriteLine($"TrackEquippedObject({wieldedItem.Name})");
 
-                if (creature.Location == null || creature.Placement == null || creature.ParentLocation == null)
-                    creature.SetChild(wieldedItem, (int)wieldedItem.CurrentWieldedLocation, out var placementId, out var parentLocation);
+            var selectable = (wieldedItem.ValidLocations.Value & EquipMask.Selectable) != 0;
+            var missileCombat = creature.CombatMode == CombatMode.Missile && (wieldedItem.ValidLocations.Value & EquipMask.MissileAmmo) != 0;
 
-                //Console.WriteLine($"TrackEquippedObject({wieldedItem.Name})")
-                if (!remove)
-                    Session.Network.EnqueueSend(new GameMessageCreateObject(wieldedItem));
-                else
-                    Session.Network.EnqueueSend(new GameMessageDeleteObject(wieldedItem));
-            }
+            if (!selectable && !missileCombat)
+                return;
+
+            if (creature.Location == null || creature.Placement == null || creature.ParentLocation == null)
+                creature.SetChild(wieldedItem, (int)wieldedItem.CurrentWieldedLocation, out var placementId, out var parentLocation);
+
+            if (!remove)
+                Session.Network.EnqueueSend(new GameMessageCreateObject(wieldedItem));
+            else
+                Session.Network.EnqueueSend(new GameMessageDeleteObject(wieldedItem));
         }
 
         public bool AddTrackedObject(WorldObject worldObject)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -379,8 +379,10 @@ namespace ACE.Server.WorldObjects
             var radsum = PhysicsObj.GetPhysicsRadius() + SightObj.GetPhysicsRadius();
             startPos.Frame.Origin += dir * radsum;
 
-            // perform line of sight test
             SightObj.CurCell = PhysicsObj.CurCell;
+            SightObj.ProjectileTarget = wo.PhysicsObj;
+
+            // perform line of sight test
             var transition = SightObj.transition(startPos, targetPos, false);
             if (transition == null) return false;
 
@@ -678,9 +680,14 @@ namespace ACE.Server.WorldObjects
             proj.OnCollideEnvironment();
         }
 
-        public void EnqueueBroadcastMotion(UniversalMotion motion)
+        public void EnqueueBroadcastMotion(UniversalMotion motion, float? maxRange = null)
         {
-            EnqueueBroadcast(new GameMessageUpdateMotion(Guid, Sequences.GetCurrentSequence(SequenceType.ObjectInstance), Sequences, motion));
+            var msg = new GameMessageUpdateMotion(Guid, Sequences.GetCurrentSequence(SequenceType.ObjectInstance), Sequences, motion);
+
+            if (maxRange == null)
+                EnqueueBroadcast(msg);
+            else
+                EnqueueBroadcast(msg, maxRange.Value);
         }
 
         public void ApplyVisualEffects(PlayScript effect)
@@ -949,7 +956,7 @@ namespace ACE.Server.WorldObjects
         /// adds to the physics animation system, and broadcasts to nearby players
         /// </summary>
         /// <returns>The amount it takes to execute the motion</returns>
-        public float ExecuteMotion(UniversalMotion motion, bool sendClient = true)
+        public float ExecuteMotion(UniversalMotion motion, bool sendClient = true, float? maxRange = null)
         {
             var motionCommand = MotionCommand.Invalid;
 
@@ -979,7 +986,7 @@ namespace ACE.Server.WorldObjects
 
             // broadcast to nearby players
             if (sendClient)
-                EnqueueBroadcastMotion(motion);
+                EnqueueBroadcastMotion(motion, maxRange);
 
             return animLength;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -864,6 +864,11 @@ namespace ACE.Server.WorldObjects
         public virtual DamageType GetDamageType(bool multiple = false)
         {
             var creature = this as Creature;
+            if (creature == null)
+            {
+                Console.WriteLine("WorldObject.GetDamageType(): null creature");
+                return DamageType.Undef;
+            }
 
             var weapon = creature.GetEquippedWeapon();
             var ammo = creature.GetEquippedAmmo();
@@ -874,9 +879,9 @@ namespace ACE.Server.WorldObjects
             DamageType damageTypes;
             var attackType = creature.GetAttackType();
             if (attackType == AttackType.Melee || ammo == null || !weapon.IsAmmoLauncher)
-                damageTypes = (DamageType)weapon.GetProperty(PropertyInt.DamageType);
+                damageTypes = (DamageType)(weapon.GetProperty(PropertyInt.DamageType) ?? 0);
             else
-                damageTypes = (DamageType)ammo.GetProperty(PropertyInt.DamageType);
+                damageTypes = (DamageType)(ammo.GetProperty(PropertyInt.DamageType) ?? 0);
 
             // returning multiple damage types
             if (multiple) return damageTypes;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -16,6 +16,12 @@ namespace ACE.Server.WorldObjects
             {
                 var wo = WorldObjectFactory.CreateNewWorldObject(item.WeenieClassId);
 
+                if (item.Palette > 0)
+                    wo.PaletteTemplate = item.Palette;
+
+                if (item.Shade > 0)
+                    wo.Shade = item.Shade;
+
                 if (item.StackSize > 0)
                     wo.StackSize = (ushort)item.StackSize;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -1,7 +1,14 @@
+using System;
 using System.Collections.Generic;
-
+using System.Numerics;
+using ACE.Entity;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
+using ACE.Server.Physics;
+using ACE.Server.Physics.Common;
+using ACE.Server.Physics.Extensions;
 
 namespace ACE.Server.WorldObjects
 {
@@ -64,6 +71,178 @@ namespace ACE.Server.WorldObjects
         void IActor.DequeueAction(LinkedListNode<IAction> node)
         {
             actionQueue.DequeueAction(node);
+        }
+
+        public uint prevCell;
+        public bool InUpdate;
+
+        /// <summary>
+        /// Used by physics engine to actually update a player position
+        /// Automatically notifies clients of updated position
+        /// </summary>
+        /// <param name="newPosition">The new position being requested, before verification through physics engine</param>
+        /// <returns>TRUE if object moves to a different landblock</returns>
+        public bool UpdatePlayerPhysics(ACE.Entity.Position newPosition, bool forceUpdate = false)
+        {
+            //Console.WriteLine($"UpdatePlayerPhysics: {newPosition.Cell:X8}, {newPosition.Pos}");
+
+            var player = this as Player;
+
+            // only handles player movement
+            if (player == null) return false;
+
+            // possible bug: while teleporting, client can still send AutoPos packets from old landblock
+            if (Teleporting && !forceUpdate) return false;
+
+            if (PhysicsObj != null)
+            {
+                var dist = (newPosition.Pos - PhysicsObj.Position.Frame.Origin).Length();
+                if (dist > PhysicsGlobals.EPSILON)
+                {
+                    var curCell = LScape.get_landcell(newPosition.Cell);
+                    if (curCell != null)
+                    {
+                        //if (PhysicsObj.CurCell == null || curCell.ID != PhysicsObj.CurCell.ID)
+                        //PhysicsObj.change_cell_server(curCell);
+
+                        PhysicsObj.set_request_pos(newPosition.Pos, newPosition.Rotation, curCell, Location.LandblockId.Raw);
+                        PhysicsObj.update_object_server();
+
+                        if (PhysicsObj.CurCell == null)
+                            PhysicsObj.CurCell = curCell;
+
+                        player.CheckMonsters();
+
+                        if (curCell.ID != prevCell)
+                        {
+                            //prevCell = curCell.ID;
+                            //Console.WriteLine("Player cell: " + curCell.ID.ToString("X8"));
+                            //var envCell = curCell as Physics.Common.EnvCell;
+                            //var seenOutside = envCell != null ? envCell.SeenOutside : true;
+                            //Console.WriteLine($"CurCell: {curCell.ID:X8}, SeenOutside: {seenOutside}");
+                        }
+                    }
+                }
+            }
+
+            // double update path: landblock physics update -> updateplayerphysics() -> update_object_server() -> Teleport() -> updateplayerphysics() -> return to end of original branch
+            if (Teleporting && !forceUpdate) return true;
+
+            var landblockUpdate = Location.Cell >> 16 != newPosition.Cell >> 16;
+            Location = newPosition;
+
+            SendUpdatePosition();
+
+            if (!InUpdate)
+                LandblockManager.RelocateObjectForPhysics(this, true);
+
+            return landblockUpdate;
+        }
+
+        public double lastDist;
+
+        public static double ProjectileTimeout = 30.0f;
+
+        private readonly double physicsCreationTime = PhysicsTimer.CurrentTime;
+
+        public double LastPhysicsUpdate;
+
+        public static double UpdateRate_Creature = 0.2f;
+
+        /// <summary>
+        /// Handles calling the physics engine for non-player objects
+        /// </summary>
+        public bool UpdateObjectPhysics()
+        {
+            if (PhysicsObj == null || !PhysicsObj.is_active())
+                return false;
+
+            // arrows / spell projectiles
+            var isMissile = Missile.HasValue && Missile.Value;
+
+            // monsters have separate physics updates
+            var creature = this as Creature;
+            var monster = creature != null && creature.IsMonster;
+
+            // determine if updates should be run for object
+            //var runUpdate = !monster && (isMissile || !PhysicsObj.IsGrounded);
+            //var runUpdate = isMissile;
+            var runUpdate = !monster && (isMissile || IsMoving);
+
+            if (creature != null)
+            {
+                if (LastPhysicsUpdate + UpdateRate_Creature <= PhysicsTimer.CurrentTime)
+                    LastPhysicsUpdate = PhysicsTimer.CurrentTime;
+                else
+                    runUpdate = false;
+            }
+
+            if (!runUpdate) return false;
+
+            if (isMissile && physicsCreationTime + ProjectileTimeout <= PhysicsTimer.CurrentTime)
+            {
+                // only for projectiles?
+                //Console.WriteLine("Timeout reached - destroying " + Name);
+                PhysicsObj.set_active(false);
+                Destroy();
+                return false;
+            }
+
+            // get position before
+            var pos = PhysicsObj.Position.Frame.Origin;
+            var prevPos = new Vector3(pos.X, pos.Y, pos.Z);
+            var cellBefore = PhysicsObj.CurCell != null ? PhysicsObj.CurCell.ID : 0;
+
+            var updated = PhysicsObj.update_object();
+
+            // get position after
+            pos = PhysicsObj.Position.Frame.Origin;
+            var newPos = new Vector3(pos.X, pos.Y, pos.Z);
+
+            // handle landblock / cell change
+            var isMoved = prevPos.IsMoved(newPos);
+            var curCell = PhysicsObj.CurCell;
+
+            if (PhysicsObj.CurCell == null)
+            {
+                //Console.WriteLine("CurCell is null");
+                PhysicsObj.set_active(false);
+                Destroy();
+                return false;
+            }
+
+            var landblockUpdate = (cellBefore >> 16) != (curCell.ID >> 16);
+            if (isMoved)
+            {
+                if (curCell.ID != cellBefore)
+                    Location.LandblockId = new LandblockId(curCell.ID);
+
+                Location.Pos = newPos;
+                //if (landblockUpdate)
+                //WorldManager.UpdateLandblock.Add(this);
+            }
+
+            if (PhysicsObj.IsGrounded)
+                SendUpdatePosition(true);
+
+            //var dist = Vector3.Distance(ProjectileTarget.Location.Pos, newPos);
+            //Console.WriteLine("Dist: " + dist);
+            //Console.WriteLine("Velocity: " + PhysicsObj.Velocity);
+
+            var spellProjectile = this as SpellProjectile;
+            if (spellProjectile != null && spellProjectile.SpellType == SpellProjectile.ProjectileSpellType.Ring)
+            {
+                var dist = Vector3.Distance(spellProjectile.SpawnPos.ToGlobal(), Location.ToGlobal());
+                var maxRange = spellProjectile.Spell.BaseRangeConstant;
+                //Console.WriteLine("Max range: " + maxRange);
+                if (dist > maxRange)
+                {
+                    PhysicsObj.set_active(false);
+                    spellProjectile.ProjectileImpact();
+                    return false;
+                }
+            }
+            return landblockUpdate;
         }
     }
 }


### PR DESCRIPTION
- Added direct visibility / line-of-sight test
- Added ExecuteMotion, which plays the animation on both the client and server.
	- EmoteManager - EmoteType.Motion now goes through ExecuteMotion, so animations like monsters going to sleep (skeletons/golems) will now be simulated properly on the server. This fixes the bug where monsters would start moving while they were still transitioning from sleep->wakeup
- Added more robust logic for animation timing while switching combat stances, for both players and creatures
- Added randomized stack size variances to mob projectiles, based on WieldedTreasure tables
- Improved timing for all monster animation transitions (combat stance, missile launches, spellcasting)
- Added randomized variance to monster melee attack delay (0.5-2s)
- Fixed a bug where monsters selected combat maneuvers that didn't exist in their motion table
- Fixed a bug where monsters would sometimes walk instead of run, when re-chasing targets
- Fixed a bug where CreateObject network messages would be re-sent when monsters swapped inventory items
