### PR TITLE
use AppDomain.CurrentDomain.UnhandledException

### DIFF
--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -35,6 +35,7 @@ namespace ACE.Server
 
         public static void Main(string[] args)
         {
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
 
             // Init our text encoding options. This will allow us to use more than standard ANSI text, which the client also supports.
@@ -119,6 +120,11 @@ namespace ACE.Server
             // This should be last
             log.Info("Initializing CommandManager...");
             CommandManager.Initialize();
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            log.Error(e.ExceptionObject);
         }
 
         private static void OnProcessExit(object sender, EventArgs e)


### PR DESCRIPTION
This will (should) catch any unhandled exception from any thread.

It will log it as an error, and the application will exit (unsafely).

The user will see the same exception twice on their console, but only one will be logged to the logger. This is expected behavior.

This was tested with the gem exception and works.

If you're wondering, there is no safe way to handle exceptions from UpdateWorld and keep going, nor is there any safe thing we can do if we're in that state to save players. We have no idea what state a player might be in when this is thrown. The could be between two very critical modifications. Furthermore, if we did try to save all players on exceptions, it could be used as an exploit to try to save players/items in a "bugged" state.

The safest thing to do is quit and trust that the last player saves are good.

Due to the way ACE handles biotas and items, dupes aren't an issue for us.