### PR TITLE
Fix Create and Monster Death Destroy()

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -991,6 +991,9 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
+            if (!loot.TimeToRot.HasValue)
+                loot.TimeToRot = Double.MaxValue;
+
             //LootGenerationFactory.Spawn(loot, session.Player.Location.InFrontOf(1.0f));
             //inventoryItem.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
             //inventoryItem.Sequences.GetNextSequence(SequenceType.ObjectVector);

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -93,15 +93,6 @@ namespace ACE.Server.Managers
         }
 
         /// <summary>
-        /// Removes a WorldObject from the landblock defined by the object's location
-        /// </summary>
-        public static void RemoveObject(WorldObject worldObject)
-        {
-            var block = GetLandblock(worldObject.Location.LandblockId, false);
-            block.RemoveWorldObject(worldObject.Guid, false);
-        }
-
-        /// <summary>
         /// Relocates an object to the appropriate landblock -- Should only be called from physics/worldmanager -- not player!
         /// </summary>
         public static void RelocateObjectForPhysics(WorldObject worldObject, bool adjacencyMove)

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -94,8 +94,7 @@ namespace ACE.Server.WorldObjects
 
             dieChain.AddAction(this, () =>
             {
-                NotifyOfEvent(RegenerationType.Destruction);
-                LandblockManager.RemoveObject(this);
+                Destroy();
                 CreateCorpse(topDamager);
             });
 

--- a/Source/ACE.Server/WorldObjects/GamePiece.cs
+++ b/Source/ACE.Server/WorldObjects/GamePiece.cs
@@ -43,10 +43,7 @@ namespace ACE.Server.WorldObjects
                 ApplyVisualEffects(global::ACE.Entity.Enum.PlayScript.Destroy);
             });
             killChain.AddDelaySeconds(1);
-            killChain.AddAction(this, () =>
-            {
-               LandblockManager.RemoveObject(this);
-            });
+            killChain.AddAction(this, Destroy);
             killChain.EnqueueChain();
         }
     }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -215,7 +215,7 @@ namespace ACE.Server.WorldObjects
                 EnqueueBroadcast(new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.Explode, GetProjectileScriptIntensity(SpellType)));
             });
             selfDestructChain.AddDelaySeconds(5.0);
-            selfDestructChain.AddAction(this, () => LandblockManager.RemoveObject(this));
+            selfDestructChain.AddAction(this, Destroy);
             selfDestructChain.EnqueueChain();
         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -868,6 +868,8 @@ namespace ACE.Server.WorldObjects
             NotifyOfEvent(RegenerationType.Destruction);
             CurrentLandblock?.RemoveWorldObject(Guid);
             RemoveBiotaFromDatabase();
+
+            // todo recycle the guid
         }
 
         public string GetPluralName()


### PR DESCRIPTION
Create now sets TimeToRot to Double.MaxValue if whatever you're creating doesn't start with a default. This will leave the created object in the world forever, or until it's picked up and placed down again, or it's destroyed (possibly by killing it)

Monster deaths now call the Destroy() command

Few other places cleaned up that should have been calling Destroy()

Note added to Destroy() where the GUID recycling will be injected.