### PR TITLE
Fix for vendors selling and/or buying items with Value of 0

### DIFF
--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -325,7 +325,7 @@ namespace ACE.Server.WorldObjects
                 if (wo.ItemType == ItemType.PromissoryNote)
                     sellRate = 1.15;
 
-                goldcost += (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1);
+                goldcost += Math.Max(1, (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1));
             }
 
             foreach (WorldObject wo in genlist)
@@ -334,7 +334,7 @@ namespace ACE.Server.WorldObjects
                 if (wo.ItemType == ItemType.PromissoryNote)
                     sellRate = 1.15;
 
-                goldcost += (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1);
+                goldcost += Math.Max(1, (uint)Math.Ceiling((wo.Value ?? 0) * sellRate - 0.1));
             }
 
             // send transaction to player for further processing and.
@@ -376,7 +376,7 @@ namespace ACE.Server.WorldObjects
                     buyRate = 1.0;
 
                 // payout scaled by the vendor's buy rate
-                payout += (int)Math.Floor((wo.Value ?? 0) * buyRate + 0.1);
+                payout += Math.Max(1, (int)Math.Floor((wo.Value ?? 0) * buyRate + 0.1));
             }
 
             return payout;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-03-12
+[gmriggs, Ripley]
+* Fix Vendors to handle 0 value items properly in buy/sell.
+
 ### 2019-03-10
 [Ripley]
 * Changed the way Name property is handled with regards to + (Admin/Sentinel characters).


### PR DESCRIPTION
Items sold or bought by vendors that report Value of 0 are treated as if they were Value of 1.

This is seen with the vendor in training academy, Oil of Rendering is meant to cost 1p, while its value is 0.

In practice this is rare, and client tends to not allow player to sale to vendors items of 0 value items

Co-Authored-By: gmriggs <gmriggs@gmail.com>