### PR TITLE
Emote Manager Null Fix

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -791,7 +791,7 @@ namespace ACE.Server.Managers
                 case EmoteType.PopUp:
                     if (player != null)
                     {
-                        if ((ConfirmationType)emote.Stat == ConfirmationType.Undefined)
+                        if ((emote.Stat == null) || ((ConfirmationType)emote.Stat == ConfirmationType.Undefined))
                             player.Session.Network.EnqueueSend(new GameEventPopupString(player.Session, emote.Message));
                         else
                         {


### PR DESCRIPTION
Fix for emote.stat being null, which is functionally equivalent as having a zero, from the TOD Lifestoned data conversion.  Weenies 13239 through 13241, the academy leather pieces, have been updated to post a pop-up on pickup; however, the conversion process didn't output a 0 for the stat field but a null.  This fix causes a null to default to zero, which is a plain popup with no confirmation feedback needed.