### PR TITLE
Fixing object spawning in visible child cell

### DIFF
--- a/Source/ACE.Server/Physics/Common/EnvCell.cs
+++ b/Source/ACE.Server/Physics/Common/EnvCell.cs
@@ -198,7 +198,7 @@ namespace ACE.Server.Physics.Common
                 {
                     if (visibleCell == null) continue;
 
-                    var envCell = GetVisible(visibleCell.ID);
+                    var envCell = GetVisible(visibleCell.ID & 0xFFFF);
                     if (envCell != null && envCell.point_in_cell(origin))
                         return envCell;
                 }


### PR DESCRIPTION
This resolves the issue with Gan-Zo's Golden Chest not spawning in the Shoushi Casino, as well as other possible spawn issues