### PR TITLE
Adding support for Asheron's Benediction

### DIFF
--- a/Source/ACE.Server/Entity/Spell.cs
+++ b/Source/ACE.Server/Entity/Spell.cs
@@ -5,6 +5,7 @@ using ACE.DatLoader.Entity;
 using ACE.DatLoader.FileTypes;
 using ACE.Database;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 
 namespace ACE.Server.Entity
 {
@@ -222,6 +223,39 @@ namespace ACE.Server.Entity
                     || Category == SpellCategory.WeaponTimeRaising
                     || Category == SpellCategory.AppraisalResistanceLowering
                     || Category == SpellCategory.SpellDamageRaising;
+            }
+        }
+
+        /// <summary>
+        /// Returns a list of MaxVitals affected by this spell
+        /// </summary>
+        public List<PropertyAttribute2nd> UpdatesMaxVitals
+        {
+            get
+            {
+                var maxVitals = new List<PropertyAttribute2nd>();
+
+                if (_spell == null)
+                    return maxVitals;
+
+                if (StatModType.HasFlag(EnchantmentTypeFlags.SecondAtt))
+                    maxVitals.Add((PropertyAttribute2nd)StatModKey);
+
+                else if (StatModType.HasFlag(EnchantmentTypeFlags.Attribute))
+                {
+                    switch ((PropertyAttribute)StatModKey)
+                    {
+                        case PropertyAttribute.Endurance:
+                            maxVitals.Add(PropertyAttribute2nd.MaxHealth);
+                            maxVitals.Add(PropertyAttribute2nd.MaxStamina);
+                            break;
+
+                        case PropertyAttribute.Self:
+                            maxVitals.Add(PropertyAttribute2nd.MaxMana);
+                            break;
+                    }
+                }
+                return maxVitals;
             }
         }
 

--- a/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
@@ -104,7 +104,9 @@ namespace ACE.Server.Managers
         private void ClearCache()
         {
             attributeModCache.Clear();
-            vitalModCache.Clear();
+            vitalModAdditiveCache.Clear();
+            vitalModMultiplierCache.Clear();
+
             skillModCache.Clear();
 
             bodyArmorModCache = null;
@@ -144,19 +146,35 @@ namespace ACE.Server.Managers
             return value;
         }
 
-        private readonly Dictionary<CreatureVital, float> vitalModCache = new Dictionary<CreatureVital, float>();
+        private readonly Dictionary<CreatureVital, float> vitalModAdditiveCache = new Dictionary<CreatureVital, float>();
+        private readonly Dictionary<CreatureVital, float> vitalModMultiplierCache = new Dictionary<CreatureVital, float>();
 
         /// <summary>
-        /// Gets the direct modifiers to a vital / secondary attribute
+        /// Gets the additive modifiers to a vital / secondary attribute
         /// </summary>
-        public override float GetVitalMod(CreatureVital vital)
+        public override float GetVitalMod_Additives(CreatureVital vital)
         {
-            if (vitalModCache.TryGetValue(vital, out var value))
+            if (vitalModAdditiveCache.TryGetValue(vital, out var value))
                 return value;
 
-            value = base.GetVitalMod(vital);
+            value = base.GetVitalMod_Additives(vital);
 
-            vitalModCache[vital] = value;
+            vitalModAdditiveCache[vital] = value;
+
+            return value;
+        }
+
+        /// <summary>
+        /// Gets the multiplicative modifiers to a vital / secondary attribute
+        /// </summary>
+        public override float GetVitalMod_Multiplier(CreatureVital vital)
+        {
+            if (vitalModMultiplierCache.TryGetValue(vital, out var value))
+                return value;
+
+            value = base.GetVitalMod_Multiplier(vital);
+
+            vitalModMultiplierCache[vital] = value;
 
             return value;
         }

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureVital.cs
@@ -94,8 +94,10 @@ namespace ACE.Server.WorldObjects.Entity
             {
                 uint total = Base;
 
-                // TODO: include all buffs
-                total += (uint)Math.Round(creature.EnchantmentManager.GetVitalMod(this));
+                var multiplier = creature.EnchantmentManager.GetVitalMod_Multiplier(this);
+                var additives = creature.EnchantmentManager.GetVitalMod_Additives(this);
+
+                total = (uint)Math.Round(total * multiplier + additives);
 
                 if (creature is Player player)
                 {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1189,5 +1189,31 @@ namespace ACE.Server.WorldObjects
 
             // send error message?
         }
+
+        /// <summary>
+        /// Called when an enchantment is added or removed,
+        /// checks if the spell affects the max vitals,
+        /// and if so, updates the client immediately
+        /// </summary>
+        public void HandleMaxVitalUpdate(Spell spell)
+        {
+            var maxVitals = spell.UpdatesMaxVitals;
+
+            if (maxVitals.Count == 0)
+                return;
+
+            var actionChain = new ActionChain();
+            actionChain.AddDelaySeconds(1.0f);      // client needs time for primary attribute updates
+            actionChain.AddAction(this, () =>
+            {
+                foreach (var maxVital in maxVitals)
+                {
+                    var playerVital = Vitals[maxVital];
+
+                    Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute2ndLevel(this, playerVital.ToEnum(), playerVital.Current));
+                }
+            });
+            actionChain.EnqueueChain();
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1176,6 +1176,8 @@ namespace ACE.Server.WorldObjects
             {
                 playerTarget.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(playerTarget.Session, new Enchantment(playerTarget, addResult.Enchantment)));
 
+                playerTarget.HandleMaxVitalUpdate(spell);
+
                 if (playerTarget != this)
                     playerTarget.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} cast {spell.Name} on you{suffix}", ChatMessageType.Magic));
             }


### PR DESCRIPTION
This adds support for vital multiplier enchantments, such as Asheron's Benediction

For adding and removing enchantments which affect MaxVitals, an UpdateVital packet is also now sent much quicker, instead of on the next VitalTick update

This resolves https://github.com/ACEmulator/ACE/issues/1607