### PR TITLE
Fix player logout, save, and session drop flows

### DIFF
--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -92,6 +92,11 @@ namespace ACE.Database
         }
 
 
+        public int GetBiotaCount()
+        {
+            return _wrappedDatabase.GetBiotaCount();
+        }
+
         public Biota GetBiota(uint id)
         {
             return _wrappedDatabase.GetBiota(id);

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -76,6 +76,12 @@ namespace ACE.Database
         }
 
 
+        public int GetBiotaCount()
+        {
+            using (var context = new ShardDbContext())
+                return context.Biota.Count();
+        }
+
         [Flags]
         enum PopulatedCollectionFlags
         {

--- a/Source/ACE.Server/Command/CommandManager.cs
+++ b/Source/ACE.Server/Command/CommandManager.cs
@@ -167,7 +167,7 @@ namespace ACE.Server.Command
             if (commandInfo.Attribute.ParameterCount != -1 && parameters.Length < commandInfo.Attribute.ParameterCount)
                 return CommandHandlerResponse.InvalidParameterCount;
 
-            if ((commandInfo.Attribute.Flags & CommandHandlerFlag.RequiresWorld) != 0 && (session == null || session.Player == null || !session.Player.InWorld))
+            if ((commandInfo.Attribute.Flags & CommandHandlerFlag.RequiresWorld) != 0 && (session == null || session.Player == null || session.Player.CurrentLandblock == null))
                 return CommandHandlerResponse.NotInWorld;
 
             if (isSUDOauthorized)

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1737,19 +1737,20 @@ namespace ACE.Server.Command.Handlers
             sb.Append($"Total CPU Time: {proc.TotalProcessorTime.Hours}h {proc.TotalProcessorTime.Minutes}m {proc.TotalProcessorTime.Seconds}s, Threads: {proc.Threads.Count}{'\n'}");
 
             // todo, add actual system memory used/avail
-            sb.Append($"{(proc.PrivateMemorySize64 >> 20)} MB used{'\n'}");  // sb.Append($"{(proc.PrivateMemorySize64 >> 20)} MB used, xxxx / yyyy MB physical mem free.{'\n'}");
+            sb.Append($"{(proc.PrivateMemorySize64 >> 20):N0} MB used{'\n'}");  // sb.Append($"{(proc.PrivateMemorySize64 >> 20)} MB used, xxxx / yyyy MB physical mem free.{'\n'}");
 
-            sb.Append($"{WorldManager.GetSessionCount()} connections, {PlayerManager.GetAllOnline().Count} players online{'\n'}");
-            sb.Append($"Total Accounts Created: {DatabaseManager.Authentication.GetAccountCount()}, Total Characters Created: {PlayerManager.GetAllOffline().Count + PlayerManager.GetAllOnline().Count}{'\n'}");
+            sb.Append($"{WorldManager.GetSessionCount():N0} connections, {PlayerManager.GetAllOnline().Count:N0} players online{'\n'}");
+            sb.Append($"Total Accounts Created: {DatabaseManager.Authentication.GetAccountCount():N0}, Total Characters Created: {(PlayerManager.GetAllOffline().Count + PlayerManager.GetAllOnline().Count):N0}{'\n'}");
 
             // 330 active objects, 1931 total objects(16777216 buckets.)
 
             // todo, expand this
             var activeLandblocks = LandblockManager.GetActiveLandblocks();
-            sb.Append($"{activeLandblocks.Count} active landblocks.{'\n'}"); // 11 total blocks loaded. 11 active. 0 pending dormancy. 0 dormant. 314 unloaded.
+            sb.Append($"{activeLandblocks.Count:N0} active landblocks.{'\n'}"); // 11 total blocks loaded. 11 active. 0 pending dormancy. 0 dormant. 314 unloaded.
             // 11 total blocks loaded. 11 active. 0 pending dormancy. 0 dormant. 314 unloaded.
 
             sb.Append($"World DB Cache Counts - Weenies: {DatabaseManager.World.GetWeenieCacheCount():N0}, LandblockInstances: {DatabaseManager.World.GetLandblockInstancesCacheCount():N0}, PointsOfInterest: {DatabaseManager.World.GetPointsOfInterestCacheCount():N0}, Cookbooks: {DatabaseManager.World.GetCookbookCacheCount():N0}, Spells: {DatabaseManager.World.GetSpellCacheCount():N0}, Encounters: {DatabaseManager.World.GetEncounterCacheCount():N0}, Events: {DatabaseManager.World.GetEventsCacheCount():N0}{'\n'}");
+            sb.Append($"Shard DB Counts - Biotas: {DatabaseManager.Shard.GetBiotaCount():N0}{'\n'}");
 
             sb.Append($"Portal.dat has {DatManager.PortalDat.FileCache.Count:N0} files cached of {DatManager.PortalDat.AllFiles.Count:N0} total{'\n'}");
             sb.Append($"Cell.dat has {DatManager.CellDat.FileCache.Count:N0} files cached of {DatManager.CellDat.AllFiles.Count:N0} total{'\n'}");

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -25,6 +25,8 @@ namespace ACE.Server.Command.Handlers
 {
     public static class AdminCommands
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // // commandname parameters
         // [CommandHandler("commandname", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 0)]
         // public static void HandleHelp(Session session, params string[] parameters)
@@ -151,8 +153,9 @@ namespace ACE.Server.Command.Handlers
                 {
                     case AccountLookupType.Subscription:
                         {
-                            throw new NotImplementedException();
-                            // break;
+                            // Send the error to a player or the console
+                            CommandHandlerHelper.WriteOutputInfo(session, "Boot by Subscription not implemented.", ChatMessageType.Broadcast);
+                            return;
                         }
                     case AccountLookupType.Character:
                         {
@@ -160,7 +163,7 @@ namespace ACE.Server.Command.Handlers
                             if (player != null)
                             {
                                 playerSession = player.Session;
-                                bootId = player.Guid.Low;
+                                bootId = player.Guid.Full;
                             }
                             break;
                         }
@@ -199,7 +202,6 @@ namespace ACE.Server.Command.Handlers
                     }
 
                     // log the boot to file
-                    ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
                     log.Info(bootText);
 
                     // finish execution of command logic
@@ -208,9 +210,8 @@ namespace ACE.Server.Command.Handlers
             }
 
             // Did not find a player
-            string errorText = "Error locating the player or account to boot.";
             // Send the error to a player or the console
-            CommandHandlerHelper.WriteOutputInfo(session, errorText, ChatMessageType.Broadcast);
+            CommandHandlerHelper.WriteOutputInfo(session, "Error locating the player or account to boot.", ChatMessageType.Broadcast);
         }
 
         // deaf < on / off >

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -151,7 +151,6 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("fakelogin", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Fake Login Complete response")]
         public static void HandleFakeLogin(Session session, params string[] parameters)
         {
-            session.Player.InWorld = true;
             session.Player.ReportCollisions = true;
             session.Player.IgnoreCollisions = false;
             session.Player.Hidden = false;
@@ -433,7 +432,7 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("save-now", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Saves your session.")]
         public static void HandleSaveNow(Session session, params string[] parameters)
         {
-            session.Player.EnqueueSaveChain();
+            session.Player.SavePlayerToDatabase();
         }
 
         /// <summary>

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -210,7 +210,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// This will return true if the player was successfully added.
         /// It will return false if the player was not found in the OfflinePlayers dictionary (which should never happen), or player already exists in the OnlinePlayers dictionary (which should never happen).
-        /// This will always be preceded by a call to GetOfflinePlayer()<para />
+        /// This will always be preceded by a call to GetOfflinePlayer()
         /// </summary>
         public static bool SwitchPlayerFromOfflineToOnline(Player player)
         {
@@ -271,10 +271,26 @@ namespace ACE.Server.Managers
             return true;
         }
 
-        public static void ProcessDeletedPlayer(uint guid)
+        /// <summary>
+        /// This will return true if the player was successfully found and removed from the OfflinePlayers dictionary.
+        /// It will return false if the player was not found in the OfflinePlayers dictionary (which should never happen).
+        /// </summary>
+        public static bool ProcessDeletedPlayer(uint guid)
         {
-            // todo
-            // update allegiance
+            playersLock.EnterWriteLock();
+            try
+            {
+                if (!offlinePlayers.Remove(guid, out var offlinePlayer))
+                    return false; // This should never happen
+
+                // TODO break allegiance, etc...
+            }
+            finally
+            {
+                playersLock.ExitWriteLock();
+            }
+
+            return true;
         }
 
 

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -271,6 +271,12 @@ namespace ACE.Server.Managers
             return true;
         }
 
+        public static void ProcessDeletedPlayer(uint guid)
+        {
+            // todo
+            // update allegiance
+        }
+
 
         /// <summary>
         /// This will return null if the name was not found.

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -173,12 +173,10 @@ namespace ACE.Server.Managers
             try
             {
                 log.DebugFormat("Removing session for {0} with id {1}", session.EndPoint, session.Network.ClientId);
-                if (sessions.Contains(session))
-                    sessions.Remove(session);
+                sessions.Remove(session);
                 if (sessionMap[session.Network.ClientId] == session)
                     sessionMap[session.Network.ClientId] = null;
-                if (loggedInClients.Contains(session.EndPoint))
-                    loggedInClients.Remove(session.EndPoint);
+                loggedInClients.Remove(session.EndPoint);
             }
             finally
             {
@@ -496,10 +494,7 @@ namespace ACE.Server.Managers
                 var deadSessions = sessions.FindAll(s => s.State == Network.Enum.SessionState.NetworkTimeout);
 
                 foreach (var session in deadSessions)
-                {
                     session.DropSession("Network Timeout");
-                    RemoveSession(session); // This will temporarily upgrade our ReadLock to a WriteLock
-                }
             }
             finally
             {

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -497,8 +497,7 @@ namespace ACE.Server.Managers
 
                 foreach (var session in deadSessions)
                 {
-                    log.Info($"client {session.Account} dropped");
-                    session.RemovePlayer();
+                    session.DropSession("Network Timeout");
                     RemoveSession(session); // This will temporarily upgrade our ReadLock to a WriteLock
                 }
             }

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -225,6 +225,8 @@ namespace ACE.Server.Network
                 Player.LogOut(true);
                 PlayerManager.SwitchPlayerFromOnlineToOffline(Player);
                 Player = null;
+
+                // At this point, if the player was on a landblock, they'll still exist on that landblock until the logout animation completes (~6s).
             }
 
             WorldManager.RemoveSession(this);

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -122,10 +122,7 @@ namespace ACE.Server.Network
 
             // Check if the player has been booted
             if (bootSession)
-            {
-                SendFinalBoot();
                 State = SessionState.NetworkTimeout;
-            }
         }
 
 
