### PR TITLE
cleaning up scatter position after initial spawn

### DIFF
--- a/Source/ACE.Server/Entity/Generator.cs
+++ b/Source/ACE.Server/Entity/Generator.cs
@@ -273,6 +273,8 @@ namespace ACE.Server.Entity
             obj.ScatterPos = new SetPosition(new Physics.Common.Position(obj.Location), SetPositionFlags.RandomScatter, genRadius);
 
             obj.EnterWorld();
+
+            obj.ScatterPos = null;
         }
 
         public void Spawn_Container(WorldObject obj)


### PR DESCRIPTION
This fixes a bug with picking up items spawned by scatter generators, and then later dropping them