### PR TITLE
Fix CoinValue

### DIFF
--- a/Source/ACE.Server/WorldObjects/Coin.cs
+++ b/Source/ACE.Server/WorldObjects/Coin.cs
@@ -1,7 +1,6 @@
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
-using ACE.Entity.Enum.Properties;
 
 namespace ACE.Server.WorldObjects
 {
@@ -26,17 +25,5 @@ namespace ACE.Server.WorldObjects
         private void SetEphemeralValues()
         {
         }        
-
-        public override int? CoinValue
-        {
-            get
-            {
-                var value = Value ?? 0;
-
-                base.CoinValue = value;
-
-                return value;
-            }
-        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -74,6 +74,8 @@ namespace ACE.Server.WorldObjects
             SortBiotasIntoInventory(inventory);
             AddBiotasToEquippedObjects(wieldedItems);
 
+            UpdateCoinValue(false);
+
             // THIS IS A TEMPORARY PATCH TO COPY OVER EXISTING CHARACTER OPTIONS FROM THE BIOTA TO THE CHARACTER OBJECT.
             // This can be removed in time. 2018-09-01 Mag-nus
             if (Character.CharacterOptions1 == 0 && Character.CharacterOptions2 == 0)
@@ -131,8 +133,6 @@ namespace ACE.Server.WorldObjects
                 if (AdvocateLevel > 4)
                     IsPsr = true; // Enable AdvocateTeleport via MapClick
             }
-
-            UpdateCoinValue(false);
 
             QuestManager = new QuestManager(this);
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -75,15 +75,6 @@ namespace ACE.Server.WorldObjects
             AddBiotasToEquippedObjects(wieldedItems);
 
             UpdateCoinValue(false);
-
-            // THIS IS A TEMPORARY PATCH TO COPY OVER EXISTING CHARACTER OPTIONS FROM THE BIOTA TO THE CHARACTER OBJECT.
-            // This can be removed in time. 2018-09-01 Mag-nus
-            if (Character.CharacterOptions1 == 0 && Character.CharacterOptions2 == 0)
-            {
-                Character.CharacterOptions1 = GetProperty((PropertyInt)9003) ?? 1355064650;
-                Character.CharacterOptions2 = GetProperty((PropertyInt)9004) ?? 34560;
-                CharacterChangesDetected = true;
-            }
         }
 
         public override void InitPhysicsObj()

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -16,11 +16,8 @@ namespace ACE.Server.WorldObjects
         {
             int coins = 0;
 
-            foreach (var possession in GetAllPossessions())
-            {
-                if (possession.WeenieType == WeenieType.Coin)
-                    coins += possession.Value ?? 0;
-            }
+            foreach (var coinStack in GetInventoryItemsOfTypeWeenieType(WeenieType.Coin))
+                coins += coinStack.Value ?? 0;
 
             if (sendUpdateMessageIfChanged && CoinValue == coins)
                 sendUpdateMessageIfChanged = false;
@@ -29,21 +26,6 @@ namespace ACE.Server.WorldObjects
 
             if (sendUpdateMessageIfChanged)
                 Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CoinValue, CoinValue ?? 0));
-        }
-
-        // todo re-think how this works..
-        private void UpdateCurrencyClientCalculations(WeenieType type)
-        {
-            int coins = 0;
-            List<WorldObject> currency = new List<WorldObject>();
-            currency.AddRange(GetInventoryItemsOfTypeWeenieType(type));
-            foreach (WorldObject wo in currency)
-            {
-                if (wo.WeenieType == WeenieType.Coin)
-                    coins += wo.StackSize.Value;
-            }
-            // send packet to client letthing them know
-            CoinValue = coins;
         }
 
 
@@ -80,7 +62,7 @@ namespace ACE.Server.WorldObjects
             {
                 TryCreateInInventoryWithNetworking(wo);
             }
-            UpdateCurrencyClientCalculations(WeenieType.Coin);
+            UpdateCoinValue(false);
             return true;
         }
 
@@ -135,7 +117,7 @@ namespace ACE.Server.WorldObjects
                     TryCreateInInventoryWithNetworking(changeobj);
                 }
 
-                UpdateCurrencyClientCalculations(WeenieType.Coin);
+                UpdateCoinValue(false);
                 return cost;
             }
             return null;

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -405,7 +405,7 @@ namespace ACE.Server.WorldObjects
 
             uint totalPyreals = 0;
             foreach (var coinStack in coinStacks)
-                totalPyreals += (uint)coinStack.CoinValue;
+                totalPyreals += (uint)(coinStack.Value ?? 0);
 
             return totalPyreals;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1792,7 +1792,7 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.HealkitMod); else SetProperty(PropertyFloat.HealkitMod, value.Value); }
         }
 
-        public virtual int? CoinValue
+        public int? CoinValue
         {
             get => GetProperty(PropertyInt.CoinValue);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.CoinValue); else SetProperty(PropertyInt.CoinValue, value.Value); }


### PR DESCRIPTION
CoinValue should not be virtual.
Coin.cs no longer overrides CoinValue. Coins don't us CoinValue, only Players do.

This also fixes a bug where the players CoinValue wasn't set on initial login (likely the result of the previous reshuffling for the EncumbranceVal/Value PR)