### PR TITLE
added try/catch to prevent crashing server during FlushPackets

### DIFF
--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -197,7 +197,14 @@ namespace ACE.Server.Network
                 }
             }
 
-            FlushPackets();
+            try
+            {
+                FlushPackets();
+            }
+            catch (Exception ex)
+            {
+                log.Error($"Failure during FlushPackets", ex);
+            }
         }
 
         // This is called from ConnectionListener.OnDataReceieve()->Session.ProcessPacket()->This
@@ -525,6 +532,19 @@ namespace ACE.Server.Network
                 packetLog.DebugFormat("[{0}] Flushing packets, count {1}", session.LoggingIdentifier, packetQueue.Count);
 
                 ServerPacket packet = packetQueue.Dequeue();
+
+                //This line was causing a System.NullReferenceException
+                //if (packet.Header.HasFlag(PacketHeaderFlags.EncryptedChecksum) && ConnectionData.PacketSequence.CurrentValue == 0)
+                //so inspect and log if we can find what is null
+                var null1 = Equals(null, packet);
+                var null2 = Equals(null, packet?.Header);
+                var null3 = Equals(null, ConnectionData);
+                var null4 = Equals(null, ConnectionData?.PacketSequence);
+
+                if (null1 || null2 || null3 || null4)
+                {
+                    log.Error($"FlushPackets null encountered, 1: {null1} 2: {null2} 3: {null3} 4: {null4}");
+                }
 
                 if (packet.Header.HasFlag(PacketHeaderFlags.EncryptedChecksum) && ConnectionData.PacketSequence.CurrentValue == 0)
                     ConnectionData.PacketSequence = new Sequence.UIntSequence(1);


### PR DESCRIPTION
added null inspection to FlushPackets after dequeueing the next packet, to aid in identifying cause of

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at ACE.Server.Network.NetworkSession.FlushPackets() in /home/gmriggs/ACE/ACE/Source/ACE.Server/Network/NetworkSession.cs:line 593
   at ACE.Server.Network.NetworkSession.Update() in /home/gmriggs/ACE/ACE/Source/ACE.Server/Network/NetworkSession.cs:line 202
   at ACE.Server.Network.Session.TickOutbound() in /home/gmriggs/ACE/ACE/Source/ACE.Server/Network/Session.cs:line 126
```