### PR TITLE
Reduce rogue physics landblocks loaded by portal desitnation parsing

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text;
@@ -8,6 +9,7 @@ using System.Threading;
 using log4net;
 
 using ACE.Database;
+using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.DatLoader;
@@ -20,11 +22,12 @@ using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
-using ACE.Database.Models.Auth;
 using ACE.Server.Physics.Entity;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.Packets;
-using System.Collections.Generic;
+using ACE.Server.Physics.Common;
+
+using Position = ACE.Entity.Position;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -2103,6 +2106,8 @@ namespace ACE.Server.Command.Handlers
                 sb.Append($"Server Performance Monitor - Not running. To start use /serverperformance start{'\n'}");
 
             sb.Append($"Physics Cache Counts - BSPCache: {BSPCache.Count:N0}, GfxObjCache: {GfxObjCache.Count:N0}, PolygonCache: {PolygonCache.Count:N0}, VertexCache: {VertexCache.Count:N0}{'\n'}");
+
+            sb.Append($"Physics Landblocks Count - {LScape.LandblocksCount:N0}{'\n'}");
 
             sb.Append($"World DB Cache Counts - Weenies: {DatabaseManager.World.GetWeenieCacheCount():N0}, LandblockInstances: {DatabaseManager.World.GetLandblockInstancesCacheCount():N0}, PointsOfInterest: {DatabaseManager.World.GetPointsOfInterestCacheCount():N0}, Cookbooks: {DatabaseManager.World.GetCookbookCacheCount():N0}, Spells: {DatabaseManager.World.GetSpellCacheCount():N0}, Encounters: {DatabaseManager.World.GetEncounterCacheCount():N0}, Events: {DatabaseManager.World.GetEventsCacheCount():N0}{'\n'}");
             sb.Append($"Shard DB Counts - Biotas: {DatabaseManager.Shard.GetBiotaCount():N0}{'\n'}");

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -116,7 +116,7 @@ namespace ACE.Server.Entity
 
         public Landblock(LandblockId id)
         {
-            //Console.WriteLine($"Loading landblock {(id.Raw | 0xFFFF):X8}");
+            //log.Debug($"Landblock({(id.Raw | 0xFFFF):X8})");
 
             Id = id;
 
@@ -761,7 +761,7 @@ namespace ACE.Server.Entity
         {
             var landblockID = Id.Raw | 0xFFFF;
 
-            log.Debug($"Landblock.Unload({landblockID:X})");
+            //log.Debug($"Landblock.Unload({landblockID:X8})");
 
             ProcessPendingWorldObjectAdditionsAndRemovals();
 

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -12,7 +12,8 @@ namespace ACE.Server.Entity
     {
         public static Vector3 ToGlobal(this Position p)
         {
-            var landblock = LScape.get_landblock(p.LandblockId.Raw);
+            // TODO: Is this necessary? It seemed to be loading rogue physics landblocks. Commented out 2019-04 Mag-nus
+            //var landblock = LScape.get_landblock(p.LandblockId.Raw);
 
             // TODO: investigate dungeons that are below actual traversable overworld terrain
             // ex., 010AFFFF
@@ -29,7 +30,8 @@ namespace ACE.Server.Entity
 
         public static Position FromGlobal(this Position p, Vector3 pos)
         {
-            var landblock = LScape.get_landblock(p.LandblockId.Raw);
+            // TODO: Is this necessary? It seemed to be loading rogue physics landblocks. Commented out 2019-04 Mag-nus
+            //var landblock = LScape.get_landblock(p.LandblockId.Raw);
 
             // TODO: investigate dungeons that are below actual traversable overworld terrain
             // ex., 010AFFFF

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -1,9 +1,11 @@
-using ACE.Entity;
 using System;
 using System.Numerics;
+
+using ACE.Entity;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Extensions;
 using ACE.Server.Physics.Util;
+
 using Position = ACE.Entity.Position;
 
 namespace ACE.Server.Entity

--- a/Source/ACE.Server/Physics/Common/LScape.cs
+++ b/Source/ACE.Server/Physics/Common/LScape.cs
@@ -37,6 +37,8 @@ namespace ACE.Server.Physics.Common
             return true;
         }
 
+        public static int LandblocksCount => Landblocks.Count;
+
         /// <summary>
         /// Loads the backing store landblock structure<para />
         /// This function is thread safe


### PR DESCRIPTION
On my test of 1000 landblocks, x: 0x20-0x40, y: 0x20-0x40,

After all landblocks load usign "loadalllandblocks" and unload, there were still ~36 physics landblocks remaining.

This reduces it to ~15.

I've also commented out the landblock unload debug message.