### PR TITLE
Load Landblock resources async again

### DIFF
--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -124,7 +124,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns a reference to a landblock, loading the landblock if not already active
         /// </summary>
-        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false, bool loadSync = false)
+        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false)
         {
             Landblock landblock = null;
 
@@ -135,7 +135,7 @@ namespace ACE.Server.Managers
                 if (landblock == null)
                 {
                     // load up this landblock
-                    landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY] = new Landblock(landblockId, loadSync);
+                    landblock = landblocks[landblockId.LandblockX, landblockId.LandblockY] = new Landblock(landblockId);
 
                     if (!activeLandblocks.Add(landblock))
                     {

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -124,7 +124,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Returns a reference to a landblock, loading the landblock if not already active
         /// </summary>
-        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false, bool loadSync = true)
+        public static Landblock GetLandblock(LandblockId landblockId, bool loadAdjacents, bool permaload = false, bool loadSync = false)
         {
             Landblock landblock = null;
 
@@ -153,7 +153,7 @@ namespace ACE.Server.Managers
             {
                 var adjacents = GetAdjacentIDs(landblock);
                 foreach (var adjacent in adjacents)
-                    GetLandblock(adjacent, false, false, false);
+                    GetLandblock(adjacent, false);
             }
 
             // cache adjacencies

--- a/Source/ACE.Server/Physics/Common/Landblock.cs
+++ b/Source/ACE.Server/Physics/Common/Landblock.cs
@@ -642,5 +642,10 @@ namespace ACE.Server.Physics.Common
             }
             return envcells;
         }
+
+        public void SortObjects()
+        {
+            ServerObjects = ServerObjects.OrderBy(i => i.Order).ToList();
+        }
     }
 }

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -80,6 +80,7 @@ namespace ACE.Server.Physics
         public PhysicsObj ProjectileTarget;
         public double PhysicsTimer_CurrentTime;
         public bool DatObject = false;
+        public int Order = 1;
 
         /// <summary>
         /// This is managed by MovementManager.MotionInterpreter, and should not be updated anywhere else.

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -343,6 +343,17 @@ namespace ACE.Server.WorldObjects
 
         public void OnTeleportComplete()
         {
+            if (CurrentLandblock != null && !CurrentLandblock.CreateWorldObjectsCompleted)
+            {
+                // If the critical landblock resources haven't been loaded yet, we keep the player in the pink bubble state
+                // We'll check periodically to see when it's safe to let them materialize in
+                var actionChain = new ActionChain();
+                actionChain.AddDelaySeconds(0.1);
+                actionChain.AddAction(this, OnTeleportComplete);
+                actionChain.EnqueueChain();
+                return;
+            }
+
             // set materialize physics state
             // this takes the player from pink bubbles -> fully materialized
             ReportCollisions = true;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Links.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Links.cs
@@ -46,6 +46,8 @@ namespace ACE.Server.WorldObjects
                 wo.Location = new Position(link.ObjCellId, link.OriginX, link.OriginY, link.OriginZ, link.AnglesX, link.AnglesY, link.AnglesZ, link.AnglesW);
                 parent.SetLinkProperties(wo);
                 CurrentLandblock?.AddWorldObject(wo);
+                if (wo.PhysicsObj != null)
+                    wo.PhysicsObj.Order = 0;
 
                 wo.ParentLink = parent;
                 parent.ChildLinks.Add(wo);


### PR DESCRIPTION
We must wait for Landblock.CreateWorldObjects() to complete before we can teleport in. For that we have a new bool CreateWorldObjectsCompleted

Players now check this bool in OnTeleportComplete() and delay materliazation until the landblock resources have finished loading. This will keep players in a pink bubble state until it's safe to spawn in.