### PR TITLE
Fix Null Spell Msg and Compiler Warnings

### DIFF
--- a/Source/ACE.Server/WorldObjects/Cow.cs
+++ b/Source/ACE.Server/WorldObjects/Cow.cs
@@ -33,20 +33,6 @@ namespace ACE.Server.WorldObjects
             UseRadius = 1;
         }
 
-        private double? resetTimestamp;
-        private double? ResetTimestamp
-        {
-            get { return resetTimestamp; }
-            set { resetTimestamp = Time.GetUnixTime(); }
-        }
-
-        private double? useTimestamp;
-        private double? UseTimestamp
-        {
-            get { return useTimestamp; }
-            set { useTimestamp = Time.GetUnixTime(); }
-        }
-
         /// <summary>
         /// This is raised by Player.HandleActionUseItem.<para />
         /// The item does not exist in the players possession.<para />

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -65,25 +65,11 @@ namespace ACE.Server.WorldObjects
                 DefaultLocked = true;
         }
 
-
-        private double? resetTimestamp;
-        private double? ResetTimestamp
-        {
-            get { return resetTimestamp; }
-            set { resetTimestamp = Time.GetUnixTime(); }
-        }
-
         private double? useLockTimestamp;
         private double? UseLockTimestamp
         {
             get { return useLockTimestamp; }
-            set { useLockTimestamp = Time.GetUnixTime(); }
-        }
-
-        private uint? LastUnlocker
-        {
-            get;
-            set;
+            set => useLockTimestamp = Time.GetUnixTime();
         }
 
         private string KeyCode

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -178,15 +178,13 @@ namespace ACE.Server.WorldObjects
             var player = this;
             var spell = new Spell(spellId);
 
-            if (spell._spellBase == null)
+            if (spell.NotFound)
             {
-                Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.MagicInvalidSpellType));
-                return false;
-            }
+                if (spell._spellBase == null)
+                    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
+                else
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
 
-            if (spell._spell == null)
-            {
-                Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
                 return false;
             }
 
@@ -280,15 +278,13 @@ namespace ACE.Server.WorldObjects
 
                 var spell = new Spell(spellId);
 
-                if (spell._spellBase == null)
+                if (spell.NotFound)
                 {
-                    Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
-                    return false;
-                }
+                    if (spell._spellBase == null)
+                        Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
+                    else
+                        Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
 
-                if (spell._spell == null)
-                {
-                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
                     return false;
                 }
 
@@ -380,7 +376,7 @@ namespace ACE.Server.WorldObjects
 
             if (spell._spellBase == null)
             {
-                Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.MagicInvalidSpellType));
+                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
                 return;
             }
 
@@ -426,7 +422,7 @@ namespace ACE.Server.WorldObjects
 
             if (spell._spellBase == null)
             {
-                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
+                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
                 return;
             }
 
@@ -476,11 +472,29 @@ namespace ACE.Server.WorldObjects
             var player = this;
             var creatureTarget = target as Creature;
 
+            if (player.IsBusy == true)
+            {
+                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YoureTooBusy));
+                return;
+            }
+            player.IsBusy = true;
+
             var spell = new Spell(spellId);
 
-            if (spell._spellBase == null)
+            if (spell.NotFound)
             {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicInvalidSpellType));
+                if (spell._spellBase == null)
+                {
+                    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
+                    Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.None));
+                }
+                else
+                {
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.MagicInvalidSpellType));
+                }
+
+                player.IsBusy = false;
                 return;
             }
 
@@ -488,23 +502,9 @@ namespace ACE.Server.WorldObjects
             {
                 player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"{spell.Name} cannot be cast on {target.Name}."));
                 player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.None));
+                player.IsBusy = false;
                 return;
             }
-
-            if (spell._spell == null)
-            {
-                player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.MagicInvalidSpellType));
-                return;
-            }
-
-            if (player.IsBusy == true)
-            {
-                player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YoureTooBusy));
-                return;
-            }
-            else
-                player.IsBusy = true;
 
             // if casting implement has spell built in,
             // use spellcraft from the item, instead of player's magic skill?
@@ -870,10 +870,17 @@ namespace ACE.Server.WorldObjects
 
             if (spell.NotFound)
             {
-                if (spell._spellBase != null)
+                if (spell._spellBase == null)
+                {
+                    Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"SpellId {spellId} Invalid."));
+                    Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.None));
+                }
+                else
+                {
                     Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
+                    Session.Network.EnqueueSend(new GameEventUseDone(Session, WeenieError.MagicInvalidSpellType));
+                }
 
-                Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType: WeenieError.MagicInvalidSpellType));
                 IsBusy = false;
                 return;
             }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
@@ -1477,6 +1478,13 @@ namespace ACE.Server.WorldObjects
         // ========================================
         // =========== Other Properties ===========
         // ========================================
+
+        private double? resetTimestamp;
+        protected double? ResetTimestamp
+        {
+            get { return resetTimestamp; }
+            set => resetTimestamp = Time.GetUnixTime();
+        }
 
         public int? Level
         {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -12,7 +12,7 @@ namespace ACE.Server.WorldObjects
         protected double? UseTimestamp
         {
             get { return useTimestamp; }
-            set { useTimestamp = Time.GetUnixTime(); }
+            set => useTimestamp = Time.GetUnixTime();
         }
 
         protected double? ResetInterval


### PR DESCRIPTION
- Completed moving UseTimestamp and ResetTimestamp to common locations, as they are used by multiple objects/Fixes new/hidden compiler warning
- Fixed null spell._spellBase issue of sending extra UseDone message and change this check to use another, less game intrusive message for notification of bad spellId being sent to the server