### PR TITLE
Fix healing

### DIFF
--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -58,7 +58,21 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionUseOnTarget(Player player, WorldObject target)
         {
+            WorldObject invTarget;
+
             var useResult = WeenieError.None;
+
+            if (player != target)
+            {
+                invTarget = player.FindObject(target.Guid.Full, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems);
+                if (invTarget == null)
+                {
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.ActionCancelled));
+                    return;
+                }
+                else
+                    target = invTarget;
+            }
 
             if (!ItemCurMana.HasValue)
             {
@@ -74,7 +88,7 @@ namespace ACE.Server.WorldObjects
                         if (!player.TryConsumeFromInventoryWithNetworking(target))
                         {
                             log.Error($"Failed to remove {target.Name} from player inventory.");
-                            return;
+                            player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.ActionCancelled));
                         }
 
                         //The Mana Stone drains 5,253 points of mana from the Wand.

--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -67,7 +67,8 @@ namespace ACE.Server.WorldObjects
                 invTarget = player.FindObject(target.Guid.Full, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems);
                 if (invTarget == null)
                 {
-                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.ActionCancelled));
+                    // Haven't looked to see if an error was sent for this case; however, this one fits
+                    player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YouDoNotOwnThatItem));
                     return;
                 }
                 else

--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -71,8 +71,8 @@ namespace ACE.Server.WorldObjects
                     player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YouDoNotOwnThatItem));
                     return;
                 }
-                else
-                    target = invTarget;
+
+                target = invTarget;
             }
 
             if (!ItemCurMana.HasValue)

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -59,7 +59,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            // Is the target item in our possession?
+            // Resolve the guid to an object that is either in our posession or on the Landblock
             var targetItem = FindObject(targetObjectGuid, SearchLocations.MyInventory | SearchLocations.MyEquippedItems | SearchLocations.Landblock);
 
             if (targetItem == null)

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -59,36 +59,8 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-
-            // Is the target the player?
-            if (targetObjectGuid == Guid.Full)
-            {
-                // using something on ourselves
-                if (sourceItem.WeenieType == WeenieType.ManaStone)
-                    ((ManaStone)sourceItem).HandleActionUseOnTarget(this, this);
-                else
-                    RecipeManager.UseObjectOnTarget(this, sourceItem, this);
-
-                return;
-            }
-
-
             // Is the target item in our possession?
-            var targetItem = FindObject(targetObjectGuid, SearchLocations.MyInventory | SearchLocations.MyEquippedItems);
-
-            if (targetItem != null)
-            {
-                if (sourceItem.WeenieType == WeenieType.ManaStone)
-                    ((ManaStone)sourceItem).HandleActionUseOnTarget(this, targetItem);
-                else
-                    RecipeManager.UseObjectOnTarget(this, sourceItem, targetItem);
-
-                return;
-            }
-
-
-            // Is the target on the landblock?
-            targetItem = FindObject(targetObjectGuid, SearchLocations.Landblock);
+            var targetItem = FindObject(targetObjectGuid, SearchLocations.MyInventory | SearchLocations.MyEquippedItems | SearchLocations.Landblock);
 
             if (targetItem == null)
             {
@@ -97,24 +69,26 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (sourceItem.WeenieType == WeenieType.Healer)
+            switch (sourceItem.WeenieType)
             {
-                if (targetItem is Player player)
-                    ((Healer)sourceItem).HandleActionUseOnTarget(this, player);
-                else
-                    SendUseDoneEvent(WeenieError.YouCantHealThat);
-            }
-            else if (sourceItem.WeenieType == WeenieType.Key)
-            {
-                ((Key)sourceItem).HandleActionUseOnTarget(this, targetItem);
-            }
-            else if (sourceItem.WeenieType == WeenieType.Lockpick)
-            {
-                ((Lockpick)sourceItem).HandleActionUseOnTarget(this, targetItem);
-            }
-            else
-            {
-                RecipeManager.UseObjectOnTarget(this, sourceItem, targetItem);
+                case WeenieType.ManaStone:
+                    ((ManaStone)sourceItem).HandleActionUseOnTarget(this, targetItem);
+                    break;
+                case WeenieType.Healer:
+                    if (targetItem is Player player)
+                        ((Healer)sourceItem).HandleActionUseOnTarget(this, player);
+                    else
+                        SendUseDoneEvent(WeenieError.YouCantHealThat);
+                    break;
+                case WeenieType.Key:
+                    ((Key)sourceItem).HandleActionUseOnTarget(this, targetItem);
+                    break;
+                case WeenieType.Lockpick:
+                    ((Lockpick)sourceItem).HandleActionUseOnTarget(this, targetItem);
+                    break;
+                default:
+                    RecipeManager.UseObjectOnTarget(this, sourceItem, targetItem);
+                    break;
             }
         }
 


### PR DESCRIPTION
- Rework and simplify slightly Player.HandleActionUseWithTarget to allow healing to work, again, and add an allowed target check into ManaStone.HandleActionUseOnTarget()