@@ -212,9 +209,16 @@ namespace ACE.Server.Network
             State = SessionState.AuthConnected;
         }
 
+        public void BootPlayer()
+        {
+            Network.EnqueueSend(new GameMessageBootAccount(this));
+
+            bootSession = true;
+        }
+
         public void DropSession(string reason)
         {
-            log.Info($"client {Account} session dropped, reason: {reason}");
+            log.Info($"Session dropped. Account: {Account}, Player: {Player?.Name}, Reason: {reason}");
 
             if (Player != null)
             {
@@ -224,19 +228,6 @@ namespace ACE.Server.Network
             }
 
             WorldManager.RemoveSession(this);
-        }
-
-        public void BootPlayer()
-        {
-            bootSession = true;
-        }
-
-        private void SendFinalBoot()
-        {
-            // Note that: Currently, if a player is able to block this specific message
-            // then they will not be booted from the server, this was noticed in practice and test.
-            // TODO: Hook in a player disconnect function and prevent the LogOffPlayer() function from firing after this diconnect has occurred.
-            Network.EnqueueSend(new GameMessageBootAccount(this));
         }
 
 

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -93,9 +93,7 @@ namespace ACE.Server.Network
             if (!CheckState(packet))
                 return;
 
-            // Prevent crash when world is not initialized yet.  Need to look at this closer as I think there are some changes needed to state handling/transitions.
-            if (Network != null)
-                Network.ProcessPacket(packet);
+            Network.ProcessPacket(packet);
 
             if (packet.Header.HasFlag(PacketHeaderFlags.Disconnect))
                 HandleDisconnectResponse();

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -555,12 +555,7 @@ namespace ACE.Server.WorldObjects
         }
 
  
