### PR TITLE
Adding house guest and storage permissions, open/closed, hook visibility, and boot system

### DIFF
--- a/Database/Updates/Shard/HousePermission.sql
+++ b/Database/Updates/Shard/HousePermission.sql
@@ -1,0 +1,13 @@
+drop table if exists house_permission;
+
+create table house_permission
+(
+	`id` int(10) unsigned not null auto_increment,
+	`house_Id` int(10) unsigned not null,
+	`player_Guid` int(10) unsigned not null,
+	`storage` bit(1) not null,
+	primary key (`id`),
+	unique key `house_Id_player_Guid_uidx` (`house_Id`, `player_Guid`),
+	key `house_Id_idx` (`house_Id`)
+	constraint `house_Id` foreign key (`object_Id`) references `biota` (`id`) on delete cascade
+);

--- a/Source/ACE.Database/Models/Shard/Biota.cs
+++ b/Source/ACE.Database/Models/Shard/Biota.cs
@@ -29,6 +29,7 @@ namespace ACE.Database.Models.Shard
             BiotaPropertiesSpellBook = new HashSet<BiotaPropertiesSpellBook>();
             BiotaPropertiesString = new HashSet<BiotaPropertiesString>();
             BiotaPropertiesTextureMap = new HashSet<BiotaPropertiesTextureMap>();
+            HousePermission = new HashSet<HousePermission>();
         }
 
         public uint Id { get; set; }
@@ -59,5 +60,6 @@ namespace ACE.Database.Models.Shard
         public ICollection<BiotaPropertiesSpellBook> BiotaPropertiesSpellBook { get; set; }
         public ICollection<BiotaPropertiesString> BiotaPropertiesString { get; set; }
         public ICollection<BiotaPropertiesTextureMap> BiotaPropertiesTextureMap { get; set; }
+        public ICollection<HousePermission> HousePermission { get; set; }
     }
 }

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -1148,7 +1148,6 @@ namespace ACE.Database.Models.Shard
             {
                 rwLock.ExitReadLock();
             }
-
         }
 
         public static List<BiotaPropertiesEnchantmentRegistry> GetEnchantments(this Biota biota, ReaderWriterLockSlim rwLock)
@@ -1345,6 +1344,60 @@ namespace ACE.Database.Models.Shard
                     {
                         biota.BiotaPropertiesSpellBook.Remove(entity);
                         entity.Object = null;
+                        return true;
+                    }
+                    finally
+                    {
+                        rwLock.ExitWriteLock();
+                    }
+                }
+                return false;
+            }
+            finally
+            {
+                rwLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        public static List<HousePermission> GetHousePermission(this Biota biota, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterReadLock();
+            try
+            {
+                return biota.HousePermission.ToList();
+            }
+            finally
+            {
+                rwLock.ExitReadLock();
+            }
+        }
+
+        public static void AddHousePermission(this Biota biota, HousePermission entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterWriteLock();
+            try
+            {
+                biota.HousePermission.Add(entity);
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+
+        public static bool TryRemoveHousePermission(this Biota biota, uint playerGuid, out HousePermission entity, ReaderWriterLockSlim rwLock)
+        {
+            rwLock.EnterUpgradeableReadLock();
+            try
+            {
+                entity = biota.HousePermission.FirstOrDefault(x => x.PlayerGuid == playerGuid);
+                if (entity != null)
+                {
+                    rwLock.EnterWriteLock();
+                    try
+                    {
+                        biota.HousePermission.Remove(entity);
+                        entity.House = null;
                         return true;
                     }
                     finally

--- a/Source/ACE.Database/Models/Shard/HousePermission.cs
+++ b/Source/ACE.Database/Models/Shard/HousePermission.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ACE.Database.Models.Shard
+{
+    public partial class HousePermission
+    {
+        public uint Id { get; set; }
+        public uint HouseId { get; set; }
+        public uint PlayerGuid { get; set; }
+        public bool Storage { get; set; }
+
+        public Biota House { get; set; }
+    }
+}

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -52,6 +52,7 @@ namespace ACE.Database.Models.Shard
         public virtual DbSet<ConfigPropertiesDouble> ConfigPropertiesDouble { get; set; }
         public virtual DbSet<ConfigPropertiesLong> ConfigPropertiesLong { get; set; }
         public virtual DbSet<ConfigPropertiesString> ConfigPropertiesString { get; set; }
+        public virtual DbSet<HousePermission> HousePermission { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -1535,6 +1536,33 @@ namespace ACE.Database.Models.Shard
                     .IsRequired()
                     .HasColumnName("value")
                     .HasColumnType("text");
+            });
+
+            modelBuilder.Entity<HousePermission>(entity =>
+            {
+                entity.ToTable("house_permission");
+
+                entity.HasIndex(e => e.HouseId)
+                    .HasName("house_Id_idx");
+
+                entity.HasIndex(e => new { e.HouseId, e.PlayerGuid })
+                    .HasName("house_Id_player_Guid_uidx")
+                    .IsUnique();
+
+                entity.Property(e => e.Id).HasColumnName("id");
+
+                entity.Property(e => e.HouseId).HasColumnName("house_Id");
+
+                entity.Property(e => e.PlayerGuid).HasColumnName("player_Guid");
+
+                entity.Property(e => e.Storage)
+                    .HasColumnName("storage")
+                    .HasColumnType("bit(1)");
+
+                entity.HasOne(d => d.House)
+                    .WithMany(p => p.HousePermission)
+                    .HasForeignKey(d => d.HouseId)
+                    .HasConstraintName("house_Guid");
             });
         }
     }

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -107,7 +107,8 @@ namespace ACE.Database
             BiotaPropertiesSkill                = 0x80000,
             BiotaPropertiesSpellBook            = 0x100000,
             BiotaPropertiesString               = 0x200000,
-            BiotaPropertiesTextureMap           = 0x400000
+            BiotaPropertiesTextureMap           = 0x400000,
+            HousePermission                     = 0x800000,
         }
 
         private static void SetBiotaPopulatedCollections(Biota biota)
@@ -137,6 +138,7 @@ namespace ACE.Database
             if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
             if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
             if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
+            if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
 
             biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
         }
@@ -178,6 +180,7 @@ namespace ACE.Database
             if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesSpellBook)) biota.BiotaPropertiesSpellBook = context.BiotaPropertiesSpellBook.Where(r => r.ObjectId == biota.Id).ToList();
             if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesString)) biota.BiotaPropertiesString = context.BiotaPropertiesString.Where(r => r.ObjectId == biota.Id).ToList();
             if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.BiotaPropertiesTextureMap)) biota.BiotaPropertiesTextureMap = context.BiotaPropertiesTextureMap.Where(r => r.ObjectId == biota.Id).ToList();
