### PR TITLE
SequenceManager simplification

### DIFF
--- a/Source/ACE.Server/Network/Sequence/SequenceManager.cs
+++ b/Source/ACE.Server/Network/Sequence/SequenceManager.cs
@@ -7,35 +7,18 @@ namespace ACE.Server.Network.Sequence
     {
         private readonly Dictionary<SequenceType, ISequence> sequenceList = new Dictionary<SequenceType, ISequence>();
 
-        public void InitializeAllSequences()
+        public void SetSequence(SequenceType type, ISequence sequence)
         {
-            var values = System.Enum.GetValues(typeof(SequenceType));
-
-            foreach (var value in values)
-                AddOrSetSequence((SequenceType)value, new ByteSequence(false));
-        }
-
-        public void AddOrSetSequence(SequenceType type, ISequence sequence)
-        {
-            if (!sequenceList.ContainsKey(type))
-                sequenceList.Add(type, sequence);
-            else
-                sequenceList[type] = sequence;
+            sequenceList[type] = sequence;
         }
 
         public byte[] GetCurrentSequence(SequenceType type)
         {
-            if (!sequenceList.ContainsKey(type))
-                throw new ArgumentOutOfRangeException("type");
-
             return sequenceList[type].CurrentBytes;
         }
 
         public byte[] GetNextSequence(SequenceType type)
         {
-            if (!sequenceList.ContainsKey(type))
-                throw new ArgumentOutOfRangeException("type");
-
             return sequenceList[type].NextBytes;
         }
     }

--- a/Source/ACE.Server/Network/Sequence/SequenceType.cs
+++ b/Source/ACE.Server/Network/Sequence/SequenceType.cs
@@ -39,6 +39,7 @@ namespace ACE.Server.Network.Sequence
         PublicUpdatePropertyString,
 
         SetStackSize,
+
         Confirmation,
 
         PrivateUpdateAttributeStrength,

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+
 using log4net;
+
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.DatLoader;
@@ -16,6 +18,7 @@ using ACE.Server.Network;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.Network.Sequence;
 using ACE.Server.Network.Structure;
 using ACE.Server.WorldObjects.Entity;
 using ACE.Server.Physics.Animation;
@@ -88,6 +91,91 @@ namespace ACE.Server.WorldObjects
             IgnoreCollisions = true; ReportCollisions = false; Hidden = true;
 
             PhysicsObj.SetPlayer();
+        }
+
+        protected override void InitializeSequences()
+        {
+            base.InitializeSequences();
+
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttribute, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttribute2ndLevel, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkill, new ByteSequence(false));
+
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyInt, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyInt64, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyBool, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyDouble, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyDataID, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyInstanceID, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdatePropertyString, new ByteSequence(false));
+
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttribute2ndLevelHealth, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttribute2ndLevelStamina, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttribute2ndLevelMana, new ByteSequence(false));
+
+            Sequences.SetSequence(SequenceType.Confirmation, new ByteSequence(false));
+
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeStrength, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeEndurance, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeQuickness, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeCoordination, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeFocus, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateAttributeSelf, new ByteSequence(false));
+
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillAxe, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillBow, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillCrossBow, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillDagger, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMace, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMeleeDefense, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMissileDefense, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSling, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSpear, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillStaff, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSword, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillThrownWeapon, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillUnarmedCombat, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillArcaneLore, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMagicDefense, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillManaConversion, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSpellcraft, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillItemAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillPersonalAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillDeception, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillHealing, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillJump, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillLockpick, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillRun, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillAwareness, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillArmsAndArmorRepair, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillCreatureAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillWeaponAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillArmorAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMagicItemAppraisal, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillCreatureEnchantment, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillItemEnchantment, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillLifeMagic, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillWarMagic, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillLeadership, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillLoyalty, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillFletching, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillAlchemy, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillCooking, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSalvaging, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillTwoHandedCombat, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillGearcraft, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillVoidMagic, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillHeavyWeapons, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillLightWeapons, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillFinesseWeapons, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillMissileWeapons, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillShield, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillDualWield, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillRecklessness, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSneakAttack, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillDirtyFighting, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillChallenge, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PrivateUpdateSkillSummoning, new ByteSequence(false));
         }
 
         private void SetEphemeralValues()

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -27,7 +27,7 @@ namespace ACE.Server.WorldObjects
             Character.TotalLogins++;
             CharacterChangesDetected = true;
 