-        public void HandleActionLogout(bool clientSessionTerminatedAbruptly = false)
-        {
-            GetLogoutChain().EnqueueChain();
-        }
-
-        public ActionChain GetLogoutChain(bool clientSessionTerminatedAbruptly = false)
+        public void EnqueueLogout(bool clientSessionTerminatedAbruptly = false)
         {
             ActionChain logoutChain = new ActionChain(this, () => LogoutInternal(clientSessionTerminatedAbruptly));
 
@@ -574,7 +569,7 @@ namespace ACE.Server.WorldObjects
                 logoutChain.AddAction(this, () => CurrentLandblock.RemoveWorldObject(Guid, false));
             }
 
-            return logoutChain;
+            logoutChain.EnqueueChain();
         }
 
         /// <summary>
@@ -585,8 +580,6 @@ namespace ACE.Server.WorldObjects
         {
             if (Fellowship != null)
                 FellowshipQuit(false);
-
-            InWorld = false;
 
             if (!clientSessionTerminatedAbruptly)
             {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -555,39 +555,17 @@ namespace ACE.Server.WorldObjects
         }
 
  
-        public void EnqueueLogout(bool clientSessionTerminatedAbruptly = false)
-        {
-            ActionChain logoutChain = new ActionChain(this, () => LogoutInternal(clientSessionTerminatedAbruptly));
-
-            var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>((uint)MotionTableId);
-            float logoutAnimationLength = motionTable.GetAnimationLength(MotionCommand.LogOut);
-            logoutChain.AddDelaySeconds(logoutAnimationLength);
-
-            if (CurrentLandblock != null)
-            {
-                // remove the player from landblock management -- after the animation has run
-                logoutChain.AddAction(this, () => CurrentLandblock.RemoveWorldObject(Guid, false));
-            }
-
-            logoutChain.EnqueueChain();
-        }
-
         /// <summary>
         /// Do the player log out work.<para />
         /// If you want to force a player to logout, use Session.LogOffPlayer().
         /// </summary>
-        private void LogoutInternal(bool clientSessionTerminatedAbruptly)
+        public void LogOut(bool clientSessionTerminatedAbruptly = false)
         {
             if (Fellowship != null)
                 FellowshipQuit(false);
 
             if (!clientSessionTerminatedAbruptly)
             {
-                var logout = new Motion(MotionStance.NonCombat, MotionCommand.LogOut);
-                EnqueueBroadcastMotion(logout);
-
-                EnqueueBroadcastPhysicsState();
-
                 // Thie retail server sends a ChatRoomTracker 0x0295 first, then the status message, 0x028B. It does them one at a time for each individual channel.
                 // The ChatRoomTracker message doesn't seem to change at all.
                 // For the purpose of ACE, we simplify this process.
@@ -596,6 +574,35 @@ namespace ACE.Server.WorldObjects
                 var lfg = new GameEventWeenieErrorWithString(Session, WeenieErrorWithString.YouHaveLeftThe_Channel, "LFG");
                 var roleplay = new GameEventWeenieErrorWithString(Session, WeenieErrorWithString.YouHaveLeftThe_Channel, "Roleplay");
                 Session.Network.EnqueueSend(general, trade, lfg, roleplay);
+            }
+
+            if (CurrentLandblock != null)
+            {
+                var logout = new Motion(MotionStance.NonCombat, MotionCommand.LogOut);
+                EnqueueBroadcastMotion(logout);
+
+                EnqueueBroadcastPhysicsState();
+
+                var logoutChain = new ActionChain();
+
+                var motionTable = DatManager.PortalDat.ReadFromDat<MotionTable>((uint)MotionTableId);
+                float logoutAnimationLength = motionTable.GetAnimationLength(MotionCommand.LogOut);
+                logoutChain.AddDelaySeconds(logoutAnimationLength);
+
+                // remove the player from landblock management -- after the animation has run
+                logoutChain.AddAction(this, () =>
+                {
+                    CurrentLandblock.RemoveWorldObject(Guid, false);
+                    SetPropertiesAtLogOut();
+                    SavePlayerToDatabase();
+                });
+
+                logoutChain.EnqueueChain();
+            }
+            else
+            {
+                SetPropertiesAtLogOut();
+                SavePlayerToDatabase();
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -6,7 +6,6 @@ using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity.Actions;
 
 namespace ACE.Server.WorldObjects
 {
@@ -33,6 +32,13 @@ namespace ACE.Server.WorldObjects
         /// Mag-nus 2018-08-19
         /// </summary>
         public readonly ReaderWriterLockSlim CharacterDatabaseLock = new ReaderWriterLockSlim();
+
+        private void SetPropertiesAtLogOut()
+        {
+            // These properties are used with offline players to determine passup rates
+            SetProperty(PropertyInt.CurrentLoyaltyAtLastLogoff, (int)GetCreatureSkill(Skill.Loyalty).Current);
+            SetProperty(PropertyInt.CurrentLeadershipAtLastLogoff, (int)GetCreatureSkill(Skill.Leadership).Current);
+        }
 
         /// <summary>
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.<para />
@@ -64,7 +70,7 @@ namespace ACE.Server.WorldObjects
             DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => log.Debug($"{Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request."));
         }
 
-        private void SaveCharacterToDatabase()
+        public void SaveCharacterToDatabase()
         {
             // Make sure our IsPlussed value is up to date
             bool isPlussed = (GetProperty(PropertyBool.IsAdmin) ?? false) || (GetProperty(PropertyBool.IsArch) ?? false) || (GetProperty(PropertyBool.IsPsr) ?? false) || (GetProperty(PropertyBool.IsSentinel) ?? false);

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -35,27 +35,10 @@ namespace ACE.Server.WorldObjects
         public readonly ReaderWriterLockSlim CharacterDatabaseLock = new ReaderWriterLockSlim();
 
         /// <summary>
-        /// Gets the ActionChain to save a character
-        /// </summary>
-        public ActionChain GetSaveChain()
-        {
-            return new ActionChain(this, SavePlayer);
-        }
-
-        /// <summary>
-        /// Creates and Enqueues an ActionChain to save a character
-        /// </summary>
-        public void EnqueueSaveChain()
-        {
-            GetSaveChain().EnqueueChain();
-        }
-
-        /// <summary>
-        /// Internal save character functionality<para  />
         /// Saves the character to the persistent database. Includes Stats, Position, Skills, etc.<para />
         /// Will also save any possessions that are marked with ChangesDetected.
         /// </summary>
-        private void SavePlayer()
+        public void SavePlayerToDatabase()
         {
             if (CharacterChangesDetected)
                 SaveCharacterToDatabase();
@@ -78,10 +61,10 @@ namespace ACE.Server.WorldObjects
 
             var requestedTime = DateTime.UtcNow;
 
-            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => log.Debug($"{Session.Player.Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request."));
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => log.Debug($"{Name} has been saved. It took {(DateTime.UtcNow - requestedTime).TotalMilliseconds:N0} ms to process the request."));
         }
 
-        public void SaveCharacterToDatabase()
+        private void SaveCharacterToDatabase()
         {
             // Make sure our IsPlussed value is up to date
             bool isPlussed = (GetProperty(PropertyBool.IsAdmin) ?? false) || (GetProperty(PropertyBool.IsArch) ?? false) || (GetProperty(PropertyBool.IsPsr) ?? false) || (GetProperty(PropertyBool.IsSentinel) ?? false);

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -1,4 +1,5 @@
 using System;
+
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.DatLoader;
@@ -98,10 +99,6 @@ namespace ACE.Server.WorldObjects
 
         public void Teleport(Position newPosition)
         {
-            if (!InWorld)
-                return;
-
-            InWorld = false;
             Teleporting = true;
 
             Session.Network.EnqueueSend(new GameMessagePlayerTeleport(this));
@@ -132,7 +129,6 @@ namespace ACE.Server.WorldObjects
             EnqueueBroadcastPhysicsState();
 
             Teleporting = false;
-            InWorld = true;
         }
 
         public void NotifyLandblocks()

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -48,7 +48,7 @@ namespace ACE.Server.WorldObjects
                 LastRequestedDatabaseSave = DateTime.UtcNow;
 
             if (LastRequestedDatabaseSave + PlayerSaveInterval <= DateTime.UtcNow)
-                SavePlayer();
+                SavePlayerToDatabase();
 
             base.HeartBeat(currentUnixTime);
         }

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -5,18 +5,12 @@ using System.Linq;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Network.GameMessages.Messages;
-
 using ACE.Server.Physics.Common;
 
 namespace ACE.Server.WorldObjects
 {
     partial class Player
     {
-        /// <summary>
-        /// This will be false when in portal space
-        /// </summary>
-        public bool InWorld { get; set; }
-
         /// <summary>
         /// ObjectId of the currently selected Target (only players and creatures)
         /// </summary>


### PR DESCRIPTION
* Shard biota counts added to /serverstatus

* There are 3 ways a player can be logged out
- Normal logout process (Session remains intact)
- Session dropped due to network timeout (Session is removed)
- Booted by admin (Session is removed)

Before, these three scenarios handled the player logout in a unique way.

Now, each scenario uses Player.LogOut() to do the logout work, which includes:
- Quit the fellowship
- Leave the chat channels (if the session didn't terminate abruptly)
- Leave the landblock (if the player is on one)
- Set the final logoff properties (server only, calculated properties used by OfflinePlayer)
- Save the player to the database

* When a session is dropped, there is a 6 second window where the player could still exist on the landblock.
This previously was a chance for exceptions (I threw them several times)

- Player.LogOut() is called
- The player is removed from PlayerManager.OnlinePlayers
- Session.Player is set to null (This must ALWAYS happen AFTER PlayerManager.SwitchPlayerFromOnlineToOffline())
- Now, a session is removed from the master sessions list as soon as it is dropped (just like before)

Any 3rd party interaction with the player can still enqueue work on that players session as Player.Session will not be null. However, since that session has been removed from WorldManager.sessions, the work will never be processed, and lost to the garbage collector.


* Player.InWorld has been removed
- This was only used by CommandManager. We don't need InWorld when we can just check for CurrentLandblock != null.