+            if (populatedCollectionFlags.HasFlag(PopulatedCollectionFlags.HousePermission)) biota.HousePermission = context.HousePermission.Where(r => r.HouseId == biota.Id).ToList();
 
             return biota;
         }

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -107,7 +107,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Gets an outdoor cell ID for a position within a landblock
         /// </summary>
-        private static uint GetOutdoorCell(this Position p)
+        public static uint GetOutdoorCell(this Position p)
         {
             var cellX = (uint)p.PositionX / Position.CellLength;
             var cellY = (uint)p.PositionY / Position.CellLength;
@@ -245,6 +245,5 @@ namespace ACE.Server.Entity
 
             return terrainPos.Z;
         }
-
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseAddAllStoragePermission.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseAddAllStoragePermission.cs
@@ -11,6 +11,8 @@ namespace ACE.Server.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             //Console.WriteLine("Received 0x25C - House - AddAllStoragePermission");
+
+            session.Player.HandleActionAllStorage();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseAddPermanentGuest.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseAddPermanentGuest.cs
@@ -1,5 +1,4 @@
-using System;
-using ACE.Server.Network.Structure;
+using ACE.Common.Extensions;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -13,7 +12,9 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             //Console.WriteLine("Received 0x245 - HouseAddPermanentGuest");
 
-            var guestName = message.Payload.ReadString();
+            var guestName = message.Payload.ReadString16L();
+
+            session.Player.HandleActionAddGuest(guestName);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseBootEveryone.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseBootEveryone.cs
@@ -11,6 +11,8 @@ namespace ACE.Server.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             //Console.WriteLine("Received 0x25F - House - BootEveryone");
+
+            session.Player.HandleActionBootAll();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseBootSpecificGuest.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseBootSpecificGuest.cs
@@ -1,4 +1,4 @@
-using System;
+using ACE.Common.Extensions;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -12,7 +12,9 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             //Console.WriteLine("Received 0x24A - BootSpecificHouseGuest");
 
-            var guestName = message.Payload.ReadString();   // player name to boot from your house
+            var playerName = message.Payload.ReadString16L();   // player name to boot from your house
+
+            session.Player.HandleActionBoot(playerName);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseChangeStoragePermission.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseChangeStoragePermission.cs
@@ -1,4 +1,5 @@
 using System;
+using ACE.Common.Extensions;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -12,8 +13,10 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             //Console.WriteLine("Received 0x249 - House - ChangeStoragePermissions");
 
-            var guestName = message.Payload.ReadString();
+            var guestName = message.Payload.ReadString16L();
             var hasPermission = Convert.ToBoolean(message.Payload.ReadUInt32());
+
+            session.Player.HandleActionModifyStorage(guestName, hasPermission);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseListAvailable.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseListAvailable.cs
@@ -15,6 +15,8 @@ namespace ACE.Server.Network.GameAction.Actions
 
             // type of house being listed
             var houseType = (HouseType)message.Payload.ReadUInt32();
