### PR TITLE
Adding max distance for CreateObject

### DIFF
--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -413,6 +413,28 @@ namespace ACE.Entity
         }
 
         /// <summary>
+        /// Returns the squared 2D distance between 2 objects
+        /// </summary>
+        public float Distance2DSquared(Position p)
+        {
+            // originally this returned the offset instead of distance...
+            if (p.LandblockId == this.LandblockId)
+            {
+                var dx = this.PositionX - p.PositionX;
+                var dy = this.PositionY - p.PositionY;
+                return dx * dx + dy * dy;
+            }
+            //if (p.LandblockId.MapScope == MapScope.Outdoors && this.LandblockId.MapScope == MapScope.Outdoors)
+            else
+            {
+                // verify this is working correctly if one of these is indoors
+                var dx = (this.LandblockId.LandblockX - p.LandblockId.LandblockX) * 192 + this.PositionX - p.PositionX;
+                var dy = (this.LandblockId.LandblockY - p.LandblockId.LandblockY) * 192 + this.PositionY - p.PositionY;
+                return dx * dx + dy * dy;
+            }
+        }
+
+        /// <summary>
         /// Returns the 3D distance between 2 objects
         /// </summary>
         public float DistanceTo(Position p)

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -123,6 +123,11 @@ namespace ACE.Server.Physics.Common
             return newObjs;
         }
 
+        public static bool InitialClamp = true;
+
+        public static float InitialClamp_Dist = 112.5f;
+        public static float InitialClamp_DistSq = InitialClamp_Dist * InitialClamp_Dist;
+
         /// <summary>
         /// Adds an object to the list of visible objects
         /// </summary>
@@ -130,6 +135,13 @@ namespace ACE.Server.Physics.Common
         {
             if (!VisibleObjectTable.ContainsKey(obj.ID))
             {
+                if (InitialClamp)
+                {
+                    var distSq = PhysicsObj.WeenieObj.WorldObject.Location.Distance2DSquared(obj.WeenieObj.WorldObject.Location);
+                    if (distSq > InitialClamp_DistSq)
+                        return false;
+                }
+
                 VisibleObjectTable.Add(obj.ID, obj);
                 return true;
             }
@@ -141,12 +153,16 @@ namespace ACE.Server.Physics.Common
         /// </summary>
         public List<PhysicsObj> AddVisibleObjects(List<PhysicsObj> objs)
         {
-            foreach (var obj in objs)
-                AddVisibleObject(obj);
+            var visibleAdded = new List<PhysicsObj>();
 
+            foreach (var obj in objs)
+            {
+                if (AddVisibleObject(obj))
+                    visibleAdded.Add(obj);
+            }
             RemoveObjectsToBeDestroyed(objs);
 
-            return AddObjects(objs);
+            return AddObjects(visibleAdded);
         }
 
         /// <summary>
@@ -247,6 +263,20 @@ namespace ACE.Server.Physics.Common
                 }
             }
             return cells;
+        }
+
+        public List<PhysicsObj> GetVisibleObjectsDist(ObjCell cell)
+        {
+            var visibleObjs = GetVisibleObjects(cell);
+
+            var dist = new List<PhysicsObj>();
+            foreach (var obj in visibleObjs)
+            {
+                var distSq = PhysicsObj.WeenieObj.WorldObject.Location.Distance2DSquared(obj.WeenieObj.WorldObject.Location);
+                if (distSq <= InitialClamp_DistSq)
+                    dist.Add(obj);
+            }
+            return dist;
         }
 
         /// <summary>
@@ -447,7 +477,7 @@ namespace ACE.Server.Physics.Common
         {
             if (PhysicsObj.DatObject) return;
 
-            var visiblePlayers = GetVisibleObjects(PhysicsObj.CurCell).Where(o => o.IsPlayer).ToList();
+            var visiblePlayers = GetVisibleObjectsDist(PhysicsObj.CurCell).Where(o => o.IsPlayer).ToList();
             AddVoyeurs(visiblePlayers);
         }
 

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -2518,7 +2518,7 @@ namespace ACE.Server.Physics
                 //Console.WriteLine(visibleObject.Name);
 
             // get the difference between current and previous visible
-            var newlyVisible = visibleObjects.Except(ObjMaint.VisibleObjectTable.Values).ToList();
+            //var newlyVisible = visibleObjects.Except(ObjMaint.VisibleObjectTable.Values).ToList();
             var newlyOccluded = ObjMaint.VisibleObjectTable.Values.Except(visibleObjects).ToList();
             //Console.WriteLine("Newly visible objects: " + newlyVisible.Count);
             //Console.WriteLine("Newly occluded objects: " + newlyOccluded.Count);
@@ -2527,6 +2527,7 @@ namespace ACE.Server.Physics
 
             // add newly visible objects, and get the previously unknowns
             var createObjs = ObjMaint.AddVisibleObjects(visibleObjects);
+            //Console.WriteLine("Create objects: " + createObjs.Count);
             /*if (createObjs.Count != newlyVisible.Count)
             {
                 Console.WriteLine($"Create objs differs from newly visible ({createObjs.Count} vs. {newlyVisible.Count})");

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -680,11 +680,17 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionForceObjDescSend(uint itemGuid)
         {
-            WorldObject wo = GetInventoryItem(new ObjectGuid(itemGuid));
-            if (wo != null)
-                EnqueueBroadcast(new GameMessageObjDescEvent(wo));
-            else
-                log.Debug($"HandleActionForceObjDescSend() - couldn't find inventory item {itemGuid:X8}");
+            var wo = FindObject(itemGuid, SearchLocations.Everywhere);
+            if (wo == null)
+            {
+                wo = CurrentLandblock?.GetWieldedObject(itemGuid);
+                if (wo == null)
+                {
+                    log.Debug($"HandleActionForceObjDescSend() - couldn't find object {itemGuid:X8}");
+                    return;
+                }
+            }
+            EnqueueBroadcast(new GameMessageObjDescEvent(wo));
         }
 
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -313,6 +313,11 @@ namespace ACE.Server.WorldObjects
             Everywhere          = 0xFF
         }
 
+        public WorldObject FindObject(uint objectGuid, SearchLocations searchLocations)
+        {
+            return FindObject(new ObjectGuid(objectGuid), searchLocations, out Container foundInContainer, out Container rootOwner, out bool wasEquipped);
+        }
+
         public WorldObject FindObject(uint objectGuid, SearchLocations searchLocations, out Container foundInContainer, out Container rootOwner, out bool wasEquipped)
         {
             return FindObject(new ObjectGuid(objectGuid), searchLocations, out foundInContainer, out rootOwner, out wasEquipped); // todo Fix this so it's not creating a new ObjectGuid


### PR DESCRIPTION
This fixes the crashes that some people are having around Holtburg, specifically with Decal plugins such as Radar Add-on + MiniMap

This adds a new layer to the visible objects / automatic culling system, which optionally sets a max distance for the initial broadcast of CreateObject messages.