### PR TITLE
Timing

### DIFF
--- a/Source/ACE.Common/RateLimiter.cs
+++ b/Source/ACE.Common/RateLimiter.cs
@@ -13,7 +13,7 @@ namespace ACE.Common
 
         public RateLimiter(int maxNumberOfEvents, TimeSpan overPeriod)
         {
-            if (maxNumberOfEvents < 1)
+            if (maxNumberOfEvents <= 0)
                 throw new ArgumentOutOfRangeException(nameof(maxNumberOfEvents), $"{nameof(maxNumberOfEvents)} must be greater than 0");
 
             if (overPeriod <= TimeSpan.Zero)

--- a/Source/ACE.Common/RateLimiter.cs
+++ b/Source/ACE.Common/RateLimiter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Diagnostics;
+
+namespace ACE.Common
+{
+    public class RateLimiter
+    {
+        private readonly int maxNumberOfEvents;
+        private readonly double overPeriodInSeconds;
+        private readonly double targetEventSpacingInSeconds;
+
+        private readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+        public RateLimiter(int maxNumberOfEvents, TimeSpan overPeriod)
+        {
+            if (maxNumberOfEvents < 1)
+                throw new ArgumentOutOfRangeException(nameof(maxNumberOfEvents), $"{nameof(maxNumberOfEvents)} must be greater than 0");
+
+            if (overPeriod <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(overPeriod), $"{nameof(overPeriod)} must be greater than TimeSpan.Zero");
+
+            this.maxNumberOfEvents = maxNumberOfEvents;
+            overPeriodInSeconds = overPeriod.TotalSeconds;
+
+            targetEventSpacingInSeconds = overPeriodInSeconds / maxNumberOfEvents;
+        }
+
+
+        private int numberOfEventsRegistered;
+
+        /// <summary>
+        /// Result > 0 : We're able to meet our target rate and must pause between events.<para />
+        /// Result = 0 : We're running right no time. A new event should be registered without delay.<para />
+        /// Result &lt; 0 : We're running behind. A new event should be registered without delay. We're failing to meet our target rate.
+        /// </summary>
+        /// <returns></returns>
+        public double GetSecondsToWaitBeforeNextEvent()
+        {
+            var elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+
+            return ((targetEventSpacingInSeconds * numberOfEventsRegistered) - elapsedSeconds);
+        }
+
+        public void RegisterEvent()
+        {
+            numberOfEventsRegistered++;
+
+            var elapsedSeconds = stopwatch.Elapsed.TotalSeconds;
+
+            if (numberOfEventsRegistered > maxNumberOfEvents || elapsedSeconds > overPeriodInSeconds)
+            {
+                numberOfEventsRegistered = 1;
+
+                stopwatch.Restart();
+            }
+        }
+    }
+}

--- a/Source/ACE.Database/WorldDatabase.cs
+++ b/Source/ACE.Database/WorldDatabase.cs
@@ -149,7 +149,7 @@ namespace ACE.Database
         }
 
         /// <summary>
-        /// This will populate all sub collections except the followign: LandblockInstances, PointsOfInterest<para />
+        /// This will populate all sub collections except the following: LandblockInstances, PointsOfInterest<para />
         /// This will also update the weenie cache.
         /// </summary>
         public Weenie GetWeenie(uint weenieClassId)

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -233,7 +233,7 @@ namespace ACE.Server.Entity
             Scenery = Entity.Scenery.Load(this);
         }
 
-        public void Tick(double lastTickDuration, double currentUnixTime)
+        public void Tick(double currentUnixTime)
         {
             // Here we'd move server objects in motion (subject to landscape) and do physics collision detection
 
@@ -248,7 +248,7 @@ namespace ACE.Server.Entity
                 var wos = worldObjects.Values.ToList();
 
                 foreach (var wo in wos)
-                    wo.Tick(lastTickDuration, currentUnixTime);
+                    wo.Tick(currentUnixTime);
             }
 
             // Heartbeat

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -123,7 +123,8 @@ namespace ACE.Server.Network
         }
 
         /// <summary>
