### PR TITLE
Change Corpse Rights ID storage properties

### DIFF
--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -108,21 +108,21 @@ namespace ACE.Server.WorldObjects
         public bool HasPermission(Player player)
         {
             // players can loot their own corpses
-            if (player.Guid.Full == OwnerId)
+            if (player.Guid.Full == VictimId)
                 return true;
 
             // players can loot monsters they killed
-            if (AllowedActivator != null && player.Guid.Full == AllowedActivator)
+            if (KillerId != null && player.Guid.Full == KillerId)
                 return true;
 
             // players can /permit other players to loot their corpse
-            if (player.HasLootPermission(new ObjectGuid(OwnerId.Value)))
+            if (player.HasLootPermission(new ObjectGuid(VictimId.Value)))
                 return true;
 
             // players in the same fellowship as the killer w/ loot sharing enabled
             if (player.Fellowship != null && player.Fellowship.ShareLoot)
             {
-                var onlinePlayer = PlayerManager.GetOnlinePlayer(AllowedActivator ?? 0);
+                var onlinePlayer = PlayerManager.GetOnlinePlayer(KillerId ?? 0);
                 if (onlinePlayer != null && onlinePlayer.Fellowship != null && player.Fellowship == onlinePlayer.Fellowship)
                     return true;
             }

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -77,7 +77,7 @@ namespace ACE.Server.WorldObjects
             UpdateVital(Health, 0);
 
             if (topDamager != null)
-                Killer = topDamager.Guid.Full;
+                KillerId = topDamager.Guid.Full;
 
             CurrentMotionState = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
             IsMonster = false;
@@ -200,19 +200,17 @@ namespace ACE.Server.WorldObjects
 
             //corpse.Location.PositionZ = corpse.Location.PositionZ - .5f; // Adding BaseDescriptionFlags |= ObjectDescriptionFlag.Corpse to Corpse objects made them immune to gravity.. this seems to fix floating corpse...
 
-            corpse.OwnerId = Guid.Full;
+            corpse.VictimId = Guid.Full;
             corpse.Name = $"Corpse of {Name}";
-
-            LandblockManager.AddObject(corpse);
 
             // set 'killed by' for looting rights
             if (killer != null)
             {
                 corpse.LongDesc = $"Killed by {killer.Name}.";
                 if (killer is CombatPet)
-                    corpse.AllowedActivator = killer.PetOwner.Value;
+                    corpse.KillerId = killer.PetOwner.Value;
                 else
-                    corpse.AllowedActivator = Killer.Value;
+                    corpse.KillerId = killer.Guid.Full;
             }
             else
                 corpse.LongDesc = $"Killed by misadventure.";

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -171,10 +171,10 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.NoCorpse); else SetProperty(PropertyBool.NoCorpse, value); }
         }
 
-        public uint? Killer
+        public bool TreasureCorpse
         {
-            get => GetProperty(PropertyInstanceId.Killer);
-            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Killer); else SetProperty(PropertyInstanceId.Killer, value.Value); }
+            get => GetProperty(PropertyBool.TreasureCorpse) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.TreasureCorpse); else SetProperty(PropertyBool.TreasureCorpse, value); }
         }
 
         public uint? DeathTreasureType

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -793,7 +793,7 @@ namespace ACE.Server.WorldObjects
         public Player GetKiller_PKLite()
         {
             if (PlayerKillerStatus == PlayerKillerStatus.PKLite)
-                return CurrentLandblock?.GetObject(new ObjectGuid(Killer ?? 0)) as Player;
+                return CurrentLandblock?.GetObject(new ObjectGuid(KillerId ?? 0)) as Player;
             else
                 return null;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -105,7 +105,7 @@ namespace ACE.Server.WorldObjects
 
             // killer = top damager for looting rights
             if (topDamager != null)
-                Killer = topDamager.Guid.Full;
+                KillerId = topDamager.Guid.Full;
 
             // broadcast death animation
             var deathAnim = new Motion(MotionStance.NonCombat, MotionCommand.Dead);
@@ -331,7 +331,7 @@ namespace ACE.Server.WorldObjects
 
             if (PlayerKillerStatus == PlayerKillerStatus.PKLite)
             {
-                var killer = CurrentLandblock?.GetObject(new ObjectGuid(Killer ?? 0));
+                var killer = CurrentLandblock?.GetObject(new ObjectGuid(KillerId ?? 0));
                 if (killer is Player)
                 {
                     PlayerKillerStatus = PlayerKillerStatus.NPK;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2456,5 +2456,17 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyInt.ResistLockpick) ?? 0;
             set { if (!value.HasValue) RemoveProperty(PropertyInt.ResistLockpick); else SetProperty(PropertyInt.ResistLockpick, value.Value); }
         }
+
+        public uint? VictimId
+        {
+            get => GetProperty(PropertyInstanceId.Victim);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Victim); else SetProperty(PropertyInstanceId.Victim, value.Value); }
+        }
+
+        public uint? KillerId
+        {
+            get => GetProperty(PropertyInstanceId.Killer);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Killer); else SetProperty(PropertyInstanceId.Killer, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
Switch Corpse Rights tracking from AllowedActivator + OwnerId to KillerId +VictimId to make better and more clear design usage