### PR TITLE
Cleanup hook related code

### DIFF
--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -126,9 +126,7 @@ namespace ACE.Server.WorldObjects
                 Value += container.Value; // This value includes the containers value itself + all child items
             }
 
-
-            if (WeenieType == WeenieType.Hook && this is Hook hook)
-                hook.OnLoad();
+            OnInitialInventoryLoadCompleted();
         }
 
         /// <summary>
@@ -333,6 +331,9 @@ namespace ACE.Server.WorldObjects
             Value += worldObject.Value;
 
             container = this;
+
+            OnAddItem();
+
             return true;
         }
 
@@ -368,6 +369,8 @@ namespace ACE.Server.WorldObjects
 
                 EncumbranceVal -= item.EncumbranceVal;
                 Value -= item.Value;
+
+                OnRemoveItem();
 
                 return true;
             }
@@ -521,9 +524,17 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// This event is raised after the containers items have been completely loaded from the database
+        /// </summary>
+        protected virtual void OnInitialInventoryLoadCompleted()
+        {
+            // empty base
+        }
+
+        /// <summary>
         /// This event is raised when player adds item to container
         /// </summary>
-        public virtual void OnAddItem()
+        protected virtual void OnAddItem()
         {
             // empty base
         }
@@ -531,7 +542,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// This event is raised when player removes item from container
         /// </summary>
-        public virtual void OnRemoveItem()
+        protected virtual void OnRemoveItem()
         {
             // empty base
         }

--- a/Source/ACE.Server/WorldObjects/Hook.cs
+++ b/Source/ACE.Server/WorldObjects/Hook.cs
@@ -92,6 +92,9 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            NoDraw = false;
+            UiHidden = false;
+
             SetupTableId = item.SetupTableId;
             MotionTableId = item.MotionTableId;
             PhysicsTableId = item.PhysicsTableId;

--- a/Source/ACE.Server/WorldObjects/Hook.cs
+++ b/Source/ACE.Server/WorldObjects/Hook.cs
@@ -73,8 +73,6 @@ namespace ACE.Server.WorldObjects
 
             if (Inventory.Count > 0)
                 OnAddItem();
-            else
-                OnRemoveItem();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -609,10 +609,7 @@ namespace ACE.Server.WorldObjects
                             {
                                 item.EmoteManager.OnDrop(this);
                                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.DropItem));
-
-                                container.OnAddItem();  // adding item to container
                             }
-
                             else if (containerRootOwner == this)
                             {
                                 if (itemAsContainer != null) // We're picking up a pack
@@ -630,9 +627,6 @@ namespace ACE.Server.WorldObjects
 
                                 if (questSolve)
                                     QuestManager.Update(item.Quest);
-
-                                if (itemRootOwner != null)
-                                    itemRootOwner.OnRemoveItem();   // removing item from container
                             }
                         }
                         EnqueueBroadcastMotion(returnStance);
@@ -680,7 +674,6 @@ namespace ACE.Server.WorldObjects
                     // the player will end up loading with this object in their inventory even though the landblock is the true owner. This is because
                     // when we load player inventory, the database still has the record that shows this player as the ContainerId for the item.
                     item.SaveBiotaToDatabase();
-                    container.SaveBiotaToDatabase();
                 }
             }
 


### PR DESCRIPTION
Hook are saved when an item is added to it. This is to prevent the possibilty of an item being lost in the event an item is added and the server crashes immediately after.

In addition, the OnAddItem and OnRemoveItem code has been cleaned up as well.