### PR TITLE
Landblock async physics loading + some physics profiling improvements *NEEDS TESTING*

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -86,7 +86,7 @@ namespace ACE.Server.Entity
         /// The clientlib backing store landblock
         /// Eventually these classes could be merged, but for now they are separate...
         /// </summary>
-        public readonly Physics.Common.Landblock _landblock;
+        public Physics.Common.Landblock _landblock { get; private set; }
 
         public CellLandblock CellLandblock { get; private set; }
         public LandblockInfo LandblockInfo { get; private set; }
@@ -116,12 +116,12 @@ namespace ACE.Server.Entity
             adjacencies.Add(Adjacency.West, null);
             adjacencies.Add(Adjacency.NorthWest, null);
 
-            _landblock = LScape.get_landblock(Id.Raw);
-
             lastActiveTime = DateTime.UtcNow;
 
             Task.Run(() =>
             {
+                _landblock = LScape.get_landblock(Id.Raw);
+
                 CreateWorldObjects();
 
                 SpawnDynamicShardObjects();
@@ -652,7 +652,7 @@ namespace ACE.Server.Entity
         {
             lastActiveTime = DateTime.UtcNow;
 
-            if (isAdjacent || _landblock.IsDungeon) return;
+            if (isAdjacent || _landblock == null || _landblock.IsDungeon) return;
 
             // for outdoor landblocks, recursively call 1 iteration to set adjacents to active
             foreach (var landblock in adjacencies.Values)
@@ -682,7 +682,7 @@ namespace ACE.Server.Entity
             LScape.unload_landblock(landblockID);
 
             // dungeon landblocks do not handle adjacents
-            if (_landblock.IsDungeon) return;
+            if (_landblock == null || _landblock.IsDungeon) return;
 
             // notify adjacents
             foreach (var adjacent in adjacencies.Where(adj => adj.Value != null))

--- a/Source/ACE.Server/Physics/Animation/AnimSequenceNode.cs
+++ b/Source/ACE.Server/Physics/Animation/AnimSequenceNode.cs
@@ -1,4 +1,5 @@
 using System;
+
 using ACE.DatLoader.Entity;
 using ACE.Server.Physics.Common;
 
@@ -94,7 +95,7 @@ namespace ACE.Server.Physics.Animation
 
         public void set_animation_id(uint animID)
         {
-            var anim = (DatLoader.FileTypes.Animation)DBObj.Get(new QualifiedDataID(8, animID));
+            var anim = DBObj.GetAnimation(animID);
             Anim = new Animation(anim);
             if (Anim == null) return;
 

--- a/Source/ACE.Server/Physics/BSP/BSPNode.cs
+++ b/Source/ACE.Server/Physics/BSP/BSPNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Collision;
 using ACE.Server.Physics.Entity;
@@ -58,7 +59,7 @@ namespace ACE.Server.Physics.BSP
                 PolyIDs = node.InPolys;
                 Polygons = new List<Polygon>();
                 foreach (var poly in node.InPolys)
-                    Polygons.Add(PolygonCache.Get(new Polygon(polys[poly], vertexArray)));
+                    Polygons.Add(PolygonCache.Get(polys[poly], vertexArray));
             }
             if (node.PosNode != null)
             {

--- a/Source/ACE.Server/Physics/Common/CellStruct.cs
+++ b/Source/ACE.Server/Physics/Common/CellStruct.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.Server.Physics.BSP;
 using ACE.Server.Physics.Entity;
 using ACE.Server.Physics.Collision;
@@ -25,7 +26,7 @@ namespace ACE.Server.Physics.Common
         {
             Polygons = new Dictionary<ushort, Polygon>();
             foreach (var poly in cellStruct.Polygons)
-                Polygons.Add(poly.Key, PolygonCache.Get(new Polygon(poly.Value, cellStruct.VertexArray)));
+                Polygons.Add(poly.Key, PolygonCache.Get(poly.Value, cellStruct.VertexArray));
 
             Portals = new List<Polygon>();
             foreach (var portal in cellStruct.Portals)
@@ -33,7 +34,7 @@ namespace ACE.Server.Physics.Common
 
             PhysicsPolygons = new Dictionary<ushort, Polygon>();
             foreach (var poly in cellStruct.PhysicsPolygons)
-                PhysicsPolygons.Add(poly.Key, PolygonCache.Get(new Polygon(poly.Value, cellStruct.VertexArray)));
+                PhysicsPolygons.Add(poly.Key, PolygonCache.Get(poly.Value, cellStruct.VertexArray));
 
             if (cellStruct.CellBSP != null)
                 CellBSP = BSPCache.Get(cellStruct.CellBSP, cellStruct.PhysicsPolygons, cellStruct.VertexArray);

--- a/Source/ACE.Server/Physics/Common/DBObj.cs
+++ b/Source/ACE.Server/Physics/Common/DBObj.cs
@@ -11,50 +11,89 @@ namespace ACE.Server.Physics.Common
         {
             // TODO: map to ACE datloaders
             // return static or mutable?
+
             if (qualifiedDID.Type == 1)
-            {
-                var landblock = DatManager.CellDat.ReadFromDat<CellLandblock>(qualifiedDID.ID);
-                return landblock;
-            }
+                return GetCellLandblock(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 2)
-            {
-                var landblockInfo = DatManager.CellDat.ReadFromDat<LandblockInfo>(qualifiedDID.ID);
-                return landblockInfo;
-            }
+                return GetLandblockInfo(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 3)
-            {
-                var envCell = DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.EnvCell>(qualifiedDID.ID);
-                return new EnvCell(envCell);
-            }
+                return GetEnvCell(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 6)
-            {
-                var gfxObj = DatManager.PortalDat.ReadFromDat<GfxObj>(qualifiedDID.ID);
-                return gfxObj;
-            }
+                return GetGfxObj(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 7)
-            {
-                var setupModel = DatManager.PortalDat.ReadFromDat<SetupModel>(qualifiedDID.ID);
-                return new Setup(setupModel);
-            }
+                return GetSetup(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 8)
-            {
-                var animation = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Animation>(qualifiedDID.ID);
-                return animation;
-            }
+                return GetAnimation(qualifiedDID.ID);
+
             if (qualifiedDID.Type == 16)
-            {
-                var environment = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Environment>(qualifiedDID.ID);
-                return environment;
-            }
+                return GetEnvironment(qualifiedDID.ID);
+
             return -1;
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 1
+        /// </summary>
+        public static DatLoader.FileTypes.CellLandblock GetCellLandblock(uint id)
+        {
+            return DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.CellLandblock>(id);
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 2
+        /// </summary>
+        public static DatLoader.FileTypes.LandblockInfo GetLandblockInfo(uint id)
+        {
+            return DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.LandblockInfo>(id);
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 3
+        /// </summary>
+        public static EnvCell GetEnvCell(uint id)
+        {
+            var envCell = DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.EnvCell>(id);
+
+            return new EnvCell(envCell);
         }
 
         /// <summary>
         /// QualifiedDID Type 6
         /// </summary>
-        public static GfxObj GetGfxObj(uint id)
+        public static DatLoader.FileTypes.GfxObj GetGfxObj(uint id)
         {
-            return DatManager.PortalDat.ReadFromDat<GfxObj>(id);
+            return DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.GfxObj>(id);
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 7
+        /// </summary>
+        public static Setup GetSetup(uint id)
+        {
+            var setupModel = DatManager.PortalDat.ReadFromDat<SetupModel>(id);
+
+            return new Setup(setupModel);
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 8
+        /// </summary>
+        public static DatLoader.FileTypes.Animation GetAnimation(uint id)
+        {
+            return DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Animation>(id);
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 16
+        /// </summary>
+        public static DatLoader.FileTypes.Environment GetEnvironment(uint id)
+        {
+            return DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Environment>(id);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Common/DBObj.cs
+++ b/Source/ACE.Server/Physics/Common/DBObj.cs
@@ -1,4 +1,5 @@
 using System;
+
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 
@@ -15,37 +16,45 @@ namespace ACE.Server.Physics.Common
                 var landblock = DatManager.CellDat.ReadFromDat<CellLandblock>(qualifiedDID.ID);
                 return landblock;
             }
-            else if (qualifiedDID.Type == 2)
+            if (qualifiedDID.Type == 2)
             {
                 var landblockInfo = DatManager.CellDat.ReadFromDat<LandblockInfo>(qualifiedDID.ID);
                 return landblockInfo;
             }
-            else if (qualifiedDID.Type == 3)
+            if (qualifiedDID.Type == 3)
             {
                 var envCell = DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.EnvCell>(qualifiedDID.ID);
                 return new EnvCell(envCell);
             }
-            else if (qualifiedDID.Type == 6)
+            if (qualifiedDID.Type == 6)
             {
                 var gfxObj = DatManager.PortalDat.ReadFromDat<GfxObj>(qualifiedDID.ID);
                 return gfxObj;
             }
-            else if (qualifiedDID.Type == 7)
+            if (qualifiedDID.Type == 7)
             {
                 var setupModel = DatManager.PortalDat.ReadFromDat<SetupModel>(qualifiedDID.ID);
                 return new Setup(setupModel);
             }
-            else if (qualifiedDID.Type == 8)
+            if (qualifiedDID.Type == 8)
             {
                 var animation = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Animation>(qualifiedDID.ID);
                 return animation;
             }
-            else if (qualifiedDID.Type == 16)
+            if (qualifiedDID.Type == 16)
             {
                 var environment = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.Environment>(qualifiedDID.ID);
                 return environment;
             }
             return -1;
+        }
+
+        /// <summary>
+        /// QualifiedDID Type 6
+        /// </summary>
+        public static GfxObj GetGfxObj(uint id)
+        {
+            return DatManager.PortalDat.ReadFromDat<GfxObj>(id);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+
 using ACE.Entity.Enum;
 using ACE.Server.Physics.BSP;
 using ACE.Server.Physics.Animation;
@@ -58,7 +59,7 @@ namespace ACE.Server.Physics.Common
             SeenOutside = envCell.SeenOutside;
 
             EnvironmentID = envCell.EnvironmentId;
-            Environment = (DatLoader.FileTypes.Environment)DBObj.Get(new QualifiedDataID(16, EnvironmentID));
+            Environment = DBObj.GetEnvironment(EnvironmentID);
             CellStructureID = envCell.CellStructure;    // environment can contain multiple?
             if (Environment.Cells != null && Environment.Cells.ContainsKey(CellStructureID))
                 CellStructure = new CellStruct(Environment.Cells[CellStructureID]);
@@ -224,7 +225,7 @@ namespace ACE.Server.Physics.Common
 
         public EnvCell add_visible_cell(uint cellID)
         {
-            var envCell = (EnvCell)DBObj.Get(new QualifiedDataID(3, cellID));
+            var envCell = DBObj.GetEnvCell(cellID);
             VisibleCells.Add(cellID, envCell);
             return envCell;
         }

--- a/Source/ACE.Server/Physics/Common/GfxObj.cs
+++ b/Source/ACE.Server/Physics/Common/GfxObj.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+
 using ACE.DatLoader.Entity;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Entity;
@@ -34,13 +35,13 @@ namespace ACE.Server.Physics.Collision
 
             Polygons = new Dictionary<ushort, Polygon>();
             foreach (var kvp in gfxObj.Polygons)
-                Polygons.Add(kvp.Key, PolygonCache.Get(new Polygon(kvp.Value, gfxObj.VertexArray)));
+                Polygons.Add(kvp.Key, PolygonCache.Get(kvp.Value, gfxObj.VertexArray));
 
             if (gfxObj.PhysicsPolygons.Count > 0)
             {
                 PhysicsPolygons = new Dictionary<ushort, Polygon>();
                 foreach (var kvp in gfxObj.PhysicsPolygons)
-                    PhysicsPolygons.Add(kvp.Key, PolygonCache.Get(new Polygon(kvp.Value, gfxObj.VertexArray)));
+                    PhysicsPolygons.Add(kvp.Key, PolygonCache.Get(kvp.Value, gfxObj.VertexArray));
 
                 PhysicsBSP = BSPCache.Get(gfxObj.PhysicsBSP, gfxObj.PhysicsPolygons, gfxObj.VertexArray);
                 PhysicsSphere = PhysicsBSP.GetSphere();

--- a/Source/ACE.Server/Physics/Common/LScape.cs
+++ b/Source/ACE.Server/Physics/Common/LScape.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -6,10 +7,12 @@ namespace ACE.Server.Physics.Common
 {
     public static class LScape
     {
-        public static int MidRadius;
-        public static int MidWidth;
-        public static Dictionary<uint, Landblock> Landblocks;
-        public static Dictionary<uint, Landblock> BlockDrawList;
+        public static int MidRadius = 5;
+        public static int MidWidth = 11;
+
+        public static ConcurrentDictionary<uint, Landblock> Landblocks = new ConcurrentDictionary<uint, Landblock>();
+        public static Dictionary<uint, Landblock> BlockDrawList = new Dictionary<uint, Landblock>();
+
         public static uint LoadedCellID;
         public static uint ViewerCellID;
         public static int ViewerXOffset;
@@ -20,22 +23,8 @@ namespace ACE.Server.Physics.Common
         //public static Surface BuildingDetailSurface;
         //public static Surface ObjectDetailSurface;
 
-        public static float AmbientLevel;
-        public static Vector3 Sunlight;
-
-        static LScape()
-        {
-            Landblocks = new Dictionary<uint, Landblock>();
-            BlockDrawList = new Dictionary<uint, Landblock>();
-
-            AmbientLevel = 0.4f;
-            Sunlight = new Vector3(1.2f, 0, 0.5f);
-
-            MidRadius = 5;
-            MidWidth = 11;
-
-            //LandblockStruct.init();
-        }
+        public static float AmbientLevel = 0.4f;
+        public static Vector3 Sunlight = new Vector3(1.2f, 0, 0.5f);
 
         public static bool SetMidRadius(int radius)
         {
@@ -74,22 +63,22 @@ namespace ACE.Server.Physics.Common
             var landblockID = blockCellID | 0xFFFF;
 
             // check if landblock is already cached
-            Landblock landblock = null;
-            Landblocks.TryGetValue(landblockID, out landblock);
-            if (landblock != null)
+            if (Landblocks.TryGetValue(landblockID, out var landblock))
                 return landblock;
 
             // if not, load into cache
             landblock = new Landblock(DBObj.GetCellLandblock(landblockID));
-            Landblocks.Add(landblockID, landblock);
-            landblock.PostInit();
+            if (Landblocks.TryAdd(landblockID, landblock))
+                landblock.PostInit();
+            else
+                Landblocks.TryGetValue(landblockID, out landblock);
 
             return landblock;
         }
 
         public static bool unload_landblock(uint landblockID)
         {
-            return Landblocks.Remove(landblockID);
+            return Landblocks.TryRemove(landblockID, out _);
         }
 
         public static ObjCell get_landcell(uint blockCellID)

--- a/Source/ACE.Server/Physics/Common/LScape.cs
+++ b/Source/ACE.Server/Physics/Common/LScape.cs
@@ -80,7 +80,7 @@ namespace ACE.Server.Physics.Common
                 return landblock;
 
             // if not, load into cache
-            landblock = new Landblock((DatLoader.FileTypes.CellLandblock)DBObj.Get(new QualifiedDataID(1, landblockID)));
+            landblock = new Landblock(DBObj.GetCellLandblock(landblockID));
             Landblocks.Add(landblockID, landblock);
             landblock.PostInit();
 
@@ -116,7 +116,7 @@ namespace ACE.Server.Physics.Common
             {
                 landblock.LandCells.TryGetValue((int)cellID, out cell);
                 if (cell != null) return cell;
-                cell = (EnvCell)DBObj.Get(new QualifiedDataID(3, blockCellID));
+                cell = DBObj.GetEnvCell(blockCellID);
                 landblock.LandCells.Add((int)cellID, cell);
                 var envCell = cell as EnvCell;
                 envCell.PostInit();

--- a/Source/ACE.Server/Physics/Common/Landblock.cs
+++ b/Source/ACE.Server/Physics/Common/Landblock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
 using ACE.Server.Physics.Animation;
@@ -45,7 +46,7 @@ namespace ACE.Server.Physics.Common
             //Console.WriteLine("Loading landblock " + ID.ToString("X8"));
             BlockInfoExists = landblock.HasObjects;
             if (BlockInfoExists)
-                Info = (LandblockInfo)DBObj.Get(new QualifiedDataID(2, ID - 1));
+                Info = DBObj.GetLandblockInfo(ID - 1);
             BlockCoord = LandDefs.blockid_to_lcoord(landblock.Id).Value;
             _landblock = landblock;
             get_land_limits();

--- a/Source/ACE.Server/Physics/Common/LandblockStruct.cs
+++ b/Source/ACE.Server/Physics/Common/LandblockStruct.cs
@@ -371,11 +371,17 @@ namespace ACE.Server.Physics.Common
         /// </summary>
         public void FinalizePVArrays()
         {
-            for (var i = 0; i < VertexArray.Vertices.Count; i++)
-                VertexArray.Vertices[i] = VertexCache.Get(VertexArray.Vertices[i]);
+            if (VertexCache.CacheEnabled)
+            {
+                for (var i = 0; i < VertexArray.Vertices.Count; i++)
+                    VertexArray.Vertices[i] = VertexCache.Get(VertexArray.Vertices[i]);
+            }
 
-            for (var i = 0; i < Polygons.Count; i++)
-                Polygons[i] = PolygonCache.Get(Polygons[i]);
+            if (PolygonCache.CacheEnabled)
+            {
+                for (var i = 0; i < Polygons.Count; i++)
+                    Polygons[i] = PolygonCache.Get(Polygons[i]);
+            }
         }
 
         public void RemoveSurfaces()

--- a/Source/ACE.Server/Physics/Common/ObjCell.cs
+++ b/Source/ACE.Server/Physics/Common/ObjCell.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+
 using ACE.Entity.Enum;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Combat;
@@ -138,9 +139,9 @@ namespace ACE.Server.Physics.Common
 
             var objCell = new ObjCell(cellID);
             if (cellID >= 0x100)
-                return (EnvCell)DBObj.Get(new QualifiedDataID(3, cellID));
-            else
-                return LandCell.Get(cellID);
+                return DBObj.GetEnvCell(cellID);
+
+            return LandCell.Get(cellID);
         }
 
         public PhysicsObj GetObject(int id)

--- a/Source/ACE.Server/Physics/Entity/BSPCache.cs
+++ b/Source/ACE.Server/Physics/Entity/BSPCache.cs
@@ -7,6 +7,11 @@ namespace ACE.Server.Physics.Entity
 {
     public static class BSPCache
     {
+        /// <summary>
+        /// Default is false
+        /// </summary>
+        public static bool CacheEnabled;
+
         public static readonly HashSet<BSPTree> BSPTrees = new HashSet<BSPTree>();
 
         public static int Requests;
@@ -14,6 +19,9 @@ namespace ACE.Server.Physics.Entity
 
         public static BSPTree Get(BSPTree bspTree)
         {
+            if (!CacheEnabled)
+                return bspTree;
+
             Requests++;
 
             //if (Requests % 1000 == 0)
@@ -34,6 +42,9 @@ namespace ACE.Server.Physics.Entity
         public static BSPTree Get(DatLoader.Entity.BSPTree bspTree, Dictionary<ushort, DatLoader.Entity.Polygon> polys, DatLoader.Entity.CVertexArray vertexArray)
         {
             var physicsBSPTree = new BSPTree(bspTree, polys, vertexArray);
+
+            if (!CacheEnabled)
+                return physicsBSPTree;
 
             return Get(physicsBSPTree);
         }

--- a/Source/ACE.Server/Physics/Entity/BSPCache.cs
+++ b/Source/ACE.Server/Physics/Entity/BSPCache.cs
@@ -27,8 +27,7 @@ namespace ACE.Server.Physics.Entity
             //if (Requests % 1000 == 0)
                 //Console.WriteLine($"BSPCache: Requests={Requests}, Hits={Hits}");
 
-            BSPTrees.TryGetValue(bspTree, out var result);
-            if (result != null)
+            if (BSPTrees.TryGetValue(bspTree, out var result))
             {
                 Hits++;
                 return result;

--- a/Source/ACE.Server/Physics/Entity/BSPCache.cs
+++ b/Source/ACE.Server/Physics/Entity/BSPCache.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.Server.Physics.BSP;
 
 namespace ACE.Server.Physics.Entity
 {
     public static class BSPCache
     {
-        public static HashSet<BSPTree> BSPTrees;
-
-        static BSPCache()
-        {
-            BSPTrees = new HashSet<BSPTree>();
-        }
+        public static readonly HashSet<BSPTree> BSPTrees = new HashSet<BSPTree>();
 
         public static int Requests;
         public static int Hits;
@@ -37,7 +33,9 @@ namespace ACE.Server.Physics.Entity
 
         public static BSPTree Get(DatLoader.Entity.BSPTree bspTree, Dictionary<ushort, DatLoader.Entity.Polygon> polys, DatLoader.Entity.CVertexArray vertexArray)
         {
-            return Get(new BSPTree(bspTree, polys, vertexArray));
+            var physicsBSPTree = new BSPTree(bspTree, polys, vertexArray);
+
+            return Get(physicsBSPTree);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
+++ b/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.Server.Physics.Collision;
 
 namespace ACE.Server.Physics.Entity
 {
     public static class GfxObjCache
     {
-        public static Dictionary<uint, GfxObj> GfxObjs;
-
-        static GfxObjCache()
-        {
-            GfxObjs = new Dictionary<uint, GfxObj>();
-        }
+        public static readonly Dictionary<uint, GfxObj> GfxObjs = new Dictionary<uint, GfxObj>();
 
         public static int Requests;
         public static int Hits;

--- a/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
+++ b/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
@@ -19,8 +19,7 @@ namespace ACE.Server.Physics.Entity
             //if (Requests % 100 == 0)
             //Console.WriteLine($"GfxObjCache: Requests={Requests}, Hits={Hits}");
 
-            GfxObjs.TryGetValue(_gfxObj.Id, out var result);
-            if (result != null)
+            if (GfxObjs.TryGetValue(_gfxObj.Id, out var result))
             {
                 Hits++;
                 return result;

--- a/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
+++ b/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using ACE.Server.Physics.Collision;
+using ACE.Server.Physics.Common;
 
 namespace ACE.Server.Physics.Entity
 {
@@ -24,6 +25,27 @@ namespace ACE.Server.Physics.Entity
                 Hits++;
                 return result;
             }
+
+            // not cached, add it
+            var gfxObj = new GfxObj(_gfxObj);
+            GfxObjs.Add(_gfxObj.Id, gfxObj);
+            return gfxObj;
+        }
+
+        public static GfxObj Get(uint rootObjectID)
+        {
+            Requests++;
+
+            //if (Requests % 100 == 0)
+            //Console.WriteLine($"GfxObjCache: Requests={Requests}, Hits={Hits}");
+
+            if (GfxObjs.TryGetValue(rootObjectID, out var result))
+            {
+                Hits++;
+                return result;
+            }
+
+            var _gfxObj = DBObj.GetGfxObj(rootObjectID);
 
             // not cached, add it
             var gfxObj = new GfxObj(_gfxObj);

--- a/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
+++ b/Source/ACE.Server/Physics/Entity/GfxObjCache.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 using ACE.Server.Physics.Collision;
 using ACE.Server.Physics.Common;
@@ -8,7 +8,7 @@ namespace ACE.Server.Physics.Entity
 {
     public static class GfxObjCache
     {
-        public static readonly Dictionary<uint, GfxObj> GfxObjs = new Dictionary<uint, GfxObj>();
+        public static readonly ConcurrentDictionary<uint, GfxObj> GfxObjs = new ConcurrentDictionary<uint, GfxObj>();
 
         public static int Requests;
         public static int Hits;
@@ -28,7 +28,7 @@ namespace ACE.Server.Physics.Entity
 
             // not cached, add it
             var gfxObj = new GfxObj(_gfxObj);
-            GfxObjs.Add(_gfxObj.Id, gfxObj);
+            gfxObj = GfxObjs.GetOrAdd(_gfxObj.Id, gfxObj);
             return gfxObj;
         }
 
@@ -49,7 +49,7 @@ namespace ACE.Server.Physics.Entity
 
             // not cached, add it
             var gfxObj = new GfxObj(_gfxObj);
-            GfxObjs.Add(_gfxObj.Id, gfxObj);
+            gfxObj = GfxObjs.GetOrAdd(_gfxObj.Id, gfxObj);
             return gfxObj;
         }
     }

--- a/Source/ACE.Server/Physics/Entity/PolygonCache.cs
+++ b/Source/ACE.Server/Physics/Entity/PolygonCache.cs
@@ -7,6 +7,11 @@ namespace ACE.Server.Physics.Entity
 {
     public static class PolygonCache
     {
+        /// <summary>
+        /// Default is false
+        /// </summary>
+        public static bool CacheEnabled;
+
         public static readonly HashSet<Polygon> Polygons = new HashSet<Polygon>();
 
         public static int Requests;
@@ -14,6 +19,9 @@ namespace ACE.Server.Physics.Entity
 
         public static Polygon Get(Polygon p)
         {
+            if (!CacheEnabled)
+                return p;
+
             Requests++;
 
             //if (Requests % 10000 == 0)
@@ -34,6 +42,9 @@ namespace ACE.Server.Physics.Entity
         public static Polygon Get(DatLoader.Entity.Polygon p, CVertexArray v)
         {
             var polygon = new Polygon(p, v);
+
+            if (!CacheEnabled)
+                return polygon;
 
             return Get(polygon);
         }

--- a/Source/ACE.Server/Physics/Entity/PolygonCache.cs
+++ b/Source/ACE.Server/Physics/Entity/PolygonCache.cs
@@ -27,8 +27,7 @@ namespace ACE.Server.Physics.Entity
             //if (Requests % 10000 == 0)
                 //Console.WriteLine($"PolygonCache: Requests={Requests}, Hits={Hits}");
 
-            Polygons.TryGetValue(p, out var result);
-            if (result != null)
+            if (Polygons.TryGetValue(p, out var result))
             {
                 Hits++;
                 return result;

--- a/Source/ACE.Server/Physics/Entity/PolygonCache.cs
+++ b/Source/ACE.Server/Physics/Entity/PolygonCache.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.DatLoader.Entity;
 
 namespace ACE.Server.Physics.Entity
 {
     public static class PolygonCache
     {
-        public static HashSet<Polygon> Polygons;
-
-        static PolygonCache()
-        {
-            Polygons = new HashSet<Polygon>();
-        }
+        public static readonly HashSet<Polygon> Polygons = new HashSet<Polygon>();
 
         public static int Requests;
         public static int Hits;
@@ -37,7 +33,9 @@ namespace ACE.Server.Physics.Entity
 
         public static Polygon Get(DatLoader.Entity.Polygon p, CVertexArray v)
         {
-            return Get(new Polygon(p, v));
+            var polygon = new Polygon(p, v);
+
+            return Get(polygon);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Entity/VertexCache.cs
+++ b/Source/ACE.Server/Physics/Entity/VertexCache.cs
@@ -1,17 +1,13 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.DatLoader.Entity;
 
 namespace ACE.Server.Physics.Entity
 {
     public static class VertexCache
     {
-        public static HashSet<Vertex> Vertices;
-
-        static VertexCache()
-        {
-            Vertices = new HashSet<Vertex>();
-        }
+        public static readonly HashSet<Vertex> Vertices = new HashSet<Vertex>();
 
         public static int Requests;
         public static int Hits;
@@ -37,7 +33,9 @@ namespace ACE.Server.Physics.Entity
 
         public static Vertex Get(SWVertex swv)
         {
-            return Get(new Vertex(swv));
+            var vertex = new Vertex(swv);
+
+            return Get(vertex);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Entity/VertexCache.cs
+++ b/Source/ACE.Server/Physics/Entity/VertexCache.cs
@@ -27,8 +27,7 @@ namespace ACE.Server.Physics.Entity
             //if (Requests % 100000 == 0)
                 //Console.WriteLine($"VertexCache: Requests={Requests}, Hits={Hits}");
 
-            Vertices.TryGetValue(v, out var result);
-            if (result != null)
+            if (Vertices.TryGetValue(v, out var result))
             {
                 Hits++;
                 return result;

--- a/Source/ACE.Server/Physics/Entity/VertexCache.cs
+++ b/Source/ACE.Server/Physics/Entity/VertexCache.cs
@@ -7,6 +7,11 @@ namespace ACE.Server.Physics.Entity
 {
     public static class VertexCache
     {
+        /// <summary>
+        /// Default is false
+        /// </summary>
+        public static bool CacheEnabled;
+
         public static readonly HashSet<Vertex> Vertices = new HashSet<Vertex>();
 
         public static int Requests;
@@ -14,6 +19,9 @@ namespace ACE.Server.Physics.Entity
 
         public static Vertex Get(Vertex v)
         {
+            if (!CacheEnabled)
+                return v;
+
             Requests++;
 
             //if (Requests % 100000 == 0)
@@ -34,6 +42,9 @@ namespace ACE.Server.Physics.Entity
         public static Vertex Get(SWVertex swv)
         {
             var vertex = new Vertex(swv);
+
+            if (!CacheEnabled)
+                return vertex;
 
             return Get(vertex);
         }

--- a/Source/ACE.Server/Physics/PhysicsPart.cs
+++ b/Source/ACE.Server/Physics/PhysicsPart.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Collision;
@@ -90,8 +90,7 @@ namespace ACE.Server.Physics
 
         public bool LoadGfxObjArray(uint rootObjectID/*, GfxObjDegradeInfo newDegrades*/)
         {
-            var gfxObj = (DatLoader.FileTypes.GfxObj)DBObj.Get(new QualifiedDataID(6, rootObjectID));
-            GfxObj = GfxObjCache.Get(gfxObj);
+            GfxObj = GfxObjCache.Get(rootObjectID);
             // degrades omitted
             return GfxObj != null;
         }

--- a/Source/ACE.Server/Physics/Setup.cs
+++ b/Source/ACE.Server/Physics/Setup.cs
@@ -94,7 +94,7 @@ namespace ACE.Server.Physics
 
         public static Setup Get(uint setupID)
         {
-            return (Setup)DBObj.Get(new QualifiedDataID(7, setupID));
+            return DBObj.GetSetup(setupID);
         }
 
         public LocationType GetHoldingLocation(int location_idx)

--- a/Source/ACE.Server/Physics/Setup.cs
+++ b/Source/ACE.Server/Physics/Setup.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Numerics;
+
 using ACE.DatLoader.Entity;
 using ACE.DatLoader.FileTypes;
 using ACE.Server.Physics.Common;
@@ -116,7 +117,7 @@ namespace ACE.Server.Physics
             setup.NumParts = 1;
             setup.Parts = new List<PhysicsPart>(1);
 
-            var gfxObj = GfxObjCache.Get((GfxObj)DBObj.Get(new QualifiedDataID(6, gfxObjID)));
+            var gfxObj = GfxObjCache.Get(gfxObjID);
             if (gfxObj != null)
             {
                 if (gfxObj.PhysicsSphere != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -1129,7 +1129,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool PlayersInRange(float range = 96.0f)
         {
-            var isDungeon = CurrentLandblock._landblock.IsDungeon;
+            var isDungeon = CurrentLandblock._landblock != null && CurrentLandblock._landblock.IsDungeon;
 
             var rangeSquared = range * range;
 
@@ -1161,7 +1161,7 @@ namespace ACE.Server.WorldObjects
             if (self != null)
                 self.Session.Network.EnqueueSend(msg);
 
-            var isDungeon = CurrentLandblock._landblock.IsDungeon;
+            var isDungeon = CurrentLandblock._landblock != null && CurrentLandblock._landblock.IsDungeon;
 
             var rangeSquared = range * range;
 


### PR DESCRIPTION
* Vertex/Polygon/BSP cache disabled by default
* GfxObjCache is now thread safe
* DBObj boxing/unboxing improvements

With the above changes, landblock physics loading uses about 30% less CPU.

* Landblock now loads physics assets in the async worker created in the landblock ctor. 
There might still be some bugs from this, will need some testing.