### PR TITLE
More profiling based improvements

### DIFF
--- a/Source/ACE.Server/Physics/Animation/MotionInterp.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionInterp.cs
@@ -169,6 +169,7 @@ namespace ACE.Server.Physics.Animation
                 }
             }
             PendingMotions.Clear();
+            if (PhysicsObj != null) PhysicsObj.IsAnimating = false;
         }
 
         public void HitGround()
@@ -225,7 +226,10 @@ namespace ACE.Server.Physics.Animation
 
                 motionData = PendingMotions.First;
                 if (motionData != null)
+                {
                     PendingMotions.Remove(motionData);
+                    PhysicsObj.IsAnimating = PendingMotions.Count > 0;
+                }
             }
         }
 
@@ -384,6 +388,7 @@ namespace ACE.Server.Physics.Animation
         public void add_to_queue(int contextID, uint motion, WeenieError jumpErrorCode)
         {
             PendingMotions.AddLast(new MotionNode(contextID, motion, jumpErrorCode));
+            PhysicsObj.IsAnimating = true;
         }
 
         public void adjust_motion(ref uint motion, ref float speed, HoldKey holdKey)
@@ -773,6 +778,9 @@ namespace ACE.Server.Physics.Animation
             return WeenieError.None;
         }
 
+        /// <summary>
+        /// Alternatively, you can use PhysicsObj.IsAnimating for better performance.
+        /// </summary>
         public bool motions_pending()
         {
             return PendingMotions.Count > 0;

--- a/Source/ACE.Server/Physics/Common/ObjCell.cs
+++ b/Source/ACE.Server/Physics/Common/ObjCell.cs
@@ -108,7 +108,7 @@ namespace ACE.Server.Physics.Common
             var target = transition.ObjectInfo.Object.ProjectileTarget;
 
             // TODO: find out what is causing the exception when .ToList() is not used.
-            foreach (var shadowObj in ShadowObjectList.ToList())
+            foreach (var shadowObj in ShadowObjectList)
             {
                 var obj = shadowObj.PhysicsObj;
 

--- a/Source/ACE.Server/Physics/Common/ObjCell.cs
+++ b/Source/ACE.Server/Physics/Common/ObjCell.cs
@@ -123,7 +123,7 @@ namespace ACE.Server.Physics.Common
                 if (state != TransitionState.OK)
                 {
                     // custom: fix hellfire spawn colliding with volcano heat, and possibly other placements
-                    if (path.InsertType == InsertType.Placement && obj.State.HasFlag(PhysicsState.Ethereal))
+                    if (path.InsertType == InsertType.Placement && (obj.State & PhysicsState.Ethereal) != 0)
                         continue;
 
                     return state;

--- a/Source/ACE.Server/Physics/Managers/MoveToManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MoveToManager.cs
@@ -420,7 +420,7 @@ namespace ACE.Server.Physics.Animation
             movementParams.Speed = MovementParams.Speed;
             movementParams.HoldKeyToApply = MovementParams.HoldKeyToApply;
 
-            if (!PhysicsObj.motions_pending())
+            if (!PhysicsObj.IsAnimating)
             {
                 var heading = MovementParams.get_desired_heading(CurrentCommand, MovingAway) + curPos.heading(CurrentTargetPosition);
                 if (heading >= 360.0f) heading -= 360.0f;
@@ -456,7 +456,7 @@ namespace ACE.Server.Physics.Animation
 
             if (!CheckProgressMade(dist))
             {
-                if (!PhysicsObj.IsInterpolating() && !PhysicsObj.motions_pending())
+                if (!PhysicsObj.IsInterpolating() && !PhysicsObj.IsAnimating)
                     FailProgressCount++;
             }
             else
@@ -604,7 +604,7 @@ namespace ACE.Server.Physics.Animation
             {
                 PreviousHeading = heading;
 
-                if (!PhysicsObj.IsInterpolating() && !PhysicsObj.motions_pending())
+                if (!PhysicsObj.IsInterpolating() && !PhysicsObj.IsAnimating)
                     FailProgressCount++;
             }
         }

--- a/Source/ACE.Server/Physics/Managers/MovementManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MovementManager.cs
@@ -188,6 +188,9 @@ namespace ACE.Server.Physics.Animation
             return MotionInterpreter;
         }
 
+        /// <summary>
+        /// Alternatively, you can use PhysicsObj.IsAnimating for better performance.
+        /// </summary>
         public bool motions_pending()
         {
             if (MotionInterpreter == null) return false;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1471,10 +1471,10 @@ namespace ACE.Server.Physics
 
         public void UpdateObjectInternal(double quantum)
         {
-            if (!TransientState.HasFlag(TransientStateFlags.Active) || CurCell == null)
+            if ((TransientState & TransientStateFlags.Active) == 0 || CurCell == null)
                 return;
 
-            if (TransientState.HasFlag(TransientStateFlags.CheckEthereal))
+            if ((TransientState & TransientStateFlags.CheckEthereal) != 0)
                 set_ethereal(false, false);
 
             JumpedThisFrame = false;
@@ -1491,12 +1491,12 @@ namespace ACE.Server.Physics
                 }
                 else
                 {
-                    if (State.HasFlag(PhysicsState.AlignPath))
+                    if ((State & PhysicsState.AlignPath) != 0)
                     {
                         var diff = newPos.Frame.Origin - Position.Frame.Origin;
                         newPos.Frame.set_vector_heading(Vector3.Normalize(diff));
                     }
-                    else if (State.HasFlag(PhysicsState.Sledding) && Velocity != Vector3.Zero)
+                    else if ((State & PhysicsState.Sledding) != 0 && Velocity != Vector3.Zero)
                         newPos.Frame.set_vector_heading(Vector3.Normalize(Velocity));
                 }
 
@@ -1517,7 +1517,7 @@ namespace ACE.Server.Physics
             }
             else
             {
-                if (MovementManager == null && TransientState.HasFlag(TransientStateFlags.OnWalkable))
+                if (MovementManager == null && (TransientState & TransientStateFlags.OnWalkable) != 0)
                     TransientState &= ~TransientStateFlags.Active;
 
                 newPos.Frame.Origin = Position.Frame.Origin;
@@ -3665,11 +3665,11 @@ namespace ACE.Server.Physics
 
             trans.InitPath(CurCell, oldPos, newPos);
 
-            if (TransientState.HasFlag(TransientStateFlags.StationaryStuck))
+            if ((TransientState & TransientStateFlags.StationaryStuck) != 0)
                 trans.CollisionInfo.FramesStationaryFall = 3;
-            else if (TransientState.HasFlag(TransientStateFlags.StationaryStop))
+            else if ((TransientState & TransientStateFlags.StationaryStop) != 0)
                 trans.CollisionInfo.FramesStationaryFall = 2;
-            else if (TransientState.HasFlag(TransientStateFlags.StationaryFall))
+            else if ((TransientState & TransientStateFlags.StationaryFall) != 0)
                 trans.CollisionInfo.FramesStationaryFall = 1;
 
             var validPos = trans.FindValidPosition();

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -2848,7 +2848,7 @@ namespace ACE.Server.Physics
 
         public void remove_shadows_from_cells()
         {
-            foreach (var shadowObj in ShadowObjects.Values.ToList())
+            foreach (var shadowObj in ShadowObjects.Values)
             {
                 if (shadowObj.Cell == null) continue;
                 var cell = shadowObj.Cell;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -81,6 +81,11 @@ namespace ACE.Server.Physics
         public double PhysicsTimer_CurrentTime;
         public bool DatObject = false;
 
+        /// <summary>
+        /// This is managed by MovementManager.MotionInterpreter, and should not be updated anywhere else.
+        /// </summary>
+        public bool IsAnimating;
+
         // server
         public Position RequestPos;
 
@@ -2588,11 +2593,6 @@ namespace ACE.Server.Physics
             particle.State = PhysicsState.Static | PhysicsState.ReportCollisions;
             particle.PartArray = PartArray.CreateParticle(particle, numParts, sortingSphere);
             return particle;
-        }
-
-        public bool motions_pending()
-        {
-            return MovementManager != null && MovementManager.motions_pending();
         }
 
         public bool movement_is_autonomous()

--- a/Source/ACE.Server/Physics/Transition.cs
+++ b/Source/ACE.Server/Physics/Transition.cs
@@ -729,7 +729,7 @@ namespace ACE.Server.Physics.Animation
             SpherePath.StepDown = false;
 
             if (transitionState == TransitionState.OK && CollisionInfo.ContactPlaneValid && CollisionInfo.ContactPlane.Normal.Z >= zVal &&
-                (!ObjectInfo.State.HasFlag(ObjectInfoState.EdgeSlide) || SpherePath.StepUp || CheckWalkable(zVal)))
+                ((ObjectInfo.State & ObjectInfoState.EdgeSlide) == 0 || SpherePath.StepUp || CheckWalkable(zVal)))
             {
                 SpherePath.Backup = SpherePath.InsertType;
                 SpherePath.InsertType = InsertType.Placement;
@@ -840,7 +840,7 @@ namespace ACE.Server.Physics.Animation
                         }
                         else
                         {
-                            if (CollisionInfo.ContactPlaneValid || !ObjectInfo.State.HasFlag(ObjectInfoState.Contact) ||
+                            if (CollisionInfo.ContactPlaneValid || (ObjectInfo.State & ObjectInfoState.Contact) == 0 ||
                                 SpherePath.StepDown || SpherePath.CheckCell == null || ObjectInfo.StepDown)
                             {
                                 return TransitionState.OK;
@@ -849,7 +849,7 @@ namespace ACE.Server.Physics.Animation
                             var zVal = PhysicsGlobals.LandingZ;
                             var stepDownHeight = 0.039999999f;  // set global
 
-                            if (ObjectInfo.State.HasFlag(ObjectInfoState.OnWalkable))
+                            if ((ObjectInfo.State & ObjectInfoState.OnWalkable) != 0)
                             {
                                 zVal = ObjectInfo.GetWalkableZ();
                                 stepDownHeight = ObjectInfo.StepDownHeight;

--- a/Source/ACE.Server/Physics/Transition.cs
+++ b/Source/ACE.Server/Physics/Transition.cs
@@ -510,7 +510,7 @@ namespace ACE.Server.Physics.Animation
                 return false;
             }
 
-            if (ObjectInfo.State.HasFlag(ObjectInfoState.FreeRotate))
+            if ((ObjectInfo.State & ObjectInfoState.FreeRotate) != 0)
                 SpherePath.CurPos.Frame.set_rotate(SpherePath.EndPos.Frame.Orientation);
 
             SpherePath.SetCheckPos(SpherePath.CurPos, SpherePath.CurCell);
@@ -518,7 +518,7 @@ namespace ACE.Server.Physics.Animation
             var redo = 0;
             if (numSteps <= 0)
             {
-                if (!ObjectInfo.State.HasFlag(ObjectInfoState.FreeRotate))  // ?
+                if ((ObjectInfo.State & ObjectInfoState.FreeRotate) == 0)  // ?
                     SpherePath.CurPos.Frame.set_rotate(SpherePath.EndPos.Frame.Orientation);
 
                 SpherePath.CellArrayValid = true;
@@ -531,7 +531,7 @@ namespace ACE.Server.Physics.Animation
 
             for (var step = 0; step < numSteps; step++)
             {
-                if (ObjectInfo.State.HasFlag(ObjectInfoState.IsViewer))
+                if ((ObjectInfo.State & ObjectInfoState.IsViewer) != 0)
                 {
                     var lastStep = numSteps - 1;
 
@@ -546,14 +546,14 @@ namespace ACE.Server.Physics.Animation
                     }
                 }
                 SpherePath.GlobalOffset = AdjustOffset(offsetPerStep);
-                if (!ObjectInfo.State.HasFlag(ObjectInfoState.IsViewer))
+                if ((ObjectInfo.State & ObjectInfoState.IsViewer) == 0)
                 {
                     if (SpherePath.GlobalOffset.LengthSquared() < PhysicsGlobals.EPSILON * PhysicsGlobals.EPSILON)
                     {
                         return (step != 0 && transitionState == TransitionState.OK);
                     }
                 }
-                if (!ObjectInfo.State.HasFlag(ObjectInfoState.FreeRotate))
+                if ((ObjectInfo.State & ObjectInfoState.FreeRotate) == 0)
                 {
                     redo = step + 1;
                     var delta = (float)redo / numSteps;
@@ -587,7 +587,7 @@ namespace ACE.Server.Physics.Animation
                     if (CollisionInfo.FramesStationaryFall > 0) break;
                 }
 
-                if (CollisionInfo.CollisionNormalValid && ObjectInfo.State.HasFlag(ObjectInfoState.PathClipped)) break;
+                if (CollisionInfo.CollisionNormalValid && (ObjectInfo.State & ObjectInfoState.PathClipped) != 0) break;
             }
 
             return transitionState == TransitionState.OK;

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -861,7 +861,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns TRUE if this object has non-cyclic animations in progress
         /// </summary>
-        public bool IsAnimating { get => PhysicsObj != null && PhysicsObj.MovementManager != null && PhysicsObj.MovementManager.motions_pending(); }
+        public bool IsAnimating { get => PhysicsObj != null && PhysicsObj.IsAnimating; }
 
         /// <summary>
         /// Executes a motion/animation for this object

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -176,7 +176,7 @@ namespace ACE.Server.WorldObjects
             // determine if updates should be run for object
             //var runUpdate = !monster && (isMissile || !PhysicsObj.IsGrounded);
             //var runUpdate = isMissile;
-            var runUpdate = !monster && (isMissile || /*IsMoving ||*/ /*!PhysicsObj.IsGrounded || */ PhysicsObj.InitialUpdates <= 1 || IsAnimating /*|| contactPlane*/);
+            var runUpdate = !monster && (isMissile || /*IsMoving ||*/ /*!PhysicsObj.IsGrounded || */ PhysicsObj.InitialUpdates <= 1 || PhysicsObj.IsAnimating /*|| contactPlane*/);
 
             if (creature != null)
             {


### PR DESCRIPTION
ToList for this loop was added here: https://github.com/ACEmulator/ACE/pull/917
This ToList consumes 10%+ CPU alone, it's a big one.
I've been load testing this for 2 days now and haven't had a crash yet. I believe we've fixed the concurrency issue in a recent commit.

ToList() removed from remove_shadows_from_cells freeing up 8.5% CPU

Move IsAnimating to PhysicsObj and managed by MotionInterp freeing up 4% CPU

There is still lag, although it's very slightly less, with 100 active load-test macros.