### PR TITLE
This fixes ServerPackets that were built with too many fragments, and thus too large

### DIFF
--- a/Source/ACE.Server/Network/ClientPacket.cs
+++ b/Source/ACE.Server/Network/ClientPacket.cs
@@ -10,6 +10,8 @@ namespace ACE.Server.Network
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
         private static readonly ILog packetLog = LogManager.GetLogger(System.Reflection.Assembly.GetEntryAssembly(), "Packets");
 
+        public static int MaxPacketSize { get; } = 1024;
+
         public BinaryReader Payload { get; private set; }
         public PacketHeaderOptional HeaderOptional { get; private set; }
         public bool IsValid { get; private set; } = false;

--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -20,7 +20,7 @@ namespace ACE.Server.Network
 
         private readonly uint listeningPort;
 
-        private readonly byte[] buffer = new byte[Packet.MaxPacketSize];
+        private readonly byte[] buffer = new byte[ClientPacket.MaxPacketSize];
 
         private readonly IPAddress listeningHost;
 

--- a/Source/ACE.Server/Network/Packet.cs
+++ b/Source/ACE.Server/Network/Packet.cs
@@ -5,10 +5,6 @@ namespace ACE.Server.Network
 {
     public abstract class Packet
     {
-        public static uint MaxPacketSize { get; } = 1024;
-
-        public static uint MaxPacketDataSize { get; } = 464u;
-
         public PacketHeader Header { get; protected set; }
         public MemoryStream Data { get; internal set; }
         public List<PacketFragment> Fragments { get; } = new List<PacketFragment>();

--- a/Source/ACE.Server/Network/ServerPacket.cs
+++ b/Source/ACE.Server/Network/ServerPacket.cs
@@ -1,11 +1,14 @@
 using System;
 using System.IO;
+
 using ACE.Common.Cryptography;
 
 namespace ACE.Server.Network
 {
     public class ServerPacket : Packet
     {
+        public static int MaxPacketSize { get; } = 464;
+
         public BinaryWriter BodyWriter { get; private set; }
 
         private uint issacXor;


### PR DESCRIPTION
Because of this bug, ACE has been sending packets with no size limit. While this works well on a local network, it could have had reliability issues over a WAN.

ServerPacket has a MaxPacketSize of 464. This stems from the original days of ACE.

I suspect this is the maximum size of AC related data we can stuff into a UDP packet (before overhead is added) to keep the UDP packet sent over the WAN in a single fragment.

If we increase this value, it could reduce some server load and byte overhead, but, if a single fragment of the UDP is lost, all fragments will be lost and have to be resent.