### PR TITLE
consolidating pyreals in death message, adding corpse_destroy_pyreals option

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -439,6 +439,8 @@ namespace ACE.Server.Managers
 
         public static readonly ReadOnlyDictionary<string, bool> DefaultBooleanProperties =
             DictOf(
+                ("corpse_destroy_pyreals", true),   // when player loses pyreals on death, should the pyreals be destroyed completely (end of retail),
+                                                    // or should they be dropped on corpse (release)
                 ("house_purchase_requirements", true),
                 ("house_rent_enabled", true),
                 ("pk_server", false)


### PR DESCRIPTION
This resolves https://github.com/ACEmulator/ACE/issues/1535

Some notes:

- The max size for a pyreal stack is 25k, so tested with 3x stacks of 10k pyreals each, instead of the 100k pyreal stacks in the original issue

- The exact message printed by this scenario was: You've lost 10,000 Pyreals, 5,000 Pyreals, your Leather Boots, your Pants, and your Jerkin!

So not exactly splitting each of the 3x 10k stacks in half, but this is the way the SpendCurrency() function works... it sorts all of the Pyreal stacks in order from smallest to largest, and then starts consuming the amount of coins

The death message has been consolidated, so the total amount of pyreals dropped is listed, instead of each of the individual stacks that were consumed from.

After much discussion about whether or not pyreals were destroyed on death, or dropped on the corpse (with people certain it seemed to work both ways), it was learned that pyreals originally dropped on death, but at some point during retail, this was changed to destroyed.

The server defaults to end of retail settings (destroyed on death), but a new config option has been added, if the server admin wishes to run with coins dropped on player corpses, similar to the earlier days

To enable this setting: /modifybool corpse_destroy_pyreals false