### PR TITLE
Fix tells via client gui (TalkDirect) to players.

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTalkDirect.cs
@@ -1,12 +1,17 @@
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
+using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
+
+using log4net;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
     public static class GameActionTalkDirect
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         [GameAction(GameActionType.TalkDirect)]
         public static void Handle(ClientMessage clientMessage, Session session)
         {
@@ -15,11 +20,28 @@ namespace ACE.Server.Network.GameAction.Actions
 
             var creature = session.Player.CurrentLandblock?.GetObject(targetGuid) as Creature;
             if (creature == null)
-                return;     // error?
+            {
+                var statusMessage = new GameEventWeenieError(session, WeenieError.CharacterNotAvailable);
+                session.Network.EnqueueSend(statusMessage);
+                return;
+            }
 
             session.Network.EnqueueSend(new GameMessageSystemChat($"You tell {creature.Name}, \"{message}\"", ChatMessageType.OutgoingTell));
 
-            creature.EmoteManager.OnTalkDirect(session.Player, message);
+            if (creature is Player targetPlayer)
+            {
+                if (targetPlayer.Squelches.Contains(session.Player))
+                {
+                    session.Network.EnqueueSend(new GameEventWeenieErrorWithString(session, WeenieErrorWithString.MessageBlocked_, $"{targetPlayer.Name} has you squelched."));
+                    //log.Warn($"Tell from {session.Player.Name} (0x{session.Player.Guid.ToString()}) to {targetPlayer.Name} (0x{targetPlayer.Guid.ToString()}) blocked due to squelch");
+                    return;
+                }
+
+                var tell = new GameEventTell(targetPlayer.Session, message, session.Player.Name, session.Player.Guid.Full, targetPlayer.Guid.Full, ChatMessageType.Tell);
+                targetPlayer.Session.Network.EnqueueSend(tell);
+            }
+            else
+                creature.EmoteManager.OnTalkDirect(session.Player, message);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionTell.cs
@@ -32,10 +32,8 @@ namespace ACE.Server.Network.GameAction.Actions
 
             if (targetPlayer.Squelches.Contains(session.Player))
             {
-                //todo: remove debug msg.
-                session.Network.EnqueueSend(new GameEventWeenieErrorWithString(session, WeenieErrorWithString.MessageBlocked_,$"{target} has you squelched."),
-                                            new GameMessageSystemChat($"DEBUG: This message was blocked. Report seeing this block to devs in discord, please.", ChatMessageType.AdminTell));
-                log.Warn($"Tell from {session.Player.Name} (0x{session.Player.Guid.ToString()}) to {targetPlayer.Name} (0x{targetPlayer.Guid.ToString()}) blocked due to squelch");
+                session.Network.EnqueueSend(new GameEventWeenieErrorWithString(session, WeenieErrorWithString.MessageBlocked_,$"{target} has you squelched."));
+                //log.Warn($"Tell from {session.Player.Name} (0x{session.Player.Guid.ToString()}) to {targetPlayer.Name} (0x{targetPlayer.Guid.ToString()}) blocked due to squelch");
                 return;
             }
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 [Ripley]
 * Fix OnDeath crash.
 * Adjusted OnDeath to use LastDamager instead of foreach.
+* Fix tells issue.
 
 ### 2019-04-05
 [Ripley]


### PR DESCRIPTION
This resolves the missing tells issue players are seeing. Some were using the `@tell player, message` form which worked, some were using TalkDirect form that comes from client GUI, which did not work.