### PR TITLE
Improved enchantment layering

### DIFF
--- a/Database/Updates/Shard/2018-12-31-00-Enchantment-Index.sql
+++ b/Database/Updates/Shard/2018-12-31-00-Enchantment-Index.sql
@@ -1,3 +1,0 @@
-ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `enchantment_Category_idx` (`enchantment_Category`);
-ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `power_Level_idx` (`power_Level`);
-ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `layer_Id_idx` (`layer_Id`);

--- a/Database/Updates/Shard/2018-12-31-00-Enchantment-Index.sql
+++ b/Database/Updates/Shard/2018-12-31-00-Enchantment-Index.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `enchantment_Category_idx` (`enchantment_Category`);
+ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `power_Level_idx` (`power_Level`);
+ALTER TABLE `biota_properties_enchantment_registry` ADD INDEX `layer_Id_idx` (`layer_Id`);

--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using ACE.Database.Models.Shard;
+using ACE.Server.Managers;
+
+namespace ACE.Server.Entity
+{
+    /// <summary>
+    /// The result of adding an enchantment,
+    /// and where it fits into the current stack
+    /// </summary>
+    public class AddEnchantmentResult
+    {
+        /// <summary>
+        ///  The resulting enchantment that was added or refreshed
+        ///  This is set in EnchantmentManager.Add()
+        /// </summary>
+        public BiotaPropertiesEnchantmentRegistry Enchantment;
+
+        /// <summary>
+        /// Determines how this enchantment relates
+        /// to the most powerful spell in this category
+        /// for the surpassing / refreshing / surpassed by message
+        /// </summary>
+        public StackType StackType;
+
+        /// <summary>
+        /// A list of existing enchantments in this stack 
+        /// </summary>
+        public List<BiotaPropertiesEnchantmentRegistry> Surpass;
+        public List<BiotaPropertiesEnchantmentRegistry> Refresh;
+        public List<BiotaPropertiesEnchantmentRegistry> Surpassed;
+
+        /// <summary>
+        /// The most powerful spells in this stack,
+        /// for each stack type
+        /// </summary>
+        public Spell SurpassSpell;
+        public Spell RefreshSpell;
+        public Spell SurpassedSpell;
+
+        /// <summary>
+        /// This handles situations where the same spell can come
+        /// from both a creature and item source
+        /// </summary>
+        public BiotaPropertiesEnchantmentRegistry RefreshCreature;
+
+        public ushort TopLayerId;
+
+        public ushort NextLayerId => (ushort)(TopLayerId + 1);
+
+        public AddEnchantmentResult() { }
+
+        public AddEnchantmentResult(StackType stackType)
+        {
+            StackType = stackType;
+        }
+
+        public void BuildStack(List<BiotaPropertiesEnchantmentRegistry> entries, Spell spell)
+        {
+            Surpass = new List<BiotaPropertiesEnchantmentRegistry>();
+            Refresh = new List<BiotaPropertiesEnchantmentRegistry>();
+            Surpassed = new List<BiotaPropertiesEnchantmentRegistry>();
+
+            var powerLevel = spell.Power;
+
+            foreach (var entry in entries)
+            {
+                if (powerLevel > entry.PowerLevel)
+                {
+                    // surpassing existing spell
+                    Surpass.Add(entry);
+                }
+                else if (powerLevel == entry.PowerLevel)
+                {
+                    // refreshing existing spell
+                    Refresh.Add(entry);
+
+                    // this could be valid
+                    // consider the case: i equip an item that casts strength 6 on me
+                    // then i cast strength 6 on myself
+                    // the self-cast would find the existing spell from the item, but it wouldn't refresh that one
+                    // it should cast to its own layer?
+
+                    if (Refresh.Count > 1)
+                        Console.WriteLine($"AddEnchantmentResult.BuildStack(): multiple refresh entries");
+                }
+                else if (powerLevel < entry.PowerLevel)
+                {
+                    // surpassed by existing spell
+                    Surpassed.Add(entry);
+                }
+
+                if (entry.LayerId > TopLayerId)
+                    TopLayerId = entry.LayerId;
+            }
+
+            SetStackType();
+            SetSpell();
+
+            if (Refresh.Count > 0)
+                SetRefreshCreature();
+        }
+
+        public void SetStackType()
+        {
+            if (Surpassed.Count > 0)
+                StackType = StackType.Surpassed;
+            else if (Refresh.Count > 0)
+                StackType = StackType.Refresh;
+            else if (Surpass.Count > 0)
+                StackType = StackType.Surpass;
+        }
+
+        public void SetSpell()
+        {
+            if (Surpass.Count > 0)
+                SurpassSpell = new Spell(Surpass[0].SpellId, false);
+
+            if (Refresh.Count > 0)
+                RefreshSpell = new Spell(Refresh[0].SpellId, false);
+
+            if (Surpassed.Count > 0)
+                SurpassedSpell = new Spell(Surpassed[0].SpellId, false);
+        }
+
+        public void SetRefreshCreature()
+        {
+            foreach (var refresh in Refresh)
+            {
+                if (refresh.Duration != -1)
+                {
+                    if (RefreshCreature != null)
+                        Console.WriteLine($"AddEnchantmentResult.GetCreatureRefresh(): found multiple duration spells");
+
+                    RefreshCreature = refresh;
+                }
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -82,8 +82,8 @@ namespace ACE.Server.Entity
                     // the self-cast would find the existing spell from the item, but it wouldn't refresh that one
                     // it should cast to its own layer?
 
-                    if (Refresh.Count > 1)
-                        Console.WriteLine($"AddEnchantmentResult.BuildStack(): multiple refresh entries");
+                    //if (Refresh.Count > 1)
+                        //Console.WriteLine($"AddEnchantmentResult.BuildStack(): multiple refresh entries");
                 }
                 else if (powerLevel < entry.PowerLevel)
                 {
@@ -130,8 +130,8 @@ namespace ACE.Server.Entity
             {
                 if (refresh.Duration != -1)
                 {
-                    if (RefreshCreature != null)
-                        Console.WriteLine($"AddEnchantmentResult.GetCreatureRefresh(): found multiple duration spells");
+                    //if (RefreshCreature != null)
+                        //Console.WriteLine($"AddEnchantmentResult.GetCreatureRefresh(): found multiple duration spells");
 
                     RefreshCreature = refresh;
                 }

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -169,7 +169,7 @@ namespace ACE.Server.Managers
 
                     if (creature != null)
                     {
-                        var spell = new Entity.Spell((uint)emote.SpellId);
+                        var spell = new Spell((uint)emote.SpellId);
                         if (targetObject != null && spell.TargetEffect > 0)
                             creature.CreateCreatureSpell(targetObject.Guid, (uint)emote.SpellId);
                         else

--- a/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
@@ -23,9 +23,9 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public override (StackType stackType, Spell surpass) Add(Enchantment enchantment, WorldObject caster)
+        public override AddEnchantmentResult Add(Spell spell, WorldObject caster)
         {
-            var result = base.Add(enchantment, caster);
+            var result = base.Add(spell, caster);
 
             ClearCache();
 

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -65,7 +65,7 @@ namespace ACE.Server.Network.Structure
         }
     }
 
-    public static class EnchantmentExtentions
+    public static class EnchantmentExtensions
     {
         public static readonly double LastTimeDegraded = 0;
         public static readonly float DefaultStatMod = 35.0f;

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -40,8 +40,8 @@ namespace ACE.Server.Network.Structure
                 return;
 
             DamageType = (DamageType)(weapon.GetProperty(PropertyInt.DamageType) ?? 0);
-            if (DamageType == 0)
-                Console.WriteLine("Warning: WeaponProfile undefined damage type for " + weapon.Guid);
+            //if (DamageType == 0)
+                //Console.WriteLine($"Warning: WeaponProfile undefined damage type for {weapon.Name} ({weapon.Guid})");
 
             WeaponTime = GetWeaponSpeed(weapon, wielder);
             WeaponSkill = (Skill)(weapon.GetProperty(PropertyInt.WeaponSkill) ?? 0);

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -734,9 +734,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            var enchantment = new Enchantment(target, Guid, (uint)spellID, 20, 1, EnchantmentMask.CreatureSpells);
-
-            target.EnchantmentManager.Add(enchantment, this);
+            target.EnchantmentManager.Add(spell, this);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, ACE.Entity.Enum.PlayScript.DirtyFightingDefenseDebuff));
 
             FightDirty_SendMessage(target, spell);
@@ -755,9 +753,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            var enchantment = new Enchantment(target, Guid, (uint)spellID, 20, 1, EnchantmentMask.CreatureSpells);
-
-            target.EnchantmentManager.Add(enchantment, this);
+            target.EnchantmentManager.Add(spell, this);
 
             // only send if not already applied?
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, ACE.Entity.Enum.PlayScript.DirtyFightingDamageOverTime));
@@ -778,9 +774,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            var enchantment = new Enchantment(target, Guid, (uint)spellID, 20, 1, EnchantmentMask.CreatureSpells);
-
-            target.EnchantmentManager.Add(enchantment, this);
+            target.EnchantmentManager.Add(spell, this);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, ACE.Entity.Enum.PlayScript.DirtyFightingAttackDebuff));
 
             FightDirty_SendMessage(target, spell);
