### PR TITLE
No more death by misadventure(when there is a killer)

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.WorldObjects
     partial class Creature
     {
         public TreasureDeath DeathTreasure { get => DeathTreasureType.HasValue ? DatabaseManager.World.GetCachedDeathTreasure(DeathTreasureType.Value) : null; }
-
+        WorldObject killerObject;
         /// <summary>
         /// Called when a monster or player dies, in conjunction with Die()
         /// </summary>
@@ -60,6 +60,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         protected virtual void Die(WorldObject lastDamager, WorldObject topDamager)
         {
+            killerObject = topDamager;
             UpdateVital(Health, 0);
 
             if (topDamager != null)
@@ -147,7 +148,8 @@ namespace ACE.Server.WorldObjects
 
             if (Killer.HasValue && Killer != 0)
             {
-                var killer = CurrentLandblock?.GetObject(new ObjectGuid(Killer ?? 0));
+                //var killer = CurrentLandblock?.GetObject(new ObjectGuid(Killer ?? 0));
+                var killer = killerObject;
 
                 if (killer != null)
                     killerName = killer.Name;


### PR DESCRIPTION
Not sure what broke the other code that was working, but I create a killerObject from the Die method(which must be called for death to occur) and transfer than down to the  CreateCorpse method