### PR TITLE
Property Dictionaries

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -183,6 +183,40 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static void SetProperty(this Biota biota, PropertyBool property, bool value, ReaderWriterLockSlim rwLock, IDictionary<PropertyBool, BiotaPropertiesBool> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesBool { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesBool.Add(entity);
+
+                        cache[property] = entity;
+
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static void SetProperty(this Biota biota, PropertyDataId property, uint value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -201,6 +235,40 @@ namespace ACE.Database.Models.Shard
                     {
                         var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
                         biota.BiotaPropertiesDID.Add(entity);
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static void SetProperty(this Biota biota, PropertyDataId property, uint value, ReaderWriterLockSlim rwLock, IDictionary<PropertyDataId, BiotaPropertiesDID> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesDID.Add(entity);
+
+                        cache[property] = entity;
+
                         biotaChanged = true;
                     }
                     finally
@@ -247,6 +315,40 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static void SetProperty(this Biota biota, PropertyFloat property, double value, ReaderWriterLockSlim rwLock, IDictionary<PropertyFloat, BiotaPropertiesFloat> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesFloat { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesFloat.Add(entity);
+
+                        cache[property] = entity;
+
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -265,6 +367,40 @@ namespace ACE.Database.Models.Shard
                     {
                         var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
                         biota.BiotaPropertiesIID.Add(entity);
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInstanceId, BiotaPropertiesIID> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesIID.Add(entity);
+
+                        cache[property] = entity;
+
                         biotaChanged = true;
                     }
                     finally
@@ -311,6 +447,40 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static void SetProperty(this Biota biota, PropertyInt property, int value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt, BiotaPropertiesInt> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesInt { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesInt.Add(entity);
+
+                        cache[property] = entity;
+
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static void SetProperty(this Biota biota, PropertyInt64 property, long value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -329,6 +499,40 @@ namespace ACE.Database.Models.Shard
                     {
                         var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
                         biota.BiotaPropertiesInt64.Add(entity);
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static void SetProperty(this Biota biota, PropertyInt64 property, long value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt64, BiotaPropertiesInt64> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesInt64.Add(entity);
+
+                        cache[property] = entity;
+
                         biotaChanged = true;
                     }
                     finally
@@ -414,6 +618,40 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static void SetProperty(this Biota biota, PropertyString property, string value, ReaderWriterLockSlim rwLock, IDictionary<PropertyString, BiotaPropertiesString> cache, out bool biotaChanged)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.TryGetValue(property, out var record))
+                {
+                    biotaChanged = (record.Value != value);
+                    record.Value = value;
+                }
+                else
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                        biota.BiotaPropertiesString.Add(entity);
+
+                        cache[property] = entity;
+
+                        biotaChanged = true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
 
         // =====================================
         // Remove
@@ -433,6 +671,38 @@ namespace ACE.Database.Models.Shard
                     {
                         biota.BiotaPropertiesBool.Remove(entity);
                         entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static bool TryRemoveProperty(this Biota biota, PropertyBool property, ReaderWriterLockSlim rwLock, IDictionary<PropertyBool, BiotaPropertiesBool> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesBool.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
                         return true;
                     }
                     finally
@@ -476,6 +746,38 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static bool TryRemoveProperty(this Biota biota, PropertyDataId property, ReaderWriterLockSlim rwLock, IDictionary<PropertyDataId, BiotaPropertiesDID> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesDID.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesDID.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static bool TryRemoveProperty(this Biota biota, PropertyFloat property, out BiotaPropertiesFloat entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -489,6 +791,38 @@ namespace ACE.Database.Models.Shard
                     {
                         biota.BiotaPropertiesFloat.Remove(entity);
                         entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static bool TryRemoveProperty(this Biota biota, PropertyFloat property, ReaderWriterLockSlim rwLock, IDictionary<PropertyFloat, BiotaPropertiesFloat> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesFloat.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesFloat.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
                         return true;
                     }
                     finally
@@ -532,6 +866,38 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static bool TryRemoveProperty(this Biota biota, PropertyInstanceId property, ReaderWriterLockSlim rwLock, IDictionary<PropertyInstanceId, BiotaPropertiesIID> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesIID.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static bool TryRemoveProperty(this Biota biota, PropertyInt property, out BiotaPropertiesInt entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -560,6 +926,38 @@ namespace ACE.Database.Models.Shard
             }
         }
 
+        public static bool TryRemoveProperty(this Biota biota, PropertyInt property, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt, BiotaPropertiesInt> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesInt.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesInt.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
         public static bool TryRemoveProperty(this Biota biota, PropertyInt64 property, out BiotaPropertiesInt64 entity, ReaderWriterLockSlim rwLock)
         {
             rwLock.EnterUpgradeableReadLock();
@@ -573,6 +971,38 @@ namespace ACE.Database.Models.Shard
                     {
                         biota.BiotaPropertiesInt64.Remove(entity);
                         entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static bool TryRemoveProperty(this Biota biota, PropertyInt64 property, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt64, BiotaPropertiesInt64> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesInt64.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesInt64.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
                         return true;
                     }
                     finally
@@ -629,6 +1059,38 @@ namespace ACE.Database.Models.Shard
                     {
                         biota.BiotaPropertiesString.Remove(entity);
                         entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static bool TryRemoveProperty(this Biota biota, PropertyString property, ReaderWriterLockSlim rwLock, IDictionary<PropertyString, BiotaPropertiesString> cache)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                if (cache.ContainsKey(property))
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        var entity = biota.BiotaPropertiesString.FirstOrDefault(x => x.Type == (uint)property);
+
+                        biota.BiotaPropertiesString.Remove(entity);
+                        entity.Object = null;
+
+                        cache.Remove(property);
+
                         return true;
                     }
                     finally

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1673,7 +1673,6 @@ namespace ACE.Server.WorldObjects
 
             var fromItem = GetInventoryItem(mergeFromGuid);
             var toItem = GetInventoryItem(mergeToGuid);
-            var missileAmmo = toItem.ItemType == ItemType.MissileWeapon;
 
             if (fromItem == null || toItem == null)
                 return;
@@ -1682,6 +1681,8 @@ namespace ACE.Server.WorldObjects
             // Check this and see if I need to call UpdateToStack to clear the action with an amount of 0 Og II
             if (toItem.MaxStackSize == toItem.StackSize)
                 return;
+
+            var missileAmmo = toItem.ItemType == ItemType.MissileWeapon;
 
             if (toItem.MaxStackSize >= (ushort)((toItem.StackSize ?? 0) + amount))
             {

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -95,9 +95,11 @@ namespace ACE.Server.WorldObjects
             Biota = weenie.CreateCopyAsBiota(guid.Full);
             Guid = guid;
 
-            CreationTimestamp = (int)Time.GetUnixTime();
-
+            InitializeSequences();
+            InitializePropertyDictionaries();
             SetEphemeralValues();
+
+            CreationTimestamp = (int)Time.GetUnixTime();
         }
 
         /// <summary>
@@ -111,6 +113,8 @@ namespace ACE.Server.WorldObjects
 
             biotaOriginatedFromDatabase = true;
 
+            InitializeSequences();
+            InitializePropertyDictionaries();
             SetEphemeralValues();
         }
 
@@ -186,8 +190,8 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
-        private void SetEphemeralValues()
-        { 
+        private void InitializeSequences()
+        {
             Sequences.AddOrSetSequence(SequenceType.ObjectPosition, new UShortSequence());
             Sequences.AddOrSetSequence(SequenceType.ObjectMovement, new UShortSequence());
             Sequences.AddOrSetSequence(SequenceType.ObjectState, new UShortSequence());
@@ -286,6 +290,24 @@ namespace ACE.Server.WorldObjects
 
             Sequences.AddOrSetSequence(SequenceType.SetStackSize, new ByteSequence(false));
             Sequences.AddOrSetSequence(SequenceType.Confirmation, new ByteSequence(false));
+        }
+
+        private void InitializePropertyDictionaries()
+        {
+            foreach (var x in Biota.BiotaPropertiesBool)
+                biotaPropertyBools[(PropertyBool)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesDID)
+                biotaPropertyDataIds[(PropertyDataId)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesFloat)
+                biotaPropertyFloats[(PropertyFloat)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesIID)
+                biotaPropertyInstanceIds[(PropertyInstanceId)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesInt)
+                biotaPropertyInts[(PropertyInt)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesInt64)
+                biotaPropertyInt64s[(PropertyInt64)x.Type] = x;
+            foreach (var x in Biota.BiotaPropertiesString)
+                biotaPropertyStrings[(PropertyString)x.Type] = x;
 
             foreach (var x in EphemeralProperties.PropertiesBool.ToList())
                 ephemeralPropertyBools.TryAdd((PropertyBool)x, null);
@@ -301,7 +323,10 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyInt64s.TryAdd((PropertyInt64)x, null);
             foreach (var x in EphemeralProperties.PropertiesString.ToList())
                 ephemeralPropertyStrings.TryAdd((PropertyString)x, null);
+        }
 
+        private void SetEphemeralValues()
+        { 
             foreach (var x in Biota.BiotaPropertiesBool.Where(i => EphemeralProperties.PropertiesBool.Contains(i.Type)).ToList())
                 ephemeralPropertyBools[(PropertyBool)x.Type] = x.Value;
             foreach (var x in Biota.BiotaPropertiesDID.Where(i => EphemeralProperties.PropertiesDataId.Contains(i.Type)).ToList())

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 using ACE.Database;
@@ -10,7 +9,6 @@ using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
-using ACE.Server.Network.Enum;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 using ACE.Database;
@@ -22,6 +23,8 @@ namespace ACE.Server.WorldObjects
     // todo: When we're confident a set of functions, or a group of properties are "final", we can wrap them in a region
     partial class WorldObject
     {
+        // These dictionaries should ONLY be referenced by SetEphemeralValues, GetProperty, SetProperty and RemoveProperty functions.
+        // They should NOT be accessed directly to get property values.
         private readonly Dictionary<PropertyBool, bool?> ephemeralPropertyBools = new Dictionary<PropertyBool, bool?>();
         private readonly Dictionary<PropertyDataId, uint?> ephemeralPropertyDataIds = new Dictionary<PropertyDataId, uint?>();
         private readonly Dictionary<PropertyFloat, double?> ephemeralPropertyFloats = new Dictionary<PropertyFloat, double?>();
@@ -30,14 +33,136 @@ namespace ACE.Server.WorldObjects
         private readonly Dictionary<PropertyInt64, long?> ephemeralPropertyInt64s = new Dictionary<PropertyInt64, long?>();
         private readonly Dictionary<PropertyString, string> ephemeralPropertyStrings = new Dictionary<PropertyString, string>();
 
+        // These dictionaries should ONLY be referenced by SetEphemeralValues, GetProperty, SetProperty and RemoveProperty functions.
+        // They should NOT be accessed directly to get property values.
+        private readonly Dictionary<PropertyBool, BiotaPropertiesBool> biotaPropertyBools = new Dictionary<PropertyBool, BiotaPropertiesBool>();
+        private readonly Dictionary<PropertyDataId, BiotaPropertiesDID> biotaPropertyDataIds = new Dictionary<PropertyDataId, BiotaPropertiesDID>();
+        private readonly Dictionary<PropertyFloat, BiotaPropertiesFloat> biotaPropertyFloats = new Dictionary<PropertyFloat, BiotaPropertiesFloat>();
+        private readonly Dictionary<PropertyInstanceId, BiotaPropertiesIID> biotaPropertyInstanceIds = new Dictionary<PropertyInstanceId, BiotaPropertiesIID>();
+        private readonly Dictionary<PropertyInt, BiotaPropertiesInt> biotaPropertyInts = new Dictionary<PropertyInt, BiotaPropertiesInt>();
+        private readonly Dictionary<PropertyInt64, BiotaPropertiesInt64> biotaPropertyInt64s = new Dictionary<PropertyInt64, BiotaPropertiesInt64>();
+        private readonly Dictionary<PropertyString, BiotaPropertiesString> biotaPropertyStrings = new Dictionary<PropertyString, BiotaPropertiesString>();
+
         #region GetProperty Functions
-        public bool? GetProperty(PropertyBool property) { if (ephemeralPropertyBools.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public uint? GetProperty(PropertyDataId property) { if (ephemeralPropertyDataIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public double? GetProperty(PropertyFloat property) { if (ephemeralPropertyFloats.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public uint? GetProperty(PropertyInstanceId property) { if (ephemeralPropertyInstanceIds.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public int? GetProperty(PropertyInt property) { if (ephemeralPropertyInts.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public long? GetProperty(PropertyInt64 property) { if (ephemeralPropertyInt64s.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
-        public string GetProperty(PropertyString property) { if (ephemeralPropertyStrings.TryGetValue(property, out var value)) return value; return Biota.GetProperty(property, BiotaDatabaseLock); }
+        public bool? GetProperty(PropertyBool property)
+        {
+            if (ephemeralPropertyBools.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyBools.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public uint? GetProperty(PropertyDataId property)
+        {
+            if (ephemeralPropertyDataIds.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyDataIds.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public double? GetProperty(PropertyFloat property)
+        {
+            if (ephemeralPropertyFloats.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyFloats.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public uint? GetProperty(PropertyInstanceId property)
+        {
+            if (ephemeralPropertyInstanceIds.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyInstanceIds.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public int? GetProperty(PropertyInt property)
+        {
+            if (ephemeralPropertyInts.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyInts.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public long? GetProperty(PropertyInt64 property)
+        {
+            if (ephemeralPropertyInt64s.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyInt64s.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
+        public string GetProperty(PropertyString property)
+        {
+            if (ephemeralPropertyStrings.TryGetValue(property, out var value))
+                return value;
+
+            BiotaDatabaseLock.EnterReadLock();
+            try
+            {
+                if (biotaPropertyStrings.TryGetValue(property, out var record))
+                    return record.Value;
+                return null;
+            }
+            finally
+            {
+                BiotaDatabaseLock.ExitReadLock();
+            }
+        }
         #endregion
 
         #region SetProperty Functions
@@ -47,7 +172,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyBools[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyBools, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -58,7 +183,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyDataIds[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyDataIds, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -69,7 +194,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyFloats[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyFloats, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -80,7 +205,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyInstanceIds[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyInstanceIds, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -91,7 +216,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyInts[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyInts, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -102,7 +227,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyInt64s[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyInt64s, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -113,7 +238,7 @@ namespace ACE.Server.WorldObjects
                 ephemeralPropertyStrings[property] = value;
             else
             {
-                Biota.SetProperty(property, value, BiotaDatabaseLock, out var biotaChanged);
+                Biota.SetProperty(property, value, BiotaDatabaseLock, biotaPropertyStrings, out var biotaChanged);
                 if (biotaChanged)
                     ChangesDetected = true;
             }
@@ -125,49 +250,51 @@ namespace ACE.Server.WorldObjects
         {
             if (ephemeralPropertyBools.ContainsKey(property))
                 ephemeralPropertyBools[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyBools))
                 ChangesDetected = true;
         }
         public void RemoveProperty(PropertyDataId property)
         {
             if (ephemeralPropertyDataIds.ContainsKey(property))
                 ephemeralPropertyDataIds[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyDataIds))
                 ChangesDetected = true;
         }
         public void RemoveProperty(PropertyFloat property)
         {
             if (ephemeralPropertyFloats.ContainsKey(property))
                 ephemeralPropertyFloats[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyFloats))
                 ChangesDetected = true;
         }
         public void RemoveProperty(PropertyInstanceId property)
         {
             if (ephemeralPropertyInstanceIds.ContainsKey(property))
                 ephemeralPropertyInstanceIds[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyInstanceIds))
                 ChangesDetected = true;
         }
+
         public void RemoveProperty(PropertyInt property)
         {
             if (ephemeralPropertyInts.ContainsKey(property))
                 ephemeralPropertyInts[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyInts))
                 ChangesDetected = true;
         }
+
         public void RemoveProperty(PropertyInt64 property)
         {
             if (ephemeralPropertyInt64s.ContainsKey(property))
                 ephemeralPropertyInt64s[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyInt64s))
                 ChangesDetected = true;
         }
         public void RemoveProperty(PropertyString property)
         {
             if (ephemeralPropertyStrings.ContainsKey(property))
                 ephemeralPropertyStrings[property] = null;
-            else if (Biota.TryRemoveProperty(property, out _, BiotaDatabaseLock))
+            else if (Biota.TryRemoveProperty(property, BiotaDatabaseLock, biotaPropertyStrings))
                 ChangesDetected = true;
         }
         #endregion


### PR DESCRIPTION
This, again, is a pretty significant change even though it seems very minor.

Previously, any time a biota property was get/set/removed, the action would iterate over the biota property collections to perform the action. As you can imagine, if the property was toward the back of the collection, the overhead was significant.

Now, we cache those records in dictionaries keyed by the property key.

This reduces the CPU needed for the actions by about 80%.

What's the catch?

The catch is that if a developer adds/removes to/from the biota property records directly, the dictionaries will get out of sync and exceptions will most likely be thrown.

This isn't a new requirement though. We already had a requirement that everything had to go through the GetProperty, SetProperty and RemoveProperty functions.


This PR also includes an exception being thrown when merging onto a stack that didn't exist. I saw this issue from VTank. Not sure how the client was actually able to perform the merge.