### PR TITLE
Change the write lock to when we actually change the property

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -153,7 +153,7 @@ namespace ACE.Database.Models.Shard
 
         public static void SetProperty(this Biota biota, PropertyBool property, bool value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesBool.FirstOrDefault(x => x.Type == (uint)property);
@@ -164,28 +164,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesBool { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesBool.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesBool { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesBool.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyBool property, bool value, ReaderWriterLockSlim rwLock, IDictionary<PropertyBool, BiotaPropertiesBool> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -195,31 +187,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesBool { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesBool.Add(entity);
+                    var entity = new BiotaPropertiesBool { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesBool.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyDataId property, uint value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesDID.FirstOrDefault(x => x.Type == (uint)property);
@@ -230,28 +214,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesDID.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesDID.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyDataId property, uint value, ReaderWriterLockSlim rwLock, IDictionary<PropertyDataId, BiotaPropertiesDID> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -261,31 +237,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesDID.Add(entity);
+                    var entity = new BiotaPropertiesDID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesDID.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyFloat property, double value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesFloat.FirstOrDefault(x => x.Type == (ushort)property);
@@ -296,28 +264,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesFloat { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesFloat.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesFloat { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesFloat.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyFloat property, double value, ReaderWriterLockSlim rwLock, IDictionary<PropertyFloat, BiotaPropertiesFloat> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -327,31 +287,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesFloat { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesFloat.Add(entity);
+                    var entity = new BiotaPropertiesFloat { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesFloat.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesIID.FirstOrDefault(x => x.Type == (uint)property);
@@ -362,28 +314,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesIID.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesIID.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInstanceId property, uint value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInstanceId, BiotaPropertiesIID> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -393,31 +337,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesIID.Add(entity);
+                    var entity = new BiotaPropertiesIID { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesIID.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInt property, int value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesInt.FirstOrDefault(x => x.Type == (uint)property);
@@ -428,28 +364,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesInt { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesInt.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesInt { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesInt.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInt property, int value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt, BiotaPropertiesInt> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -459,31 +387,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesInt { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesInt.Add(entity);
+                    var entity = new BiotaPropertiesInt { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesInt.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInt64 property, long value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesInt64.FirstOrDefault(x => x.Type == (uint)property);
@@ -494,28 +414,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesInt64.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesInt64.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyInt64 property, long value, ReaderWriterLockSlim rwLock, IDictionary<PropertyInt64, BiotaPropertiesInt64> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -525,31 +437,23 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesInt64.Add(entity);
+                    var entity = new BiotaPropertiesInt64 { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesInt64.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetPosition(this Biota biota, PositionType positionType, Position position, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesPosition.FirstOrDefault(x => x.PositionType == (uint)positionType);
@@ -567,28 +471,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesPosition { ObjectId = biota.Id, PositionType = (ushort)positionType, ObjCellId = position.Cell, OriginX = position.PositionX, OriginY = position.PositionY, OriginZ = position.PositionZ, AnglesW = position.RotationW, AnglesX = position.RotationX, AnglesY = position.RotationY, AnglesZ = position.RotationZ, Object = biota };
-                        biota.BiotaPropertiesPosition.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesPosition { ObjectId = biota.Id, PositionType = (ushort)positionType, ObjCellId = position.Cell, OriginX = position.PositionX, OriginY = position.PositionY, OriginZ = position.PositionZ, AnglesW = position.RotationW, AnglesX = position.RotationX, AnglesY = position.RotationY, AnglesZ = position.RotationZ, Object = biota };
+                    biota.BiotaPropertiesPosition.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyString property, string value, ReaderWriterLockSlim rwLock, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 var result = biota.BiotaPropertiesString.FirstOrDefault(x => x.Type == (uint)property);
@@ -599,28 +495,20 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesString.Add(entity);
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesString.Add(entity);
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 
         public static void SetProperty(this Biota biota, PropertyString property, string value, ReaderWriterLockSlim rwLock, IDictionary<PropertyString, BiotaPropertiesString> cache, out bool biotaChanged)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterWriteLock();
             try
             {
                 if (cache.TryGetValue(property, out var record))
@@ -630,25 +518,17 @@ namespace ACE.Database.Models.Shard
                 }
                 else
                 {
-                    rwLock.EnterWriteLock();
-                    try
-                    {
-                        var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
-                        biota.BiotaPropertiesString.Add(entity);
+                    var entity = new BiotaPropertiesString { ObjectId = biota.Id, Type = (ushort)property, Value = value, Object = biota };
+                    biota.BiotaPropertiesString.Add(entity);
 
-                        cache[property] = entity;
+                    cache[property] = entity;
 
-                        biotaChanged = true;
-                    }
-                    finally
-                    {
-                        rwLock.ExitWriteLock();
-                    }
+                    biotaChanged = true;
                 }
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitWriteLock();
             }
         }
 

--- a/Source/ACE.Database/Models/Shard/CharacterExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterExtensions.cs
@@ -107,7 +107,7 @@ namespace ACE.Database.Models.Shard
 
         public static bool HasAsFriend(this Character character, uint friendId, ReaderWriterLockSlim rwLock)
         {
-            rwLock.EnterUpgradeableReadLock();
+            rwLock.EnterReadLock();
             try
             {
                 foreach (var record in character.CharacterPropertiesFriendList)
@@ -120,7 +120,7 @@ namespace ACE.Database.Models.Shard
             }
             finally
             {
-                rwLock.ExitUpgradeableReadLock();
+                rwLock.ExitReadLock();
             }
         }
 
@@ -256,17 +256,15 @@ namespace ACE.Database.Models.Shard
 
         public static List<CharacterPropertiesSpellBar> GetSpellsInBar(this Character character, int barNumber, ReaderWriterLockSlim rwLock)
         {
-            IEnumerable<CharacterPropertiesSpellBar> results;
             rwLock.EnterReadLock();
             try
             {
-                results = character.CharacterPropertiesSpellBar.Where(x => x.SpellBarNumber == barNumber);
+                return character.CharacterPropertiesSpellBar.Where(x => x.SpellBarNumber == barNumber).ToList();
             }
             finally
             {
                 rwLock.ExitReadLock();
             }
-            return results.ToList();
         }
 
         /// <summary>

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -215,7 +215,7 @@ namespace ACE.Database
         {
             if (BiotaContexts.TryGetValue(biota, out var cachedContext))
             {
-                rwLock.EnterWriteLock();
+                rwLock.EnterReadLock();
                 try
                 {
                     SetBiotaPopulatedCollections(biota);
@@ -234,7 +234,7 @@ namespace ACE.Database
                 }
                 finally
                 {
-                    rwLock.ExitWriteLock();
+                    rwLock.ExitReadLock();
                 }
             }
 
@@ -242,7 +242,7 @@ namespace ACE.Database
 
             BiotaContexts.Add(biota, context);
 
-            rwLock.EnterWriteLock();
+            rwLock.EnterReadLock();
             try
             {
                 SetBiotaPopulatedCollections(biota);
@@ -263,7 +263,7 @@ namespace ACE.Database
             }
             finally
             {
-                rwLock.ExitWriteLock();
+                rwLock.ExitReadLock();
             }
         }
 
@@ -286,7 +286,7 @@ namespace ACE.Database
             {
                 BiotaContexts.Remove(biota);
 
-                rwLock.EnterWriteLock();
+                rwLock.EnterReadLock();
                 try
                 {
                     cachedContext.Biota.Remove(biota);
@@ -305,7 +305,7 @@ namespace ACE.Database
                 }
                 finally
                 {
-                    rwLock.ExitWriteLock();
+                    rwLock.ExitReadLock();
                 }
             }
 
@@ -570,7 +570,7 @@ namespace ACE.Database
         {
             if (CharacterContexts.TryGetValue(character, out var cachedContext))
             {
-                rwLock.EnterWriteLock();
+                rwLock.EnterReadLock();
                 try
                 {
                     try
@@ -587,7 +587,7 @@ namespace ACE.Database
                 }
                 finally
                 {
-                    rwLock.ExitWriteLock();
+                    rwLock.ExitReadLock();
                 }
             }
 
@@ -595,7 +595,7 @@ namespace ACE.Database
 
             CharacterContexts.Add(character, context);
 
-            rwLock.EnterWriteLock();
+            rwLock.EnterReadLock();
             try
             {
                 context.Character.Add(character);
@@ -614,7 +614,7 @@ namespace ACE.Database
             }
             finally
             {
-                rwLock.ExitWriteLock();
+                rwLock.ExitReadLock();
             }
         }
 


### PR DESCRIPTION
This changes the SaveBiota from using a Write lock to using a Read lock. The benefit here is that now the biota can still be read while it is in the process of being saved.

We don't need a write lock when we save the biota because the only properties that will be changed are record id's that will be added for records that are new. The save process will not add or remove records from the biota being saved, nor will it update any other values.

Because we maintain the context for the life of the biota, when we add/save, it's simply a one way change, meaning, only the database will change. The biota itself is just read and compared to the clone that the context holds. Thus, this is a safe way to do it.

This also improves performance by reducing the amount of time a biota lock results in thread contention.