### PR TITLE
Fixing Oswald's Dirk Quest

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -57,7 +57,7 @@ namespace ACE.Server.Managers
             var emoteType = (EmoteType)emote.Type;
 
             //if (Debug)
-            //Console.WriteLine($"{WorldObject.Name}.ExecuteEmote({emoteType})");
+                //Console.WriteLine($"{WorldObject.Name}.ExecuteEmote({emoteType})");
 
             var text = emote.Message;
 
@@ -89,8 +89,8 @@ namespace ACE.Server.Managers
                 case EmoteType.AddContract:
 
                     //if (player != null)
-                    //Contracts werent in emote table
-                    //player.AddContract(emote.Stat);
+                        //Contracts werent in emote table
+                        //player.AddContract(emote.Stat);
                     break;
 
                 case EmoteType.AdminSpam:
@@ -182,10 +182,10 @@ namespace ACE.Server.Managers
 
                 case EmoteType.CastSpellInstant:
 
-                    if (creature != null && targetObject != null)
+                    if (creature != null)
                     {
                         var spell = new Spell((uint)emote.SpellId);
-                        if (targetObject != null && spell != null)
+                        if (spell != null)
                             creature.TryCastSpell(spell, targetObject, creature);
                     }
                     break;
@@ -1251,6 +1251,11 @@ namespace ACE.Server.Managers
         public void OnAttack(Creature attacker)
         {
             ExecuteEmoteSet(EmoteCategory.NewEnemy, null, attacker);
+        }
+
+        public void OnReceiveCritical(Creature attacker)
+        {
+            ExecuteEmoteSet(EmoteCategory.ReceiveCritical, null, attacker);
         }
 
         public void OnDeath(DamageHistory damageHistory)

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -409,7 +409,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called when a creature hits a target
         /// </summary>
