### PR TITLE
Adding synchronized ServerObject loading for non-adjacents

### DIFF
--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -124,7 +124,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns a reference to a landblock, loading the landblock if not already active
         /// </summary>
-        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false, bool loadSync = false)
+        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false, bool loadSync = true)
         {
             Landblock landblock = null;
 
@@ -153,7 +153,7 @@ namespace ACE.Server.Managers
             {
                 var adjacents = GetAdjacentIDs(landblock);
                 foreach (var adjacent in adjacents)
-                    GetLandblock(adjacent, false);
+                    GetLandblock(adjacent, false, false, false);
             }
 
             // cache adjacencies


### PR DESCRIPTION
This fixes some bugs with objects appearing invisible when first loading into some landblocks