### PR TITLE
Add missing WieldSkillType to loot melee weapons

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -25,7 +25,6 @@ namespace ACE.Server.Factories
             int spellArray = 0;
             int cantripArray = 0;
             int equipSetId = 0;
-            int wieldDifficulty = 0;
 
             int materialType = 0;
             int armorType = 0;
@@ -7799,7 +7798,6 @@ namespace ACE.Server.Factories
                             materialType = GetMaterialType(7, 1);
                         }
                     }
-                    wieldDifficulty = 150;
                     break;
                 default:
                     lowSpellTier = 6;
@@ -9346,7 +9344,6 @@ namespace ACE.Server.Factories
                                 break;
                         }
                     }
-                    wieldDifficulty = 180;
                     break;
             }
 
@@ -9388,10 +9385,25 @@ namespace ACE.Server.Factories
             wo.SetProperty(PropertyInt.ItemWorkmanship, workmanship);
             wo.SetProperty(PropertyInt.Value, GetValue(tier, workmanship, LootTables.materialModifier[(int)wo.GetProperty(PropertyInt.GemType)], LootTables.materialModifier[(int)wo.GetProperty(PropertyInt.MaterialType)]));
 
-            if (wieldDifficulty > 0)
-                wo.SetProperty(PropertyInt.WieldDifficulty, wieldDifficulty);
-            else
-                wo.RemoveProperty(PropertyInt.WieldDifficulty);
+            if (tier > 6)
+            {
+                int wield;
+
+                wo.SetProperty(PropertyInt.WieldRequirements, (int)WieldRequirement.Level);
+                wo.SetProperty(PropertyInt.WieldSkillType, (int)Skill.Axe);  // Set by examples from PCAP data
+
+                switch (tier)
+                {
+                    case 7:
+                        wield = 150; // In this instance, used for indicating player level, rather than skill level
+                        break;
+                    default:
+                        wield = 180; // In this instance, used for indicating player level, rather than skill level
+                        break;
+                }
+
+                wo.SetProperty(PropertyInt.WieldDifficulty, wield);
+            }
 
             /////Setting random color
             wo.SetProperty(PropertyInt.PaletteTemplate, ThreadSafeRandom.Next(1, 2047));

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -122,6 +122,26 @@ namespace ACE.Server.Factories
 
             wo.RemoveProperty(PropertyInt.ItemSkillLevelLimit);
 
