### PR TITLE
ProcessPacket performance added to /serverperformance

### DIFF
--- a/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
+++ b/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
@@ -227,7 +227,7 @@ namespace ACE.Server.Managers
             var sb = new StringBuilder();
 
             sb.Append($"Monitoring Durations: ~5m {Monitors5mRunTime.TotalMinutes:N2} min, ~1h {Monitors1hRunTime.TotalMinutes:N2} min, ~24h {Monitors24hRunTime.TotalMinutes:N2} min{'\n'}");
-            sb.Append($"~5m Hits   Avg  Long  Last - ~1h Hits   Avg  Long  Last - ~24h Hits  Avg  Long  Last (s) - Name{'\n'}");
+            sb.Append($"~5m Hits   Avg  Long  Last Tot - ~1h Hits   Avg  Long  Last  Tot - ~24h Hits  Avg  Long  Last   Tot (s) - Name{'\n'}");
 
             sb.Append($"Calls from WorldManager.UpdateWorld(){'\n'}");
             for (int i = (int)MonitorType.PlayerManager_Tick; i <= (int)MonitorType.DoSessionWork; i++)
@@ -257,9 +257,9 @@ namespace ACE.Server.Managers
 
         private static void AddMonitorOutputToStringBuilder(RateMonitor monitor5m, RateMonitor monitor1h, RateMonitor monitor24h, MonitorType monitorType, StringBuilder sb)
         {
-            sb.Append($"{monitor5m.TotalEvents.ToString().PadLeft(7)} {monitor5m.AverageEventDuration:N4} {monitor5m.LongestEvent:N3} {monitor5m.LastEvent:N3} - " +
-                      $"{monitor1h.TotalEvents.ToString().PadLeft(7)} {monitor1h.AverageEventDuration:N4} {monitor1h.LongestEvent:N3} {monitor1h.LastEvent:N3} - " +
-                      $"{monitor24h.TotalEvents.ToString().PadLeft(7)} {monitor24h.AverageEventDuration:N4} {monitor24h.LongestEvent:N3} {monitor24h.LastEvent:N3} - " +
+            sb.Append($"{monitor5m.TotalEvents.ToString().PadLeft(7)} {monitor5m.AverageEventDuration:N4} {monitor5m.LongestEvent:N3} {monitor5m.LastEvent:N3} {monitor5m.TotalSeconds.ToString("N0").PadLeft(3)} - " +
+                      $"{monitor1h.TotalEvents.ToString().PadLeft(7)} {monitor1h.AverageEventDuration:N4} {monitor1h.LongestEvent:N3} {monitor1h.LastEvent:N3} {monitor1h.TotalSeconds.ToString("N0").PadLeft(4)} - " +
+                      $"{monitor24h.TotalEvents.ToString().PadLeft(7)} {monitor24h.AverageEventDuration:N4} {monitor24h.LongestEvent:N3} {monitor24h.LastEvent:N3} {monitor24h.TotalSeconds.ToString("N0").PadLeft(5)} - " +
                       $"{monitorType}{'\n'}");
         }
     }