+
+            session.Player.HandleActionListAvailable(houseType);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemoveAllPermanentGuests.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemoveAllPermanentGuests.cs
@@ -11,6 +11,8 @@ namespace ACE.Server.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             //Console.WriteLine("Received 0x25E - House - RemoveAllPermanentGuests");
+
+            session.Player.HandleActionRemoveAllGuests();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemoveAllStoragePermission.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemoveAllStoragePermission.cs
@@ -11,6 +11,7 @@ namespace ACE.Server.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             //Console.WriteLine("Received 0x24C - House - RemoveAllStoragePermission");
+            session.Player.HandleActionRemoveAllStorage();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemovePermanentGuest.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRemovePermanentGuest.cs
@@ -1,4 +1,5 @@
 using System;
+using ACE.Common.Extensions;
 using ACE.Server.Network.Structure;
 
 namespace ACE.Server.Network.GameAction.Actions
@@ -13,7 +14,9 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             //Console.WriteLine("Received 0x246 - HouseRemovePermanentGuest");
 
-            var guestName = message.Payload.ReadString();
+            var guestName = message.Payload.ReadString16L();
+
+            session.Player.HandleActionRemoveGuest(guestName);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRequestFullGuestList.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseRequestFullGuestList.cs
@@ -7,10 +7,12 @@ namespace ACE.Server.Network.GameAction.Actions
     /// </summary>
     public static class GameActionHouseRequestFullGuestList
     {
-        [GameAction(GameActionType.RemoveAllStoragePermission)]
+        [GameAction(GameActionType.RequestFullGuestList)]
         public static void Handle(ClientMessage message, Session session)
         {
             //Console.WriteLine("Received 0x24D - House - RequestFullGuestList");
+
+            session.Player.HandleActionGuestList();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseSetHooksVisibility.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseSetHooksVisibility.cs
@@ -13,6 +13,8 @@ namespace ACE.Server.Network.GameAction.Actions
             //Console.WriteLine("Received 0x266 - House - SetHooksVisibility");
 
             var visible = Convert.ToBoolean(message.Payload.ReadUInt32());
+
+            session.Player.HandleActionSetHooksVisible(visible);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseSetOpenStatus.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionHouseSetOpenStatus.cs
@@ -14,6 +14,8 @@ namespace ACE.Server.Network.GameAction.Actions
             //Console.WriteLine("Received 0x247 - SetOpenHouseStatus");
 
             var openHouse = Convert.ToBoolean(message.Payload.ReadUInt32());
+
+            session.Player.HandleActionSetOpenStatus(openHouse);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventHouseUpdateRestrictions.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventHouseUpdateRestrictions.cs
@@ -6,11 +6,12 @@ namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventHouseUpdateRestrictions : GameEventMessage
     {
-        public GameEventHouseUpdateRestrictions(Session session, ObjectGuid sender, RestrictionDB restrictions)
+        public GameEventHouseUpdateRestrictions(Session session, ObjectGuid sender, RestrictionDB restrictions, byte houseSequence)
             : base(GameEventType.HouseUpdateRestrictions, GameMessageGroup.UIQueue, session)
         {
             //Console.WriteLine("Sending 0x248 - House - UpdateRestrictions");
 
+            Writer.Write(houseSequence);
             Writer.Write(sender.Full);  // The object restrictions are being updated for
             Writer.Write(restrictions);
         }

--- a/Source/ACE.Server/Network/Structure/RestrictionDB.cs
+++ b/Source/ACE.Server/Network/Structure/RestrictionDB.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ACE.Entity;
+using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.Structure
 {
@@ -10,10 +12,24 @@ namespace ACE.Server.Network.Structure
     public class RestrictionDB
     {
         public uint Version = 0x10000002;   // If high word is not 0, this value indicates the version of the message.
-        public uint Bitmask;                // 0 = private dwelling, 1 = open to public
+        public uint OpenStatus;             // 0 = private dwelling, 1 = open to public
         public ObjectGuid MonarchID;        // Allegiance monarch (if allegiance access granted)
         public Dictionary<ObjectGuid, uint> Table;  // Set of permissions on a per user basis. Key is the character id,
                                                     // value is 0 = dwelling access only, 1 = storage access as well
+
+        public RestrictionDB()
+        {
+            Table = new Dictionary<ObjectGuid, uint>();
+        }
+
+        public RestrictionDB(House house)
+        {
+            OpenStatus = Convert.ToUInt32(house.OpenStatus);
+
+            Table = new Dictionary<ObjectGuid, uint>();
+            foreach (var guest in house.Guests)
+                Table.Add(guest.Key.Guid, Convert.ToUInt32(guest.Value));
+        }
     }
 
     public static class RestrictionDBExtensions
@@ -21,7 +37,7 @@ namespace ACE.Server.Network.Structure
         public static void Write(this BinaryWriter writer, RestrictionDB restrictions)
         {
             writer.Write(restrictions.Version);
-            writer.Write(restrictions.Bitmask);
+            writer.Write(restrictions.OpenStatus);
             writer.Write(restrictions.MonarchID.Full);
             writer.Write(restrictions.Table);
         }

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -121,9 +121,11 @@ namespace ACE.Server.WorldObjects
                 Value += container.Value; // This value includes the containers value itself + all child items
             }
 
-            var hook = this as Hook;
-            if (hook != null)
-                hook.OnAddItem();
+            if (WeenieType == WeenieType.Hook)
+            {
+                var hook = this as Hook;
+                hook.OnLoad();
+            }
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Hook.cs
+++ b/Source/ACE.Server/WorldObjects/Hook.cs
@@ -57,7 +57,7 @@ namespace ACE.Server.WorldObjects
             if (player == null) return;
 
             // verify permissions to use hook
-            if (HouseOwner == null || HouseOwner.Value != player.Guid.Full)
+            if (!House.HasPermission(player))
             {
                 player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"The {Name} is locked"));
                 player.SendUseDoneEvent();
@@ -155,6 +155,16 @@ namespace ACE.Server.WorldObjects
                         return MotionCommand.Pickup20;
                 }
             }
