### PR TITLE
Gear Knight display fixes

### DIFF
--- a/Source/ACE.DatLoader/Entity/SexCG.cs
+++ b/Source/ACE.DatLoader/Entity/SexCG.cs
@@ -74,10 +74,15 @@ namespace ACE.DatLoader.Entity
         }
 
         // Hair (Head)
-        public uint GetHeadObject(uint hairStyle)
+        public uint? GetHeadObject(uint hairStyle)
         {
             HairStyleCG hairstyle = HairStyleList[Convert.ToInt32(hairStyle)];
-            return hairstyle.ObjDesc.AnimPartChanges[0].PartID;
+
+            // Gear Knights, both Olthoi types have multiple anim part changes.
+            if (hairstyle.ObjDesc.AnimPartChanges.Count == 1)
+                return hairstyle.ObjDesc.AnimPartChanges[0].PartID;
+            else
+                return null;
         }
         public uint GetHairTexture(uint hairStyle)
         {

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -581,6 +581,11 @@ namespace ACE.Entity.Enum.Properties
         AllegianceOfficerRank                   = 9010,
         [ServerOnly]
         HouseRentTimestamp                      = 9011,
+        /// <summary>
+        ///  Stores the player's selected hairstyle at creation or after a barber use. This is used only for Gear Knights and Olthoi characters who have more than a single part/texture for a "hairstyle" (BodyStyle)
+        /// </summary>
+        [ServerOnly]
+        Hairstyle = 9012,
     }
 
     public static class PropertyIntExtensions

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -59,6 +59,11 @@ namespace ACE.Server.Factories
             // Get the hair first, because we need to know if you're bald, and that's the name of that tune!
             var hairstyle = sex.HairStyleList[Convert.ToInt32(characterCreateInfo.Apperance.HairStyle)];
 
+            // Olthoi and Gear Knights have a "Body Style" instead of a hair style. These styles have multiple model/texture changes, instead of a single head/hairstyle.
+            // Storing this value allows us to send the proper appearance ObjDesc
+            if (hairstyle.ObjDesc.AnimPartChanges.Count > 1)
+                player.SetProperty(PropertyInt.Hairstyle, (int)characterCreateInfo.Apperance.HairStyle);
+
             // Certain races (Undead, Tumeroks, Others?) have multiple body styles available. This is controlled via the "hair style".
             if (hairstyle.AlternateSetup > 0)
                 player.SetProperty(PropertyDataId.Setup, hairstyle.AlternateSetup);
@@ -71,7 +76,10 @@ namespace ACE.Server.Factories
             player.SetProperty(PropertyDataId.DefaultMouthTexture, sex.GetDefaultMouthTexture(characterCreateInfo.Apperance.Mouth));
             player.Character.HairTexture = sex.GetHairTexture(characterCreateInfo.Apperance.HairStyle);
             player.Character.DefaultHairTexture = sex.GetDefaultHairTexture(characterCreateInfo.Apperance.HairStyle);
-            player.SetProperty(PropertyDataId.HeadObject, sex.GetHeadObject(characterCreateInfo.Apperance.HairStyle));
+            // HeadObject can be null if we're dealing with GearKnight or Olthoi
+            var headObject = sex.GetHeadObject(characterCreateInfo.Apperance.HairStyle);
+            if(headObject != null)
+                player.SetProperty(PropertyDataId.HeadObject, (uint)headObject);
 
             // Skin is stored as PaletteSet (list of Palettes), so we need to read in the set to get the specific palette
             var skinPalSet = DatManager.PortalDat.ReadFromDat<PaletteSet>(sex.SkinPalSet);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -1068,7 +1068,10 @@ namespace ACE.Server.WorldObjects
         protected void AddBaseModelData(ACE.Entity.ObjDesc objDesc)
         {
             // Hair/head
-            if (HeadObjectDID.HasValue && !HairStyle.HasValue)
+
+            // if (HeadObjectDID.HasValue && !HairStyle.HasValue)
+            // This Heritage check has been added for backwards compatibility. It works around the butthead Gear Knights appearance.
+            if (HeadObjectDID.HasValue && !HairStyle.HasValue && Heritage.HasValue && Heritage != (int)HeritageGroup.Gearknight)
                 objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = 0x10, PartID = HeadObjectDID.Value });
             else if (HairStyle.HasValue && Heritage.HasValue && Gender.HasValue)
             {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -1068,9 +1068,29 @@ namespace ACE.Server.WorldObjects
         protected void AddBaseModelData(ACE.Entity.ObjDesc objDesc)
         {
             // Hair/head
-            if (HeadObjectDID.HasValue)
+            if (HeadObjectDID.HasValue && !HairStyle.HasValue)
                 objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = 0x10, PartID = HeadObjectDID.Value });
-            //AddModel(0x10, HeadObjectDID.Value);
+            else if (HairStyle.HasValue && Heritage.HasValue && Gender.HasValue)
+            {
+                // This indicates we have a Gear Knight or Olthoi(that is, player types treat "hairstyle" as a "Body Style")
+
+                // Load the CharGen data. It has all the anim & texture changes for the Body Style defined within it
+                var cg = DatManager.PortalDat.CharGen;
+                SexCG sex = cg.HeritageGroups[(uint)Heritage].Genders[(int)Gender];
+                if (sex.HairStyleList.Count > (int)HairStyle) // just check for a valid entry...
+                {
+                    HairStyleCG hairstyle = sex.HairStyleList[(int)HairStyle];
+
+                    // Add all the texture changes
+                    foreach (var tm in hairstyle.ObjDesc.TextureChanges)
+                        objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = tm.PartIndex, OldTexture = tm.OldTexture, NewTexture = tm.NewTexture });
+
+                    // Add all the animation part changes
+                    foreach (var part in hairstyle.ObjDesc.AnimPartChanges)
+                        objDesc.AnimPartChanges.Add(new ACE.Entity.AnimationPartChange { PartIndex = part.PartIndex, PartID = part.PartID });
+                }
+            }
+
             if (this is Player player)
                 objDesc.TextureChanges.Add(new ACE.Entity.TextureMapChange { PartIndex = 0x10, OldTexture = player.Character.DefaultHairTexture, NewTexture = player.Character.HairTexture });
             //AddTexture(0x10, DefaultHairTextureDID.Value, HairTextureDID.Value);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1478,6 +1478,11 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyDataId.PaletteBase); else SetProperty(PropertyDataId.PaletteBase, value.Value); }
         }
 
+        public int? HairStyle
+        {
+            get => GetProperty(PropertyInt.Hairstyle);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.Hairstyle); else SetProperty(PropertyInt.Hairstyle, value.Value); }
+        }
 
         // ========================================
         // =========== Other Properties ===========

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # ACEmulator Change Log
 
 ### 2019-03-30
+[OptimShi]
+* Fixed Gear Knights being literal buttheads. (Their abdomen was being swapped with their heads)
+
 [Ripley]
 * Fixed CharGen issue for Dual Wield characters. 2x Melee Weapons are created if Dual Wield is trained or specialized.
 


### PR DESCRIPTION
This corrects the appearance of Gear Knights. (And should also apply to Olthoi characters, once enabled).

There is a work around for older Gear Knight players, as well, so they should look normal (but may not have accurate colors as chosen by player, and they never will due to missing data)

This addresses issue #1294 
