### PR TITLE
Allow passthrough of permaload flag to landblocks loaded by adjacent load

### DIFF
--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -144,7 +144,7 @@ namespace ACE.Server.Managers
             {
                 var adjacents = GetAdjacentIDs(landblock);
                 foreach (var adjacent in adjacents)
-                    GetLandblock(adjacent, false);
+                    GetLandblock(adjacent, false, permaload);
             }
 
             // cache adjacencies

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-03-14
+[Ripley]
+* Allow passthrough of permaload flag to landblocks loaded by adjacent load.
+
 ### 2019-03-12
 [gmriggs, Ripley]
 * Fix Vendors to handle 0 value items properly in buy/sell.


### PR DESCRIPTION
If landblock is set to permaload and it also set to load its adajcents, those landblocks should also be marked as permaload