### PR TITLE
Use LastUnlocker for chests + Make sure player looting is player that has chest open.

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
@@ -52,6 +52,7 @@ namespace ACE.Entity.Enum.Properties
         CombatTarget                     = 27,
         [Ephemeral]
         HealthQueryTarget                = 28,
+        [ServerOnly][Ephemeral]
         LastUnlocker                     = 29,
         CrashAndTurnTarget               = 30,
         AllowedActivator                 = 31,

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1084,13 +1084,13 @@ namespace ACE.Server.Command.Handlers
 
                     if (!string.IsNullOrWhiteSpace(lockCode))
                     {
-                        res = @lock.Unlock(lockCode);
+                        res = @lock.Unlock(session.Player.Guid.Full, lockCode);
                         ChatPacket.SendServerMessage(session, $"Crack {wo.WeenieType} via {lockCode} result: {res}.{opening}", ChatMessageType.Broadcast);
                     }
                     else if (resistLockpick.HasValue && resistLockpick > 0)
                     {
                         var difficulty = 0;
-                        res = @lock.Unlock((uint)(resistLockpick * 2), ref difficulty);
+                        res = @lock.Unlock(session.Player.Guid.Full, (uint)(resistLockpick * 2), ref difficulty);
                         ChatPacket.SendServerMessage(session, $"Crack {wo.WeenieType} with skill {resistLockpick}*2 result: {res}.{opening}", ChatMessageType.Broadcast);
                     }
                     else

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -179,6 +179,13 @@ namespace ACE.Server.WorldObjects
             {
                 if (!IsOpen)
                 {
+                    if (LastUnlocker.HasValue && LastUnlocker != player.Guid.Full)
+                    {
+                        player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"The {Name} was unlocked by someone else!")); // CUSTOM, what did retail actually do?
+                        player.SendUseDoneEvent();
+                        return;
+                    }
+
                     var rotateTime = player.Rotate(this);
 
                     var actionChain = new ActionChain();
@@ -226,17 +233,27 @@ namespace ACE.Server.WorldObjects
         /// Used for unlocking a chest via lockpick, so contains a skill check
         /// player.Skills[Skill.Lockpick].Current should be sent for the skill check
         /// </summary>
-        public UnlockResults Unlock(uint playerLockpickSkillLvl, ref int difficulty)
+        public UnlockResults Unlock(uint unlockerGuid, uint playerLockpickSkillLvl, ref int difficulty)
         {
-            return LockHelper.Unlock(this, playerLockpickSkillLvl, ref difficulty);
+            var result = LockHelper.Unlock(this, playerLockpickSkillLvl, ref difficulty);
+
+            if (result == UnlockResults.UnlockSuccess)
+                LastUnlocker = unlockerGuid;
+
+            return result;
         }
 
         /// <summary>
         /// Used for unlocking a chest via a key
         /// </summary>
-        public UnlockResults Unlock(string keyCode)
+        public UnlockResults Unlock(uint unlockerGuid, string keyCode)
         {
-            return LockHelper.Unlock(this, keyCode);
+            var result = LockHelper.Unlock(this, keyCode);
+
+            if (result == UnlockResults.UnlockSuccess)
+                LastUnlocker = unlockerGuid;
+
+            return result;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -240,7 +240,7 @@ namespace ACE.Server.WorldObjects
         /// Used for unlocking a door via lockpick, so contains a skill check
         /// player.Skills[Skill.Lockpick].Current should be sent for the skill check
         /// </summary>
-        public UnlockResults Unlock(uint playerLockpickSkillLvl, ref int difficulty)
+        public UnlockResults Unlock(uint unlockerGuid, uint playerLockpickSkillLvl, ref int difficulty)
         {
             return LockHelper.Unlock(this, playerLockpickSkillLvl, ref difficulty);
         }
@@ -248,7 +248,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Used for unlocking a door via a key
         /// </summary>
-        public UnlockResults Unlock(string keyCode)
+        public UnlockResults Unlock(uint unlockerGuid, string keyCode)
         {
             return LockHelper.Unlock(this, keyCode);
         }

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -21,8 +21,8 @@ namespace ACE.Server.WorldObjects
     }
     public interface Lock
     {
-        UnlockResults Unlock(string keyCode);
-        UnlockResults Unlock(uint playerLockpickSkillLvl, ref int difficulty);
+        UnlockResults Unlock(uint unlockerGuid, string keyCode);
+        UnlockResults Unlock(uint unlockerGuid, uint playerLockpickSkillLvl, ref int difficulty);
     }
     public class UnlockerHelper
     {
@@ -54,7 +54,7 @@ namespace ACE.Server.WorldObjects
                     UnlockResults result = UnlockResults.IncorrectKey;
                     var difficulty = 0;
                     if (unlocker.WeenieType == WeenieType.Lockpick)
-                        result = @lock.Unlock(player.Skills[Skill.Lockpick].Current, ref difficulty);
+                        result = @lock.Unlock(player.Guid.Full, player.Skills[Skill.Lockpick].Current, ref difficulty);
                     else if (unlocker is Key woKey)
                     {
                         if (target is Door woDoor)
@@ -65,7 +65,7 @@ namespace ACE.Server.WorldObjects
                                 return;
                             }
                         }
-                        result = @lock.Unlock(woKey.KeyCode);
+                        result = @lock.Unlock(player.Guid.Full, woKey.KeyCode);
                     }
 
                     switch (result)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -367,7 +367,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (CurrentLandblock?.GetObject(lastUsedContainerId) is Container lastUsedContainer)
                 {
-                    if (lastUsedContainer.IsOpen)
+                    if (lastUsedContainer.IsOpen && lastUsedContainer.Viewer == Guid.Full)
                     {
                         result = lastUsedContainer.GetInventoryItem(objectGuid, out foundInContainer);
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1294,6 +1294,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.Open); else SetProperty(PropertyBool.Open, value); }
         }
 
+        public uint? LastUnlocker
+        {
+            get => GetProperty(PropertyInstanceId.LastUnlocker);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.LastUnlocker); else SetProperty(PropertyInstanceId.LastUnlocker, value.Value); }
+        }
+
         public bool IsLocked
         {
             get => GetProperty(PropertyBool.Locked) ?? false;


### PR DESCRIPTION
When a chest is unlocked, LastUnlocker is set.

When a chest is opened, if this property has a value, the only the player that unlocked it can open it.

todo: When a container is reset/regen, LastUnlocker should be set to null.