### PR TITLE
Missiles aren't childeren. Return to peace when dequipping ammo

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChangeCombatMode.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChangeCombatMode.cs
@@ -9,7 +9,7 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             uint newCombatMode = message.Payload.ReadUInt32();
 
-            session.Player.SetCombatMode((CombatMode)newCombatMode);
+            session.Player.HandleGameActionChangeCombatMode((CombatMode)newCombatMode);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -181,7 +181,7 @@ namespace ACE.Server.WorldObjects
             if (IsInChildLocation(worldObject)) // Is this equipped item visible to others?
                 EnqueueBroadcast(false, new GameMessageSound(Guid, Sound.WieldObject));
 
-            if (worldObject.ParentLocation != null && wieldedLocation != (int)EquipMask.MissileAmmo)
+            if (worldObject.ParentLocation != null)
                 EnqueueBroadcast(new GameMessageParentEvent(this, worldObject, (int?)worldObject.ParentLocation ?? 0, (int?)worldObject.Placement ?? 0));
 
             EnqueueBroadcast(new GameMessageObjDescEvent(this));
@@ -259,9 +259,6 @@ namespace ACE.Server.WorldObjects
             if (((EquipMask)item.CurrentWieldedLocation & EquipMask.Selectable) != 0)
                 return true;
 
-            if (((EquipMask)item.CurrentWieldedLocation & EquipMask.MissileAmmo) != 0)
-                return true;
-
             return false;
         }
 
@@ -313,12 +310,6 @@ namespace ACE.Server.WorldObjects
                         placement = ACE.Entity.Enum.Placement.RightHandCombat;
                         parentLocation = ACE.Entity.Enum.ParentLocation.RightHand;
                     }
-                    break;
-
-                case EquipMask.MissileAmmo:
-                    // quiver = 5 for arrows/bolts?
-                    placement = ACE.Entity.Enum.Placement.RightHandCombat;
-                    parentLocation = ACE.Entity.Enum.ParentLocation.RightHand;
                     break;
 
                 case EquipMask.Held:

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -338,7 +338,7 @@ namespace ACE.Server.WorldObjects
         /// ParentLocation = null<para />
         /// Location = null
         /// </summary>
-        private void ClearChild(WorldObject item)
+        protected void ClearChild(WorldObject item)
         {
             item.Placement = ACE.Entity.Enum.Placement.Resting;
             item.ParentLocation = null;

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -805,6 +805,22 @@ namespace ACE.Server.WorldObjects
 
             switch (newCombatMode)
             {
+                case CombatMode.NonCombat:
+                {
+                    switch (currentCombatStance)
+                    {
+                        case MotionStance.BowCombat:
+                        case MotionStance.CrossbowCombat:
+                        case MotionStance.AtlatlCombat:
+                        {
+                            var equippedAmmo = GetEquippedAmmo();
+                            if (equippedAmmo != null)
+                                ClearChild(equippedAmmo); // We must clear the placement/parent when going back to peace
+                            break;
+                        }
+                    }
+                    break;
+                }
                 case CombatMode.Melee:
                     // todo expand checks
                     break;
@@ -817,11 +833,18 @@ namespace ACE.Server.WorldObjects
                         case MotionStance.CrossbowCombat:
                         case MotionStance.AtlatlCombat:
                         {
-                            if (GetEquippedAmmo() == null)
+                            var equippedAmmo = GetEquippedAmmo();
+                            if (equippedAmmo == null)
                             {
                                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You are out of ammunition!"));
                                 Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.YouAreOutOfAmmunition));
                                 newCombatMode = CombatMode.NonCombat;
+                            }
+                            else
+                            {
+                                // We must set the placement/parent when going into combat
+                                equippedAmmo.Placement = ACE.Entity.Enum.Placement.RightHandCombat;
+                                equippedAmmo.ParentLocation = ACE.Entity.Enum.ParentLocation.RightHand;
                             }
                             break;
                         }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -795,5 +795,47 @@ namespace ACE.Server.WorldObjects
             else
                 return null;
         }
+
+        /// <summary>
+        /// This method processes the Game Action (F7B1) Change Combat Mode (0x0053)
+        /// </summary>
+        public void HandleGameActionChangeCombatMode(CombatMode newCombatMode)
+        {
+            var currentCombatStance = GetCombatStance();
+
+            switch (newCombatMode)
+            {
+                case CombatMode.Melee:
+                    // todo expand checks
+                    break;
+
+                case CombatMode.Missile:
+                {
+                    switch (currentCombatStance)
+                    {
+                        case MotionStance.BowCombat:
+                        case MotionStance.CrossbowCombat:
+                        case MotionStance.AtlatlCombat:
+                        {
+                            if (GetEquippedAmmo() == null)
+                            {
+                                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You are out of ammunition!"));
+                                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.YouAreOutOfAmmunition));
+                                newCombatMode = CombatMode.NonCombat;
+                            }
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case CombatMode.Magic:
+                    // todo expand checks
+                    break;
+
+            }
+
+            SetCombatMode(newCombatMode);
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -283,6 +283,12 @@ namespace ACE.Server.WorldObjects
 
             if (dequipObjectAction != DequipObjectAction.ToCorpseOnDeath)
             {
+                if (CombatMode == CombatMode.Missile && wieldedLocation == (int)EquipMask.MissileAmmo)
+                {
+                    SetCombatMode(CombatMode.NonCombat);
+                    return true;
+                }
+
                 if (CombatMode == CombatMode.NonCombat || (wieldedLocation != (int)EquipMask.MeleeWeapon && wieldedLocation != (int)EquipMask.MissileWeapon && wieldedLocation != (int)EquipMask.Held && wieldedLocation != (int)EquipMask.Shield))
                     return true;
 
@@ -754,6 +760,14 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionGetAndWieldItem(uint itemGuid, int wieldLocation)
         {
+            // todo fix this, it seems IsAnimating is always true for a player
+            // todo we need to know when a player is busy to avoid additional actions during that time
+            /*if (IsAnimating)
+            {
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, WeenieError.YoureTooBusy));
+                return;
+            }*/
+
             var item = FindObject(new ObjectGuid(itemGuid), SearchLocations.Everywhere, out _, out var rootOwner, out var wasEquipped);
 
             if (item == null)


### PR DESCRIPTION
Issues that still exist:

Player_Inventory.HandleActionGetAndWieldItem() needs a way to prevent further actions when the player is currently in a busy state (animating from a previous action)

If you are in combat mode, with your arrow visible, and someone logs in next to you, they will not see your arrow. *FIXED*