### PR TITLE
Fixing monster corpse spawn bug

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -140,7 +140,7 @@ namespace ACE.Server.WorldObjects
             dieChain.AddDelaySeconds(animLength + 1.0f);
 
             // enter portal space
-            dieChain.AddAction(this, CreateCorpse);
+            dieChain.AddAction(this, () => CreateCorpse(topDamager));
             dieChain.AddAction(this, TeleportOnDeath);
             dieChain.AddAction(this, SetLifestoneProtection);
             dieChain.AddAction(this, SetMinimumTimeSincePK);


### PR DESCRIPTION
This fixes the elusive bug when killing some monsters, where the 'alive' version would appear again, as a frozen/duplicate copy

Thanks to everyone who helped track this one down (Keith, Jyrus)