### PR TITLE
Support AdvocateItem RadarBlipColor changes

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -136,7 +136,6 @@ namespace ACE.Entity.Enum.Properties
         PhysicsState                             = 93,
         [ServerOnly]
         TargetType                               = 94,
-        [Ephemeral]
         RadarBlipColor                           = 95,
         EncumbranceCapacity                      = 96,
         LoginTimestamp                           = 97,

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -898,8 +898,8 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetInt64Stat:
-                    player.UpdateProperty(player, (PropertyInt64)emote.Stat, emote.Amount);
-                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt64(player, (PropertyInt64)emote.Stat, Convert.ToInt64(emote.Amount)));
+                    player.UpdateProperty(player, (PropertyInt64)emote.Stat, emote.Amount64);
+                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt64(player, (PropertyInt64)emote.Stat, Convert.ToInt64(emote.Amount64)));
                     break;
 
                 case EmoteType.SetIntStat:

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -900,7 +900,10 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetIntStat:
-                    player.SetProperty((PropertyInt)emote.Stat, (int)emote.Amount);
+                    //player.SetProperty((PropertyInt)emote.Stat, (int)emote.Amount);
+                    //player.UpdateProperty(player, (PropertyInt)emote.Stat, (int)emote.Amount);
+                    player.UpdateProperty(player, (PropertyInt)emote.Stat, emote.Amount);
+                    player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
                     break;
 
                 case EmoteType.SetMouthPalette:

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -870,8 +870,11 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetBoolStat:
-                    player.UpdateProperty(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true);
-                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyBool(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true));
+                    if (player != null)
+                    {
+                        player.UpdateProperty(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true);
+                        player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyBool(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true));
+                    }
                     break;
 
                 case EmoteType.SetEyePalette:
@@ -885,8 +888,11 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetFloatStat:
-                    player.UpdateProperty(player, (PropertyFloat)emote.Stat, emote.Percent);
-                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyFloat(player, (PropertyFloat)emote.Stat, Convert.ToDouble(emote.Percent)));
+                    if (player != null)
+                    {
+                        player.UpdateProperty(player, (PropertyFloat)emote.Stat, emote.Percent);
+                        player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyFloat(player, (PropertyFloat)emote.Stat, Convert.ToDouble(emote.Percent)));
+                    }
                     break;
 
                 case EmoteType.SetHeadObject:
@@ -898,13 +904,19 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetInt64Stat:
-                    player.UpdateProperty(player, (PropertyInt64)emote.Stat, emote.Amount64);
-                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt64(player, (PropertyInt64)emote.Stat, Convert.ToInt64(emote.Amount64)));
+                    if (player != null)
+                    {
+                        player.UpdateProperty(player, (PropertyInt64)emote.Stat, emote.Amount64);
+                        player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt64(player, (PropertyInt64)emote.Stat, Convert.ToInt64(emote.Amount64)));
+                    }
                     break;
 
                 case EmoteType.SetIntStat:
-                    player.UpdateProperty(player, (PropertyInt)emote.Stat, emote.Amount);
-                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
+                    if (player != null)
+                    {
+                        player.UpdateProperty(player, (PropertyInt)emote.Stat, emote.Amount);
+                        player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
+                    }
                     break;
 
                 case EmoteType.SetMouthPalette:

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -870,7 +870,8 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetBoolStat:
-                    targetObject.SetProperty((PropertyBool)emote.Stat, emote.Amount == 0 ? false : true);
+                    player.UpdateProperty(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true);
+                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyBool(player, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true));
                     break;
 
                 case EmoteType.SetEyePalette:
@@ -884,7 +885,8 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetFloatStat:
-                    targetObject.SetProperty((PropertyFloat)emote.Stat, (float)emote.Amount);
+                    player.UpdateProperty(player, (PropertyFloat)emote.Stat, (double)emote.Percent);
+                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyFloat(player, (PropertyFloat)emote.Stat, Convert.ToDouble(emote.Percent)));
                     break;
 
                 case EmoteType.SetHeadObject:
