### PR TITLE
Make sure prior container is closed when using a new one

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionNoLongerViewingContents.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionNoLongerViewingContents.cs
@@ -1,19 +1,14 @@
-using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
     public static class GameActionNoLongerViewingContents
     {
         [GameAction(GameActionType.NoLongerViewingContents)]
-
         public static void Handle(ClientMessage message, Session session)
         {
             var objectGuid = message.Payload.ReadUInt32();
 
-            var container = session.Player.CurrentLandblock?.GetObject(objectGuid) as Container;
-
-            if (container != null && container.Viewer == session.Player.Guid.Full)
-                container.Close(session.Player);
+            session.Player.HandleActionNoLongerViewingContents(objectGuid);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -102,9 +102,6 @@ namespace ACE.Server.WorldObjects
 
             if (IsLocked)
             {
-                if (player.LastUsedContainerId == Guid)
-                    player.LastUsedContainerId = ObjectGuid.Invalid;
-
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));
                 return;
             }

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -478,7 +478,12 @@ namespace ACE.Server.WorldObjects
             SendInventory(player);
         }
 
-        public void SendInventory(Player player)
+        protected virtual float DoOnOpenMotionChanges()
+        {
+            return 0;
+        }
+
+        private void SendInventory(Player player)
         {
             // send createobject for all objects in this container's inventory to player
             var itemsToSend = new List<GameMessage>();
@@ -502,11 +507,6 @@ namespace ACE.Server.WorldObjects
             // send sub-containers
             foreach (var container in Inventory.Values.Where(i => i is Container))
                 player.Session.Network.EnqueueSend(new GameEventViewContents(player.Session, (Container)container));
-        }
-
-        protected virtual float DoOnOpenMotionChanges()
-        {
-            return 0;
         }
 
         public virtual void Close(Player player)

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -440,15 +440,13 @@ namespace ACE.Server.WorldObjects
                 return;
 
             // If we have a previous container open, let's close it
-            if (player.LastUsedContainerId != ObjectGuid.Invalid && player.LastUsedContainerId != Guid)
+            if (player.LastOpenedContainerId != ObjectGuid.Invalid && player.LastOpenedContainerId != Guid)
             {
-                var lastUsedContainer = CurrentLandblock?.GetObject(player.LastUsedContainerId) as Container;
+                var lastOpenedContainer = CurrentLandblock?.GetObject(player.LastOpenedContainerId) as Container;
 
-                if (lastUsedContainer != null && lastUsedContainer.IsOpen && lastUsedContainer.Viewer == player.Guid.Full)
-                    lastUsedContainer.Close(player);
+                if (lastOpenedContainer != null && lastOpenedContainer.IsOpen && lastOpenedContainer.Viewer == player.Guid.Full)
+                    lastOpenedContainer.Close(player);
             }