-            Sequences.AddOrSetSequence(SequenceType.ObjectInstance, new UShortSequence((ushort)Character.TotalLogins));
+            Sequences.SetSequence(SequenceType.ObjectInstance, new UShortSequence((ushort)Character.TotalLogins));
 
             // SendSelf will trigger the entrance into portal space
             SendSelf();

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -190,106 +190,29 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
-        private void InitializeSequences()
+        protected virtual void InitializeSequences()
         {
-            Sequences.AddOrSetSequence(SequenceType.ObjectPosition, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectMovement, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectState, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectVector, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectTeleport, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectServerControl, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectForcePosition, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectVisualDesc, new UShortSequence());
-            Sequences.AddOrSetSequence(SequenceType.ObjectInstance, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectPosition, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectMovement, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectState, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectVector, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectTeleport, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectServerControl, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectForcePosition, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectVisualDesc, new UShortSequence());
+            Sequences.SetSequence(SequenceType.ObjectInstance, new UShortSequence());
 
-            Sequences.AddOrSetSequence(SequenceType.Motion, new UShortSequence(1, 0x7FFF)); // MSB is reserved, so set max value to exclude it.
+            Sequences.SetSequence(SequenceType.Motion, new UShortSequence(1, 0x7FFF)); // MSB is reserved, so set max value to exclude it.
 
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttribute, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeStrength, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeEndurance, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeQuickness, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeCoordination, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeFocus, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttributeSelf, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttribute2ndLevel, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttribute2ndLevelHealth, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttribute2ndLevelStamina, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateAttribute2ndLevelMana, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyInt, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyInt64, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyBool, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyDouble, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyDataID, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyInstanceId, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.PublicUpdatePropertyString, new ByteSequence(false));
 
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkill, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillAxe, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillBow, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillCrossBow, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillDagger, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMace, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMeleeDefense, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMissileDefense, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSling, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSpear, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillStaff, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSword, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillThrownWeapon, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillUnarmedCombat, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillArcaneLore, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMagicDefense, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillManaConversion, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSpellcraft, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillItemAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillPersonalAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillDeception, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillHealing, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillJump, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillLockpick, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillRun, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillAwareness, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillArmsAndArmorRepair, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillCreatureAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillWeaponAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillArmorAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMagicItemAppraisal, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillCreatureEnchantment, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillItemEnchantment, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillLifeMagic, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillWarMagic, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillLeadership, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillLoyalty, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillFletching, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillAlchemy, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillCooking, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSalvaging, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillTwoHandedCombat, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillGearcraft, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillVoidMagic, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillHeavyWeapons, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillLightWeapons, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillFinesseWeapons, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillMissileWeapons, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillShield, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillDualWield, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillRecklessness, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSneakAttack, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillDirtyFighting, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillChallenge, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdateSkillSummoning, new ByteSequence(false));
-
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyBool, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyInt, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyInt64, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyDouble, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyString, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyDataID, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PrivateUpdatePropertyInstanceID, new ByteSequence(false));
-
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyBool, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyInt, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyInt64, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyDouble, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyString, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyDataID, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.PublicUpdatePropertyInstanceId, new ByteSequence(false));
-
-            Sequences.AddOrSetSequence(SequenceType.SetStackSize, new ByteSequence(false));
-            Sequences.AddOrSetSequence(SequenceType.Confirmation, new ByteSequence(false));
+            Sequences.SetSequence(SequenceType.SetStackSize, new ByteSequence(false));
         }
 
         private void InitializePropertyDictionaries()


### PR DESCRIPTION
Previously, WorldObject init every sequence.

Now, WorldObject only inits the base and public sequences used by (possibly and/or probably) all world objects.

Player, then further inits the sequences used by players.

This reduces the footprint of non-player WorldObjects, which are the overhwleming majority.

In addition, SequenceManager itself has received some very minor tweaks for efficiency and simplificaiton.