### PR TITLE
Adding physics simulation for corpses

### DIFF
--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -128,7 +128,7 @@ namespace ACE.Entity
             var dy = Convert.ToSingle(Math.Cos(heading) * distanceInFront);
 
             // move the Z slightly up and let gravity pull it down.  just makes things easier.
-            var bumpHeight = 0.0f;
+            var bumpHeight = 0.5f;
             if (rotate180)
             {
                 var rotate = new Quaternion(0, 0, qz, qw) * Quaternion.CreateFromYawPitchRoll(0, 0, (float)Math.PI);

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -72,14 +72,17 @@ namespace ACE.Server.WorldObjects
             if (topDamager != null)
                 Killer = topDamager.Guid.Full;
 
+            CurrentMotionState = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            IsMonster = false;
+
             // broadcast death animation
             var motionDeath = new Motion(MotionStance.NonCombat, MotionCommand.Dead);
-            EnqueueBroadcastMotion(motionDeath);
+            var deathAnimLength = ExecuteMotion(motionDeath);
 
             var dieChain = new ActionChain();
 
             // wait for death animation to finish
-            var deathAnimLength = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.Dead);
+            //var deathAnimLength = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.Dead);
             dieChain.AddDelaySeconds(deathAnimLength);
 
             dieChain.AddAction(this, () =>
@@ -181,9 +184,12 @@ namespace ACE.Server.WorldObjects
                     corpse.Biota.BiotaPropertiesTextureMap.Add(new Database.Models.Shard.BiotaPropertiesTextureMap { ObjectId = corpse.Guid.Full, Index = textureChange.PartIndex, OldId = textureChange.OldTexture, NewId = textureChange.NewTexture, Order = i++ });
             }
 
-            corpse.Location = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationFinalPositionFromStart(Location, ObjScale ?? 1, MotionCommand.Dead);
-            corpse.Location.SetLandblock();
-            corpse.Location.SetLandCell();
+            //corpse.Location = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationFinalPositionFromStart(Location, ObjScale ?? 1, MotionCommand.Dead);
+
+            //corpse.Location.SetLandblock();
+            //corpse.Location.SetLandCell();
+
+            corpse.Location = new Position(Location);
 
             //corpse.Location.PositionZ = corpse.Location.PositionZ - .5f; // Adding BaseDescriptionFlags |= ObjectDescriptionFlag.Corpse to Corpse objects made them immune to gravity.. this seems to fix floating corpse...
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -234,6 +234,7 @@ namespace ACE.Server.WorldObjects
                     Location.LandblockId = new LandblockId(curCell.ID);
 
                 Location.Pos = newPos;
+                Location.Rotation = PhysicsObj.Position.Frame.Orientation;
                 //if (landblockUpdate)
                 //WorldManager.UpdateLandblock.Add(this);
             }


### PR DESCRIPTION
This patch adds physics simulation during the death animations for corpses, which fixes issues such as corpses getting stuck in walls and unreachable places, and not spawning corpses

This resolves https://github.com/ACEmulator/ACE/issues/1305 and https://github.com/ACEmulator/ACE/issues/1309