+        }
+
+        public void OnLoad()
+        {
+            var hidden = Inventory.Count == 0 && !(House.HouseHooksVisible ?? true);
+
+            NoDraw = hidden;
+            UiHidden = hidden;
+
+            OnAddItem();
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/House.cs
+++ b/Source/ACE.Server/WorldObjects/House.cs
@@ -2,13 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ACE.Common;
-using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
+using ACE.Server.Managers;
 using ACE.Server.Network.Structure;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -16,9 +16,26 @@ namespace ACE.Server.WorldObjects
 {
     public class House: WorldObject
     {
-        public SlumLord SlumLord { get => (SlumLord)ChildLinks.FirstOrDefault(l => l as SlumLord != null); }
-        public List<Hook> Hooks { get => (List<Hook>)ChildLinks.Where(l => l as Hook != null); }
-        public List<Storage> Storage { get => (List<Storage>)ChildLinks.Where(l => l as Storage != null); }
+        public Dictionary<IPlayer, bool> Guests;
+
+        public static int MaxGuests = 32;
+
+        /// <summary>
+        /// house open/closed status
+        /// 0 = closed, 1 = open
+        /// </summary>
+        public bool OpenStatus
+        {
+            get => Convert.ToBoolean(HouseStatus);
+            set => HouseStatus = Convert.ToInt32(value);
+        }
+
+        public SlumLord SlumLord { get => ChildLinks.FirstOrDefault(l => l as SlumLord != null) as SlumLord; }
+        public List<Hook> Hooks { get => ChildLinks.Where(l => l is Hook).Select(l => l as Hook).ToList(); }
+        public List<Storage> Storage { get => ChildLinks.Where(l => l is Storage).Select(l => l as Storage).ToList(); }
+        public WorldObject BootSpot => ChildLinks.FirstOrDefault(i => i.WeenieType == WeenieType.BootSpot);
+
+        public HashSet<IPlayer> StorageAccess => Guests.Where(i => i.Value).Select(i => i.Key).ToHashSet();
 
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
@@ -38,6 +55,9 @@ namespace ACE.Server.WorldObjects
 
         private void SetEphemeralValues()
         {
+            DefaultScriptId = (uint)ACE.Entity.Enum.PlayScript.RestrictionEffectBlue;
+
+            BuildGuests();
         }
 
         /// <summary>
@@ -102,8 +122,15 @@ namespace ACE.Server.WorldObjects
             if (HouseOwner != null && wo is SlumLord)
                 wo.CurrentMotionState = new Motion(MotionStance.Invalid, MotionCommand.On);
 
+            // the inventory items haven't been loaded yet
+            if (wo is Hook && !(HouseHooksVisible ?? true))
+            {
+                wo.NoDraw = true;
+                wo.UiHidden = true;
+            }
+
             //if (HouseOwner != null)
-                //Console.WriteLine($"{Name}.SetLinkProperties({wo.Name}) - houseID: {HouseId:X8}, owner: {HouseOwner:X8}, instance: {HouseInstance:X8}");
+            //Console.WriteLine($"{Name}.SetLinkProperties({wo.Name}) - houseID: {HouseId:X8}, owner: {HouseOwner:X8}, instance: {HouseInstance:X8}");
         }
 
         public override void UpdateLinkProperties(WorldObject wo)
@@ -118,5 +145,83 @@ namespace ACE.Server.WorldObjects
         }
 
         public bool IsApartment => HouseType != null && (HouseType)HouseType.Value == ACE.Entity.Enum.HouseType.Apartment;
+
+        /// <summary>
+        /// Returns TRUE if this player has storage access
+        /// </summary>
+        public bool HasPermission(Player player)
+        {
+            if (HouseOwner == null)
+                return false;
+
+            if (player.Guid.Full == HouseOwner.Value)
+                return true;
+
+            return StorageAccess.Contains(player);
+        }
+
+        public bool? HouseHooksVisible
+        {
+            get => GetProperty(PropertyBool.HouseHooksVisible);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.HouseHooksVisible); else SetProperty(PropertyBool.HouseHooksVisible, value.Value); }
+        }
+
+        public void BuildGuests()
+        {
+            Guests = new Dictionary<IPlayer, bool>();
+
+            var housePermissions = Biota.GetHousePermission(BiotaDatabaseLock);
+
+            foreach (var housePermission in Biota.HousePermission)
+            {
+                var player = PlayerManager.FindByGuid(housePermission.PlayerGuid);
+                if (player == null)
+                {
+                    Console.WriteLine($"{Name}.BuildGuests(): couldn't find guest {housePermission.PlayerGuid}");
+                    continue;
+                }
+                Guests.Add(player, housePermission.Storage);
+            }
+        }
+
+        public void AddGuest(IPlayer guest, bool storage)
+        {
+            var housePermission = new HousePermission();
+            housePermission.HouseId = Guid.Full;
+            housePermission.PlayerGuid = guest.Guid.Full;
+            housePermission.Storage = storage;
+
+            Biota.AddHousePermission(housePermission, BiotaDatabaseLock);
+            ChangesDetected = true;
+        }
+
+        public void UpdateGuest(IPlayer guest, bool storage)
+        {
+            var existing = FindGuest(guest);
+
+            if (existing == null || existing.Storage == storage)
+                return;
+
+            existing.Storage = storage;
+            ChangesDetected = true;
+        }
+
+        public void RemoveGuest(IPlayer guest)
+        {
+            Biota.TryRemoveHousePermission(guest.Guid.Full, out var entity, BiotaDatabaseLock);
+            ChangesDetected = true;
+        }
+
+        public HousePermission FindGuest(IPlayer guest)
+        {
+            var housePermissions = Biota.GetHousePermission(BiotaDatabaseLock);
+
+            var existing = housePermissions.FirstOrDefault(i => i.PlayerGuid == guest.Guid.Full);
+
+            if (existing == null)
+                Console.WriteLine($"{Name}.FindGuest({guest.Guid}): couldn't find {guest.Name}");
+
+            return existing;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -69,7 +69,7 @@ namespace ACE.Server.WorldObjects
             if (attackFrames.Count == 1)
                 delayTime = attackFrames[0] * animLength;
             else
-                log.Warn($"{Name}.GetAttackFrames(): MotionTableId: {MotionTableId:X8}, MotionStance: {CurrentMotionState.Stance}, Motion: {maneuver.Motion:X8}, AttackFrames.Count({attackFrames.Count}) != 1");
+                log.Warn($"{Name}.GetAttackFrames(): MotionTableId: {MotionTableId:X8}, MotionStance: {CurrentMotionState.Stance}, Motion: {maneuver.Motion}, AttackFrames.Count({attackFrames.Count}) != 1");
 
             actionChain.AddDelaySeconds(delayTime);
             actionChain.AddAction(this, () =>

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
@@ -12,12 +13,15 @@ using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.Network.Structure;
 
 namespace ACE.Server.WorldObjects
 {
     partial class Player
     {
         public House House;
+
+        public Dictionary<IPlayer, bool> Guests => House.Guests;
 
         /// <summary>
         /// Called when player clicks the 'Buy house' button,
@@ -338,6 +342,422 @@ namespace ACE.Server.WorldObjects
 
             var loaded = LandblockManager.GetLandblock(landblockId, false);
             return loaded.GetObject(new ObjectGuid(houseGuid)) as House;
+        }
+
+        public void AddHouseGuest(IPlayer guest, bool storage)
+        {
+            var house = GetHouse();
+            house.AddGuest(guest, storage);
+
+            Guests.Add(guest, storage);
+            UpdateRestrictionDB();
+        }
+
+        public void ModifyHouseGuest(IPlayer guest, bool storage)
+        {
+            var house = GetHouse();
+            house.UpdateGuest(guest, storage);
+
+            Guests[guest] = storage;
+            UpdateRestrictionDB();
+        }
+
+        public void RemoveHouseGuest(IPlayer guest)
+        {
+            var house = GetHouse();
+            house.RemoveGuest(guest);
+
+            Guests.Remove(guest);
+            UpdateRestrictionDB();
+        }
+
+        public void Sync(House house)
+        {
+            house.Guests = House.Guests;
+            house.OpenStatus = House.OpenStatus;
+        }
+
+
+        public void HandleActionAddGuest(string guestName)
+        {
+            //Console.WriteLine($"{Name}.HandleActionAddGuest({guestName})");
+
+            var guest = PlayerManager.FindByName(guestName, out bool isOnline);
+
+            if (guest == null)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{guestName} not found", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (guest.Equals(this))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You already have access to your house.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (Guests.ContainsKey(guest))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{guest.Name} is already on your guest list.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (Guests.Count == House.MaxGuests)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your guest list has already reached the maximum limit ({House.MaxGuests})", ChatMessageType.Broadcast));
+                return;
+            }
+
+            AddHouseGuest(guest, false);
+
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"{guest.Name} added to your guest list.", ChatMessageType.Broadcast));
+
+            // notify online guest for addition
+            if (isOnline)
+            {
+                var onlineGuest = PlayerManager.GetOnlinePlayer(guest.Guid);
+                onlineGuest.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} has added you to their house guest list.", ChatMessageType.Broadcast));
+            }
+        }
+
+        public void HandleActionRemoveGuest(string guestName)
+        {
+            //Console.WriteLine($"{Name}.HandleActionRemoveGuest({guestName})");
+
+            var guest = PlayerManager.FindByName(guestName, out bool isOnline);
+
+            if (guest == null)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{guestName} not found", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (guest.Equals(this))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You have permanent access to your house.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (!Guests.ContainsKey(guest))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{guest.Name} isn't on your guest list.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            RemoveHouseGuest(guest);
+
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"{guest.Name} removed from your guest list.", ChatMessageType.Broadcast));
+
+            // notify online guest removed
+            if (isOnline)
+            {
+                var onlineGuest = PlayerManager.GetOnlinePlayer(guest.Guid);
+                onlineGuest.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} has removed you from their house guest list.", ChatMessageType.Broadcast));
+
+                // if guest access is removed while player is in house,
+                // they will be stuck in restriction space
+                if (onlineGuest.Location.GetOutdoorCell() == House.Location.GetOutdoorCell())
+                    HandleActionBoot(onlineGuest.Name);
+            }
+        }
+
+        public void HandleActionRemoveAllGuests()
+        {
+            //Console.WriteLine($"{Name}.HandleActionRemoveAllGuests()");
+
+            if (Guests.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guest list is empty.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            foreach (var guest in Guests.Keys)
+                HandleActionRemoveGuest(guest.Name);
+        }
+
+        public void HandleActionGuestList()
+        {
+            //Console.WriteLine($"{Name}.HandleActionGuestList()");
+
+            if (Guests.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guest list is empty.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var sb = new StringBuilder($"{Name}'s {House.SlumLord.Name} guest list:\n");
+            foreach (var guest in Guests)
+            {
+                var storage = guest.Value ? "* " : "";
+                sb.Append(storage + guest.Key.Name + "\n");
+            }
+
+            Session.Network.EnqueueSend(new GameMessageSystemChat(sb.ToString(), ChatMessageType.Broadcast));
+            return;
+        }
+
+        public void HandleActionSetOpenStatus(bool openStatus)
+        {
+            //Console.WriteLine($"{Name}.HandleActionSetOpenStatus({openStatus})");
+
+            if (openStatus == House.OpenStatus)
+            {
+                if (openStatus)
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("Your house is already open.", ChatMessageType.Broadcast));
+                else
+                    Session.Network.EnqueueSend(new GameMessageSystemChat("Your house is already restricted to guests only.", ChatMessageType.Broadcast));
+
+                return;
+            }
+
+            House.OpenStatus = openStatus;
+
+            UpdateRestrictionDB();
+
+            if (openStatus)
+                Session.Network.EnqueueSend(new GameMessageSystemChat("Your house is open to everyone now.", ChatMessageType.Broadcast));
+            else
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("Your house is restricted to guests only.", ChatMessageType.Broadcast));
+
+                // boot anyone not on the guest list,
+                // else they will be stuck in restricted space
+                HandleActionBootAll(false);
+            }
+        }
+
+        public void HandleActionSetHooksVisible(bool visible)
+        {
+            //Console.WriteLine($"{Name}.HandleActionSetHooksVisible({visible})");
+
+            var visibleStr = visible ? "visible" : "invisible";
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"Your hooks are set to {visibleStr}.", ChatMessageType.Broadcast));
+
+            var house = GetHouse();
+
+            if (visible == (house.HouseHooksVisible ?? true)) return;
+
+            house.HouseHooksVisible = visible;
+
+            var state = PhysicsState.Ethereal | PhysicsState.IgnoreCollisions;
+            if (!visible) state |= PhysicsState.NoDraw;
+
+            foreach (var hook in house.Hooks.Where(i => i.Inventory.Count == 0))
+            {
+                var setState = new GameMessageSetState(hook, state);
+                var update = new GameMessagePublicUpdatePropertyBool(hook, PropertyBool.UiHidden, !visible);
+
+                house.SlumLord.EnqueueBroadcast(setState, update);
+            }
+        }
+
+        public void HandleActionModifyStorage(string guestName, bool hasPermission)
+        {
+            //Console.WriteLine($"{Name}.HandleActionModifyStorage({guestName}, {hasPermission})");
+
+            var storage = PlayerManager.FindByName(guestName, out bool isOnline);
+
+            if (storage == null)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{guestName} not found", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (storage.Equals(this))
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("You have permanent access to your house storage.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var existing = Guests.TryGetValue(storage, out var storageAccess);
+            if (hasPermission)
+            {
+                if (!existing)
+                {
+                    if (Guests.Count == House.MaxGuests)
+                    {
+                        Session.Network.EnqueueSend(new GameMessageSystemChat($"Your guest list has already reached the maximum limit ({House.MaxGuests})", ChatMessageType.Broadcast));
+                        return;
+                    }
+                    AddHouseGuest(storage, true);
+                }
+                else
+                {
+                    if (storageAccess)
+                    {
+                        Session.Network.EnqueueSend(new GameMessageSystemChat($"{storage.Name} already has access to your house storage.", ChatMessageType.Broadcast));
+                        return;
+                    }
+                    ModifyHouseGuest(storage, true);
+                }
+
+                var andStr = !existing ? "and " : "";
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{storage.Name} granted access to your house {andStr}storage.", ChatMessageType.Broadcast));
+
+                // notify online storage guest added
+                if (isOnline)
+                {
+                    var onlineGuest = PlayerManager.GetOnlinePlayer(storage.Guid);
+                    onlineGuest.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} has granted you access to their house {andStr}storage.", ChatMessageType.Broadcast));
+                }
+            }
+            else
+            {
+                if (!existing || !storageAccess)
+                {
+                    var storageStr = existing ? " storage" : "";
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{storage.Name} doesn't have access to your house{storageStr}.", ChatMessageType.Broadcast));
+                    return;
+                }
+
+                ModifyHouseGuest(storage, false);
+
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{storage.Name} no longer has access to your house storage.", ChatMessageType.Broadcast));
+
+                // notify online storage guest added
+                if (isOnline)
+                {
+                    var onlineGuest = PlayerManager.GetOnlinePlayer(storage.Guid);
+                    onlineGuest.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} has revoked access to their house storage.", ChatMessageType.Broadcast));
+
+                    // if they are in house, and have storage opened?
+                }
+            }
+        }
+
+        public void HandleActionAllStorage()
+        {
+            //Console.WriteLine($"{Name}.HandleActionAllStorage()");
+
+            if (Guests.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guest list is empty.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var noStorage = Guests.Where(g => !g.Value).ToList();
+
+            if (noStorage.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guests already have access to your storage.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            foreach (var guest in noStorage)
+                HandleActionModifyStorage(guest.Key.Name, true);
+        }
+
+        public void HandleActionRemoveAllStorage()
+        {
+            //Console.WriteLine($"{Name}.HandleActionRemoveAllStorage()");
+
+            if (Guests.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guest list is empty.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var storage = Guests.Where(g => g.Value).ToList();
+
+            if (storage.Count == 0)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"Your house guests don't have storage access.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            foreach (var guest in storage)
+                HandleActionModifyStorage(guest.Key.Name, false);
+        }
+
+        public void HandleActionBoot(string playerName)
+        {
+            //Console.WriteLine($"{Name}.HandleActionBoot({playerName})");
+
+            var player = PlayerManager.GetOnlinePlayer(playerName);
+
+            if (player == null)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{playerName} is not online.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            // is this player in the house landcell?
+            if (player.Location.GetOutdoorCell() != House.Location.GetOutdoorCell())
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"{player.Name} is not on your property.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            // play script?
+            player.Teleport(House.BootSpot.Location);
+
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"{player.Name} has been booted from your house.", ChatMessageType.Broadcast));
+
+            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} has booted you from their house.", ChatMessageType.Broadcast));
+        }
+
+        public void HandleActionBootAll(bool guests = true)
+        {
+            //Console.WriteLine($"{Name}.HandleActionBootAll()");
+
+            // since it can be an open house, the guest list wouldn't be enough here?
+            var players = PlayerManager.GetAllOnline();
+
+            var houseLandblock = House.Location.Landblock;
+            var houseCell = House.Location.GetOutdoorCell();
+
+            var booted = 0;
+            foreach (var player in players)
+            {
+                // exclude self
+                if (player.Equals(this)) continue;
+
+                // quick test
+                if (player.Location.Landblock != houseLandblock)
+                    continue;
+
+                if (player.Location.GetOutdoorCell() != houseCell)
+                    continue;
+
+                // keep guests if closing house
+                if (!guests && Guests.ContainsKey(player))
+                    continue;
+
+                HandleActionBoot(player.Name);
+                booted++;
+            }
+
+            if (guests && booted == 0)
+            {
+                var elseStr = Location.GetOutdoorCell() == houseCell ? "else " : "";
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"There is no one {elseStr}on your property.", ChatMessageType.Broadcast));
+            }
+        }
+
+        public void HandleActionListAvailable(HouseType houseType)
+        {
+            Console.WriteLine($"{Name}.HandleActionListAvailable({houseType})");
+        }
+
+        // allegiance guest permissions
+
+        public byte HouseSequence;
+
+        public void UpdateRestrictionDB()
+        {
+            // fix event broadcast so it doesn't require a player session beforehand
+            var house = GetHouse();
+            if (house.PhysicsObj == null) return;
+
+            HouseSequence++;
+
+            Sync(house);
+
+            var restrictions = new RestrictionDB(house);
+
+            var nearbyPlayers = house.PhysicsObj.ObjMaint.VoyeurTable.Values.Select(v => (Player)v.WeenieObj.WorldObject).ToList();
+            foreach (var player in nearbyPlayers)
+                player.Session.Network.EnqueueSend(new GameEventHouseUpdateRestrictions(player.Session, house.Guid, restrictions, HouseSequence));
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -142,7 +142,7 @@ namespace ACE.Server.WorldObjects
             //Location = newPosition;
             //SendUpdatePosition();
 
-            UpdatePlayerPhysics(newPosition, true);
+            UpdatePlayerPhysics(new Position(newPosition), true);
 
             Hidden = true;
             IgnoreCollisions = true;

--- a/Source/ACE.Server/WorldObjects/Storage.cs
+++ b/Source/ACE.Server/WorldObjects/Storage.cs
@@ -42,7 +42,7 @@ namespace ACE.Server.WorldObjects
             if (player == null) return;
 
             // verify permissions to use storage
-            if (HouseOwner == null || HouseOwner.Value != player.Guid.Full)
+            if (!House.HasPermission(player))
             {
                 player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"The {Name} is locked!"));
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -155,8 +155,10 @@ namespace ACE.Server.WorldObjects
                 writer.Write(HouseOwner ?? 0);
 
             if ((weenieFlags & WeenieHeaderFlag.HouseRestrictions) != 0)
