### PR TITLE
Handle Account in use reject for all cases

### DIFF
--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -111,13 +111,8 @@ namespace ACE.Server.Network.Handlers
 
             if (WorldManager.Find(account.AccountName) != null)
             {
-                var foundSession = WorldManager.Find(account.AccountName);
-
-                if (foundSession.State == SessionState.AuthConnected)
-                {
-                    session.SendCharacterError(CharacterError.AccountInUse);
-                    session.BootSession("Account In Use: Found another session already logged in for this account.", new GameMessageCharacterError(CharacterError.AccountInUse));
-                }
+                session.SendCharacterError(CharacterError.AccountInUse);
+                session.BootSession("Account In Use: Found another session already logged in for this account.", new GameMessageCharacterError(CharacterError.AccountInUse));
                 return;
             }
 


### PR DESCRIPTION
If a session exists in any state for a given account, the account should be rejected.

In current master, the 2'nd account is rejected if the first account is at the character selection screen, but not when the 1st account is in the world.