### PR TITLE
Improving allegiance XP passup

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt64.cs
@@ -20,7 +20,15 @@ namespace ACE.Entity.Enum.Properties
         AvailableLuminance  = 6,
         [SendOnLogin]
         MaximumLuminance    = 7,
-        InteractionReqs     = 8
+        InteractionReqs     = 8,
+
+        /* custom */
+        [ServerOnly]
+        AllegianceXPCached    = 9000,
+        [ServerOnly]
+        AllegianceXPGenerated = 9001,
+        [ServerOnly]
+        AllegianceXPReceived  = 9002,
     }
 
     public static class PropertyInt64Extensions

--- a/Source/ACE.Server/Entity/IPlayer.cs
+++ b/Source/ACE.Server/Entity/IPlayer.cs
@@ -52,7 +52,9 @@ namespace ACE.Server.Entity
 
         uint? Patron { get; set; }
 
-        int? AllegianceCPPool { get; set; }
+        ulong AllegianceXPCached { get; set; }
+
+        ulong AllegianceXPGenerated { get; set; }
 
 
         uint GetCurrentLoyalty();

--- a/Source/ACE.Server/Entity/OfflinePlayer.cs
+++ b/Source/ACE.Server/Entity/OfflinePlayer.cs
@@ -292,10 +292,16 @@ namespace ACE.Server.Entity
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Patron); else SetProperty(PropertyInstanceId.Patron, value.Value); }
         }
 
-        public int? AllegianceCPPool
+        public ulong AllegianceXPCached
         {
-            get => GetProperty(PropertyInt.AllegianceCpPool);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.AllegianceCpPool); else SetProperty(PropertyInt.AllegianceCpPool, value.Value); }
+            get => (ulong)(GetProperty(PropertyInt64.AllegianceXPCached) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt64.AllegianceXPCached); else SetProperty(PropertyInt64.AllegianceXPCached, (long)value); }
+        }
+
+        public ulong AllegianceXPGenerated
+        {
+            get => (ulong)(GetProperty(PropertyInt64.AllegianceXPGenerated) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt64.AllegianceXPGenerated); else SetProperty(PropertyInt64.AllegianceXPGenerated, (long)value); }
         }
 
 

--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -241,11 +241,12 @@ namespace ACE.Server.Managers
                 //patron.CPCached += passupAmount;
                 //patron.CPPoolToUnload += passupAmount;
 
-                patron.AllegianceCPPool += (int)passupAmount;
+                vassal.AllegianceXPGenerated += generatedAmount;
+                patron.AllegianceXPCached += passupAmount;
 
                 var onlinePatron = PlayerManager.GetOnlinePlayer(patron.Guid);
                 if (onlinePatron != null)
-                    onlinePatron.AddCPPoolToUnload(false);
+                    onlinePatron.AddAllegianceXP(false);
 
                 // call recursively
                 PassXP(patronNode, passupAmount, false);

--- a/Source/ACE.Server/Network/Structure/AllegianceData.cs
+++ b/Source/ACE.Server/Network/Structure/AllegianceData.cs
@@ -73,6 +73,8 @@ namespace ACE.Server.Network.Structure
                 loyalty = (ushort)player.GetCurrentLoyalty();
                 leadership = (ushort)player.GetCurrentLeadership();
                 name = player.Name;
+
+                cpTithed = (uint)player.AllegianceXPGenerated;
             }
 
             writer.Write(characterID);

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -43,7 +43,7 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(setTurbineChatChannels, general, trade, lfg, roleplay);
 
             // check if vassals earned XP while offline
-            AddCPPoolToUnload(true);
+            AddAllegianceXP(true);
 
             HandleDBUpdates();
         }

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -186,12 +186,6 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public int? AllegianceCPPool
-        {
-            get => GetProperty(PropertyInt.AllegianceCpPool);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.AllegianceCpPool); else SetProperty(PropertyInt.AllegianceCpPool, value.Value); }
-        }
-
         // ========================================
         // ===== Player Properties - Titles========
         // ========================================


### PR DESCRIPTION
Managing the conversions between int -> long for allegiance passup XP can be error-prone, so this patch adds Int64 properties for these values

Generated and received XP from the allegiance is now tracked, and these fields are also stored as Int64 (although the network protocol sends the 'cpTithed / generated' as uint, so the display for these will cap out at ~4 billion still...