### PR TITLE
More item destruction fixes

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -399,7 +399,10 @@ namespace ACE.Server.Entity
             if (wo == null) return;
 
             wo.CurrentLandblock = null;
-            wo.TimeToRot = null;
+
+            // Weenies can come with a default of 0 or -1. If they still have that value, we want to retain it.
+            if (wo.TimeToRot.HasValue && wo.TimeToRot != 0 && wo.TimeToRot != -1)
+                wo.TimeToRot = null;
 
             if (!adjacencyMove)
             {

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -881,7 +881,7 @@ namespace ACE.Server.Managers
                         item = WorldObjectFactory.CreateNewWorldObject((uint)emote.WeenieClassId);
                         if (item == null) break;
 
-                        success = player.TryRemoveItemFromInventoryWithNetworking(item, (ushort)emote.Amount);
+                        success = player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, (ushort)emote.Amount);
                     }
                     break;
 

--- a/Source/ACE.Server/Managers/EmoteManagerExample.cs
+++ b/Source/ACE.Server/Managers/EmoteManagerExample.cs
@@ -602,7 +602,7 @@ namespace ACE.Server.Managers
                         item = WorldObjectFactory.CreateNewWorldObject(wcid);
                         if (item == null) break;
 
-                        var success = player.TryRemoveItemFromInventoryWithNetworking(item, (ushort)emote.Amount);
+                        var success = player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, (ushort)emote.Amount);
                     }
                     break;
 

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -109,7 +109,7 @@ namespace ACE.Server.Managers
                     {
                         if (target.OwnerId == player.Guid.Full  || player.GetInventoryItem(target.Guid) != null)
                         {
-                            player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)recipe.Recipe.SuccessDestroyTargetAmount);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(target, (ushort)recipe.Recipe.SuccessDestroyTargetAmount);
                         }
                         else if (target.WielderId == player.Guid.Full)
                         {
@@ -132,7 +132,7 @@ namespace ACE.Server.Managers
                     {
                         if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
-                            player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)recipe.Recipe.SuccessDestroySourceAmount);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(source, (ushort)recipe.Recipe.SuccessDestroySourceAmount);
                         }
                         else if (source.WielderId == player.Guid.Full)
                         {
@@ -176,7 +176,7 @@ namespace ACE.Server.Managers
                     {
                         if (target.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
-                            player.TryRemoveItemFromInventoryWithNetworking(target, (ushort)recipe.Recipe.FailDestroyTargetAmount);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(target, (ushort)recipe.Recipe.FailDestroyTargetAmount);
                         }
                         else if (target.WielderId == player.Guid.Full)
                         {
@@ -199,7 +199,7 @@ namespace ACE.Server.Managers
                     {
                         if (source.OwnerId == player.Guid.Full || player.GetInventoryItem(target.Guid) != null)
                         {
-                            player.TryRemoveItemFromInventoryWithNetworking(source, (ushort)recipe.Recipe.FailDestroySourceAmount);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(source, (ushort)recipe.Recipe.FailDestroySourceAmount);
                         }
                         else if (source.WielderId == player.Guid.Full)
                         {

--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -66,7 +66,7 @@ namespace ACE.Server.WorldObjects
 
             player.ApplyConsumable(Name, GetSoundDid(), buffType, (uint)Boost, SpellDID);
 
-            player.TryRemoveItemFromInventoryWithNetworking(this, 1);
+            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
 
             var sendUseDoneEvent = new GameEventUseDone(player.Session);
             player.Session.Network.EnqueueSend(sendUseDoneEvent);

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -136,7 +136,7 @@ namespace ACE.Server.WorldObjects
 
                 // Ok this was not known to us, so we used the contract - now remove it from inventory.
                 // HandleActionRemoveItemFromInventory is has it's own action chain.
-                player.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
             }
             else
                 ChatPacket.SendServerMessage(player.Session, "You already have this quest tracked: " + contractTracker.ContractDetails.ContractName, ChatMessageType.Broadcast);

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -82,7 +82,7 @@ namespace ACE.Server.WorldObjects
                 if (healer != target)
                     target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{healer.Name} fails to heal you.", ChatMessageType.Broadcast));
                 if (UsesLeft <= 0)
-                    healer.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                    healer.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
                 return;
             }
 
@@ -112,7 +112,7 @@ namespace ACE.Server.WorldObjects
                 target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{healer.Name} heals you for {healAmount} points.", ChatMessageType.Broadcast));
 
             if (UsesLeft <= 0)
-                healer.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                healer.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -30,7 +30,7 @@ namespace ACE.Server.WorldObjects
             // to-do don't consume "Limitless Lockpick" rare.
             unlocker.Structure--;
             if (unlocker.Structure < 1)
-                player.TryRemoveItemFromInventoryWithNetworking(unlocker, 1);
+                player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(unlocker, 1);
             player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session));
             player.Session.Network.EnqueueSend(new GameMessagePublicUpdatePropertyInt(unlocker, PropertyInt.Structure, (int)unlocker.Structure));
             player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your lockpicks have {unlocker.Structure} uses left.", ChatMessageType.Craft));

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -131,17 +131,8 @@ namespace ACE.Server.WorldObjects
                 // destroy all stacks of currency required / sale
                 foreach (WorldObject wo in cost)
                 {
-                    TryRemoveFromInventoryWithNetworking(wo);
-
-                    /*TryRemoveFromInventory(wo.Guid);
-                    ObjectGuid clearContainer = new ObjectGuid(0);
-                    Session.Network.EnqueueSend(new GameMessagePublicUpdateInstanceID(wo, PropertyInstanceId.Container, clearContainer));
-
-                    // clean up the shard database.
-                    throw new NotImplementedException();
-                    // todo fix for EF
-                    //DatabaseManager.Shard.DeleteObject(wo.SnapShotOfAceObject(), null);*/
-                    Session.Network.EnqueueSend(new GameMessageDeleteObject(wo));
+                    if (TryRemoveFromInventoryWithNetworking(wo))
+                        wo.Destroy();
                 }
 
                 // if there is change - readd - do this at the end to try to prevent exploiting

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -108,7 +108,12 @@ namespace ACE.Server.WorldObjects
             if (amount >= (worldObject.StackSize ?? 1))
             {
                 if (TryRemoveFromInventoryWithNetworking(worldObject))
+                {
                     worldObject.Destroy();
+                    return true;
+                }
+
+                return false;
             }
 
             worldObject.StackSize -= amount;

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -103,10 +103,13 @@ namespace ACE.Server.WorldObjects
         /// This method is used to remove X number of items from a stack.<para />
         /// If amount to remove is greater or equal to the current stacksize, the stack will be destroyed..
         /// </summary>
-        public bool TryRemoveItemFromInventoryWithNetworking(WorldObject worldObject, ushort amount)
+        public bool TryRemoveItemFromInventoryWithNetworkingWithDestroy(WorldObject worldObject, ushort amount)
         {
             if (amount >= (worldObject.StackSize ?? 1))
-                return TryRemoveFromInventoryWithNetworking(worldObject);
+            {
+                if (TryRemoveFromInventoryWithNetworking(worldObject))
+                    worldObject.Destroy();
+            }
 
             worldObject.StackSize -= amount;
 
@@ -161,6 +164,7 @@ namespace ACE.Server.WorldObjects
                     return false;
                 }
             }