-
-            player.LastUsedContainerId = Guid;
 
             if (!IsOpen)
             {
@@ -468,6 +466,8 @@ namespace ACE.Server.WorldObjects
         public virtual void Open(Player player)
         {
             if (IsOpen) return;
+
+            player.LastOpenedContainerId = Guid;
 
             IsOpen = true;
 
@@ -525,8 +525,8 @@ namespace ACE.Server.WorldObjects
                 {
                     player.Session.Network.EnqueueSend(new GameEventCloseGroundContainer(player.Session, this));
 
-                    if (player.LastUsedContainerId == Guid)
-                        player.LastUsedContainerId = ObjectGuid.Invalid;
+                    if (player.LastOpenedContainerId == Guid)
+                        player.LastOpenedContainerId = ObjectGuid.Invalid;
 
                     // send deleteobject for all objects in this container's inventory to player
                     // this seems logical, but it bugs out the client for re-opening chests w/ respawned items

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -439,6 +439,17 @@ namespace ACE.Server.WorldObjects
             if (!(wo is Player player))
                 return;
 
+            // If we have a previous container open, let's close it
+            if (player.LastUsedContainerId != ObjectGuid.Invalid && player.LastUsedContainerId != Guid)
+            {
+                var lastUsedContainer = CurrentLandblock?.GetObject(player.LastUsedContainerId) as Container;
+
+                if (lastUsedContainer != null && lastUsedContainer.IsOpen && lastUsedContainer.Viewer == player.Guid.Full)
+                    lastUsedContainer.Close(player);
+            }
+
+            player.LastUsedContainerId = Guid;
+
             if (!IsOpen)
             {
                 Open(player);

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -382,9 +382,9 @@ namespace ACE.Server.WorldObjects
 
             if (searchLocations.HasFlag(SearchLocations.LastUsedContainer))
             {
-                if (CurrentLandblock?.GetObject(LastUsedContainerId) is Container lastUsedContainer)
+                if (CurrentLandblock?.GetObject(LastOpenedContainerId) is Container lastOpenedContainer)
                 {
-                    if (lastUsedContainer is Vendor lastUsedVendor)
+                    if (lastOpenedContainer is Vendor lastUsedVendor)
                     {
                         if (lastUsedVendor.AllItemsForSale.TryGetValue(objectGuid, out result))
                         {
@@ -392,13 +392,13 @@ namespace ACE.Server.WorldObjects
                             return result;
                         }
                     }
-                    if (lastUsedContainer.IsOpen && lastUsedContainer.Viewer == Guid.Full)
+                    if (lastOpenedContainer.IsOpen && lastOpenedContainer.Viewer == Guid.Full)
                     {
-                        result = lastUsedContainer.GetInventoryItem(objectGuid, out foundInContainer);
+                        result = lastOpenedContainer.GetInventoryItem(objectGuid, out foundInContainer);
 
                         if (result != null)
                         {
-                            rootOwner = lastUsedContainer;
+                            rootOwner = lastOpenedContainer;
                             return result;
                         }
                     }

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -153,12 +153,7 @@ namespace ACE.Server.WorldObjects
             LastUseTime = 0.0f;
 
             if (success)
-            {
-                if (item is Container)
-                    LastUsedContainerId = item.Guid;
-
                 item.OnActivate(this);
-            }
 
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(LastUseTime);
@@ -173,6 +168,20 @@ namespace ACE.Server.WorldObjects
         public void SendUseDoneEvent(WeenieError errorType = WeenieError.None)
         {
             Session.Network.EnqueueSend(new GameEventUseDone(Session, errorType));
+        }
+
+
+        /// <summary>
+        /// This method processes the Game Action (F7B1) No Longer Viewing Contents (0x0195)
+        /// This is raised when we:
+        /// - have a container open and open up a second container without closing the first container.
+        /// </summary>
+        public void HandleActionNoLongerViewingContents(uint objectGuid)
+        {
+            var container = CurrentLandblock?.GetObject(objectGuid) as Container;
+
+            if (container != null && container.Viewer == Guid.Full)
+                container.Close(this);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// This is set by HandleActionUseItem / TryUseItem
         /// </summary>
-        public ObjectGuid LastUsedContainerId { get; set; }
+        public ObjectGuid LastOpenedContainerId { get; set; }
 
         /// <summary>
         /// Handles the 'GameAction 0x35 - UseWithTarget' network message
@@ -130,7 +130,7 @@ namespace ACE.Server.WorldObjects
 
             if (item != null)
             {
-                if (item.CurrentLandblock != null && !item.Visibility && item.Guid != LastUsedContainerId)
+                if (item.CurrentLandblock != null && !item.Visibility && item.Guid != LastOpenedContainerId)
                     CreateMoveToChain(item, (success) => TryUseItem(item, success));
                 else
                     TryUseItem(item);

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -96,7 +96,7 @@ namespace ACE.Server.WorldObjects
             if (action != VendorType.Undef)
                 DoVendorEmote(action, player);
 
-            player.LastUsedContainerId = Guid;
+            player.LastOpenedContainerId = Guid;
         }
 
         /// <summary>
@@ -208,8 +208,8 @@ namespace ACE.Server.WorldObjects
 
             if (dist > UseRadius)
             {
-                if (LastPlayer.LastUsedContainerId == Guid)
-                    LastPlayer.LastUsedContainerId = ObjectGuid.Invalid;
+                if (LastPlayer.LastOpenedContainerId == Guid)
+                    LastPlayer.LastOpenedContainerId = ObjectGuid.Invalid;
 
                 EmoteManager.DoVendorEmote(VendorType.Close, LastPlayer);
                 LastPlayer = null;

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -209,7 +209,7 @@ namespace ACE.Server.WorldObjects
             if (dist > UseRadius)
             {
                 if (LastPlayer.LastUsedContainerId == Guid)
-                    LastPlayer.LastUsedContainerId = new ObjectGuid(0);
+                    LastPlayer.LastUsedContainerId = ObjectGuid.Invalid;
 
                 EmoteManager.DoVendorEmote(VendorType.Close, LastPlayer);
                 LastPlayer = null;

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -710,11 +710,13 @@ namespace ACE.Server.WorldObjects
             return adjusted;
         }
 
+        // TODO: This isn't overriden by any child object. Should we be using the virtual functions in Container instead?
         public virtual void Open(WorldObject opener)
         {
             // empty base, override in child objects
         }
 
+        // TODO: This isn't overriden by any child object. Should we be using the virtual functions in Container instead?
         public virtual void Close(WorldObject closer)
         {
             // empty base, override in child objects


### PR DESCRIPTION
I noticed that in some cases, under load, corpses were remaining on the landblock (not decaying), because the IsOpen flag remained true. This was because either the closing ActOnUse message was being lost, or, VTank was not sending these when extra server load was present.

Now, when we ActOnUse on a new container, and our previous container is still IsOpen by us, we close it.

Also, LastUsedContainer has been changed to LastOpenedContainer which is more descriptive of its actual function.