### PR TITLE
AddWorldObjectInternal Fix

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -534,25 +534,26 @@ namespace ACE.Server.Entity
 
         private void AddWorldObjectInternal(WorldObject wo)
         {
-            if (!worldObjects.ContainsKey(wo.Guid))
-                pendingAdditions[wo.Guid] = wo;
-            else
-                pendingRemovals.Remove(wo.Guid);
-
             wo.CurrentLandblock = this;
 
             if (wo.PhysicsObj == null)
                 wo.InitPhysicsObj();
 
             if (wo.PhysicsObj.CurCell == null)
-            { 
+            {
                 var success = wo.AddPhysicsObj();
                 if (!success)
                 {
+                    wo.CurrentLandblock = null;
                     log.Warn($"AddWorldObjectInternal: couldn't spawn {wo.Name}");
                     return;
                 }
             }
+
+            if (!worldObjects.ContainsKey(wo.Guid))
+                pendingAdditions[wo.Guid] = wo;
+            else
+                pendingRemovals.Remove(wo.Guid);
 
             // if adding a player to this landblock,
             // tell them about other nearby objects


### PR DESCRIPTION
Check to see if AddPhysicsObj failed first, before we actually add the object to the landblock.

I did not actually play test this...

Edit: Play tested it. Seems normal to me.