### PR TITLE
Adding server persistence for spellbook filters

### DIFF
--- a/Database/Updates/Shard/2019-01-17-00-Spellbook_Filters.sql
+++ b/Database/Updates/Shard/2019-01-17-00-Spellbook_Filters.sql
@@ -1,0 +1,3 @@
+USE `ace_shard`;
+
+ALTER TABLE `character` ADD COLUMN `spellbook_Filters` int(10) unsigned NOT NULL DEFAULT '16383' AFTER `gameplay_Options`;

--- a/Source/ACE.Database/Models/Shard/Character.cs
+++ b/Source/ACE.Database/Models/Shard/Character.cs
@@ -27,6 +27,7 @@ namespace ACE.Database.Models.Shard
         public int CharacterOptions1 { get; set; }
         public int CharacterOptions2 { get; set; }
         public byte[] GameplayOptions { get; set; }
+        public uint SpellbookFilters { get; set; }
         public uint HairTexture { get; set; }
         public uint DefaultHairTexture { get; set; }
 

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -1250,6 +1250,10 @@ namespace ACE.Database.Models.Shard
                     .IsRequired()
                     .HasColumnName("name")
                     .HasColumnType("varchar(255)");
+
+                entity.Property(e => e.SpellbookFilters)
+                    .HasColumnName("spellbook_Filters")
+                    .HasDefaultValueSql("'16383'");
 
                 entity.Property(e => e.TotalLogins)
                     .HasColumnName("total_Logins")

--- a/Source/ACE.Entity/Enum/SpellBookFilterOptions.cs
+++ b/Source/ACE.Entity/Enum/SpellBookFilterOptions.cs
@@ -1,0 +1,24 @@
+namespace ACE.Entity.Enum
+{
+    /// <summary>
+    /// The various options for filtering the spellbook
+    /// </summary>
+    public enum SpellBookFilterOptions: uint
+    {
+        None     = 0x0000,
+        Creature = 0x0001,
+        Item     = 0x0002,
+        Life     = 0x0004,
+        War      = 0x0008,
+        Level1   = 0x0010,
+        Level2   = 0x0020,
+        Level3   = 0x0040,
+        Level4   = 0x0080,
+        Level5   = 0x0100,
+        Level6   = 0x0200,
+        Level7   = 0x0400,
+        Level8   = 0x0800,
+        Level9   = 0x1000,
+        Void     = 0x2000,
+    }
+}

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSpellbookFilter.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSpellbookFilter.cs
@@ -1,0 +1,15 @@
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Network.GameAction.Actions
+{
+    public static class GameActionSpellbookFilter
+    {
+        [GameAction(GameActionType.SpellbookFilter)]
+        public static void Handle(ClientMessage message, Session session)
+        {
+            var filters = (SpellBookFilterOptions)message.Payload.ReadUInt32();
+
+            session.Player.HandleSpellbookFilters(filters);
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPlayerDescription.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPlayerDescription.cs
@@ -311,8 +311,10 @@ namespace ACE.Server.Network.GameEvent.Events
             if (Session.Player.Character.GameplayOptions != null && Session.Player.Character.GameplayOptions.Length > 0)
                 optionFlags |= CharacterOptionDataFlag.GameplayOptions;
 
+            optionFlags |= CharacterOptionDataFlag.SpellbookFilters;
+
             Writer.Write((uint)optionFlags);
-            Writer.Write((int)Session.Player.Character.CharacterOptions1);
+            Writer.Write(Session.Player.Character.CharacterOptions1);
 
             if (shortcuts.Count > 0)
                 Writer.Write(shortcuts);
@@ -337,11 +339,11 @@ namespace ACE.Server.Network.GameEvent.Events
             {
             }*/
 
-            if ((optionFlags & CharacterOptionDataFlag.SpellbookFilters) != 0)
-                Writer.Write(0u);
+            //if ((optionFlags & CharacterOptionDataFlag.SpellbookFilters) != 0)
+            Writer.Write(Session.Player.Character.SpellbookFilters);
 
             if ((optionFlags & CharacterOptionDataFlag.CharacterOptions2) != 0)
-                Writer.Write((int)Session.Player.Character.CharacterOptions2);
+                Writer.Write(Session.Player.Character.CharacterOptions2);
 
             /*if ((optionFlags & DescriptionOptionFlag.Unk100) != 0)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1218,5 +1218,10 @@ namespace ACE.Server.WorldObjects
 
             return caster.SpellDID == spell.Id;
         }
+
+        public void HandleSpellbookFilters(SpellBookFilterOptions filters)
+        {
+            Character.SpellbookFilters = (uint)filters;
+        }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/ACEmulator/ACE/issues/1283 for the unhandled GameAction message

This PR has a shard update SQL script to install:
Database/Updates/Shard/2019-01-17-00-Spellbook_Filters.sql