### PR TITLE
Fixing invisible player bug

### DIFF
--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -2196,6 +2196,8 @@ namespace ACE.Server.Physics
                 {
                     newlyVisible = player.handle_visible_cells();
                     player.enqueue_objs(newlyVisible);
+
+                    player.ObjMaint.AddVoyeur(this);
                 }
             }
         }


### PR DESCRIPTION
This bug occurs when players re-enter visibility to an unmoving player