@@ -792,9 +786,7 @@ namespace ACE.Server.WorldObjects
             spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            enchantment = new Enchantment(target, Guid, (uint)spellID, 20, 1, EnchantmentMask.CreatureSpells);
-
-            target.EnchantmentManager.Add(enchantment, this);
+            target.EnchantmentManager.Add(spell, this);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, ACE.Entity.Enum.PlayScript.DirtyFightingHealDebuff));
 
             FightDirty_SendMessage(target, spell);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -14,7 +14,6 @@ using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
 using ACE.Server.Network;
-using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Structure;


### PR DESCRIPTION
This fixes some differences between the way ACE was handling Enchantment layers that differed from retail

Previously, for the 'surpassed' and 'surpassing' cases, ACE would not write enchantments if they were surpassed by an existing enchantment, or in the 'surpassing' case, it would modify the old enchantment, instead of adding a new layer.

The proper functionality here is to write the new enchantments in both cases, always increasing the layer id.

Also previously, ACE was sort of implicitly managing the most powerful enchantment as always being the top layer enchantment for that category (in GetEnchantments_TopLayer). Since it can no longer be assumed that the top layer id for category is the most powerful enchantment, this function has been modified so that it sorts by descending PowerLevel within the category, instead of descending LayerID

The enchantments db table has also been updated to index all of the fields we are searching on in the enchantment queries. This greatly improves the speed of the EnchantmentManager queries.

This also fixes some bugs with layering between creature-cast and item-cast enchantments, particularly when an item casts a spell that a creature already has. This was the cause of one of the EF duplicate key errors in https://github.com/ACEmulator/ACE/issues/1194, particularly the one reported by @fartwhif for the enchantments table.

The repro steps for this issue are:

/dispel
/buff &lt;self&gt; 3
/ci gemlugianarmor3
&lt;use gem&gt;
&lt;log out&gt;

This should fix some of the core architecture issues that https://github.com/ACEmulator/ACE/pull/1203 patched