### PR TITLE
Updating the 'item is low on mana / out of mana' system

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1247,11 +1247,28 @@ namespace ACE.Server.Command.Handlers
             var targetGuid = new ObjectGuid(targetID.Value);
             var target = session.Player.CurrentLandblock?.GetObject(targetGuid);
             if (target == null)
+                target = session.Player.CurrentLandblock?.GetWieldedObject(targetGuid);
+
+            if (target == null)
             {
                 CommandHandlerHelper.WriteOutputInfo(session, "ERROR: couldn't find " + targetGuid);
                 return null;
             }
             return target;
+        }
+
+        [CommandHandler("givemana", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Gives mana to the last appraised object", "givemana <amount>")]
+        public static void HandleGiveMana(Session session, params string[] parameters)
+        {
+            if (parameters.Length == 0) return;
+            var amount = Int32.Parse(parameters[0]);
+
+            var obj = GetLastAppraisedObject(session);
+            if (obj == null) return;
+
+            amount = Math.Min(amount, obj.ItemMaxMana ?? 0);
+            obj.ItemCurMana += amount;
+            session.Network.EnqueueSend(new GameMessageSystemChat($"You give {amount} points of mana to the {obj.Name}.", ChatMessageType.Magic));
         }
 
         [CommandHandler("debugemote", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Debugs a hardcoded emote for the last appraised object", "debugemote")]

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSound.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSound.cs
@@ -5,7 +5,7 @@ namespace ACE.Server.Network.GameMessages.Messages
 {
     public class GameMessageSound : GameMessage
     {
-        public GameMessageSound(ObjectGuid guid, Sound soundId, float volume)
+        public GameMessageSound(ObjectGuid guid, Sound soundId, float volume = 1.0f)
             : base(GameMessageOpcode.Sound, GameMessageGroup.SmartboxQueue)
         {
             Writer.WriteGuid(guid);

--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -1,14 +1,13 @@
+using System;
+using System.Linq;
+
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
-using ACE.DatLoader;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace ACE.Server.WorldObjects
 {
@@ -69,7 +68,7 @@ namespace ACE.Server.WorldObjects
                         var sourceMana = target.ItemCurMana.Value;
                         if (!player.TryRemoveItemWithNetworking(target)) throw new Exception($"Failed to remove {target.Name} from player inventory.");
                         ItemCurMana = (int)Math.Round(Efficiency.Value * target.ItemCurMana.Value);
-                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"The {Name} drains {ItemCurMana} points of mana from the {target.Name}.\nThe {target.Name} is destroyed.", ChatMessageType.Broadcast));
+                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"The {Name} drains {ItemCurMana.Value.ToString("N0")} points of mana from the {target.Name}.\nThe {target.Name} is destroyed.", ChatMessageType.Broadcast));
                         SetUiEffect(player, ACE.Entity.Enum.UiEffects.Magical);
                     }
                 }
@@ -114,8 +113,8 @@ namespace ACE.Server.WorldObjects
                         {
                             var itemsNeedingMana = origItemsNeedingMana.Where(k => k.Value.ItemCurMana.Value + k.Value.ManaGiven < k.Value.ItemMaxMana.Value).ToList();
                             var additionalManaNeeded = itemsNeedingMana.Sum(k => k.Value.ItemMaxMana.Value - k.Value.ItemCurMana.Value - k.Value.ManaGiven);
-                            var additionalManaText = (additionalManaNeeded > 0) ? $"\nYou need {additionalManaNeeded} more mana to fully charge your items." : string.Empty;
-                            var msg = $"The {Name} gives {itemsGivenMana.Sum(k => k.Value.ManaGiven).ToString("n0")} points of mana to the following items: {itemsGivenMana.Select(c => c.Value.Name).Aggregate((a, b) => a + ", " + b)}{additionalManaText}";
+                            var additionalManaText = (additionalManaNeeded > 0) ? $"\nYou need {additionalManaNeeded.ToString("N0")} more mana to fully charge your items." : string.Empty;
+                            var msg = $"The {Name} gives {itemsGivenMana.Sum(k => k.Value.ManaGiven).ToString("N0")} points of mana to the following items: {itemsGivenMana.Select(c => c.Value.Name).Aggregate((a, b) => a + ", " + b)}.{additionalManaText}";
                             itemsGivenMana.ForEach(k => k.Value.ItemCurMana += k.Value.ManaGiven);
                             player.Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
                             if (!Destroy(player))
@@ -139,8 +138,8 @@ namespace ACE.Server.WorldObjects
                         var manaToPour = Math.Min(targetManaNeeded, ItemCurMana.Value);
                         target.ItemCurMana += manaToPour;
                         var additionalManaNeeded = targetManaNeeded - manaToPour;
-                        var additionalManaText = (additionalManaNeeded > 0) ? $"\nYou need {additionalManaNeeded} more mana to fully charge your {target.Name}." : string.Empty;
-                        var msg = $"The {Name} gives {manaToPour} points of mana to the {target.Name}.{additionalManaText}";
+                        var additionalManaText = (additionalManaNeeded > 0) ? $"\nYou need {additionalManaNeeded.ToString("N0")} more mana to fully charge your {target.Name}." : string.Empty;
+                        var msg = $"The {Name} gives {manaToPour.ToString("N0")} points of mana to the {target.Name}.{additionalManaText}";
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
                         if (!Destroy(player))
                         {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -238,16 +238,27 @@ namespace ACE.Server.WorldObjects
                         if (item.ItemCurMana < 1 || item.ItemCurMana == null)
                         {
                             item.IsAffecting = false;
-                            Session.Network.EnqueueSend(new GameMessageSystemChat($"Your {item.Name} is out of mana.", ChatMessageType.Magic));
+                            var msg = new GameMessageSystemChat($"Your {item.Name} is out of Mana.", ChatMessageType.Magic);
+                            var sound = new GameMessageSound(Guid, Sound.ItemManaDepleted);
+                            Session.Network.EnqueueSend(msg, sound);
                             if (item.WielderId != null)
                             {
                                 if (item.Biota.BiotaPropertiesSpellBook != null)
                                 {
-                                    for (int i = 0; i < item.Biota.BiotaPropertiesSpellBook.Count; i++)
+                                    // unsure if these messages / sounds were ever sent in retail,
+                                    // or if it just purged the enchantments invisibly
+                                    // doing a delay here to prevent 'SpellExpired' sounds from overlapping with 'ItemManaDepleted'
+                                    var actionChain = new ActionChain();
+                                    actionChain.AddDelaySeconds(2.0f);
+                                    actionChain.AddAction(this, () =>
                                     {
-                                        // TODO: layering
-                                        RemoveItemSpell(item.Guid, (uint)item.Biota.BiotaPropertiesSpellBook.ElementAt(i).Spell);
-                                    }
+                                        for (int i = 0; i < item.Biota.BiotaPropertiesSpellBook.Count; i++)
+                                        {
+                                            // TODO: layering
+                                            RemoveItemSpell(item.Guid, (uint)item.Biota.BiotaPropertiesSpellBook.ElementAt(i).Spell);
+                                        }
+                                    });
+                                    actionChain.EnqueueChain();
                                 }
                             }
                         }
@@ -255,10 +266,10 @@ namespace ACE.Server.WorldObjects
                         {
                             // get time until empty
                             var secondsUntilEmpty = ((item.ItemCurMana - deltaExtra) * timePerBurn);
-                            if (secondsUntilEmpty <= 30 && (!item.ItemManaDepletionMessageTimestamp.HasValue || (DateTime.Now - item.ItemManaDepletionMessageTimestamp.Value).TotalSeconds > 30))
+                            if (secondsUntilEmpty <= 120 && (!item.ItemManaDepletionMessageTimestamp.HasValue || (DateTime.Now - item.ItemManaDepletionMessageTimestamp.Value).TotalSeconds > 120))
                             {
                                 item.ItemManaDepletionMessageTimestamp = DateTime.Now;
-                                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your {item.Name} is almost out of mana.", ChatMessageType.Magic));
+                                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your {item.Name} is low on Mana.", ChatMessageType.Magic));
                             }
                         }
                     }


### PR DESCRIPTION
- Added the 'ItemManaDepleted' sound effect
- Added a small delay between 'ItemManaDepleted' sound and 'SpellExpired' messages/sound effects. Not sure if retail just purged the item enchantments invisibly?
- Changed the low mana warning timer from 30s -> 2m
- Added commas to all numbers >= 1,000
- Added /givemana developer function
- Changed the wording of some messages to match retail:
   - mana -> Mana for low/depleted messages
   - added a missing . to the end of item lists