-        /// This is run in parallel from our main loop.
+        /// This is run in parallel from our main loop.<para />
+        /// This will send outgoing packets as well as the final logoff message.
         /// </summary>
         public void TickInParallel()
         {

--- a/Source/ACE.Server/WorldObjects/Container_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Container_Tick.cs
@@ -3,12 +3,12 @@ namespace ACE.Server.WorldObjects
 {
     partial class Container
     {
-        public override void Tick(double lastTickDuration, double currentUnixTime)
+        public override void Tick(double currentUnixTime)
         {
             foreach (var wo in Inventory.Values)
-                wo.Tick(lastTickDuration, currentUnixTime);
+                wo.Tick(currentUnixTime);
 
-            base.Tick(lastTickDuration, currentUnixTime);
+            base.Tick(currentUnixTime);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Tick.cs
@@ -3,14 +3,14 @@ namespace ACE.Server.WorldObjects
 {
     partial class Creature
     {
-        public override void Tick(double lastTickDuration, double currentUnixTime)
+        public override void Tick(double currentUnixTime)
         {
             foreach (var wo in EquippedObjects.Values)
-                wo.Tick(lastTickDuration, currentUnixTime);
+                wo.Tick(currentUnixTime);
 
-            Monster_Tick(lastTickDuration, currentUnixTime);
+            Monster_Tick(currentUnixTime);
 
-            base.Tick(lastTickDuration, currentUnixTime);
+            base.Tick(currentUnixTime);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -11,7 +11,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Primary dispatch for monster think
         /// </summary>
-        private void Monster_Tick(double lastTickDuration, double currentUnixTime)
+        private void Monster_Tick(double currentUnixTime)
         {
             if (lastMonsterTick + monsterTickInterval > DateTime.UtcNow)
                 return;
@@ -22,13 +22,7 @@ namespace ACE.Server.WorldObjects
 
             IsMonster = true;
 
-            if (AttackTarget != null && AttackTarget.IsDestroyed)
-            {
-                Sleep();
-                return;
-            }
-
-            if (!AttackTarget.IsVisible(this))
+            if (AttackTarget != null && (AttackTarget.IsDestroyed || !AttackTarget.IsVisible(this)))
             {
                 Sleep();
                 return;

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -12,7 +12,7 @@ namespace ACE.Server.WorldObjects
 
         private DateTime lastSendAgeIntUpdateTime;
 
-        public override void Tick(double lastTickDuration, double currentUnixTime)
+        public override void Tick(double currentUnixTime)
         {
             if (initialAgeTime == DateTime.MinValue)
             {
@@ -31,7 +31,7 @@ namespace ACE.Server.WorldObjects
                 lastSendAgeIntUpdateTime = DateTime.UtcNow;
             }
 
-            base.Tick(lastTickDuration, currentUnixTime);
+            base.Tick(currentUnixTime);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.Entity;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
@@ -21,7 +22,7 @@ namespace ACE.Server.WorldObjects
         private double? cachedHeartbeatTimestamp;
         private double cachedHeartbeatInterval;
 
-        public virtual void Tick(double lastTickDuration, double currentUnixTime)
+        public virtual void Tick(double currentUnixTime)
         {
             actionQueue.RunActions();
 


### PR DESCRIPTION
gmriggs, if you could please use your timing utils to verify that UpdateGameWorld is averaging 60fps.

Also, I think checking if the session count >= 5 just to save 1ms for this line of code is wasteful: Parallel.ForEach(sessions, s => s.TickInParallel());

On my system, the average overhead for the Parallel.ForEach call was 1ms to 2ms.

TickInParallel takes on average, .1ms to .3ms but can spike to 5ms to 15ms.

I think adding extra optimizations to ACE for player ranges of < 10 are a bit unnecessary. The server will already be extremely fast in such a scenario.