+
             return TryRemoveFromInventoryWithNetworking(item);
         }
 
@@ -1073,7 +1077,7 @@ namespace ACE.Server.WorldObjects
                         double multiplier = (salvageSkill / 225.0);
                         double multiplier2 = .6 > multiplier ? .6 : multiplier;
                         amount += (int)Math.Ceiling(workmanship * multiplier2);
-                        TryRemoveItemFromInventoryWithNetworking(item, 1);
+                        TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, 1);
                         salvageBags[counter] = WorldObjectFactory.CreateNewWorldObject((uint)dict[materials[counter]]);
                         salvageBags[counter].SetProperty(PropertyInt.Structure, amount);
                         salvageBags[counter].SetProperty(PropertyInt.NumItemsInMaterial, numItems);
@@ -1104,7 +1108,7 @@ namespace ACE.Server.WorldObjects
                         double multiplier = (salvageSkill / 225.0);
                         double multiplier2 = .6 > multiplier ? .6 : multiplier;
                         amount += (int)Math.Ceiling(workmanship * multiplier2);
-                        TryRemoveItemFromInventoryWithNetworking(item, 1);
+                        TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, 1);
                         salvageBags[materialsPlace].SetProperty(PropertyInt.Structure, amount);
                         salvageBags[materialsPlace].SetProperty(PropertyInt.NumItemsInMaterial, numItems);
                         salvageBags[materialsPlace].SetProperty(PropertyInt.ItemWorkmanship, amount);