--- a/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
+++ b/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
@@ -257,9 +257,9 @@ namespace ACE.Server.Managers
 
         private static void AddMonitorOutputToStringBuilder(RateMonitor monitor5m, RateMonitor monitor1h, RateMonitor monitor24h, MonitorType monitorType, StringBuilder sb)
         {
-            sb.Append($"{monitor5m.TotalEvents.ToString().PadLeft(7)} {monitor5m.AverageEventDuration:N4} {monitor5m.LongestEvent:N3} {monitor5m.LastEvent:N3} {monitor5m.TotalSeconds.ToString("N0").PadLeft(3)} - " +
-                      $"{monitor1h.TotalEvents.ToString().PadLeft(7)} {monitor1h.AverageEventDuration:N4} {monitor1h.LongestEvent:N3} {monitor1h.LastEvent:N3} {monitor1h.TotalSeconds.ToString("N0").PadLeft(4)} - " +
-                      $"{monitor24h.TotalEvents.ToString().PadLeft(7)} {monitor24h.AverageEventDuration:N4} {monitor24h.LongestEvent:N3} {monitor24h.LastEvent:N3} {monitor24h.TotalSeconds.ToString("N0").PadLeft(5)} - " +
+            sb.Append($"{monitor5m.TotalEvents.ToString().PadLeft(7)} {monitor5m.AverageEventDuration:N4} {monitor5m.LongestEvent:N3} {monitor5m.LastEvent:N3} {((int)monitor5m.TotalSeconds).ToString().PadLeft(3)} - " +
+                      $"{monitor1h.TotalEvents.ToString().PadLeft(7)} {monitor1h.AverageEventDuration:N4} {monitor1h.LongestEvent:N3} {monitor1h.LastEvent:N3} {((int)monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
+                      $"{monitor24h.TotalEvents.ToString().PadLeft(7)} {monitor24h.AverageEventDuration:N4} {monitor24h.LongestEvent:N3} {monitor24h.LastEvent:N3} {((int)monitor24h.TotalSeconds).ToString().PadLeft(5)} - " +
                       $"{monitorType}{'\n'}");
         }
     }

--- a/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
+++ b/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
@@ -40,6 +40,10 @@ namespace ACE.Server.Managers
             DoSessionWork_TickOutbound,
             DoSessionWork_RemoveSessions,
 
+            // These are all found in WorldManager.ProcessPacket()
+            ProcessPacket_0,
+            ProcessPacket_1,
+
             MonitorMaxItems // Keep this at the end to properly size our monitors array
         }
 
@@ -242,6 +246,10 @@ namespace ACE.Server.Managers
 
             sb.Append($"Calls from WorldManager.DoSessionWork(){'\n'}");
             for (int i = (int)MonitorType.DoSessionWork_TickInbound; i <= (int)MonitorType.DoSessionWork_RemoveSessions; i++)
+                AddMonitorOutputToStringBuilder(monitors5m[i], monitors1h[i], monitors24h[i], (MonitorType)i, sb);
+
+            sb.Append($"Calls from WorldManager.ProcessPacket(){'\n'}");
+            for (int i = (int)MonitorType.ProcessPacket_0; i <= (int)MonitorType.ProcessPacket_1; i++)
                 AddMonitorOutputToStringBuilder(monitors5m[i], monitors1h[i], monitors24h[i], (MonitorType)i, sb);
 
             return sb.ToString();

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -92,6 +92,7 @@ namespace ACE.Server.Managers
         {
             if (listenerEndpoint.Port == ConfigManager.Config.Server.Network.Port + 1)
             {
+                ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
                 if (packet.Header.Flags.HasFlag(PacketHeaderFlags.ConnectResponse))
                 {
                     packetLog.Debug($"{packet}, {endPoint}");
@@ -121,11 +122,6 @@ namespace ACE.Server.Managers
                         session.State = SessionState.AuthConnected;
                         session.Network.sendResync = true;
                         AuthenticationHandler.HandleConnectResponse(session);
-                        return;
-                    }
-                    else
-                    {
-                        return;
                     }
 
                 }
@@ -137,60 +133,67 @@ namespace ACE.Server.Managers
                 {
                     log.ErrorFormat("Packet from {0} rejected. Packet sent to listener 1 and is not a ConnectResponse or CICMDCommand", endPoint);
                 }
+                ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
             }
