### PR TITLE
Changes to support PCAP exported data being used in database

### DIFF
--- a/Source/ACE.Database/SQLFormatters/SQLWriter.cs
+++ b/Source/ACE.Database/SQLFormatters/SQLWriter.cs
@@ -234,6 +234,14 @@ namespace ACE.Database.SQLFormatters
                         }
                     }
                     break;
+                case PropertyDataId.PCAPRecordedObjectDesc:
+                    return ((ObjectDescriptionFlag)value).ToString();
+                case PropertyDataId.PCAPRecordedPhysicsDesc:
+                    return ((PhysicsDescriptionFlag)value).ToString();
+                case PropertyDataId.PCAPRecordedWeenieHeader:
+                    return ((WeenieHeaderFlag)value).ToString();
+                case PropertyDataId.PCAPRecordedWeenieHeader2:
+                    return ((WeenieHeaderFlag2)value).ToString();
             }
 
             return property.GetValueEnumName(value);

--- a/Source/ACE.Entity/Enum/Properties/PositionType.cs
+++ b/Source/ACE.Entity/Enum/Properties/PositionType.cs
@@ -177,5 +177,8 @@ namespace ACE.Entity.Enum.Properties
         /// </summary>
         RelativeDestination = 26,
         TeleportedCharacter = 27,
+
+        [ServerOnly]
+        PCAPRecordedLocation = 8040
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
@@ -134,6 +134,37 @@ namespace ACE.Entity.Enum.Properties
         [ServerOnly]
         OlthoiDeathTreasureType    = 61,
 
+        [ServerOnly]
+        PCAPRecordedWeenieHeader   = 8001,
+        [ServerOnly]
+        PCAPRecordedWeenieHeader2  = 8002,
+        [ServerOnly]
+        PCAPRecordedObjectDesc     = 8003,
+        [ServerOnly]
+        PCAPRecordedPhysicsDesc    = 8005,
+        [ServerOnly]
+        PCAPRecordedParentLocation = 8003,
+        [ServerOnly]
+        PCAPRecordedDefaultScript  = 8019,
+        [ServerOnly]
+        PCAPRecordedTimestamp1     = 8021,
+        [ServerOnly]
+        PCAPRecordedTimestamp2     = 8022,
+        [ServerOnly]
+        PCAPRecordedTimestamp3     = 8023,
+        [ServerOnly]
+        PCAPRecordedTimestamp4     = 8024,
+        [ServerOnly]
+        PCAPRecordedTimestamp5     = 8025,
+        [ServerOnly]
+        PCAPRecordedTimestamp6     = 8026,
+        [ServerOnly]
+        PCAPRecordedTimestamp7     = 8027,
+        [ServerOnly]
+        PCAPRecordedTimestamp8     = 8028,
+        [ServerOnly]
+        PCAPRecordedTimestamp9     = 8029
+
         //[ServerOnly]
         //HairTexture                = 9001,
         //[ServerOnly]
@@ -169,6 +200,9 @@ namespace ACE.Entity.Enum.Properties
                 case PropertyDataId.DeathTreasureType:
                     // todo
                     break;
+
+                case PropertyDataId.PCAPRecordedParentLocation:
+                    return System.Enum.GetName(typeof(ParentLocation), value);
             }
 
             return null;

--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -191,7 +191,28 @@ namespace ACE.Entity.Enum.Properties
         [SendOnLogin]
         WeaponAuraElemental            = 170,
         [SendOnLogin]
-        WeaponAuraManaConv             = 171
+        WeaponAuraManaConv             = 171,
+
+        [ServerOnly]
+        PCAPRecordedWorkmanship        = 8004,
+        [ServerOnly]
+        PCAPRecordedVelocityX          = 8010,
+        [ServerOnly]
+        PCAPRecordedVelocityY          = 8011,
+        [ServerOnly]
+        PCAPRecordedVelocityZ          = 8012,
+        [ServerOnly]
+        PCAPRecordedAccelerationX      = 8013,
+        [ServerOnly]
+        PCAPRecordedAccelerationY      = 8014,
+        [ServerOnly]
+        PCAPRecordedAccelerationZ      = 8015,
+        [ServerOnly]
+        PCAPRecordeOmegaX              = 8016,
+        [ServerOnly]
+        PCAPRecordeOmegaY              = 8017,
+        [ServerOnly]
+        PCAPRecordeOmegaZ              = 8018
     }
 
     public static class PropertyFloatExtensions

