### PR TITLE
Returning ObjDesc for items on housing hooks

### DIFF
--- a/Source/ACE.Server/WorldObjects/Hook.cs
+++ b/Source/ACE.Server/WorldObjects/Hook.cs
@@ -18,6 +18,10 @@ namespace ACE.Server.WorldObjects
     {
         public House House { get => ParentLink as House; }
 
+        public bool HasItem => Inventory != null && Inventory.Count > 0;
+
+        public WorldObject Item => Inventory != null ? Inventory.Values.FirstOrDefault() : null;
+
         /// <summary>
         /// Default hook profiles
         /// </summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -994,6 +994,9 @@ namespace ACE.Server.WorldObjects
 
         public virtual ACE.Entity.ObjDesc CalculateObjDesc()
         {
+            if (this is Hook hook && hook.HasItem)
+                return hook.Item.CalculateObjDesc();
+
             ACE.Entity.ObjDesc objDesc = new ACE.Entity.ObjDesc();
             ClothingTable item;
 


### PR DESCRIPTION
This fixes https://github.com/ACEmulator/ACE/issues/1293 and https://github.com/ACEmulator/ACE/issues/1304