@@ -896,12 +898,13 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetInt64Stat:
-                    player.SetProperty((PropertyInt64)emote.Stat, (int)emote.Amount);
+                    player.UpdateProperty(player, (PropertyInt64)emote.Stat, emote.Amount);
+                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt64(player, (PropertyInt64)emote.Stat, Convert.ToInt64(emote.Amount)));
                     break;
 
                 case EmoteType.SetIntStat:
                     player.UpdateProperty(player, (PropertyInt)emote.Stat, emote.Amount);
-                    player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
+                    player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
                     break;
 
                 case EmoteType.SetMouthPalette:

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -885,7 +885,7 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetFloatStat:
-                    player.UpdateProperty(player, (PropertyFloat)emote.Stat, (double)emote.Percent);
+                    player.UpdateProperty(player, (PropertyFloat)emote.Stat, emote.Percent);
                     player.EnqueueBroadcast(false, new GameMessagePublicUpdatePropertyFloat(player, (PropertyFloat)emote.Stat, Convert.ToDouble(emote.Percent)));
                     break;
 

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -900,8 +900,6 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.SetIntStat:
-                    //player.SetProperty((PropertyInt)emote.Stat, (int)emote.Amount);
-                    //player.UpdateProperty(player, (PropertyInt)emote.Stat, (int)emote.Amount);
                     player.UpdateProperty(player, (PropertyInt)emote.Stat, emote.Amount);
                     player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
                     break;

--- a/Source/ACE.Server/WorldObjects/AdvocateItem.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateItem.cs
@@ -2,6 +2,8 @@ using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Network.GameMessages.Messages;
 using System.Collections.Generic;
 
 namespace ACE.Server.WorldObjects