--- a/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
@@ -70,7 +70,12 @@ namespace ACE.Entity.Enum.Properties
         TeleportedCharacter              = 42,
         Pet                              = 43,
         PetOwner                         = 44,
-        PetDevice                        = 45
+        PetDevice                        = 45,
+
+        [ServerOnly]
+        PCAPRecordedObjectIID            = 8000,
+        [ServerOnly]
+        PCAPRecordedParentIID            = 8008
     }
 
     public static class PropertyInstanceIdExtensions

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -521,6 +521,9 @@ namespace ACE.Entity.Enum.Properties
         [SendOnLogin]
         Enlightenment                            = 390,
 
+        [ServerOnly]
+        PCAPRecordedAutonomousMovement           = 8007,
+
         //[ServerOnly]
         //TotalLogins                              = 9001,
         //[ServerOnly]

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -71,7 +71,10 @@ namespace ACE.Entity.Enum.Properties
         UseSendsSignal                  = 51,
 
         [Description("Gear Plating Name")]
-        GearPlatingName                 = 52
+        GearPlatingName                 = 52,
+
+        [ServerOnly]
+        PCAPRecordedCurrentMotionState  = 8006
     }
 
     public static class PropertyStringExtensions

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -756,7 +756,9 @@ namespace ACE.Server.Command.Handlers
                 if (teleportPOI == null)
                     return;
                 var weenie = DatabaseManager.World.GetCachedWeenie(teleportPOI.WeenieClassId);
-                session.Player.Teleport(weenie.GetPosition(PositionType.Destination));
+                var portalDest = new Position(weenie.GetPosition(PositionType.Destination));
+                session.Player.AdjustDungeon(portalDest);
+                session.Player.Teleport(portalDest);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Networking.cs
@@ -75,7 +75,26 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-            foreach (var w in EquippedObjects.Values.Where(x => (x.CurrentWieldedLocation & (EquipMask.Clothing | EquipMask.Armor | EquipMask.Cloak)) != 0).OrderBy(x => x.Priority))
+            var eo = EquippedObjects.Values.Where(x => (x.CurrentWieldedLocation & (EquipMask.Clothing | EquipMask.Armor | EquipMask.Cloak)) != 0).OrderBy(x => x.Priority).ToList();
+
+            if (eo.Count == 0)
+            {
+                if (Biota.BiotaPropertiesAnimPart.Count > 0 || Biota.BiotaPropertiesPalette.Count > 0 || Biota.BiotaPropertiesTextureMap.Count > 0)
+                {
+                    foreach (var animPart in Biota.BiotaPropertiesAnimPart.OrderBy(b => b.Order))
+                        objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = animPart.Index, PartID = animPart.AnimationId });
+
+                    foreach (var subPalette in Biota.BiotaPropertiesPalette)
+                        objDesc.SubPalettes.Add(new ACE.Entity.SubPalette { SubID = subPalette.SubPaletteId, Offset = subPalette.Offset, NumColors = subPalette.Length });
+
+                    foreach (var textureMap in Biota.BiotaPropertiesTextureMap.OrderBy(b => b.Order))
+                        objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = textureMap.Index, OldTexture = textureMap.OldId, NewTexture = textureMap.NewId });
+
+                    return objDesc;
+                }
+            }
+
+            foreach (var w in eo)
             {
                 if ((w.CurrentWieldedLocation == EquipMask.HeadWear) && !showHelm && (this is Player))
                     continue;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # ACEmulator Change Log
 
+### 2018-12-07
+[Ripley]
+* Added some properties so the SQL writers could annotate them for readability (PCAP imported properties, used for dev reference only)
+* Updated Creature.CalculateObjDesc to support reading in of PCAP'd ObjDesc data. This bootstraps weenie appearance without the need to divine clothing data (base and objects(palette + shade))
+* Fix issue with telepoi command
+
 ### 2018-11-29
 [Mag-nus]
 * Improved design and performance for SequenceManager


### PR DESCRIPTION
* Added some properties so the writers could annotate them for readability
* Updated Creature.CalculateObjDesc to support reading in of PCAP'd ObjDesc data. This bootstraps weenie appearance without the need to divine clothing data (base and objects(palette + shade))