### PR TITLE
More profiling based improvements

### DIFF
--- a/Source/ACE.Common/RateMonitor.cs
+++ b/Source/ACE.Common/RateMonitor.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+
+namespace ACE.Common
+{
+    public class RateMonitor
+    {
+        private readonly Stopwatch stopwatch = new Stopwatch();
+
+        /// <summary>
+        /// Last event duration in seconds
+        /// </summary>
+        public double LastEvent { get; private set; }
+
+        public long TotalEvents { get; private set; }
+
+        public double TotalSeconds { get; private set; }
+
+        /// <summary>
+        /// Longest event duration in seconds
+        /// </summary>
+        public double LongestEvent { get; private set; }
+
+        /// <summary>
+        /// Shortest event duration in seconds
+        /// </summary>
+        public double ShortestEvent { get; private set; }
+
+        /// <summary>
+        /// Average event duration in seconds
+        /// </summary>
+        public double AverageEventDuration => TotalSeconds / TotalEvents;
+
+        public void RegisterEventStart()
+        {
+            stopwatch.Reset();
+            stopwatch.Start();
+        }
+
+        /// <summary>
+        /// returns the elapsed seconds for this event
+        /// </summary>
+        public double RegisterEventEnd()
+        {
+            stopwatch.Stop();
+
+            LastEvent = stopwatch.Elapsed.TotalSeconds;
+
+            TotalEvents++;
+            TotalSeconds += LastEvent;
+
+            if (LastEvent > LongestEvent)
+                LongestEvent = LastEvent;
+
+            if (LastEvent < ShortestEvent)
+                ShortestEvent = LastEvent;
+
+            return LastEvent;
+        }
+
+        public void ClearEventHistory()
+        {
+            LastEvent = 0;
+            TotalEvents = 0;
+            TotalSeconds = 0;
+            LongestEvent = 0;
+            ShortestEvent = 0;
+        }
+
+        public override string ToString()
+        {
+            return $"Total Events: {TotalEvents:N0}, Average: {AverageEventDuration:N4} s, Longest: {LongestEvent:N4} s, Shortest: {ShortestEvent:N4} s, Last: {LastEvent:N4} s";
+        }
+    }
+}

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -242,23 +242,24 @@ namespace ACE.Database
 
         }
 
-        public List<Biota> GetObjectsByLandblockInParallel(ushort landblockId)
+        public List<Biota> GetDecayableObjectsByLandblock(ushort landblockId)
         {
-            return _wrappedDatabase.GetObjectsByLandblockInParallel(landblockId);
+            return _wrappedDatabase.GetDecayableObjectsByLandblock(landblockId);
+        }
+
+        public List<Biota> GetDecayableObjectsByLandblockInParallel(ushort landblockId)
+        {
+            return _wrappedDatabase.GetDecayableObjectsByLandblockInParallel(landblockId);
+        }
+
+        public List<Biota> GetStaticObjectsByLandblock(ushort landblockId)
+        {
+            return _wrappedDatabase.GetStaticObjectsByLandblock(landblockId);
         }
 
         public List<Biota> GetStaticObjectsByLandblockInParallel(ushort landblockId)
         {
             return _wrappedDatabase.GetStaticObjectsByLandblockInParallel(landblockId);
-        }
-
-        public void GetObjectsByLandblockInParallel(ushort landblockId, Action<List<Biota>> callback)
-        {
-            _queue.Add(new Task(() =>
-            {
-                var c = _wrappedDatabase.GetObjectsByLandblockInParallel(landblockId);
-                callback?.Invoke(c);
-            }));
         }
 
 

--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -127,7 +127,7 @@ namespace ACE.Database
             }));
         }
 
-        public void SaveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
+        public void SaveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -136,7 +136,7 @@ namespace ACE.Database
             }));
         }
 
