### PR TITLE
keepOpen option added to DatDatabase FileStream

### DIFF
--- a/Source/ACE.DatLoader/CellDatDatabase.cs
+++ b/Source/ACE.DatLoader/CellDatDatabase.cs
@@ -5,7 +5,7 @@ namespace ACE.DatLoader
 {
     public class CellDatDatabase : DatDatabase
     {
-        public CellDatDatabase(string filename) : base(filename)
+        public CellDatDatabase(string filename, bool keepOpen = false) : base(filename, keepOpen)
         {
         }
 

--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -18,14 +18,14 @@ namespace ACE.DatLoader
         public static PortalDatDatabase HighResDat { get; private set; }
         public static PortalDatDatabase LanguageDat { get; private set; }
 
-        public static void Initialize(string datFileDirectory)
+        public static void Initialize(string datFileDirectory, bool keepOpen = false)
         {
             var datDir = Path.GetFullPath(Path.Combine(datFileDirectory));
 
             try
             {
                 datFile = Path.Combine(datDir, "client_cell_1.dat");
-                CellDat = new CellDatDatabase(datFile);
+                CellDat = new CellDatDatabase(datFile, keepOpen);
                 count = CellDat.AllFiles.Count;
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
             }
@@ -38,7 +38,7 @@ namespace ACE.DatLoader
             try
             {
                 datFile = Path.Combine(datDir, "client_portal.dat");
-                PortalDat = new PortalDatDatabase(datFile);
+                PortalDat = new PortalDatDatabase(datFile, keepOpen);
                 count = PortalDat.AllFiles.Count;
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
             }
@@ -52,7 +52,7 @@ namespace ACE.DatLoader
             datFile = Path.Combine(datDir, "client_highres.dat");
             if (File.Exists(datFile))
             { 
-                HighResDat = new PortalDatDatabase(datFile);
+                HighResDat = new PortalDatDatabase(datFile, keepOpen);
                 count = HighResDat.AllFiles.Count;
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
             }
@@ -61,7 +61,7 @@ namespace ACE.DatLoader
             datFile = Path.Combine(datDir, "client_local_English.dat");
             if (File.Exists(datFile))
             {
-                LanguageDat = new PortalDatDatabase(datFile);
+                LanguageDat = new PortalDatDatabase(datFile, keepOpen);
                 count = LanguageDat.AllFiles.Count;
                 log.Info($"Successfully opened {datFile} file, containing {count} records");
             }

--- a/Source/ACE.DatLoader/PortalDatDatabase.cs
+++ b/Source/ACE.DatLoader/PortalDatDatabase.cs
@@ -7,7 +7,7 @@ namespace ACE.DatLoader
 {
     public class PortalDatDatabase : DatDatabase
     {
-        public PortalDatDatabase(string filename) : base(filename)
+        public PortalDatDatabase(string filename, bool keepOpen = false) : base(filename, keepOpen)
         {
             BadData = ReadFromDat<BadData>(BadData.FILE_ID);
             ChatPoseTable = ReadFromDat<ChatPoseTable>(ChatPoseTable.FILE_ID);

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -67,7 +67,7 @@ namespace ACE.Server
             ServerManager.Initialize();
 
             log.Info("Initializing DatManager...");
-            DatManager.Initialize(ConfigManager.Config.Server.DatFilesDirectory);
+            DatManager.Initialize(ConfigManager.Config.Server.DatFilesDirectory, true);
 
             log.Info("Initializing DatabaseManager...");
             DatabaseManager.Initialize();


### PR DESCRIPTION
Default is off, which should act exactly as ACE did before.

The use of this feature is set in Program.cs via the following line:
DatManager.Initialize(ConfigManager.Config.Server.DatFilesDirectory, true);

I did not actually profile this, so, I don't know if reusing the filestream actually makes a difference. This is the reason for the **NEEDS TESTING** tag.