### PR TITLE
GameMessagePlayerTeleport was malformed

### DIFF
--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessagePlayerTeleport.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessagePlayerTeleport.cs
@@ -7,11 +7,8 @@ namespace ACE.Server.Network.GameMessages.Messages
         public GameMessagePlayerTeleport(Player player)
             : base(GameMessageOpcode.PlayerTeleport, GameMessageGroup.SmartboxQueue)
         {
+            Writer.Write((ushort)0);
             Writer.Write(player.Sequences.GetNextSequence(Sequence.SequenceType.ObjectTeleport));
-            // Don't see these in traces or protocol spec:
-            // Writer.Write(0u);
-            // Writer.Write(0u);
-            // Writer.Write((ushort)0);
         }
     }
 }


### PR DESCRIPTION
Furthermore, in retail, the sequence sent in GameMessagePlayerTeleport is always the PREVIOUS sequence value, and then the sequence get's incremented AFTER the message is actually secent (and thus, sent in the next UpdatePosition message).

For simplicity, ACE just increments the sequence BEFORE this message is sent. It doesn't seem to affect the client or decal and is cleaner this way.