### PR TITLE
Fixing vendor trade notes

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -174,6 +174,8 @@ namespace ACE.Server.WorldObjects
 
                     foreach (var gen in genlist)
                         TryCreateInInventoryWithNetworking(gen);
+
+                    Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.PickUpItem));
                 }
                 else // not enough cash.
                 {
@@ -181,7 +183,7 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-            vendor.BuyItemsFinalTransaction(this, uqlist, valid);
+            vendor.BuyItems_FinalTransaction(this, uqlist, valid);
         }
 
         public void FinalizeSellTransaction(WorldObject vendor, bool valid, List<WorldObject> purchaselist, uint payout)
@@ -190,6 +192,8 @@ namespace ACE.Server.WorldObjects
             if (valid)
             {
                 CreateCurrency(WeenieType.Coin, payout);
+
+                Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.PickUpItem));
             }
         }
 
@@ -208,7 +212,7 @@ namespace ACE.Server.WorldObjects
             var vendor = (CurrentLandblock?.GetObject(vendorId) as Vendor);
 
             if (vendor != null)
-                vendor.BuyValidateTransaction(vendorId, items, this);
+                vendor.BuyItems_ValidateTransaction(vendorId, items, this);
         }
 
         /// <summary>
@@ -260,7 +264,7 @@ namespace ACE.Server.WorldObjects
             var vendor = CurrentLandblock?.GetObject(vendorId) as Vendor;
 
             if (vendor != null)
-                vendor.SellItemsValidateTransaction(this, purchaselist);
+                vendor.SellItems_ValidateTransaction(this, purchaselist);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -14,12 +14,14 @@ using log4net;
 namespace ACE.Server.WorldObjects
 {
     /// <summary>
-    /// ** Usage Data Flow **
-    ///     HandleActionApproachVendor
     /// ** Buy Data Flow **
-    /// Player.HandleActionBuy->Vendor.BuyItemsValidateTransaction->Player.HandleActionBuyFinalTransaction->Vendor.BuyItemsFinalTransaction
+    ///
+    /// Player.HandleActionBuyItem -> Vendor.BuyItems_ValidateTransaction -> Player.FinalizeBuyTransaction -> Vendor.BuyItems_FinalTransaction
+    ///     
     /// ** Sell Data Flow **
-    /// Player.HandleActionSell->Vendor.SellItemsValidateTransaction->Player.HandleActionSellFinalTransaction->Vendor.SellItemsFinalTransaction
+    ///
+    /// Player.HandleActionSellItem -> Vendor.SellItems_ValidateTransaction -> Player.FinalizeSellTransaction -> Vendor.SellItems_FinalTransaction
+    /// 
     /// </summary>
     public class Vendor : Creature
     {
@@ -51,7 +53,6 @@ namespace ACE.Server.WorldObjects
             BaseDescriptionFlags |= ObjectDescriptionFlag.Vendor;
         }
 
-
         /// <summary>
         /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />
@@ -68,7 +69,7 @@ namespace ACE.Server.WorldObjects
             var actionChain = new ActionChain();
             var rotateTime = Rotate(player);    // vendor rotates towards player
             actionChain.AddDelaySeconds(rotateTime);
-            actionChain.AddAction(this, () => ApproachVendor(player));
+            actionChain.AddAction(this, () => ApproachVendor(player, VendorType.Open));
             actionChain.EnqueueChain();
         }
 
@@ -95,7 +96,6 @@ namespace ACE.Server.WorldObjects
                         defaultItemsForSale.Add(wo.Guid, wo);
                     }
                 }
-
                 inventoryloaded = true;
             }
         }
@@ -141,10 +141,11 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Sends Vendor Inventory to player
+        /// Sends the latest vendor inventory list to player,
+        /// rotates vendor towards player, and performs the appropriate emote.
         /// </summary>
-        /// <param name="player"></param>
-        private void ApproachVendor(Player player)
+        /// <param name="action">The action performed by the player</param>
+        private void ApproachVendor(Player player, VendorType action = VendorType.Undef)
         {
             // default inventory
             List<WorldObject> vendorlist = new List<WorldObject>();
@@ -160,20 +161,20 @@ namespace ACE.Server.WorldObjects
             player.ApproachVendor(this, vendorlist);
 
             var rotateTime = Rotate(player); // vendor rotates to player
-            DoVendorEmote(VendorType.Open, player);
+
+            if (action != VendorType.Undef)
+            {
+                DoVendorEmote(action, player);
+            }
         }
 
 
         /// <summary>
-        /// Player has started a buy transaction
-        /// Create objects, send object to player for final validation.
+        /// Handles validation for player buying items from vendor
         /// </summary>
