### PR TITLE
Dispose ShardContext on RemoveBiota

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -398,6 +398,8 @@ namespace ACE.Database
                 finally
                 {
                     rwLock.ExitReadLock();
+
+                    cachedContext.Dispose();
                 }
             }
 


### PR DESCRIPTION
This is just a partial fix for dispoing contexts properly.

The contexts that are released from BiotaContexts as biotas go out of scope are never disposed. They are only finalized when the GC collects them. I plan to come up with a solution for that as well.