### PR TITLE
Adding multistrike weapons

### DIFF
--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventCombatCommenceAttack.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventCombatCommenceAttack.cs
@@ -1,8 +1,8 @@
 namespace ACE.Server.Network.GameEvent.Events
 {
-    public class GameEventCombatCommmenceAttack : GameEventMessage
+    public class GameEventCombatCommenceAttack : GameEventMessage
     {
-        public GameEventCombatCommmenceAttack(Session session)
+        public GameEventCombatCommenceAttack(Session session)
             : base(GameEventType.CombatCommenceAttack, GameMessageGroup.UIQueue, session)
         {
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -69,11 +69,15 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Returns the currently equipped primary melee weapon
+        /// Returns the current equipped active melee weapon
+        /// This will normally be the primary melee weapon, but if dual wielding, this will be the weapon for the next attack
         /// </summary>
         public WorldObject GetEquippedMeleeWeapon()
         {
-            return EquippedObjects.Values.FirstOrDefault(e => e.ParentLocation == ACE.Entity.Enum.ParentLocation.RightHand && (e.CurrentWieldedLocation == EquipMask.MeleeWeapon || e.CurrentWieldedLocation == EquipMask.TwoHanded));
+            if (!IsDualWieldAttack || DualWieldAlternate)
+                return EquippedObjects.Values.FirstOrDefault(e => e.ParentLocation == ACE.Entity.Enum.ParentLocation.RightHand && (e.CurrentWieldedLocation == EquipMask.MeleeWeapon || e.CurrentWieldedLocation == EquipMask.TwoHanded));
+            else
+                return GetDualWieldWeapon();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -1,0 +1,90 @@
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using MAttackType = ACE.Entity.Enum.AttackType;
+
+namespace ACE.Server.WorldObjects
+{
+    /// <summary>
+    /// Creature melee combat for players and monsters
+    /// </summary>
+    partial class Creature
+    {
+        /// <summary>
+        /// Returns TRUE for DualWieldCombat mode
+        /// </summary>
+        public bool IsDualWieldAttack { get => CurrentMotionState?.Stance == MotionStance.DualWieldCombat; }
+
+        /// <summary>
+        /// Dual wield alternate will be true if *next* attack is offhand
+        /// </summary>
+        public bool DualWieldAlternate;
+
+        /// <summary>
+        /// Returns TRUE for TwoHandedCombat mode
+        /// </summary>
+        public bool TwoHandedCombat { get => CurrentMotionState?.Stance == MotionStance.TwoHandedSwordCombat || CurrentMotionState?.Stance == MotionStance.TwoHandedStaffCombat; }
+
+        /// <summary>
+        /// Determines if a weapon can double or triple strike,
+        /// and appends the appropriate multistrike prefix to a MotionCommand
+        /// </summary>
+        public string MultiStrike(MAttackType attackType, string action)
+        {
+            if ((attackType & MAttackType.MultiStrike) == 0)
+                return action;
+
+            var doubleStrike = action.EndsWith("Thrust") ? MAttackType.DoubleThrust : MAttackType.DoubleSlash;
+            var tripleStrike = (MAttackType)((int)doubleStrike * 2);
+
+            if (attackType.HasFlag(tripleStrike))
+                return $"Triple{action}";
+            if (attackType.HasFlag(doubleStrike))
+                return $"Double{action}";
+            else
+                return action;
+        }
+
+        /// <summary>
+        /// Returns the attack types for a weapon
+        /// </summary>
+        public MAttackType GetWeaponAttackType(WorldObject weapon)
+        {
+            var attackType = MAttackType.Undef;     // unarmed?
+            if (weapon != null)
+                attackType = (MAttackType)(weapon.GetProperty(PropertyInt.AttackType) ?? 0);
+
+            return attackType;
+        }
+
+        /// <summary>
+        /// Returns the number of strikes for a weapon
+        /// between 1-3 strikes
+        /// </summary>
+        public int GetNumStrikes(WorldObject weapon)
+        {
+            var attackType = GetWeaponAttackType(weapon);
+
+            return GetNumStrikes(attackType);
+        }
+
+        /// <summary>
+        /// Returns the number of strikes for an AttackType
+        /// between 1-3 strikes
+        /// </summary>
+        public int GetNumStrikes(MAttackType attackType)
+        {
+            if (CurrentMotionState.Stance == MotionStance.TwoHandedSwordCombat || CurrentMotionState.Stance == MotionStance.TwoHandedStaffCombat)
+                return 2;
+
+            if ((attackType & MAttackType.MultiStrike) == 0)
+                return 1;
+
+            if (attackType.HasFlag(MAttackType.TripleSlash) || attackType.HasFlag(MAttackType.TripleThrust) || attackType.HasFlag(MAttackType.OffhandTripleSlash) || attackType.HasFlag(MAttackType.OffhandTripleThrust))
+                return 3;
+            else if (attackType.HasFlag(MAttackType.DoubleSlash) || attackType.HasFlag(MAttackType.DoubleThrust) || attackType.HasFlag(MAttackType.OffhandDoubleSlash) || attackType.HasFlag(MAttackType.OffhandDoubleThrust))
+                return 2;
+            else
+                return 1;
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -22,11 +22,6 @@ namespace ACE.Server.WorldObjects
     partial class Player
     {
         /// <summary>
-        /// Returns TRUE if player is currently performing a dual wield attack
-        /// </summary>
-        public bool IsDualWieldAttack { get => CurrentMotionState?.Stance == MotionStance.DualWieldCombat; }
-
-        /// <summary>
         /// Returns the current attack skill for the player
         /// </summary>
         public override Skill GetCurrentAttackSkill()

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -140,7 +140,7 @@ namespace ACE.Server.WorldObjects
 
                 if (creature.IsAlive && GetCharacterOption(CharacterOption.AutoRepeatAttacks))
                 {
-                    Session.Network.EnqueueSend(new GameEventCombatCommmenceAttack(Session));
+                    Session.Network.EnqueueSend(new GameEventCombatCommenceAttack(Session));
                     Session.Network.EnqueueSend(new GameEventAttackDone(Session));
 
                     var nextAttack = new ActionChain();


### PR DESCRIPTION
- There are a bunch of Bandit weapons that can be used for testing. https://github.com/ACEmulator/ACE-World-16PY/search?q=TripleSlash will show a bunch of multistrike weapons. /ci 12053 for a Bandit Lightning Dagger

- The animation hit frames were synced up reasonably well, but I am still looking for something in the data that can tell us exactly which animation frames to strike on.

- Two-handed weapons are temporarily double-striking, while cleaving is still being added

- Fixed a bug with fist combat mode being broken

- Improved dual wielding combat so that the stats from the offhand weapon are used on the offhand attacks

- Added more comments to Player_Melee

- Fixed a bug where melee combat was not sending the 'AttackDone' network message when 'Auto-repeat' attacks option was disabled, with the power bar refilling (but not attacking again)

- Fixed a bug where players could poke things with a staff, and other melee weapons that weren't supposed to thrust

- Multistrike anomalies: shieldless combat cannot thrust, shield combat cannot slash (no animation links for these stances)