@@ -26,48 +28,70 @@ namespace ACE.Server.WorldObjects
 
         private void SetEphemeralValues()
         {
-            if (Biota.BiotaPropertiesEmote.Count == 0)
-            {
-                Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
-                {
-                    ObjectId = Guid.Full,
-                    Category = (uint)EmoteCategory.Wield,
-                    Probability = 1,
-                    BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
-                    {
-                        new BiotaPropertiesEmoteAction
-                        {
-                            EmoteId = uint.MaxValue,
-                            Order = 0,
-                            Type = (int)EmoteType.SetIntStat,
-                            Delay = 0,
-                            Extent = 1,
-                            Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
-                            Amount = (int)ACE.Entity.Enum.RadarColor.Advocate
-                        }
-                    }
-                });
+            //if (Biota.BiotaPropertiesEmote.Count == 0)
+            //{
+            //    Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
+            //    {
+            //        ObjectId = Guid.Full,
+            //        Category = (uint)EmoteCategory.Wield,
+            //        Probability = 1,
+            //        BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
+            //        {
+            //            new BiotaPropertiesEmoteAction
+            //            {
+            //                EmoteId = uint.MaxValue,
+            //                Order = 0,
+            //                Type = (int)EmoteType.SetIntStat,
+            //                Delay = 0,
+            //                Extent = 1,
+            //                Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
+            //                Amount = (int)ACE.Entity.Enum.RadarColor.Advocate
+            //            }
+            //        }
+            //    });
 
-                Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
-                {
-                    ObjectId = Guid.Full,
-                    Category = (uint)EmoteCategory.UnWield,
-                    Probability = 1,
-                    BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
-                    {
-                        new BiotaPropertiesEmoteAction
-                        {
-                            EmoteId = uint.MaxValue,
-                            Order = 0,
-                            Type = (int)EmoteType.SetIntStat,
-                            Delay = 0,
-                            Extent = 1,
-                            Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
-                            Amount = null
-                        }
-                    }
-                });
-            }
+            //    Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
+            //    {
+            //        ObjectId = Guid.Full,
+            //        Category = (uint)EmoteCategory.UnWield,
+            //        Probability = 1,
+            //        BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
+            //        {
+            //            new BiotaPropertiesEmoteAction
+            //            {
+            //                EmoteId = uint.MaxValue,
+            //                Order = 0,
+            //                Type = (int)EmoteType.SetIntStat,
+            //                Delay = 0,
+            //                Extent = 1,
+            //                Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
+            //                Amount = null
+            //            }
+            //        }
+            //    });
+            //}
+        }
+
+        public override void OnWield(Creature creature)
+        {
+            //var player = creature as Player;
+
+            //player.UpdateProperty(player, ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor, (int)ACE.Entity.Enum.RadarColor.Advocate);
+            //player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
+            creature.RadarColor = ACE.Entity.Enum.RadarColor.Advocate;
+            creature.EnqueueBroadcast(true, new GameMessagePublicUpdatePropertyInt(creature, PropertyInt.RadarBlipColor, (int)creature.RadarColor));
+            creature.SetProperty(PropertyBool.AdvocateState, true);
+
+            base.OnWield(creature);
+        }
+
+        public override void OnUnWield(Creature creature)
+        {
+            creature.RadarColor = null;
+            creature.EnqueueBroadcast(true, new GameMessagePublicUpdatePropertyInt(creature, PropertyInt.RadarBlipColor, 0));
+            creature.SetProperty(PropertyBool.AdvocateState, false);
+
+            base.OnUnWield(creature);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/AdvocateItem.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateItem.cs
@@ -1,6 +1,8 @@
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
+using ACE.Entity.Enum;
+using System.Collections.Generic;
 
 namespace ACE.Server.WorldObjects
 {
@@ -24,6 +26,48 @@ namespace ACE.Server.WorldObjects
 
         private void SetEphemeralValues()
         {
+            if (Biota.BiotaPropertiesEmote.Count == 0)
+            {
+                Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
+                {
+                    ObjectId = Guid.Full,
+                    Category = (uint)EmoteCategory.Wield,
+                    Probability = 1,
+                    BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
+                    {
+                        new BiotaPropertiesEmoteAction
+                        {
+                            EmoteId = uint.MaxValue,
+                            Order = 0,
+                            Type = (int)EmoteType.SetIntStat,
+                            Delay = 0,
+                            Extent = 1,
+                            Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
+                            Amount = (int)ACE.Entity.Enum.RadarColor.Advocate
+                        }
+                    }
+                });
+
+                Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
+                {
+                    ObjectId = Guid.Full,
+                    Category = (uint)EmoteCategory.UnWield,
+                    Probability = 1,
+                    BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
+                    {
+                        new BiotaPropertiesEmoteAction
+                        {
+                            EmoteId = uint.MaxValue,
+                            Order = 0,
+                            Type = (int)EmoteType.SetIntStat,
+                            Delay = 0,
+                            Extent = 1,
+                            Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
+                            Amount = null
+                        }
+                    }
+                });
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/AdvocateItem.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateItem.cs
@@ -28,56 +28,10 @@ namespace ACE.Server.WorldObjects
 
         private void SetEphemeralValues()
         {
-            //if (Biota.BiotaPropertiesEmote.Count == 0)
-            //{
-            //    Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
-            //    {
-            //        ObjectId = Guid.Full,
-            //        Category = (uint)EmoteCategory.Wield,
-            //        Probability = 1,
-            //        BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
-            //        {
-            //            new BiotaPropertiesEmoteAction
-            //            {
-            //                EmoteId = uint.MaxValue,
-            //                Order = 0,
-            //                Type = (int)EmoteType.SetIntStat,
-            //                Delay = 0,
-            //                Extent = 1,
-            //                Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
-            //                Amount = (int)ACE.Entity.Enum.RadarColor.Advocate
-            //            }
-            //        }
-            //    });
-
-            //    Biota.BiotaPropertiesEmote.Add(new BiotaPropertiesEmote
-            //    {
-            //        ObjectId = Guid.Full,
-            //        Category = (uint)EmoteCategory.UnWield,
-            //        Probability = 1,
-            //        BiotaPropertiesEmoteAction = new List<BiotaPropertiesEmoteAction>
-            //        {
-            //            new BiotaPropertiesEmoteAction
-            //            {
-            //                EmoteId = uint.MaxValue,
-            //                Order = 0,
-            //                Type = (int)EmoteType.SetIntStat,
-            //                Delay = 0,
-            //                Extent = 1,
-            //                Stat = (int)ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor,
-            //                Amount = null
-            //            }
-            //        }
-            //    });
-            //}
         }
 
         public override void OnWield(Creature creature)
         {
-            //var player = creature as Player;
-
-            //player.UpdateProperty(player, ACE.Entity.Enum.Properties.PropertyInt.RadarBlipColor, (int)ACE.Entity.Enum.RadarColor.Advocate);
-            //player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyInt(player, (PropertyInt)emote.Stat, Convert.ToInt32(emote.Amount)));
             creature.RadarColor = ACE.Entity.Enum.RadarColor.Advocate;
             creature.EnqueueBroadcast(true, new GameMessagePublicUpdatePropertyInt(creature, PropertyInt.RadarBlipColor, (int)creature.RadarColor));
             creature.SetProperty(PropertyBool.AdvocateState, true);

--- a/Source/ACE.Server/WorldObjects/AdvocateItem.cs
+++ b/Source/ACE.Server/WorldObjects/AdvocateItem.cs
@@ -1,10 +1,8 @@
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
-using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Network.GameMessages.Messages;
-using System.Collections.Generic;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -224,7 +224,7 @@ namespace ACE.Server.WorldObjects
 
             TrySetChild(worldObject);
 
-            worldObject.EmoteManager.OnWield(this);
+            worldObject.OnWield(this);
 
             return true;
         }
@@ -292,7 +292,7 @@ namespace ACE.Server.WorldObjects
             var wo = worldObject;
             Children.Remove(Children.Find(s => s.Guid == wo.Guid.Full));
 
-            worldObject.EmoteManager.OnUnwield(this);
+            worldObject.OnUnWield(this);
 
             return true;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -104,5 +104,15 @@ namespace ACE.Server.WorldObjects
 
             return wo;
         }
+
+        public virtual void OnWield(Creature creature)
+        {
+            EmoteManager.OnWield(creature);
+        }
+
+        public virtual void OnUnWield(Creature creature)
+        {
+            EmoteManager.OnUnwield(creature);
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -87,6 +87,12 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual void EnqueueAction(IAction action)
         {
+            //if (CurrentLandblock == null && Wielder != null)
+            //{
+            //    Wielder.CurrentLandblock.EnqueueAction(action);
+            //    return;
+            //}
+
             if (CurrentLandblock == null)
             {
                 if (isDestroyed)
@@ -125,6 +131,10 @@ namespace ACE.Server.WorldObjects
                     else if (this is Container container && !container.InventoryLoaded)
                     {
                         // Containers enqueue the loading of their inventory from callbacks. It's possible the callback happened before the container was added to the landblock
+                    }
+                    else if(this is AdvocateItem)
+                    {
+                        // AdvocateItem is a wielded item and emote queues on Wield/UnWield. CurrentLandblock is always null for wielded items at present.
                     }
                     else
                         log.WarnFormat("Item 0x{0:X8}:{1} has enqueued an action but is not attached to a landblock.", Guid.Full, Name);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -87,12 +87,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public virtual void EnqueueAction(IAction action)
         {
-            //if (CurrentLandblock == null && Wielder != null)
-            //{
-            //    Wielder.CurrentLandblock.EnqueueAction(action);
-            //    return;
-            //}
-
             if (CurrentLandblock == null)
             {
                 if (isDestroyed)
@@ -132,7 +126,7 @@ namespace ACE.Server.WorldObjects
                     {
                         // Containers enqueue the loading of their inventory from callbacks. It's possible the callback happened before the container was added to the landblock
                     }
-                    else if(this is AdvocateItem)
+                    else if (this is AdvocateItem)
                     {
                         // AdvocateItem is a wielded item and emote queues on Wield/UnWield. CurrentLandblock is always null for wielded items at present.
                     }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -126,10 +126,6 @@ namespace ACE.Server.WorldObjects
                     {
                         // Containers enqueue the loading of their inventory from callbacks. It's possible the callback happened before the container was added to the landblock
                     }
-                    else if (this is AdvocateItem)
-                    {
-                        // AdvocateItem is a wielded item and emote queues on Wield/UnWield. CurrentLandblock is always null for wielded items at present.
-                    }
                     else
                         log.WarnFormat("Item 0x{0:X8}:{1} has enqueued an action but is not attached to a landblock.", Guid.Full, Name);
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-03-27
+[Ripley]
+* Support AdvocateItem changing/updating Radar Blip Color in similar fashion to retail servers.
+
 ### 2019-03-25
 [OptimShi]
 * Appraised items on houseing hooks now show the details on the hooked item.


### PR DESCRIPTION
When Advocates equipped their Aegis (AdvocateItem) RadarBlipColor changed from White (Default) to Pink (Advocate) and the reverse occurred on unequip.