-        public void SaveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        public void SaveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
         {
             var initialCallTime = DateTime.UtcNow;
 
@@ -173,7 +173,7 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
+        public void RemoveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -182,7 +182,7 @@ namespace ACE.Database
             }));
         }
 
-        public void RemoveBiotas(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
+        public void RemoveBiotasInParallel(IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, Action<TimeSpan, TimeSpan> performanceResults)
         {
             var initialCallTime = DateTime.UtcNow;
 
@@ -213,7 +213,7 @@ namespace ACE.Database
         }
 
 
-        public void GetPlayerBiotas(uint id, Action<PlayerBiotas> callback)
+        public void GetPlayerBiotasInParallel(uint id, Action<PlayerBiotas> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -222,7 +222,7 @@ namespace ACE.Database
             }));
         }
 
-        public void GetInventory(uint parentId, bool includedNestedItems, Action<List<Biota>> callback)
+        public void GetInventoryInParallel(uint parentId, bool includedNestedItems, Action<List<Biota>> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -232,7 +232,7 @@ namespace ACE.Database
 
         }
 
-        public void GetWieldedItems(uint parentId, Action<List<Biota>> callback)
+        public void GetWieldedItemsInParallel(uint parentId, Action<List<Biota>> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -242,17 +242,17 @@ namespace ACE.Database
 
         }
 
-        public List<Biota> GetObjectsByLandblock(ushort landblockId)
+        public List<Biota> GetObjectsByLandblockInParallel(ushort landblockId)
         {
             return _wrappedDatabase.GetObjectsByLandblockInParallel(landblockId);
         }
 
-        public List<Biota> GetStaticObjectsByLandblock(ushort landblockId)
+        public List<Biota> GetStaticObjectsByLandblockInParallel(ushort landblockId)
         {
             return _wrappedDatabase.GetStaticObjectsByLandblockInParallel(landblockId);
         }
 
