### PR TITLE
Fix char creation heritage group skill cost overrides

### DIFF
--- a/Source/ACE.DatLoader/Entity/SkillCG.cs
+++ b/Source/ACE.DatLoader/Entity/SkillCG.cs
@@ -5,14 +5,14 @@ namespace ACE.DatLoader.Entity
     public class SkillCG : IUnpackable
     {
         public uint SkillNum { get; private set; }
-        public uint NormalCost { get; private set; }
-        public uint PrimaryCost { get; private set; }
+        public int NormalCost { get; private set; }
+        public int PrimaryCost { get; private set; }
 
         public void Unpack(BinaryReader reader)
         {
             SkillNum    = reader.ReadUInt32();
-            NormalCost  = reader.ReadUInt32();
-            PrimaryCost = reader.ReadUInt32();
+            NormalCost  = reader.ReadInt32();
+            PrimaryCost = reader.ReadInt32();
         }
     }
 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -412,7 +412,6 @@ namespace ACE.Server.Entity
                 wo.EnqueueActionBroadcast((Player p) => p.RemoveTrackedObject(wo, true));
 
                 wo.PhysicsObj.DestroyObject();
-                wo.IsDestroyed = true;
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -83,8 +83,6 @@ namespace ACE.Server.WorldObjects
         public WorldObject ProjectileSource;
         public WorldObject ProjectileTarget;
 
-        public bool IsDestroyed = false;
-
         public WorldObject() { }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -61,16 +61,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public Landblock CurrentLandblock { get; internal set; }
 
-        private bool busyState;
-        private bool movingState;
-
         public int ManaGiven { get; set; }
 
         public DateTime? ItemManaDepletionMessageTimestamp { get; set; } = null;
         public DateTime? ItemManaConsumptionTimestamp { get; set; } = null;
 
-        public bool IsBusy { get => busyState; set => busyState = value; }
-        public bool IsMovingTo { get => movingState; set => movingState = value; }
+        public bool IsBusy { get; set; }
+        public bool IsMovingTo { get; set; }
         public bool IsShield { get => CombatUse != null && CombatUse == ACE.Entity.Enum.CombatUse.Shield; }
         public bool IsTwoHanded { get => CurrentWieldedLocation != null && CurrentWieldedLocation == EquipMask.TwoHanded; }
         public bool IsBow { get => DefaultCombatStyle != null && (DefaultCombatStyle == CombatStyle.Bow || DefaultCombatStyle == CombatStyle.Crossbow); }


### PR DESCRIPTION
Previously, character creation wasn't taking into account skill credit overrides.

For example, every heritage group defines Arcane Lore as being 0 credits to train and 2 to spec, where as the main skill table in the dat defines Arcane Lore as 4 credits to train.

This will correctly take into account heritage group overrides.


WorldObject IsBusy and IsMovingTo have simply been changed to auto properties. IsDestroyed has been removed as it was never used.