-        public virtual void OnDamageTarget(WorldObject target, CombatType attackType)
+        public virtual void OnDamageTarget(WorldObject target, CombatType attackType, bool critical)
         {
             // empty base for non-player creatures?
         }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -126,7 +126,7 @@ namespace ACE.Server.WorldObjects
             if (damage != null)
             {
                 var attackType = GetAttackType();
-                OnDamageTarget(target, attackType);
+                OnDamageTarget(target, attackType, critical);
 
                 if (targetPlayer != null)
                     targetPlayer.TakeDamage(this, damageType, damage.Value, bodyPart, critical);
@@ -192,8 +192,11 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called when a player hits a target
         /// </summary>
-        public override void OnDamageTarget(WorldObject target, CombatType attackType)
+        public override void OnDamageTarget(WorldObject target, CombatType attackType, bool critical)
         {
+            if (critical)
+                target.EmoteManager.OnReceiveCritical(this);
+
             var attackSkill = GetCreatureSkill(GetCurrentWeaponSkill());
             var difficulty = GetTargetEffectiveDefenseSkill(target);
 

--- a/Source/ACE.Server/WorldObjects/Player_Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Monster.cs
@@ -45,8 +45,9 @@ namespace ACE.Server.WorldObjects
         {
             var attackable = monster.GetProperty(PropertyBool.Attackable) ?? false;
             var tolerance = (Tolerance)(monster.GetProperty(PropertyInt.Tolerance) ?? 0);
+            var targetingTactic = monster.GetProperty(PropertyInt.TargetingTactic) ?? 0;
 
-            if (attackable && monster.MonsterState == State.Idle && tolerance == Tolerance.None)
+            if ((attackable || targetingTactic != 0) && monster.MonsterState == State.Idle && tolerance == Tolerance.None)
             {
                 //Console.WriteLine($"[{Timers.RunningTime}] - {monster.Name} ({monster.Guid}) - waking up");
                 monster.AttackTarget = this;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -443,6 +443,9 @@ namespace ACE.Server.WorldObjects
 
                 amount = (uint)Math.Round(damage.Value);    // full amount for debugging
 
+                if (critical)
+                    target.EmoteManager.OnReceiveCritical(player);
+
                 if (target.IsAlive)
                 {
                     string verb = null, plural = null;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -60,7 +60,8 @@ namespace ACE.Server.WorldObjects
             Missile = true;
             AlignPath = true;
             PathClipped = true;
-            Ethereal = false;
+            if (!Spell.Name.Equals("Rolling Death"))
+                Ethereal = false;
             IgnoreCollisions = false;
 
             if (SpellType == ProjectileSpellType.Bolt || SpellType == ProjectileSpellType.Streak

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -142,11 +142,14 @@ namespace ACE.Server.WorldObjects
 
             PhysicsObj.SetScaleStatic(ObjScale ?? 1.0f);
 
+            PhysicsObj.State = defaultState;
+
             // gaerlan rolling balls of death
             if (Name.Equals("Rolling Death"))
+            {
                 PhysicsObj.SetScaleStatic(1.0f);
-
-            PhysicsObj.State = defaultState;
+                PhysicsObj.State |= PhysicsState.Ethereal;
+            }
 
             //if (creature != null) AllowEdgeSlide = true;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -43,9 +43,9 @@ namespace ACE.Server.WorldObjects
             }
 
             // spells only castable on creatures?
-            var targetCreature = target as Creature;
+            /*var targetCreature = target as Creature;
             if (targetCreature == null)
-                return;
+                return;*/
 
             // perform resistance check, if applicable
             var resisted = TryResistSpell(spell, target);
@@ -893,6 +893,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         protected void WarMagic(WorldObject target, Spell spell)
         {
+            if (target == null)
+            {
+                // handle untargetted spells (Rolling Balls of Death)
+                WarMagic(spell);
+                return;
+            }
+
             var spellType = SpellProjectile.GetProjectileSpellType(spell.Id);
             // Bolt, Streak, Arc
             if (spell.NumProjectiles == 1)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -14,19 +14,22 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsWithinUseRadiusOf(WorldObject wo)
         {
-            var matchIndoor = Location.Indoors == wo.Location.Indoors;
+            /*var matchIndoor = Location.Indoors == wo.Location.Indoors;
             var globalPos = matchIndoor ? Location.ToGlobal() : Location.Pos;
             var targetGlobalPos = matchIndoor ? wo.Location.ToGlobal() : wo.Location.Pos;
 
             var originDist = Vector3.Distance(globalPos, targetGlobalPos);
             var radSum = PhysicsObj.GetRadius() + wo.PhysicsObj.GetRadius();
-            var radDist = originDist - radSum;
+            var radDist = originDist - radSum;*/
             var useRadius = wo.UseRadius ?? 0.6f;
+
+            var cylDist = (float)Physics.Common.Position.CylinderDistance(PhysicsObj.GetRadius(), PhysicsObj.GetHeight(), PhysicsObj.Position,
+                wo.PhysicsObj.GetRadius(), wo.PhysicsObj.GetHeight(), wo.PhysicsObj.Position);
 
             // if (this is Player player)
             //    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"OriginDist: {originDist}, RadDist: {radDist}, MyRadius: {PhysicsObj.GetRadius()}, TargetRadius: {wo.PhysicsObj.GetRadius()}, MyUseRadius: {UseRadius ?? 0}, TargetUseRadius: {wo.UseRadius ?? 0}", ChatMessageType.System));
 
-            return radDist <= useRadius;
+            return cylDist <= useRadius;
         }
 
         /// <summary>


### PR DESCRIPTION
Notes during playthrough:

http://asheron.wikia.com/wiki/Oswald%27s_Dirk_Quest

- On the very first step of the quest, when picking up the Empty Mug from the table, I noticed that I had to jump up onto the table to actually get within pickup range. I updated the Player_Use distance check function to use the same cylinder distance check from physics, but even this seemed to produce the exact same result.

- In the 2nd trial with the Rolling Balls of Death, the balls weren't spawning, and I checked Gaerlan's Citadel - they were also broken again there too. They were broken from the recent change to EmoteType.CastSpellInstant to call WorldObject_Magic.TryCastSpell, which was only handling targetted spells. Updated these code paths to also handle untargeted spells.

Note, when comparing to retail video, the balls do not seem to be moving at diagonal angles - I remember having to manually set them to roll straight forward in Gaerlan's Citadel (using the angle o the invisible NPC that spawns them), so maybe there is some logic missing here to get the correct angle. I will be looking more into this.

- In the 3rd trial room, the target wasn't responding to criticals. EmoteCategory.ReceiveCritical was added, along with all of the appropriate hooks.

Also in the 3rd room, there are a bunch of invisible mobs that should be launching arrows at the player, according to this video:

https://youtu.be/C1OzPYKHqOg?t=524

https://github.com/ACEmulator/ACE-World-16PY/blob/2176c4566725c33ce691a76cf69954fa891cf0e3/Database/3-Core/9%20WeenieDefaults/SQL/Creature/Human/24139%20Invisible%20Assailant.sql

I am not seeing bow/arrows or any create_lists for these Invisible Assailants, so this is another data issue that will need to be investigated more...

- In the reward chest room, Oswald's Chest seemed to spawn 2 daggers. Also, the chest to the right, after lockpicking it, appeared to be empty (although the 2 chests behind the door had items)...