-        public void GetObjectsByLandblock(ushort landblockId, Action<List<Biota>> callback)
+        public void GetObjectsByLandblockInParallel(ushort landblockId, Action<List<Biota>> callback)
         {
             _queue.Add(new Task(() =>
             {
@@ -290,7 +290,7 @@ namespace ACE.Database
         }
 
 
-        public void AddCharacter(Biota biota, ReaderWriterLockSlim biotaLock, IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> possessions, Character character, ReaderWriterLockSlim characterLock, Action<bool> callback)
+        public void AddCharacterInParallel(Biota biota, ReaderWriterLockSlim biotaLock, IEnumerable<(Biota biota, ReaderWriterLockSlim rwLock)> possessions, Character character, ReaderWriterLockSlim characterLock, Action<bool> callback)
         {
             _queue.Add(new Task(() =>
             {

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1419,7 +1419,7 @@ namespace ACE.Server.Command.Handlers
             foreach (var possession in possessions)
                 possessedBiotas.Add((possession.Biota, possession.BiotaDatabaseLock));
 
-            DatabaseManager.Shard.AddCharacter(player.Biota, player.BiotaDatabaseLock, possessedBiotas, player.Character, player.CharacterDatabaseLock, null);
+            DatabaseManager.Shard.AddCharacterInParallel(player.Biota, player.BiotaDatabaseLock, possessedBiotas, player.Character, player.CharacterDatabaseLock, null);
 
             session.LogOffPlayer();
         }

--- a/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
+++ b/Source/ACE.Server/Command/Handlers/Processors/DatabasePerfTest.cs
@@ -181,7 +181,7 @@ namespace ACE.Server.Command.Handlers.Processors
             initialQueueWaitTime = TimeSpan.Zero;
             totalQueryExecutionTime = TimeSpan.Zero;
 
-            DatabaseManager.Shard.SaveBiotas(biotas, result =>
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result =>
             {
                 if (result)
                     Interlocked.Increment(ref trueResults);
@@ -213,7 +213,7 @@ namespace ACE.Server.Command.Handlers.Processors
                 initialQueueWaitTime = TimeSpan.Zero;
                 totalQueryExecutionTime = TimeSpan.Zero;
 
-                DatabaseManager.Shard.SaveBiotas(biotas, result =>
+                DatabaseManager.Shard.SaveBiotasInParallel(biotas, result =>
                 {
                     if (result)
                         Interlocked.Increment(ref trueResults);
@@ -242,7 +242,7 @@ namespace ACE.Server.Command.Handlers.Processors
             initialQueueWaitTime = TimeSpan.Zero;
             totalQueryExecutionTime = TimeSpan.Zero;
 
-            DatabaseManager.Shard.RemoveBiotas(biotas, result =>
+            DatabaseManager.Shard.RemoveBiotasInParallel(biotas, result =>
             {
                 if (result)
                     Interlocked.Increment(ref trueResults);

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -113,11 +113,14 @@ namespace ACE.Server.Entity
 
             lastActiveTime = DateTime.UtcNow;
 
-            Task.Run(() => CreateWorldObjects());
+            Task.Run(() =>
+            {
+                CreateWorldObjects();
 
-            Task.Run(() => SpawnDynamicShardObjects());
+                SpawnDynamicShardObjects();
 
-            Task.Run(() => SpawnEncounters());
+                SpawnEncounters();
+            });
 
             //LoadMeshes(objects);
         }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -132,7 +132,7 @@ namespace ACE.Server.Entity
         private void CreateWorldObjects()
         {
             var objects = DatabaseManager.World.GetCachedInstancesByLandblock(Id.Landblock);
-            var shardObjects = DatabaseManager.Shard.GetStaticObjectsByLandblockInParallel(Id.Landblock);
+            var shardObjects = DatabaseManager.Shard.GetStaticObjectsByLandblock(Id.Landblock);
             var factoryObjects = WorldObjectFactory.CreateNewWorldObjects(objects, shardObjects);
 
             actionQueue.EnqueueAction(new ActionEventDelegate(() =>
@@ -151,7 +151,7 @@ namespace ACE.Server.Entity
         /// </summary>
         private void SpawnDynamicShardObjects()
         {
-            var corpses = DatabaseManager.Shard.GetObjectsByLandblockInParallel(Id.Landblock);
+            var corpses = DatabaseManager.Shard.GetDecayableObjectsByLandblock(Id.Landblock);
             var factoryShardObjects = WorldObjectFactory.CreateWorldObjects(corpses);
 
             actionQueue.EnqueueAction(new ActionEventDelegate(() =>

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -132,7 +132,7 @@ namespace ACE.Server.Entity
         private void CreateWorldObjects()
         {
             var objects = DatabaseManager.World.GetCachedInstancesByLandblock(Id.Landblock);
-            var shardObjects = DatabaseManager.Shard.GetStaticObjectsByLandblock(Id.Landblock);
+            var shardObjects = DatabaseManager.Shard.GetStaticObjectsByLandblockInParallel(Id.Landblock);
             var factoryObjects = WorldObjectFactory.CreateNewWorldObjects(objects, shardObjects);
 
             actionQueue.EnqueueAction(new ActionEventDelegate(() =>
@@ -151,7 +151,7 @@ namespace ACE.Server.Entity
         /// </summary>
         private void SpawnDynamicShardObjects()
         {
-            var corpses = DatabaseManager.Shard.GetObjectsByLandblock(Id.Landblock);
+            var corpses = DatabaseManager.Shard.GetObjectsByLandblockInParallel(Id.Landblock);
             var factoryShardObjects = WorldObjectFactory.CreateWorldObjects(corpses);
 
             actionQueue.EnqueueAction(new ActionEventDelegate(() =>
@@ -681,7 +681,7 @@ namespace ACE.Server.Entity
                     biotas.Add((corpse.Biota, corpse.BiotaDatabaseLock));
             }
 
-            DatabaseManager.Shard.SaveBiotas(biotas, result => { });
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => { });
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -116,30 +116,25 @@ namespace ACE.Server.Managers
                 var landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY];
                 var autoLoad = propagate && landblockId.MapScope == MapScope.Outdoors;
 
-                // standard check/lock/recheck pattern
                 if (landblock == null || autoLoad && !landblock.AdjacenciesLoaded)
                 {
-                    landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY];
-                    if (landblock == null || autoLoad && !landblock.AdjacenciesLoaded)
+                    if (landblock == null)
                     {
-                        if (landblock == null)
+                        // load up this landblock
+                        landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY] = new Landblock(landblockId);
+
+                        // Set Permaload flag, as required, for new landblock to be loaded
+                        landblock.Permaload = permaload;
+
+                        if (!activeLandblocks.Add(landblock))
                         {
-                            // load up this landblock
-                            landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY] = new Landblock(landblockId);
-
-                            // Set Permaload flag, as required, for new landblock to be loaded
-                            landblock.Permaload = permaload;
-
-                            if (!activeLandblocks.Add(landblock))
-                            {
-                                log.Error("LandblockManager: failed to add " + (landblock.Id.Raw | 0xFFFF).ToString("X8") + " to active landblocks!");
-                                return landblock;
-                            }
+                            log.Error("LandblockManager: failed to add " + (landblock.Id.Raw | 0xFFFF).ToString("X8") + " to active landblocks!");
+                            return landblock;
                         }
-                        SetAdjacencies(landblockId, autoLoad);
-                        if (autoLoad)
-                            landblock.AdjacenciesLoaded = true;
                     }
+                    SetAdjacencies(landblockId, autoLoad);
+                    if (autoLoad)
+                        landblock.AdjacenciesLoaded = true;
                 }
 
                 return landblock;

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -92,7 +92,7 @@ namespace ACE.Server.Managers
             {
                 foreach (var character in characters)
                 {
-                    DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
+                    DatabaseManager.Shard.GetPlayerBiotasInParallel(character.Id, biotas =>
                     {
                         var session = new Session();
                         var player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
@@ -107,7 +107,7 @@ namespace ACE.Server.Managers
         /// </summary>
         public static void AddPlayer(Character character)
         {
-            DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
+            DatabaseManager.Shard.GetPlayerBiotasInParallel(character.Id, biotas =>
             {
                 var session = new Session();
                 var player = new Player(biotas.Player, biotas.Inventory, biotas.WieldedItems, character, session);
@@ -426,7 +426,7 @@ namespace ACE.Server.Managers
         public static void PlayerEnterWorld(Session session, Character character)
         {
             var start = DateTime.UtcNow;
-            DatabaseManager.Shard.GetPlayerBiotas(character.Id, biotas =>
+            DatabaseManager.Shard.GetPlayerBiotasInParallel(character.Id, biotas =>
             {
                 log.Debug($"GetPlayerBiotas for {character.Name} took {(DateTime.UtcNow - start).TotalMilliseconds:N0} ms");
 

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -667,23 +667,15 @@ namespace ACE.Server.Managers
             {
                 sessionCount = sessions.Count;
 
-                // The session tick processes all inbound GameAction messages
+                // The session tick inbound processes all inbound GameAction messages
                 foreach (var s in sessions)
-                    s.Tick();
+                    s.TickInbound();
 
-                // The session TickInParallel processes pending actions and handles outgoing messages
-                // It typically takes .1 to .3 ms to process. However, it can spike to 15ms depending on the clients load/activity or the host system.
-                // The overhead for Parallel.ForEach is typically 1ms to 2ms.
-                if (sessionCount >= 5)
-                {
-                    Parallel.ForEach(sessions, s => s.TickInParallel());
-                }
-                else
-                {
-                    foreach (var s in sessions)
-                        s.TickInParallel();
-                }
+                // Do not combine the above and below loops. All inbound messages should be processed first and then all outbound messages should be processed second.
 
+                // The session tick outbound processes pending actions and handles outgoing messages
+                foreach (var s in sessions)
+                    s.TickOutbound();
 
                 // Removes sessions in the NetworkTimeout state, including sessions that have reached a timeout limit.
                 var deadSessions = sessions.FindAll(s => s.State == Network.Enum.SessionState.NetworkTimeout);

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -140,7 +140,7 @@ namespace ACE.Server.Network.Handlers
                     possessedBiotas.Add((possession.Biota, possession.BiotaDatabaseLock));
 
                 // We must await here -- 
-                DatabaseManager.Shard.AddCharacter(player.Biota, player.BiotaDatabaseLock, possessedBiotas, player.Character, player.CharacterDatabaseLock, saveSuccess =>
+                DatabaseManager.Shard.AddCharacterInParallel(player.Biota, player.BiotaDatabaseLock, possessedBiotas, player.Character, player.CharacterDatabaseLock, saveSuccess =>
                 {
                     if (!saveSuccess)
                     {

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -379,7 +379,9 @@ namespace ACE.Server.Network
         private void ProcessFragment(ClientPacketFragment fragment)
         {
             packetLog.DebugFormat("[{0}] Processing fragment {1}", session.LoggingIdentifier, fragment.Header.Sequence);
+
             ClientMessage message = null;
+
             // Check if this fragment is split
             if (fragment.Header.Count != 1)
             {
@@ -516,6 +518,7 @@ namespace ACE.Server.Network
             while (packetQueue.Count > 0)
             {
                 packetLog.DebugFormat("[{0}] Flushing packets, count {1}", session.LoggingIdentifier, packetQueue.Count);
+
                 ServerPacket packet = packetQueue.Dequeue();
 
                 if (packet.Header.HasFlag(PacketHeaderFlags.EncryptedChecksum) && ConnectionData.PacketSequence.CurrentValue == 0)
@@ -540,6 +543,7 @@ namespace ACE.Server.Network
         private void SendPacket(ServerPacket packet)
         {
             packetLog.DebugFormat("[{0}] Sending packet {1}", session.LoggingIdentifier, packet.GetHashCode());
+
             if (packet.Header.HasFlag(PacketHeaderFlags.EncryptedChecksum))
             {
                 uint issacXor = session.GetIssacValue(PacketDirection.Server);
@@ -579,6 +583,7 @@ namespace ACE.Server.Network
         private void SendBundle(NetworkBundle bundle, GameMessageGroup group)
         {
             packetLog.DebugFormat("[{0}] Sending Bundle", session.LoggingIdentifier);
+
             bool writeOptionalHeaders = true;
 
             List<MessageFragment> fragments = new List<MessageFragment>();
@@ -680,6 +685,7 @@ namespace ACE.Server.Network
         private void WriteOptionalHeaders(NetworkBundle bundle, ServerPacket packet)
         {
             PacketHeader packetHeader = packet.Header;
+
             if (bundle.SendAck) // 0x4000
             {
                 packetHeader.Flags |= PacketHeaderFlags.AckSequence;

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -114,20 +114,6 @@ namespace ACE.Server.Network
         }
 
         /// <summary>
-        /// Enqueues sending of messages with a time delay
-        /// </summary>
-        public void EnqueueSend(IActor actor, float delay, params GameMessage[] messages)
-        {
-            var actionChain = new ActionChain();
-            actionChain.AddDelaySeconds(delay);
-            actionChain.AddAction(actor, () =>
-            {
-                EnqueueSend(messages);
-            });
-            actionChain.EnqueueChain();
-        }
-
-        /// <summary>
         /// Enqueues a ServerPacket for sending to this client.
         /// Currently this is only used publicly once during login.  If that changes it's thread safety should be re
         /// </summary>

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -27,10 +27,8 @@ namespace ACE.Server.Network
 
         private readonly Session session;
 
-        //private readonly Object currentBundleLock = new Object();
         private ConcurrentDictionary<GameMessageGroup, Object> currentBundleLocks = new ConcurrentDictionary<GameMessageGroup, Object>();
         private ConcurrentDictionary<GameMessageGroup, NetworkBundle> currentBundles = new ConcurrentDictionary<GameMessageGroup, NetworkBundle>();
-        //private NetworkBundle currentBundle = new NetworkBundle();
 
         private ConcurrentDictionary<uint, ClientPacket> outOfOrderPackets = new ConcurrentDictionary<uint, ClientPacket>();
         private ConcurrentDictionary<uint, MessageBuffer> partialFragments = new ConcurrentDictionary<uint, MessageBuffer>();
@@ -216,6 +214,7 @@ namespace ACE.Server.Network
         public void ProcessPacket(ClientPacket packet)
         {
             packetLog.DebugFormat("[{0}] Processing packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
+
             // Check if this packet's sequence is a sequence which we have already processed.
             // There are some exceptions:
             // Sequence 0 as we have several Seq 0 packets during connect.  This also cathes a case where it seems CICMDCommand arrives at any point with 0 sequence value too.
@@ -233,6 +232,7 @@ namespace ACE.Server.Network
             if (packet.Header.Sequence > desiredSeq)
             {
                 packetLog.WarnFormat("[{0}] Packet {1} received out of order", session.LoggingIdentifier, packet.Header.Sequence);
+
                 if (!outOfOrderPackets.ContainsKey(packet.Header.Sequence))
                     outOfOrderPackets.TryAdd(packet.Header.Sequence, packet);
 
@@ -289,7 +289,6 @@ namespace ACE.Server.Network
         private void HandlePacket(ClientPacket packet)
         {
             packetLog.DebugFormat("[{0}] Handling packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
-
 
             // Upon a client's request of packet retransmit the session CRC salt/offset becomes out of sync somehow.
             // This hack recovers the correct offset and makes WAN client sessions at least reliable enough to test with.
@@ -531,7 +530,6 @@ namespace ACE.Server.Network
                 packet.Header.Iteration = 0x14;
                 packet.Header.Time = (ushort)ConnectionData.ServerTime;
 
-
                 if (packet.Header.Sequence >= 2u)
                     cachedPackets.TryAdd(packet.Header.Sequence, packet);
 
@@ -568,6 +566,7 @@ namespace ACE.Server.Network
                 sb.AppendLine(payload.BuildPacketString());
                 packetLog.Debug(sb.ToString());
             }
+
             socket.SendTo(payload, session.EndPoint);
         }
 

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 
-using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.Handlers;

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -148,7 +148,9 @@ namespace ACE.Server.Network
         /// </summary>
         public void Update()
         {
-            currentBundles.Keys.ToList().ForEach(group =>
+            var groups = currentBundles.Keys.ToList();
+
+            foreach (var group in groups)
             {
                 var currentBundleLock = currentBundleLocks[group];
                 var currentBundle = currentBundles[group];
@@ -201,7 +203,8 @@ namespace ACE.Server.Network
                     SendBundle(bundleToSend, group);
                     nextSend = DateTime.UtcNow.AddMilliseconds(minimumTimeBetweenBundles);
                 }
-            });
+            }
+
             FlushPackets();
         }
 

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -114,19 +114,18 @@ namespace ACE.Server.Network
 
 
         /// <summary>
-        /// This is run in series from our main loop.
+        /// This will process all inbound GameActions.
         /// </summary>
-        public void Tick()
+        public void TickInbound()
         {
             if (Player != null)
                 InboundGameActionQueue.RunActions();
         }
 
         /// <summary>
-        /// This is run in parallel from our main loop.<para />
         /// This will send outgoing packets as well as the final logoff message.
         /// </summary>
-        public void TickInParallel()
+        public void TickOutbound()
         {
             // Checks if the session has stopped responding.
             if (DateTime.UtcNow.Ticks >= Network.TimeoutTick)

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -40,7 +40,7 @@ namespace ACE.Server.WorldObjects
             // A player has their possessions passed via the ctor. All other world objects must load their own inventory
             if (!(this is Player) && !(new ObjectGuid(ContainerId ?? 0).IsPlayer()))
             {
-                DatabaseManager.Shard.GetInventory(biota.Id, false, biotas =>
+                DatabaseManager.Shard.GetInventoryInParallel(biota.Id, false, biotas =>
                 {
                     EnqueueAction(new ActionEventDelegate(() => SortBiotasIntoInventory(biotas)));
                 });

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -78,7 +78,7 @@ namespace ACE.Server.WorldObjects
 
             var requestedTime = DateTime.UtcNow;
 
-            DatabaseManager.Shard.SaveBiotas(biotas, result => log.Debug($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request."));
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => log.Debug($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request."));
         }
 
         public void SaveCharacterToDatabase()

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+
 using ACE.DatLoader;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity.Actions;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects.Entity;
@@ -497,8 +499,13 @@ namespace ACE.Server.WorldObjects
                     var spell = new Server.Entity.Spell(spellID);
                     if (spell.NotFound)
                     {
-                        Session.Network.EnqueueSend(this, 3.0f, new GameMessageSystemChat("To install Dirty Fighting, please apply the latest patches from https://github.com/ACEmulator/ACE-World-16PY-Patches", ChatMessageType.Broadcast));
-                        break;
+                        var actionChain = new ActionChain();
+                        actionChain.AddDelaySeconds(3.0f);
+                        actionChain.AddAction(this, () =>
+                        {
+                            Session.Network.EnqueueSend(new GameMessageSystemChat("To install Dirty Fighting, please apply the latest patches from https://github.com/ACEmulator/ACE-World-16PY-Patches", ChatMessageType.Broadcast));
+                        });
+                        actionChain.EnqueueChain();
                     }
                     break;  // performance improvement: only check first spell
                 }
@@ -513,8 +520,13 @@ namespace ACE.Server.WorldObjects
                     var spell = new Server.Entity.Spell(spellID);
                     if (spell.NotFound)
                     {
-                        Session.Network.EnqueueSend(this, 3.0f, new GameMessageSystemChat("To install Void Magic, please apply the latest patches from https://github.com/ACEmulator/ACE-World-16PY-Patches", ChatMessageType.Broadcast));
-                        break;
+                        var actionChain = new ActionChain();
+                        actionChain.AddDelaySeconds(3.0f);
+                        actionChain.AddAction(this, () =>
+                        {
+                            Session.Network.EnqueueSend(new GameMessageSystemChat("To install Void Magic, please apply the latest patches from https://github.com/ACEmulator/ACE-World-16PY-Patches", ChatMessageType.Broadcast));
+                        });
+                        actionChain.EnqueueChain();
                     }
                     break;  // performance improvement: only check first spell (measured 102ms to check 75 uncached void spells)
                 }


### PR DESCRIPTION
There are 2 major changes in this PR.

1) NetworkSession GameMessageGroup based bundles have been switched from a concurrent dictionary to an array. An array will be many times more performant as there are only 12 elements and they're aligned to a 64bit boundary, thus making get/sets atomic. As such, we can simplify the way we lock access to each element.

2) Landblock ctor async code has been grouped up into a single thread. Furthermore, the database work being performed inside that thread will no longer spawn more threads by using parallel calls. This makes sure that landblock construction an obtaining assets doesn't eat up the applications idle threads from the pool. We want to save those threads for more important work that will help keep UpdateGameWorld running smoothly.

Renamed the Session tick functions to be more appropriate. 

Removed the unnecessary check/recheck code from LandblockManager.GetLandblock. This is a common routine for a pattern we used to be using but are no longer, thus, there is no need for the check/recheck.