+            if (tier > 6)
+            {
+                int wield;
+
+                wo.SetProperty(PropertyInt.WieldRequirements, (int)WieldRequirement.Level);
+                wo.SetProperty(PropertyInt.WieldSkillType, (int)Skill.Axe);  // Set by examples from PCAP data
+
+                switch (tier)
+                {
+                    case 7:
+                        wield = 150; // In this instance, used for indicating player level, rather than skill level
+                        break;
+                    default:
+                        wield = 180; // In this instance, used for indicating player level, rather than skill level
+                        break;
+                }
+
+                wo.SetProperty(PropertyInt.WieldDifficulty, wield);
+            }
+
             if (isMagical)
             {
                 wo.SetProperty(PropertyInt.UiEffects, (int)UiEffects.Magical);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -195,6 +195,7 @@ namespace ACE.Server.Factories
             }
             else
             {
+                // Fifty/Fifty chance of caster weapon rolling either an elemental or non-elemental caster
                 chance = ThreadSafeRandom.Next(1, 100);
                 if (chance > 50)
                 {
@@ -208,6 +209,7 @@ namespace ACE.Server.Factories
                     int element = ThreadSafeRandom.Next(0, 7);
                     casterWeenie = LootTables.CasterWeaponsMatrix[casterType][element];
 
+                    // If element is Nether, Void Magic is required, else War Magic is required for all other elements
                     if (element == 7)
                         wieldSkillType = Skill.VoidMagic;
                     else
@@ -215,11 +217,14 @@ namespace ACE.Server.Factories
                 }
                 else
                 {
-                    // Determine plain caster type: 0 - Orb, 1 - Sceptre, 2 - Staff, 3 - Wand
+                    // Determine plain caster type for non-elemental caster: 0 - Orb, 1 - Sceptre, 2 - Staff, 3 - Wand
                     subType = ThreadSafeRandom.Next(0, 3);
                     casterWeenie = LootTables.CasterWeaponsMatrix[wield][subType];
-                    // TODO: Should wieldSkillType also have a chance for Creature, Item, or Life for non-elemental casters
-                    wieldSkillType = Skill.WarMagic;
+                    chance = ThreadSafeRandom.Next(1, 100);
+                    if (chance <= 50)
+                        wieldSkillType = Skill.WarMagic;
+                    else
+                        wieldSkillType = Skill.VoidMagic;
                 }
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -104,7 +104,6 @@ namespace ACE.Server.Factories
             int wield = 0; //done
             Skill wieldSkillType = Skill.None;
             WieldRequirement wieldRequirement = WieldRequirement.RawSkill;
-            int wieldLevelRequirement = 0;
             int chance = 0;
             int subType = 0;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -195,39 +195,31 @@ namespace ACE.Server.Factories
             }
             else
             {
-                // Determine the Elemental Damage Mod amount
-                elementalDamageMod = GetMaxDamageMod(tier, 18);
-
-                // Determine caster type: 1 - Sceptre, 2 - Baton, 3 - Staff
-                int casterType = ThreadSafeRandom.Next(1, 3);
-
-                // Determine element type: 0 - Slashing, 1 - Piercing, 2 - Blunt, 3 - Frost, 4 - Fire, 5 - Acid, 6 - Electric, 7 - Nether
-                int element = ThreadSafeRandom.Next(0, 7);
-                casterWeenie = LootTables.CasterWeaponsMatrix[casterType][element];
-
-                if (element == 7)
+                chance = ThreadSafeRandom.Next(1, 100);
+                if (chance > 50)
                 {
-                    wieldSkillType = Skill.VoidMagic;
+                    // Determine the Elemental Damage Mod amount
+                    elementalDamageMod = GetMaxDamageMod(tier, 18);
+
+                    // Determine caster type: 1 - Sceptre, 2 - Baton, 3 - Staff
+                    int casterType = ThreadSafeRandom.Next(1, 3);
+
+                    // Determine element type: 0 - Slashing, 1 - Piercing, 2 - Blunt, 3 - Frost, 4 - Fire, 5 - Acid, 6 - Electric, 7 - Nether
+                    int element = ThreadSafeRandom.Next(0, 7);
+                    casterWeenie = LootTables.CasterWeaponsMatrix[casterType][element];
+
+                    if (element == 7)
+                        wieldSkillType = Skill.VoidMagic;
+                    else
+                        wieldSkillType = Skill.WarMagic;
                 }
                 else
                 {
-                    // Determine skill of wield requirement
-                    chance = ThreadSafeRandom.Next(0, 3);
-                    switch (chance)
-                    {
-                        case 0:
-                            wieldSkillType = Skill.WarMagic;
-                            break;
-                        case 2:
-                            wieldSkillType = Skill.CreatureEnchantment;
-                            break;
-                        case 3:
-                            wieldSkillType = Skill.ItemEnchantment;
-                            break;
-                        default:
-                            wieldSkillType = Skill.LifeMagic;
-                            break;
-                    }
+                    // Determine plain caster type: 0 - Orb, 1 - Sceptre, 2 - Staff, 3 - Wand
+                    subType = ThreadSafeRandom.Next(0, 3);
+                    casterWeenie = LootTables.CasterWeaponsMatrix[wield][subType];
+                    // TODO: Should wieldSkillType also have a chance for Creature, Item, or Life for non-elemental casters
+                    wieldSkillType = Skill.WarMagic;
                 }
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -10,6 +10,8 @@ namespace ACE.Server.Factories
     {
         private static WorldObject CreateWeapon(int tier, bool isMagical)
         {
+            Skill wieldSkillType = Skill.None;
+
             int weaponWeenie = 0;
             int damage = 0;
             double damageVariance = 0;
@@ -33,6 +35,7 @@ namespace ACE.Server.Factories
             {
                 case 0:
                     // Heavy Weapons
+                    wieldSkillType = Skill.HeavyWeapons;
                     int heavyWeaponsType = ThreadSafeRandom.Next(0, 22);
                     weaponWeenie = LootTables.HeavyWeaponsMatrix[heavyWeaponsType][eleType];
 
@@ -115,6 +118,7 @@ namespace ACE.Server.Factories
                     break;
                 case 1:
                     // Light Weapons;
+                    wieldSkillType = Skill.LightWeapons;
                     int lightWeaponsType = ThreadSafeRandom.Next(0, 19);
                     weaponWeenie = LootTables.LightWeaponsMatrix[lightWeaponsType][eleType];
 
@@ -196,6 +200,7 @@ namespace ACE.Server.Factories
                     break;
                 case 2:
                     // Finesse Weapons;
+                    wieldSkillType = Skill.FinesseWeapons;
                     int finesseWeaponsType = ThreadSafeRandom.Next(0, 22);
                     weaponWeenie = LootTables.FinesseWeaponsMatrix[finesseWeaponsType][eleType];
 
@@ -278,6 +283,7 @@ namespace ACE.Server.Factories
                     break;
                 case 3:
                     // Two handed
+                    wieldSkillType = Skill.TwoHandedCombat;
                     int twoHandedWeaponsType = ThreadSafeRandom.Next(0, 11);
                     weaponWeenie = LootTables.TwoHandedWeaponsMatrix[twoHandedWeaponsType][eleType];
 
@@ -343,6 +349,7 @@ namespace ACE.Server.Factories
 
             wo.SetProperty(PropertyInt.WieldDifficulty, wieldDiff);
             wo.SetProperty(PropertyInt.WieldRequirements, (int)wieldRequirments);
+            wo.SetProperty(PropertyInt.WieldSkillType, (int)wieldSkillType);
 
             if (wieldDiff == 0)
             {


### PR DESCRIPTION
- Remove other Magic skill types from elemental casters; only Void and War Magic skill used for wield requirements
- Allow for non-elemental casters to have wield requirements
- Add wieldSkillType to loot melee weapons
- Add Level wield requirement for tier 7 & 8 jewelry
- Correctly apply the Level wield requirement for tier 7 & 8 on armor/clothing
