### PR TITLE
GeneratorHeartbeat() is now ticked independantly from Heartbeat()

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -341,7 +341,7 @@ namespace ACE.Server.Entity
                 var first = sortedGeneratorsByNextGeneratorHeartbeat.First.Value;
 
                 // If they wanted to run before or at now
-                if (first.NextHeartbeatTime <= currentUnixTime)
+                if (first.NextGeneratorHeartbeatTime <= currentUnixTime)
                 {
                     sortedGeneratorsByNextGeneratorHeartbeat.RemoveFirst();
                     first.GeneratorHeartbeat(currentUnixTime);

--- a/Source/ACE.Server/WorldObjects/Container_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Container_Tick.cs
@@ -3,12 +3,12 @@ namespace ACE.Server.WorldObjects
 {
     partial class Container
     {
-        public override void HeartBeat(double currentUnixTime)
+        public override void Heartbeat(double currentUnixTime)
         {
             foreach (var wo in Inventory.Values)
-                wo.HeartBeat(currentUnixTime);
+                wo.Heartbeat(currentUnixTime);
 
-            base.HeartBeat(currentUnixTime);
+            base.Heartbeat(currentUnixTime);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Tick.cs
@@ -6,16 +6,16 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called every ~5 seconds for Creatures
         /// </summary>
-        public override void HeartBeat(double currentUnixTime)
+        public override void Heartbeat(double currentUnixTime)
         {
             foreach (var wo in EquippedObjects.Values)
-                wo.HeartBeat(currentUnixTime);
+                wo.Heartbeat(currentUnixTime);
 
             VitalHeartBeat();
 
             EmoteManager.HeartBeat();
 
-            base.HeartBeat(currentUnixTime);
+            base.Heartbeat(currentUnixTime);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -40,7 +40,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called every ~5 seconds for Players
         /// </summary>
-        public override void HeartBeat(double currentUnixTime)
+        public override void Heartbeat(double currentUnixTime)
         {
             NotifyLandblocks();
 
@@ -59,7 +59,7 @@ namespace ACE.Server.WorldObjects
             if (LastRequestedDatabaseSave + PlayerSaveInterval <= DateTime.UtcNow)
                 SavePlayerToDatabase();
 
-            base.HeartBeat(currentUnixTime);
+            base.Heartbeat(currentUnixTime);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -92,7 +92,7 @@ namespace ACE.Server.WorldObjects
 
             InitializePropertyDictionaries();
             SetEphemeralValues();
-            InitializeHeartBeat();
+            InitializeHeartbeats();
 
             CreationTimestamp = (int)Time.GetUnixTime();
         }
@@ -110,7 +110,7 @@ namespace ACE.Server.WorldObjects
 
             InitializePropertyDictionaries();
             SetEphemeralValues();
-            InitializeHeartBeat();
+            InitializeHeartbeats();
         }
 
         /// <summary>
@@ -248,10 +248,6 @@ namespace ACE.Server.WorldObjects
                 ephemeralPositions[(PositionType)x.PositionType] = new Position(x.ObjCellId, x.OriginX, x.OriginY, x.OriginZ, x.AnglesX, x.AnglesY, x.AnglesZ, x.AnglesW);
 
             AddGeneratorProfiles();
-
-            // mosswartfood is both a creature and a generator with a HeartbeatInterval of 5 and a RegenerationInterval of 0
-            if (!(this is Creature) && IsGenerator)
-                HeartbeatInterval = RegenerationInterval;
 
             BaseDescriptionFlags = ObjectDescriptionFlag.Attackable;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -495,7 +495,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called every ~5 seconds for object generators
         /// </summary>
-        public void Generator_HeartBeat()
+        protected void Generator_HeartBeat()
         {
             //Console.WriteLine($"{Name}.Generator_HeartBeat({HeartbeatInterval})");
 


### PR DESCRIPTION
There is no longer a DefaultHeartbeatInterval.

Heartbeats only happen if a HeartbeatInterval exists and is greater than 0.
Heartbeats are still staggered over heartbeatSpreadInterval (5s).

Generators will GeneratorHeartBeat() on the next tick after object construction.

However, if RegenerationInterval is 0, they will not beat again.