-                //writer.Write(HouseRestrictions ?? 0u);
-                writer.Write(new RestrictionDB());
+            {
+                var house = this as House;
+                writer.Write(new RestrictionDB(house));
+            }
 
             if ((weenieFlags & WeenieHeaderFlag.HookItemTypes) != 0)
                 writer.Write((uint?)HookItemType ?? 0);
@@ -716,9 +718,9 @@ namespace ACE.Server.WorldObjects
             if (HouseOwner != null)
                 weenieHeaderFlag |= WeenieHeaderFlag.HouseOwner;
 
-            //TODO: HousingRestriction ACL property
             //if (HouseRestrictions != null)
-            //    weenieHeaderFlag |= WeenieHeaderFlag.HouseRestrictions;
+            if (this is House)
+                weenieHeaderFlag |= WeenieHeaderFlag.HouseRestrictions;
 
             var hookItemTypeInt = GetProperty(PropertyInt.HookItemType);
             if (hookItemTypeInt != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1096,22 +1096,11 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.House); else SetProperty(PropertyInstanceId.House, value.Value); }
         }
 
-        public int? HouseType
-        {
-            get => GetProperty(PropertyInt.HouseType);
-            set { if (value.HasValue) RemoveProperty(PropertyInt.HouseType); else SetProperty(PropertyInt.HouseType, value.Value); }
-        }
-
-        /// <summary>
-        /// Housing links to another packet, that needs sent.. The HouseRestrictions ACL Control list that contains all the housing data
-        /// </summary>
         public uint? HouseOwner
         {
             get => GetProperty(PropertyInstanceId.HouseOwner);
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.HouseOwner); else SetProperty(PropertyInstanceId.HouseOwner, value.Value); }
         }
