### PR TITLE
Fix giving items back and forth

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1499,11 +1499,17 @@ namespace ACE.Server.WorldObjects
 
             // This is a hack because our Player_Tracking->RemoveTrackedEquippedObject() is doing GameMessageDeleteObject, not GameMessagePickupEvent
             // Without this, when you give an equipped item to a player, the player won't see it appear in their inventory
-            new ActionChain(target, () =>
+            // A bug still exists in the following scenario:
+            // Player A equips weapon, gives weapon (while equipped) to player B.
+            // Player B then gives weapon back to A. Player B is now bugged. The fix is to fix RemoveTrackedEquippedObject
+            if (itemWasEquipped)
             {
-                target.Session.Network.EnqueueSend(new GameMessageCreateObject(item));
-                target.Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, targetContainer));
-            }).EnqueueChain();
+                new ActionChain(target, () =>
+                {
+                    target.Session.Network.EnqueueSend(new GameMessageCreateObject(item));
+                    target.Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, targetContainer));
+                }).EnqueueChain();
+            }
         }
 
         private void GiveObjecttoNPC(WorldObject target, WorldObject item, Container itemFoundInContainer, Container itemRootOwner, bool itemWasEquipped, int amount, ActionChain actionChain)


### PR DESCRIPTION
We have to add certain "hacks" to the code because Player_Tracking->RemoveTrackedEquippedObject() is doing GameMessageDeleteObject, not GameMessagePickupEvent