### PR TITLE
Vendors work again, with nearly no change.

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -242,20 +242,16 @@ namespace ACE.Server.WorldObjects
                 else
                 {
                     // remove item from inventory.
-                    TryRemoveFromInventory(profile.Guid);
+                    TryRemoveFromInventoryWithNetworking(item);
                 }
 
                 //Session.Network.EnqueueSend(new GameMessagePrivateUpdateInstanceId(profile, PropertyInstanceId.Container, new ObjectGuid(0).Full));
 
                 item.SetPropertiesForVendor();
-
-                // clean up the shard database.
-                throw new NotImplementedException();
-                // todo fix for EF
-                //DatabaseManager.Shard.DeleteObject(item.SnapShotOfAceObject(), null);
-
                 Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
                 purchaselist.Add(item);
+                //update item in database
+                item.SaveBiotaToDatabase();
             }
 
             var vendor = CurrentLandblock?.GetObject(vendorId) as Vendor;

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -250,7 +250,10 @@ namespace ACE.Server.WorldObjects
                 item.SetPropertiesForVendor();
                 Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
                 purchaselist.Add(item);
-                //update item in database
+                // We must update the database with the latest ContainerId.
+                // If we don't, the player can drop the item, log out, and log back in. If the landblock hasn't queued a database save in that time,
+                // the player will end up loading with this object in their inventory even though the landblock is the true owner. This is because
+                // when we load player inventory, the database still has the record that shows this player as the ContainerId for the item.
                 item.SaveBiotaToDatabase();
             }
 


### PR DESCRIPTION
Get's rid of old code. Removes item from player with networking, and saves item to database once it has been transfered to Vendor.