-
-        public uint? HouseRestrictions { get; set; }
 
         /// <summary>
         /// The timestamp the player originally purchased house
@@ -1120,6 +1109,18 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyInt.HousePurchaseTimestamp);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.HousePurchaseTimestamp); else SetProperty(PropertyInt.HousePurchaseTimestamp, value.Value); }
+        }
+
+        public int HouseStatus
+        {
+            get => GetProperty(PropertyInt.HouseStatus) ?? 0;
+            set { if (value == 0) RemoveProperty(PropertyInt.HouseStatus); else SetProperty(PropertyInt.HouseStatus, value); }
+        }
+
+        public int? HouseType
+        {
+            get => GetProperty(PropertyInt.HouseType);
+            set { if (value.HasValue) RemoveProperty(PropertyInt.HouseType); else SetProperty(PropertyInt.HouseType, value.Value); }
         }
 
         public int? HookItemType


### PR DESCRIPTION
The following commands have been added for housing:

@house boot <name> - Removes a player from your house.
@house boot -all - Removes everyone from your house.
@house guest add <name> - Adds players to your house guest list.
@house guest remove <name> - Removes players from your house guest list.
@house guest remove_all - Removes all guests from your house guest list.
@house guest list - Shows the current guest list.
@house storage add <name> - Gives a player permission to use your house storage.
@house storage remove <name> - Removes permission to use your house storage from a player.
@house storage remove_all - Removes all storage permissions from guests.
@house open - Creates an open house.
@house close - Closes your house.
@house hooks on|off - Makes the hooks in your house visible or invisible.

This patch requires a new table to be added to the shard database:
install Database/Updates/Shard/HousePermission.sql