### PR TITLE
Adding case insensitive quest lookup to emote

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -1029,7 +1029,7 @@ namespace ACE.Server.Managers
 
             // optional criteria
             if (questName != null)
-                emoteSet = emoteSet.Where(e => e.Quest.Equals(questName));
+                emoteSet = emoteSet.Where(e => e.Quest.Equals(questName, StringComparison.OrdinalIgnoreCase));
             if (vendorType != null)
                 emoteSet = emoteSet.Where(e => e.VendorType != null && e.VendorType.Value == (uint)vendorType);
             if (wcid != null)

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -74,7 +74,7 @@ namespace ACE.Server.Managers
         /// </summary>
         public CharacterPropertiesQuestRegistry GetQuest(string questName)
         {
-            return Quests.FirstOrDefault(q => q.QuestName.Equals(questName));
+            return Quests.FirstOrDefault(q => q.QuestName.Equals(questName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace ACE.Server.Managers
         {
             var questName = GetQuestName(quest);
 
-            var existing = Quests.FirstOrDefault(q => q.QuestName == questName);
+            var existing = Quests.FirstOrDefault(q => q.QuestName.Equals(questName, StringComparison.OrdinalIgnoreCase));
 
             if (existing == null)
             {
@@ -185,7 +185,7 @@ namespace ACE.Server.Managers
 
             var questName = GetQuestName(questFormat);
 
-            var quests = Quests.Where(q => q.QuestName.Equals(questName)).ToList();
+            var quests = Quests.Where(q => q.QuestName.Equals(questName, StringComparison.OrdinalIgnoreCase)).ToList();
             foreach (var quest in quests)
                 Quests.Remove(quest);
         }


### PR DESCRIPTION
This can fix some emote chains where there are inconsistencies in uppercase and lowercase letters for the quest names, for example:

https://github.com/ACEmulator/ACE-World-16PY/blob/2176c4566725c33ce691a76cf69954fa891cf0e3/Database/3-Core/9%20WeenieDefaults/SQL/Creature/Human/07560%20Feruza%20ibn%20Salaq.sql

When the player gives Feruza ibn Salaq a Chunk of Low-Grade Chorizite, it updates the quest 'ChoriziteA', but then tries to find the quest 'CHORIZITEA' in all caps for the response.

It is possible this could also fix some other issues with emote/questname lookups, ie. https://github.com/ACEmulator/ACE/issues/1198 (still looking for exact repro steps there)