### PR TITLE
PropertyDump added

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -437,6 +437,34 @@ namespace ACE.Server.Command.Handlers
 
 
         // ==================================
+        // World Object Properties
+        // ==================================
+
+        [CommandHandler("propertydump", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Lists all properties for the last world object you examined.")]
+        public static void HandlePropertyDump(Session session, params string[] parameters)
+        {
+            var targetID = session.Player.CurrentAppraisalTarget;
+            if (targetID == null)
+            {
+                ChatPacket.SendServerMessage(session, "ERROR: no examined history", ChatMessageType.System);
+                return;
+            }
+            var targetGuid = new ObjectGuid(targetID.Value);
+            var target = session.Player.GetInventoryItem(targetGuid);
+            if (target == null)
+                target = session.Player.CurrentLandblock?.GetObject(targetGuid);
+            if (target == null)
+            {
+                ChatPacket.SendServerMessage(session, "ERROR: couldn't find " + targetGuid, ChatMessageType.System);
+                return;
+            }
+
+            session.Network.EnqueueSend(new GameMessageSystemChat("", ChatMessageType.System));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"{target.DebugOutputString(target)}", ChatMessageType.System));
+        }
+
+
+        // ==================================
         // Player Properties
         // ==================================
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+
 using log4net;
+
 using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
@@ -467,11 +469,6 @@ namespace ACE.Server.WorldObjects
             var success = true;
             GameEventIdentifyObjectResponse identifyResponse = new GameEventIdentifyObjectResponse(examiner, this, success);
             examiner.Network.EnqueueSend(identifyResponse);
-
-#if DEBUG
-            examiner.Network.EnqueueSend(new GameMessageSystemChat("", ChatMessageType.System));
-            examiner.Network.EnqueueSend(new GameMessageSystemChat($"{DebugOutputString(GetType(), this)}", ChatMessageType.System));
-#endif
         }
 
         public void ReadBookPage(Session reader, uint pageNum)
@@ -492,12 +489,12 @@ namespace ACE.Server.WorldObjects
         }
 
  
-        private string DebugOutputString(Type type, WorldObject obj)
+        public string DebugOutputString(WorldObject obj)
         {
             var sb = new StringBuilder();
 
             sb.AppendLine("ACE Debug Output:");
-            sb.AppendLine("ACE Class File: " + type.Name + ".cs");
+            sb.AppendLine("ACE Class File: " + GetType().Name + ".cs");
             sb.AppendLine("Guid: " + obj.Guid.Full + " (0x" + obj.Guid.Full.ToString("X") + ")");
 
             sb.AppendLine("----- Private Fields -----");


### PR DESCRIPTION
Properties are no longer spit out on ident in debug builds.

Now, you can use /propertydump to spit out all the properties of the last item you identified.