### PR TITLE
Give item fix

### DIFF
--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -15,7 +15,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The maximum number of seconds for an empty corpse to stick around
         /// </summary>
-        private static readonly double emptyDecayTime = 15.0;
+        public static readonly double EmptyDecayTime = 15.0;
 
         /// <summary>
         /// Flag indicates if a corpse is from a monster or a player
@@ -81,7 +81,7 @@ namespace ACE.Server.WorldObjects
         {
             // empty corpses decay faster
             if (Inventory.Count == 0)
-                TimeToRot = emptyDecayTime;
+                TimeToRot = EmptyDecayTime;
             else
                 // a player corpse decays after 5 mins * playerLevel with a minimum of 1 hour
                 TimeToRot = Math.Max(3600, (player.Level ?? 1) * 300);

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1332,11 +1332,9 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Giver methods used upon successful acceptance of item by NPC
+        /// Giver methods used upon successful acceptance of item by NPC<para />
+        /// The item will be destroyed after processing.
         /// </summary>
-        /// <param name="item"></param>
-        /// <param name="amount"></param>
-        /// <param name="target"></param>
         private void ItemAccepted(WorldObject item, uint amount, WorldObject target)
         {
             if (item.CurrentWieldedLocation != null)
@@ -1349,6 +1347,8 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem, 1));
 
             Session.Network.EnqueueSend(new GameEventInventoryRemoveObject(Session, item));
+
+            item.Destroy();
         }
 
         // ===========================

--- a/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
@@ -49,6 +49,14 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            var corpse = this as Corpse;
+
+            if (corpse != null && corpse.Inventory.Count == 0 && TimeToRot.Value > Corpse.EmptyDecayTime)
+            {
+                TimeToRot = Corpse.EmptyDecayTime;
+                return;
+            }
+
             TimeToRot -= elapsed.TotalSeconds;
 
             // Is there still time left?
@@ -68,7 +76,7 @@ namespace ACE.Server.WorldObjects
             decayCompleted = true;
 
             // If this is a player corpse, puke out the corpses contents onto the landblock
-            if (this is Corpse corpse && !corpse.IsMonster)
+            if (corpse != null && !corpse.IsMonster)
             {
                 var inventoryGUIDs = corpse.Inventory.Keys.ToList();
 


### PR DESCRIPTION
Fixed corpses not decaying at Corpse.EmptyDecayTime after they were looted.

Fixed items given to NPC's reappearing back in your inventory. Item.Destroy() was not being called on the object after it was processed. Destroy() will remove the item from the database, thus, breaking the link from the player.