### PR TITLE
Fix the legacy Open/Close virtual functions in WorldObject base

### DIFF
--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -195,7 +195,7 @@ namespace ACE.Server.Managers
                 case EmoteType.CloseMe:
 
                     // animation delay?
-                    if (targetObject is Container container)
+                    if (WorldObject is Container container)
                         container.Close(null);
                     break;
 

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -195,8 +195,8 @@ namespace ACE.Server.Managers
                 case EmoteType.CloseMe:
 
                     // animation delay?
-                    if (targetObject != null)
-                        targetObject.Close(WorldObject);
+                    if (targetObject is Container container)
+                        container.Close(null);
                     break;
 
                 case EmoteType.CreateTreasure:
@@ -809,7 +809,8 @@ namespace ACE.Server.Managers
 
                 case EmoteType.OpenMe:
 
-                    WorldObject.Open(WorldObject);
+                    if (WorldObject is Container container2)
+                        container2.Open(null);
                     break;
 
                 case EmoteType.PetCastSpellOnOwner:

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -710,18 +710,6 @@ namespace ACE.Server.WorldObjects
             return adjusted;
         }
 
-        // TODO: This isn't overriden by any child object. Should we be using the virtual functions in Container instead?
-        public virtual void Open(WorldObject opener)
-        {
-            // empty base, override in child objects
-        }
-
-        // TODO: This isn't overriden by any child object. Should we be using the virtual functions in Container instead?
-        public virtual void Close(WorldObject closer)
-        {
-            // empty base, override in child objects
-        }
-
         /// <summary>
         /// Returns a strike message based on damage type and severity
         /// </summary>


### PR DESCRIPTION
I don't understand the emote system, but it seems odd to me that
CloseMe does **targetObject**.Close()
and
OpenMe does **WorldObject**.Open()

Shouldn't they be performing the action on the same object?