### PR TITLE
Alleg Fixes plus fix for No Default SQL

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -103,6 +103,19 @@ namespace ACE.Server.Managers
         }
 
         /// <summary>
+        /// Adds a newly created character to the list of all players on the server
+        /// </summary>
+        public static void AddPlayer(Character character)
+        {
+            DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
+            {
+                var session = new Session();
+                var player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
+                AllPlayers.Add(player);
+            });
+        }
+
+        /// <summary>
         /// Returns an offline player record from the AllPlayers list
         /// </summary>
         /// <param name="playerGuid"></param>

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -148,6 +148,7 @@ namespace ACE.Server.Network.Handlers
                         return;
                     }
 
+                    WorldManager.AddPlayer(player.Character);
                     session.Characters.Add(player.Character);
 
                     SendCharacterCreateResponse(session, CharacterGenerationVerificationResponse.Ok, player.Guid, characterCreateInfo.Name);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -49,7 +49,6 @@ namespace ACE.Server.WorldObjects
             Character.Id = guid.Full;
             Character.AccountId = accountId;
             Character.Name = GetProperty(PropertyString.Name);
-            Character.IsPlussed = true;
             CharacterChangesDetected = true;
 
             // Make sure properties this WorldObject requires are not null.
@@ -59,6 +58,8 @@ namespace ACE.Server.WorldObjects
             Attackable = true;
 
             SetProperty(PropertyString.DateOfBirth, $"{DateTime.UtcNow:dd MMMM yyyy}");
+
+            SetEphemeralValues();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -49,7 +49,7 @@ namespace ACE.Server.WorldObjects
             Character.Id = guid.Full;
             Character.AccountId = accountId;
             Character.Name = GetProperty(PropertyString.Name);
-            Character.IsPlussed = true;
+            Character.IsPlussed = false;
             CharacterChangesDetected = true;
 
             // Make sure properties this WorldObject requires are not null.

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -49,7 +49,7 @@ namespace ACE.Server.WorldObjects
             Character.Id = guid.Full;
             Character.AccountId = accountId;
             Character.Name = GetProperty(PropertyString.Name);
-            Character.IsPlussed = false;
+            Character.IsPlussed = true;
             CharacterChangesDetected = true;
 
             // Make sure properties this WorldObject requires are not null.

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -49,6 +49,7 @@ namespace ACE.Server.WorldObjects
             Character.Id = guid.Full;
             Character.AccountId = accountId;
             Character.Name = GetProperty(PropertyString.Name);
+            Character.IsPlussed = true;
             CharacterChangesDetected = true;
 
             // Make sure properties this WorldObject requires are not null.
@@ -58,8 +59,6 @@ namespace ACE.Server.WorldObjects
             Attackable = true;
 
             SetProperty(PropertyString.DateOfBirth, $"{DateTime.UtcNow:dd MMMM yyyy}");
-
-            SetEphemeralValues();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an issue where a new characters will not show as joining an allegiance until a server restart. If the new character is the patron the server will crash, also fixed. During testing of the latest server code found that character creation was broken. Added that fix here by setting up Character.IsPlussed to 'true' in ..ACE\Source\ACE.Server\WorldObjects\Player.cs. I am not sure if it should be 'true' or 'false'.