### PR TITLE
Fix DamageType for Boost spells

### DIFF
--- a/Source/ACE.Server/Entity/SpellProperties.cs
+++ b/Source/ACE.Server/Entity/SpellProperties.cs
@@ -303,7 +303,7 @@ namespace ACE.Server.Entity
         public float DamageRatio { get => _spell.DamageRatio ?? 1.0f; }
 
         /// <summary>
-        /// TODO: how is this different from EType?
+        /// DamageType used by LifeMagic spells that specifies Health, Mana, or Stamina for the Boost type spells
         /// </summary>
         public DamageType DamageType2 { get => (DamageType)(_spell.DamageType ?? 0); }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -199,7 +199,7 @@ namespace ACE.Server.WorldObjects
                     int boost = Physics.Common.Random.RollDice(minBoostValue, maxBoostValue);
                     damage = boost < 0 ? (uint)Math.Abs(boost) : 0;
 
-                    switch (spell.DamageType)
+                    switch (spell.DamageType2)
                     {
                         case DamageType.Mana:
                             newSpellTargetVital = (int)Math.Min(spellTarget.Mana.Current + boost, spellTarget.Mana.MaxValue);


### PR DESCRIPTION
Change DamageType to DamageType2 for LifeMagic Boost spells