-        /// <param name="vendorid">GUID of Vendor</param>
-        /// <param name="items">Item Profile, Ammount and ID</param>
-        /// <param name="player"></param>
-        public void BuyValidateTransaction(ObjectGuid vendorid, List<ItemProfile> items, Player player)
+        public void BuyItems_ValidateTransaction(ObjectGuid vendorid, List<ItemProfile> items, Player player)
         {
-            // que transactions.
+            // queue transactions
             List<ItemProfile> filteredlist = new List<ItemProfile>();
             List<WorldObject> uqlist = new List<WorldObject>();
             List<WorldObject> genlist = new List<WorldObject>();
@@ -210,16 +211,20 @@ namespace ACE.Server.WorldObjects
             // calculate price. (both unique and item profile)
             foreach (WorldObject wo in uqlist)
             {
-                goldcost = goldcost + (uint)Math.Ceiling((SellPrice ?? 1) * (wo.Value ?? 0) - 0.1);
-                wo.Value = wo.Value;                    // Also set the stack's value for unique items, using the builtin WO calculations
-                wo.EncumbranceVal = wo.EncumbranceVal;  // Also set the stack's encumbrance for unique items, using the builtin WO calculations
+                var sellRate = SellPrice ?? 1.0;
+                if (wo.ItemType == ItemType.PromissoryNote)
+                    sellRate = 1.15;
+
+                goldcost += (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1);
             }
 
             foreach (WorldObject wo in genlist)
             {
-                goldcost = goldcost + (uint)Math.Ceiling((SellPrice ?? 1) * (wo.Value ?? 0) - 0.1);
-                wo.Value = wo.Value;                    // Also set the stack's value for stock items, using the builtin WO calculations
-                wo.EncumbranceVal = wo.EncumbranceVal;  // Also set the stack's encumbrance for stock items, using the builtin WO calculations
+                var sellRate = SellPrice ?? 1.0;
+                if (wo.ItemType == ItemType.PromissoryNote)
+                    sellRate = 1.15;
+
+                goldcost += (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1);
             }
 
             // send transaction to player for further processing and.
@@ -227,10 +232,10 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Handles the final phase of the transaction.. removing unique items and updating players local
-        /// from vendors items list.
+        /// Handles the final phase of the transaction
+        ///  for player buying items from vendor
         /// </summary>
-        public void BuyItemsFinalTransaction(Player player, List<WorldObject> uqlist, bool valid)
+        public void BuyItems_FinalTransaction(Player player, List<WorldObject> uqlist, bool valid)
         {
             if (!valid) // re-add unique temp stock items.
             {
@@ -240,12 +245,13 @@ namespace ACE.Server.WorldObjects
                         uniqueItemsForSale.Add(wo.Guid, wo);
                 }
             }
-
-            ApproachVendor(player);
+            ApproachVendor(player, VendorType.Buy);
         }
 
-
-        public void SellItemsValidateTransaction(Player player, List<WorldObject> items)
+        /// <summary>
+        /// Handles validation for player selling items to vendor
+        /// </summary>
+        public void SellItems_ValidateTransaction(Player player, List<WorldObject> items)
         {
             // todo: filter rejected / accepted send item spec result back to player
             uint payout = 0;
@@ -254,9 +260,12 @@ namespace ACE.Server.WorldObjects
 
             foreach (WorldObject wo in items)
             {
+                var buyRate = BuyPrice ?? 1;
+                if (wo.ItemType == ItemType.PromissoryNote)
+                    buyRate = 1.0;
+
                 // payout scaled by the vendor's buy rate
-                //for each looks at each item, stack or not, so no need to multiple by stack size.
-                payout = payout + (uint)Math.Floor((BuyPrice ?? 1) * (wo.Value ?? 0) + 0.1);
+                payout += (uint)Math.Floor((wo.Value ?? 0) * buyRate + 0.1);
 
                 if (!wo.MaxStackSize.HasValue & !wo.MaxStructure.HasValue)
                 {
@@ -265,15 +274,14 @@ namespace ACE.Server.WorldObjects
                     wo.PlacementPosition = null;
                     wo.WielderId = null;
                     wo.CurrentWieldedLocation = null;
-                    // TODO: create enum for this once we understand this better.
-                    // This is needed to make items lay flat on the ground.
-                    wo.Placement = global::ACE.Entity.Enum.Placement.Resting;
+                    wo.Placement = ACE.Entity.Enum.Placement.Resting;
                     uniqueItemsForSale.Add(wo.Guid, wo);
                 }
                 accepted.Add(wo);
             }
 
-            ApproachVendor(player);
+            ApproachVendor(player, VendorType.Sell);
+
             player.FinalizeSellTransaction(this, true, accepted, payout);
         }
 
@@ -282,6 +290,14 @@ namespace ACE.Server.WorldObjects
             switch (vendorType)
             {
                 case VendorType.Open:
+                    EmoteManager.DoVendorEmote(vendorType, player);
+                    break;
+
+                case VendorType.Buy:    // player buys item from vendor
+                    EmoteManager.DoVendorEmote(vendorType, player);
+                    break;
+
+                case VendorType.Sell:   // player sells item to vendor
                     EmoteManager.DoVendorEmote(vendorType, player);
                     break;
 

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -327,6 +327,13 @@ namespace ACE.Server.WorldObjects
             if (LastPlayer == null)
                 return;
 
+            // handles player logging out at vendor
+            if (LastPlayer.CurrentLandblock == null)
+            {
+                LastPlayer = null;
+                return;
+            }
+
             var dist = Vector3.Distance(Location.ToGlobal(), LastPlayer.Location.ToGlobal());
             if (dist > UseRadius)
             {


### PR DESCRIPTION
This fixes a bug where vendor buy/sell prices for trade notes weren't matched up on the server

This resulted in the player thinking they were buying a trade node for a certain price, and then being charged a lot more for it

It also resulted in a player selling a trade note to a vendor, and receiving less than the actual trade note value

This also adds various small vendor details, such as the Buy/Sell emotes, and PickupEvent sound effects when a transaction has been made