@@ -1148,7 +1152,7 @@ namespace ACE.Server.WorldObjects
                     double multiplier = (salvageSkill / 225.0);
                     double multiplier2 = .6 > multiplier ? .6 : multiplier;
                     amount += (int)Math.Ceiling(workmanship * multiplier2);
-                    TryRemoveItemFromInventoryWithNetworking(item, 1);
+                    TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, 1);
                 }
 
                 WorldObject wo = WorldObjectFactory.CreateNewWorldObject((uint)dict[materialType]);
@@ -1359,7 +1363,7 @@ namespace ACE.Server.WorldObjects
             if (item.CurrentWieldedLocation != null)
                 UnwieldItemWithNetworking(this, item, 0);       // refactor, duplicate code from above
 
-            TryRemoveItemFromInventoryWithNetworking(item, (ushort)amount);
+            TryRemoveItemFromInventoryWithNetworkingWithDestroy(item, (ushort)amount);
 
             Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
             Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -189,8 +189,12 @@ namespace ACE.Server.WorldObjects
                 {
                     player.LearnSpellWithNetworking(SpellId);
                     player.EnqueueBroadcastMotion(motionReady);
+
                     if (player.TryRemoveFromInventoryWithNetworking(this))
+                    {
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat("The scroll is destroyed.", ChatMessageType.Magic));
+                        Destroy();
+                    }
                 });
             }
             else

--- a/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
+++ b/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
@@ -87,7 +87,7 @@ namespace ACE.Server.WorldObjects
                                 player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
 
                                 //Destroy the gem we used successfully
-                                player.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                                player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
 
                                 break;
                             }
@@ -127,7 +127,7 @@ namespace ACE.Server.WorldObjects
                             player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
 
                             //Destroy the gem we used successfully
-                            player.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
 
                             break;
                         }
@@ -152,7 +152,7 @@ namespace ACE.Server.WorldObjects
                             player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
 
                             //Destroy the gem we used successfully
-                            player.TryRemoveItemFromInventoryWithNetworking(this, 1);
+                            player.TryRemoveItemFromInventoryWithNetworkingWithDestroy(this, 1);
 
                             break;
                         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
@@ -57,13 +57,16 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            TimeToRot -= elapsed.TotalSeconds;
-
-            // Is there still time left?
             if (TimeToRot > 0)
-                return;
+            {
+                TimeToRot -= elapsed.TotalSeconds;
 
-            TimeToRot = 0; // We force it to 0 to make sure it doesn't end up at -1. -1 indicates no rot.
+                // Is there still time left?
+                if (TimeToRot > 0)
+                    return;
+
+                TimeToRot = -2; // We force it to -2 to make sure it doesn't end up at 0 or -1. 0 indicates instant rot. -1 indicates no rot. 0 and -1 can be found in weenie defaults
+            }
 
             if (this is Container container && container.IsOpen)
             {


### PR DESCRIPTION
Retain TimeToRot magic values of 0 and -1. They may have come from the weenie.

Destroy stacks that are consumed.

Destroy consumables when they're consumed.