### PR TITLE
Add and Make Use of Shade/Palette in ItemProfile for Vendors

### DIFF
--- a/Source/ACE.Server/Entity/ItemProfile.cs
+++ b/Source/ACE.Server/Entity/ItemProfile.cs
@@ -7,5 +7,7 @@ namespace ACE.Server.Entity
         public uint Amount;
         public uint ObjectGuid;
         public uint WeenieClassId;
+        public int? Palette;
+        public double? Shade;
     }
 }

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -125,9 +125,16 @@ namespace ACE.Server.WorldObjects
         private List<WorldObject> ItemProfileToWorldObjects(ItemProfile itemprofile)
         {
             List<WorldObject> worldobjects = new List<WorldObject>();
+
             while (itemprofile.Amount > 0)
             {
                 WorldObject wo = WorldObjectFactory.CreateNewWorldObject(itemprofile.WeenieClassId);
+
+                if (itemprofile.Palette.HasValue)
+                    wo.PaletteTemplate = itemprofile.Palette;
+                if (itemprofile.Shade.HasValue)
+                    wo.Shade = itemprofile.Shade;
+
                 // can we stack this ?
                 if (wo.MaxStackSize.HasValue)
                 {
@@ -209,6 +216,8 @@ namespace ACE.Server.WorldObjects
                 if (DefaultItemsForSale.ContainsKey(new ObjectGuid(item.ObjectGuid)))
                 {
                     item.WeenieClassId = DefaultItemsForSale[new ObjectGuid(item.ObjectGuid)].WeenieClassId;
+                    item.Palette = DefaultItemsForSale[new ObjectGuid(item.ObjectGuid)].PaletteTemplate;
+                    item.Shade = DefaultItemsForSale[new ObjectGuid(item.ObjectGuid)].Shade;
                     filteredlist.Add(item);
                 }
 


### PR DESCRIPTION
This allows vendors to sell items of specific color/shade when it was specified, and matches what you saw in the the buy window