### PR TITLE
Players need to DequipWithNetworking on final missile launch

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -111,9 +111,13 @@ namespace ACE.Server.WorldObjects
 
             if (ammo.StackSize == 0)
             {
-                TryDequipObjectWithBroadcasting(ammo.Guid, out _, out _);
-
-                ammo.Destroy();
+                if (this is Player player)
+                    player.TryDequipObjectWithNetworking(ammo.Guid, out _, Player.DequipObjectAction.ConsumeItem);
+                else
+                {
+                    TryDequipObjectWithBroadcasting(ammo.Guid, out _, out _);
+                    ammo.Destroy();
+                }
             }
             else
             {


### PR DESCRIPTION
For players, we TryDequipObjectWithNetworking with ConsumeItem and that will also call the Destroy for us.

Monsters, we TryDequipObjectWithBroadcasting.

Players and Monsters treat this a little differently.

Key being that players use WithNetworking (since they have sessions and require more info), and creatures use WithBroadcasting (since they don't have sessions and don't have clients that need updates)