### PR TITLE
Improved caster built-in spells

### DIFF
--- a/Source/ACE.Server/Entity/SpellFormula.cs
+++ b/Source/ACE.Server/Entity/SpellFormula.cs
@@ -288,7 +288,7 @@ namespace ACE.Server.Entity
         /// Returns the total casting time,
         /// based on windup + cast gestures
         /// </summary>
-        public float GetCastTime(uint motionTableID, float speed)
+        public float GetCastTime(uint motionTableID, float speed, bool isWeaponSpell = false)
         {
             var windupMotion = WindupGestures.First();
             var castMotion = CastGesture;
@@ -303,7 +303,7 @@ namespace ACE.Server.Entity
             var castTime = motionTable.GetAnimationLength(MotionStance.Magic, castMotion) / speed;
 
             // FastCast = no windup motion
-            if (Spell.Flags.HasFlag(SpellFlags.FastCast))
+            if (Spell.Flags.HasFlag(SpellFlags.FastCast) || isWeaponSpell)
                 return castTime;
 
             return windupTime + castTime;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -540,7 +540,7 @@ namespace ACE.Server.WorldObjects
             {
                 var chance = 1.0f - SkillCheck.GetMagicSkillChance((int)magicSkill, (int)difficulty);
                 var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
-                if (chance < rng)
+                if (chance < rng || isWeaponSpell)
                     castingPreCheckStatus = CastingPreCheckStatus.Success;
             }
 
@@ -587,14 +587,14 @@ namespace ACE.Server.WorldObjects
             spell.Formula.GetPlayerFormula(player);
 
             string spellWords = spell._spellBase.GetSpellWords(DatManager.PortalDat.SpellComponentsTable);
-            if (spellWords != null)
+            if (spellWords != null && !isWeaponSpell)
                 EnqueueBroadcast(new GameMessageCreatureMessage(spellWords, Name, Guid.Full, ChatMessageType.Spellcasting));
 
             var spellChain = new ActionChain();
             var castSpeed = 2.0f;   // hardcoded for player spell casting?
 
             // do wind-up gestures: fastcast has no windup (creature enchantments)
-            if (!spell.Flags.HasFlag(SpellFlags.FastCast))
+            if (!spell.Flags.HasFlag(SpellFlags.FastCast) && !isWeaponSpell)
             {
                 // note that ACE is currently sending the windup motion and the casting gesture
                 // at the same time. the client is automatically queueing these animations to run at the correct time.
@@ -620,7 +620,7 @@ namespace ACE.Server.WorldObjects
                 EnqueueBroadcastMotion(motionCastSpell);
             });
 
-            var castingDelay = spell.Formula.GetCastTime(MotionTableId, castSpeed);
+            var castingDelay = spell.Formula.GetCastTime(MotionTableId, castSpeed, isWeaponSpell);
             spellChain.AddDelaySeconds(castingDelay);
 
             spellChain.AddAction(this, () =>


### PR DESCRIPTION
This resolves https://github.com/ACEmulator/ACE/issues/1325

- Casting built-in spells no longer has a chance to fizzle
- The windup animation has been removed, only the cast motion is performed
- The player doesn't shout the spell words