-            else if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
+            else // ConfigManager.Config.Server.Network.Port + 0
             {
-                packetLog.Debug($"{packet}, {endPoint}");
-                if (!loggedInClients.Contains(endPoint) && loggedInClients.Count >= ConfigManager.Config.Server.Network.MaximumAllowedSessions)
+                ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
+                if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
                 {
-                    log.InfoFormat("Login Request from {0} rejected. Server full.", endPoint);
-                    SendLoginRequestReject(endPoint, CharacterError.LogonServerFull);
-                }
-                else if (ServerManager.ShutdownInitiated)
-                {
-                    log.InfoFormat("Login Request from {0} rejected. Server shutting down.", endPoint);
-                    SendLoginRequestReject(endPoint, CharacterError.ServerCrash);
-                }
-                else
-                {
-                    log.DebugFormat("Login Request from {0}", endPoint);
-                    var session = FindOrCreateSession(endPoint);
-                    if (session != null)
+                    packetLog.Debug($"{packet}, {endPoint}");
+                    if (!loggedInClients.Contains(endPoint) && loggedInClients.Count >= ConfigManager.Config.Server.Network.MaximumAllowedSessions)
                     {
-                        if (session.State == SessionState.AuthConnectResponse)
-                        {
-                            // connect request packet sent to the client was corrupted in transit and session entered an unspecified state.
-                            // ignore the request and remove the broken session and the client will start a new session.
-                            RemoveSession(session);
-                            log.Warn($"Bad handshake from {endPoint}, aborting session.");
-                        }
-                        session.ProcessPacket(packet);
-                    }
-                    else
-                    {
-                        log.InfoFormat("Login Request from {0} rejected. Failed to find or create session.", endPoint);
+                        log.InfoFormat("Login Request from {0} rejected. Server full.", endPoint);
                         SendLoginRequestReject(endPoint, CharacterError.LogonServerFull);
                     }
-                }
-            }
-            else if (sessionMap.Length > packet.Header.Id && loggedInClients.Contains(endPoint))
-            {
-                var session = sessionMap[packet.Header.Id];
-                if (session != null)
-                {
-                    if (session.EndPoint.Equals(endPoint))
-                        session.ProcessPacket(packet);
+                    else if (ServerManager.ShutdownInitiated)
+                    {
+                        log.InfoFormat("Login Request from {0} rejected. Server shutting down.", endPoint);
+                        SendLoginRequestReject(endPoint, CharacterError.ServerCrash);
+                    }
                     else
-                        log.WarnFormat("Session for Id {0} has IP {1} but packet has IP {2}", packet.Header.Id, session.EndPoint, endPoint);
+                    {
+                        log.DebugFormat("Login Request from {0}", endPoint);
+                        var session = FindOrCreateSession(endPoint);
+                        if (session != null)
+                        {
+                            if (session.State == SessionState.AuthConnectResponse)
+                            {
+                                // connect request packet sent to the client was corrupted in transit and session entered an unspecified state.
+                                // ignore the request and remove the broken session and the client will start a new session.
+                                RemoveSession(session);
+                                log.Warn($"Bad handshake from {endPoint}, aborting session.");
+                            }
+
+                            session.ProcessPacket(packet);
+                        }
+                        else
+                        {
+                            log.InfoFormat("Login Request from {0} rejected. Failed to find or create session.", endPoint);
+                            SendLoginRequestReject(endPoint, CharacterError.LogonServerFull);
+                        }
+                    }
+                }
+                else if (sessionMap.Length > packet.Header.Id && loggedInClients.Contains(endPoint))
+                {
+                    var session = sessionMap[packet.Header.Id];
+                    if (session != null)
+                    {
+                        if (session.EndPoint.Equals(endPoint))
+                            session.ProcessPacket(packet);
+                        else
+                            log.WarnFormat("Session for Id {0} has IP {1} but packet has IP {2}", packet.Header.Id, session.EndPoint, endPoint);
+                    }
+                    else
+                    {
+                        log.WarnFormat("Null Session for Id {0}", packet.Header.Id);
+                    }
                 }
                 else
                 {
-                    log.WarnFormat("Null Session for Id {0}", packet.Header.Id);
+                    log.WarnFormat("unsolicited packet from {0}", endPoint);
                 }
-            }
-            else
-            {
-                log.WarnFormat("unsolicited packet from {0}", endPoint);
+                ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
             }
         }
 


### PR DESCRIPTION
In addition, a Total Seconds (Tot) column has been added to /serverperformance.

This new column is a much easier way to see how much resources a particular system is consuming.