### PR TITLE
Network Stability Improvements

### DIFF
--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -60,9 +60,10 @@ namespace ACE.Server.Network
 
         /// <summary>
         /// This is referenced by multiple thread:<para />
-        /// [ConnectionListener Thread] WorldManager.ProcessPacket()->Session.ProcessPacket()->NetworkSession.ProcessPacket()->DoRequestForRetransmission()<para />
+        /// [ConnectionListener Thread + 0] WorldManager.ProcessPacket()->SendLoginRequestReject()<para />
+        /// [ConnectionListener Thread + 0] WorldManager.ProcessPacket()->Session.ProcessPacket()->NetworkSession.ProcessPacket()->DoRequestForRetransmission()<para />
+        /// [ConnectionListener Thread + 1] WorldManager.ProcessPacket()->Session.ProcessPacket()->NetworkSession.ProcessPacket()-> ... AuthenticationHandler<para />
         /// [World Manager Thread] WorldManager.UpdateWorld()->Session.Update(lastTick)->This.Update(lastTick)<para />
-        ///It is also referenced ONCE by EnqueueSend when the client first connects to the server, but there's no collision risk at that point.
         /// </summary>
         private readonly ConcurrentQueue<ServerPacket> packetQueue = new ConcurrentQueue<ServerPacket>();
 


### PR DESCRIPTION
It was possible for packetQueue to get corrupt when clients request packet retransmits. At that point, multiple threads could be enqueing work.

This adds slight overhead by converting it to a ConcurrentQueue, but, should also (hopefully) fix the "corrupt sessions" issue people were seeing.

This should also fix the exception that was reported in NetowrkSession.FlushPackets()