### PR TITLE
LootGen Changes/fixes

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -4,11 +4,8 @@ using System;
 using log4net;
 
 using ACE.Database;
-using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
-using ACE.Entity.Enum.Properties;
-using ACE.Factories;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Factories
@@ -132,9 +129,9 @@ namespace ACE.Server.Factories
 
             if (lootBias != LootBias.Armor && lootBias != LootBias.Weapons && lootBias != LootBias.MagicEquipment && profile.MagicItemMinAmount > 0)
             {
-                // 33% chance to drop a summoning essence
-                itemChance = ThreadSafeRandom.Next(0, 2);
-                if (itemChance == 2)
+                // 17% chance to drop a summoning essence
+                itemChance = ThreadSafeRandom.Next(1, 6);
+                if (itemChance == 6)
                 {
                     lootWorldObject = CreateSummoningEssence(profile.Tier);
 
@@ -518,6 +515,44 @@ namespace ACE.Server.Factories
             }
 
             return wield;
+        }
+
+        private static int GetWieldToIndex(int wieldDiff)
+        {
+            int index = 0;
+
+            switch(wieldDiff)
+            {
+                case 250:
+                    index = 1;
+                    break;
+                case 300:
+                    index = 2;
+                    break;
+                case 325:
+                    index = 3;
+                    break;
+                case 350:
+                    index = 4;
+                    break;
+                case 370:
+                    index = 5;
+                    break;
+                case 400:
+                    index = 6;
+                    break;
+                case 420:
+                    index = 7;
+                    break;
+                case 430:
+                    index = 8;
+                    break;
+                default:
+                    index = 0;
+                    break;
+            }
+
+            return index;
         }
 
         private static double GetManaRate()
@@ -1507,20 +1542,35 @@ namespace ACE.Server.Factories
             return eleMod;
         }
 
+        private enum LootWeaponType
+        {
+            Axe,
+            Dagger,
+            DaggerMulti,
+            Mace,
+            Spear,
+            Sword,
+            SwordMulti,
+            Staff,
+            UA,
+            Jitte,
+            TwoHanded = 0,
+            Cleaving = 0,
+            Spears,
+        }
+
         //The percentages for variances need to be fixed
-        private static double GetVariance(int category, int type)
+        private static double GetVariance(Skill category, LootWeaponType type)
         {
             double variance = 0;
             int chance = ThreadSafeRandom.Next(0, 100);
 
             switch (category)
             {
-                case 1:
-                    //Heavy Weapons
+                case Skill.HeavyWeapons:
                     switch (type)
                     {
-                        case 1:
-                            //Axe
+                        case LootWeaponType.Axe:
                             if (chance < 10)
                                 variance = .90;
                             else if (chance < 30)
@@ -1532,8 +1582,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .99;
                             break;
-                        case 2:
-                            //Dagger
+                        case LootWeaponType.Dagger:
                             if (chance < 10)
                                 variance = .47;
                             else if (chance < 30)
@@ -1545,8 +1594,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .62;
                             break;
-                        case 3:
-                            //Dagger MultiStrike
+                        case LootWeaponType.DaggerMulti:
                             if (chance < 10)
                                 variance = .40;
                             else if (chance < 30)
@@ -1558,8 +1606,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .58;
                             break;
-                        case 4:
-                            //Mace
+                        case LootWeaponType.Mace:
                             if (chance < 10)
                                 variance = .30;
                             else if (chance < 30)
@@ -1571,8 +1618,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .46;
                             break;
-                        case 5:
-                            //Spear
+                        case LootWeaponType.Spear:
                             if (chance < 10)
                                 variance = .59;
                             else if (chance < 30)
@@ -1584,8 +1630,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .75;
                             break;
-                        case 6:
-                            //Staff
+                        case LootWeaponType.Staff:
                             if (chance < 10)
                                 variance = .38;
                             else if (chance < 30)
@@ -1597,8 +1642,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .52;
                             break;
-                        case 7:
-                            //Sword
+                        case LootWeaponType.Sword:
                             if (chance < 10)
                                 variance = .47;
                             else if (chance < 30)
@@ -1610,8 +1654,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .62;
                             break;
-                        case 8:
-                            //Sword Multistrike
+                        case LootWeaponType.SwordMulti:
                             if (chance < 10)
                                 variance = .40;
                             else if (chance < 30)
@@ -1623,8 +1666,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .60;
                             break;
-                        case 9:
-                            //UA
+                        case LootWeaponType.UA:
                             if (chance < 10)
                                 variance = .44;
                             else if (chance < 30)
@@ -1638,11 +1680,11 @@ namespace ACE.Server.Factories
                             break;
                     }
                     break;
-                case 2:
-                    //Finesse/Light Weapons
+                case Skill.LightWeapons:
+                case Skill.FinesseWeapons:
                     switch (type)
                     {
-                        case 1:
+                        case LootWeaponType.Axe:
                             //Axe
                             if (chance < 10)
                                 variance = .80;
@@ -1655,7 +1697,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .95;
                             break;
-                        case 2:
+                        case LootWeaponType.Dagger:
                             //Dagger
                             if (chance < 10)
                                 variance = .42;
@@ -1668,7 +1710,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .60;
                             break;
-                        case 3:
+                        case LootWeaponType.DaggerMulti:
                             //Dagger MultiStrike
                             if (chance < 10)
                                 variance = .24;
@@ -1681,7 +1723,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .45;
                             break;
-                        case 4:
+                        case LootWeaponType.Mace:
                             //Mace
                             if (chance < 10)
                                 variance = .23;
@@ -1694,7 +1736,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .43;
                             break;
-                        case 5:
+                        case LootWeaponType.Jitte:
                             //Jitte
                             if (chance < 10)
                                 variance = .325;
@@ -1707,7 +1749,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .50;
                             break;
-                        case 6:
+                        case LootWeaponType.Spear:
                             //Spear
                             if (chance < 10)
                                 variance = .65;
@@ -1720,7 +1762,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .80;
                             break;
-                        case 7:
+                        case LootWeaponType.Staff:
                             //Staff
                             if (chance < 10)
                                 variance = .325;
@@ -1733,7 +1775,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .50;
                             break;
-                        case 8:
+                        case LootWeaponType.Sword:
                             //Sword
                             if (chance < 10)
                                 variance = .42;
@@ -1746,7 +1788,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .60;
                             break;
-                        case 9:
+                        case LootWeaponType.SwordMulti:
                             //Sword Multistrike
                             if (chance < 10)
                                 variance = .24;
@@ -1759,7 +1801,7 @@ namespace ACE.Server.Factories
                             else
                                 variance = .45;
                             break;
-                        case 10:
+                        case LootWeaponType.UA:
                             //UA
                             if (chance < 10)
                                 variance = .44;
@@ -1774,7 +1816,7 @@ namespace ACE.Server.Factories
                             break;
                     }
                     break;
-                case 3:
+                case Skill.TwoHandedCombat:
                     /// Two Handed only have one set of variances
                     if (chance < 5)
                         variance = .30;
@@ -1790,13 +1832,13 @@ namespace ACE.Server.Factories
                         variance = .55;
                     break;
                 default:
-                    break;
+                    return 0;
             }
 
             return variance;
         }
 
-        private static int GetMaxDamage(int weaponType, int tier, int wieldDiff, int baseWeapon)
+        private static int GetMaxDamage(Skill weaponType, int wieldDiff, LootWeaponType baseWeapon)
         {
             ///weaponType: 1 Heavy, 2 Finesse/Light, 3 two-handed
             ///baseWeapon: 1 Axe, 2 Dagger, 3 DaggerMulti, 4 Mace, 5 Spear, 6 Sword, 7 SwordMulti, 8 Staff, 9 UA
@@ -1831,75 +1873,28 @@ namespace ACE.Server.Factories
                 { 14, 19, 23, 28, 33, 37, 42, 45, 48 }
             };
 
-            int tieredDamage = 0;
-            int finalDamage = 0;
+            int damageTable = 0;
 
             switch (weaponType)
             {
-                case 1:
-                    tieredDamage = heavyWeaponDamageTable[baseWeapon - 1, tier - 1];
+                case Skill.HeavyWeapons:
+                    damageTable = heavyWeaponDamageTable[(int)baseWeapon, GetWieldToIndex(wieldDiff)];
                     break;
-                case 2:
-                    tieredDamage = lightWeaponDamageTable[baseWeapon - 1, tier - 1];
+                case Skill.FinesseWeapons:
+                case Skill.LightWeapons:
+                    damageTable = lightWeaponDamageTable[(int)baseWeapon, GetWieldToIndex(wieldDiff)];
                     break;
-                case 3:
-                    tieredDamage = twohandedWeaponDamageTable[baseWeapon - 1, tier - 1];
+                case Skill.TwoHandedCombat:
+                    damageTable = twohandedWeaponDamageTable[(int)baseWeapon, GetWieldToIndex(wieldDiff)];
                     break;
+                default:
+                    return 0;
             }
 
-            float chanceOffset = 0f;
-            double chance = ThreadSafeRandom.Next(0.0f, 1.0f);
+            // To add a little bit of randomness to Max weapon damage
+            int maxDamageVariance = ThreadSafeRandom.Next(-4,2);
 
-            if (wieldDiff > 0)
-                chanceOffset = 0.02f;
-            else if (wieldDiff > 250)
-                chanceOffset = 0.03f;
-            else if (wieldDiff > 300)
-                chanceOffset = 0.04f;
-            else if (wieldDiff > 325)
-                chanceOffset = 0.05f;
-            else if (wieldDiff > 350)
-                chanceOffset = 0.06f;
-            else if (wieldDiff > 370)
-                chanceOffset = 0.07f;
-            else if (wieldDiff > 400)
-                chanceOffset = 0.08f;
-            else if (wieldDiff > 420)
-                chanceOffset = 0.1f;
-
-            chance = chance + chanceOffset;
-            if (tieredDamage < 10)
-            {
-                if (chance < .026)
-                    finalDamage = tieredDamage - 3;
-                else if (chance < .5)
-                    finalDamage = tieredDamage - 2;
-                else if (chance < .977)
-                    finalDamage = tieredDamage - 1;
-                else
-                    finalDamage = tieredDamage;
-            }
-            else
-            {
-                if (chance < .005)
-                    finalDamage = tieredDamage - 7;
-                else if (chance < .026)
-                    finalDamage = tieredDamage - 6;
-                else if (chance < .162)
-                    finalDamage = tieredDamage - 5;
-                else if (chance < .5)
-                    finalDamage = tieredDamage - 4;
-                else if (chance < .841)
-                    finalDamage = tieredDamage - 3;
-                else if (chance < .977)
-                    finalDamage = tieredDamage - 2;
-                else if (chance < .995)
-                    finalDamage = tieredDamage - 1;
-                else
-                    finalDamage = tieredDamage;
-            }
-
-            return finalDamage;
+            return damageTable + maxDamageVariance;
         }
 
         private static int GetLowSpellTier(int tier)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -345,7 +345,7 @@ namespace ACE.Server.Factories
                     ////Random Armor Items
                     if (armorType == 3)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 15);
+                        int armorPiece = ThreadSafeRandom.Next(0, 31);
                         switch (armorPiece)
                         {
                             case 0:
@@ -429,7 +429,7 @@ namespace ACE.Server.Factories
                                 materialType = GetMaterialType(7, 1);
                                 break;
                             case 10:
-                                ////Qafiya
+                                ////Horned Helm
                                 armorWeenie = 76;
                                 armorPieceType = 2;
                                 spellArray = 1;
@@ -503,6 +503,94 @@ namespace ACE.Server.Factories
                             case 19:
                                 ////large Kite Shield
                                 armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////Qafiya
+                                armorWeenie = 128;
                                 armorPieceType = 5;
                                 spellArray = 10;
                                 cantripArray = 10;
@@ -1153,7 +1241,7 @@ namespace ACE.Server.Factories
                     ////Random Armor Items
                     if (armorType == 7)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
                         switch (armorPiece)
                         {
                             case 0:
@@ -1237,7 +1325,7 @@ namespace ACE.Server.Factories
                                 materialType = GetMaterialType(7, 1);
                                 break;
                             case 10:
-                                ////Qafiya
+                                ////Horned Helm
                                 armorWeenie = 76;
                                 armorPieceType = 2;
                                 spellArray = 1;
@@ -1383,6 +1471,94 @@ namespace ACE.Server.Factories
                             case 28:
                                 ////RTower Shield
                                 armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
                                 armorPieceType = 5;
                                 spellArray = 10;
                                 cantripArray = 10;
@@ -2139,332 +2315,337 @@ namespace ACE.Server.Factories
                     }
                     if (armorType == 11)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
-                        if (armorPiece == 0)
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
+                        switch (armorPiece)
                         {
-                            ////bandana
-                            armorWeenie = 28612;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 1)
-                        {
-                            ////beret
-                            armorWeenie = 28605;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            ////Cloth Cap
-                            armorWeenie = 118;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            ////Cloth gloves
-                            armorWeenie = 121;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            ////Cowl
-                            armorWeenie = 119;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            ////crown
-                            armorWeenie = 296;
-                            armorPieceType = 1;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            ////Fez
-                            armorWeenie = 5894;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            ////hood
-                            armorWeenie = 5905;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            ////Kasa
-                            armorWeenie = 5901;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            ////Metal cap
-                            armorWeenie = 46;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            ////Qafiya
-                            armorWeenie = 76;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            ////turban
-                            armorWeenie = 135;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            ////loafers
-                            armorWeenie = 28610;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            ////sandals
-                            armorWeenie = 129;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 14)
-                        {
-                            ////shoes
-                            armorWeenie = 132;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 15)
-                        {
-                            ////slippers
-                            armorWeenie = 133;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 16)
-                        {
-                            ////steel toed boots
-                            armorWeenie = 7897;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(6, 1);
-                        }
-                        else if (armorPiece == 17)
-                        {
-                            ////buckler
-                            armorWeenie = 44;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 18)
-                        {
-                            ////kite shield
-                            armorWeenie = 91;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 19)
-                        {
-                            ////large Kite Shield
-                            armorWeenie = 92;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 20)
-                        {
-                            ////Circlet
-                            armorWeenie = 29528;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 21)
-                        {
-                            ////Armet
-                            armorWeenie = 8488;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 22)
-                        {
-                            ////Baigha
-                            armorWeenie = 550;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 23)
-                        {
-                            ////Heaume
-                            armorWeenie = 74;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 24)
-                        {
-                            ////Helmet
-                            armorWeenie = 75;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 25)
-                        //{
-                        //    ////Horned Helm
-                        //    armorWeenie = 92;
-                        //    armorPieceType = 5;
-                        //    spellArray = 10;
-                        //    cantripArray = 10;
-                        //}
-                        else if (armorPiece == 25)
-                        {
-                            ////Kabuton
-                            armorWeenie = 77;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 26)
-                        {
-                            ////sollerets
-                            armorWeenie = 107;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 27)
-                        {
-                            ////viamontian laced boots
-                            armorWeenie = 28611;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 28)
-                        {
-                            ////RTower Shield
-                            armorWeenie = 95;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 29)
-                        //{
-                        //    ////Signet Crown
-                        //    armorWeenie = 31868;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44801;
-                        //    equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Faran Over-Robe
-                        //    armorWeenie = 44799;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Dho Vest and  Over-Robe
-                        //    armorWeenie = 44800;
-                        //    equipSetId = 14;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 33)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44802;
-                        //    ////equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        else
-                        {
-                            ////Round Shield
-                            armorWeenie = 93;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
+                            case 0:
+                                ////bandana
+                                armorWeenie = 28612;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 1:
+                                ////beret
+                                armorWeenie = 28605;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 2:
+                                ////Cloth Cap
+                                armorWeenie = 118;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 3:
+                                ////Cloth gloves
+                                armorWeenie = 121;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 4:
+                                ////Cowl
+                                armorWeenie = 119;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 5:
+                                ////crown
+                                armorWeenie = 296;
+                                armorPieceType = 1;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 6:
+                                ////Fez
+                                armorWeenie = 5894;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 7:
+                                ////hood
+                                armorWeenie = 5905;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 8:
+                                ////Kasa
+                                armorWeenie = 5901;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 9:
+                                ////Metal cap
+                                armorWeenie = 46;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 10:
+                                ////Horned Helm
+                                armorWeenie = 76;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 11:
+                                ////turban
+                                armorWeenie = 135;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 12:
+                                ////loafers
+                                armorWeenie = 28610;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 13:
+                                ////sandals
+                                armorWeenie = 129;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 14:
+                                ////shoes
+                                armorWeenie = 132;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 15:
+                                ////slippers
+                                armorWeenie = 133;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 16:
+                                ////steel toed boots
+                                armorWeenie = 7897;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(6, 1);
+                                break;
+                            case 17:
+                                ////buckler
+                                armorWeenie = 44;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 18:
+                                ////kite shield
+                                armorWeenie = 91;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 19:
+                                ////large Kite Shield
+                                armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////Circlet
+                                armorWeenie = 29528;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////Armet
+                                armorWeenie = 8488;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                ////Baigha
+                                armorWeenie = 550;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Heaume
+                                armorWeenie = 74;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Helmet
+                                armorWeenie = 75;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Kabuton
+                                armorWeenie = 77;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////sollerets
+                                armorWeenie = 107;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////viamontian laced boots
+                                armorWeenie = 28611;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////RTower Shield
+                                armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            default:
+                                ////Round Shield
+                                armorWeenie = 93;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
                         }
                     }
                     break;
@@ -3209,332 +3390,337 @@ namespace ACE.Server.Factories
                     }
                     if (armorType == 11)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
-                        if (armorPiece == 0)
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
+                        switch (armorPiece)
                         {
-                            ////bandana
-                            armorWeenie = 28612;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 1)
-                        {
-                            ////beret
-                            armorWeenie = 28605;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            ////Cloth Cap
-                            armorWeenie = 118;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            ////Cloth gloves
-                            armorWeenie = 121;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            ////Cowl
-                            armorWeenie = 119;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            ////crown
-                            armorWeenie = 296;
-                            armorPieceType = 1;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            ////Fez
-                            armorWeenie = 5894;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            ////hood
-                            armorWeenie = 5905;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            ////Kasa
-                            armorWeenie = 5901;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            ////Metal cap
-                            armorWeenie = 46;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            ////Qafiya
-                            armorWeenie = 76;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            ////turban
-                            armorWeenie = 135;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            ////loafers
-                            armorWeenie = 28610;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            ////sandals
-                            armorWeenie = 129;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 14)
-                        {
-                            ////shoes
-                            armorWeenie = 132;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 15)
-                        {
-                            ////slippers
-                            armorWeenie = 133;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 16)
-                        {
-                            ////steel toed boots
-                            armorWeenie = 7897;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(6, 1);
-                        }
-                        else if (armorPiece == 17)
-                        {
-                            ////buckler
-                            armorWeenie = 44;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 18)
-                        {
-                            ////kite shield
-                            armorWeenie = 91;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 19)
-                        {
-                            ////large Kite Shield
-                            armorWeenie = 92;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 20)
-                        {
-                            ////Circlet
-                            armorWeenie = 29528;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 21)
-                        {
-                            ////Armet
-                            armorWeenie = 8488;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 22)
-                        {
-                            ////Baigha
-                            armorWeenie = 550;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 23)
-                        {
-                            ////Heaume
-                            armorWeenie = 74;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 24)
-                        {
-                            ////Helmet
-                            armorWeenie = 75;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 25)
-                        //{
-                        //    ////Horned Helm
-                        //    armorWeenie = 92;
-                        //    armorPieceType = 5;
-                        //    spellArray = 10;
-                        //    cantripArray = 10;
-                        //}
-                        else if (armorPiece == 25)
-                        {
-                            ////Kabuton
-                            armorWeenie = 77;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 26)
-                        {
-                            ////sollerets
-                            armorWeenie = 107;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 27)
-                        {
-                            ////viamontian laced boots
-                            armorWeenie = 28611;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 28)
-                        {
-                            ////RTower Shield
-                            armorWeenie = 95;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 29)
-                        //{
-                        //    ////Signet Crown
-                        //    armorWeenie = 31868;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44801;
-                        //    equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Faran Over-Robe
-                        //    armorWeenie = 44799;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Dho Vest and  Over-Robe
-                        //    armorWeenie = 44800;
-                        //    equipSetId = 14;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 33)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44802;
-                        //    ////equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        else
-                        {
-                            ////Round Shield
-                            armorWeenie = 93;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
+                            case 0:
+                                ////bandana
+                                armorWeenie = 28612;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 1:
+                                ////beret
+                                armorWeenie = 28605;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 2:
+                                ////Cloth Cap
+                                armorWeenie = 118;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 3:
+                                ////Cloth gloves
+                                armorWeenie = 121;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 4:
+                                ////Cowl
+                                armorWeenie = 119;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 5:
+                                ////crown
+                                armorWeenie = 296;
+                                armorPieceType = 1;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 6:
+                                ////Fez
+                                armorWeenie = 5894;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 7:
+                                ////hood
+                                armorWeenie = 5905;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 8:
+                                ////Kasa
+                                armorWeenie = 5901;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 9:
+                                ////Metal cap
+                                armorWeenie = 46;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 10:
+                                ////Horned Helm
+                                armorWeenie = 76;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 11:
+                                ////turban
+                                armorWeenie = 135;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 12:
+                                ////loafers
+                                armorWeenie = 28610;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 13:
+                                ////sandals
+                                armorWeenie = 129;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 14:
+                                ////shoes
+                                armorWeenie = 132;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 15:
+                                ////slippers
+                                armorWeenie = 133;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 16:
+                                ////steel toed boots
+                                armorWeenie = 7897;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(6, 1);
+                                break;
+                            case 17:
+                                ////buckler
+                                armorWeenie = 44;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 18:
+                                ////kite shield
+                                armorWeenie = 91;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 19:
+                                ////large Kite Shield
+                                armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////Circlet
+                                armorWeenie = 29528;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////Armet
+                                armorWeenie = 8488;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                ////Baigha
+                                armorWeenie = 550;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Heaume
+                                armorWeenie = 74;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Helmet
+                                armorWeenie = 75;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Kabuton
+                                armorWeenie = 77;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////sollerets
+                                armorWeenie = 107;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////viamontian laced boots
+                                armorWeenie = 28611;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////RTower Shield
+                                armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            default:
+                                ////Round Shield
+                                armorWeenie = 93;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
                         }
                     }
                     break;
@@ -4456,356 +4642,340 @@ namespace ACE.Server.Factories
                     }
                     if (armorType == 15)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
-                        if (armorPiece == 0)
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
+                        switch (armorPiece)
                         {
-                            ////bandana
-                            armorWeenie = 28612;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 1)
-                        {
-                            ////beret
-                            armorWeenie = 28605;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            ////Cloth Cap
-                            armorWeenie = 118;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            ////Cloth gloves
-                            armorWeenie = 121;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            ////Cowl
-                            armorWeenie = 119;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            ////crown
-                            armorWeenie = 296;
-                            armorPieceType = 1;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            ////Fez
-                            armorWeenie = 5894;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            ////hood
-                            armorWeenie = 5905;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            ////Kasa
-                            armorWeenie = 5901;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            ////Metal cap
-                            armorWeenie = 46;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            ////Qafiya
-                            armorWeenie = 76;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            ////turban
-                            armorWeenie = 135;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            ////loafers
-                            armorWeenie = 28610;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            ////sandals
-                            armorWeenie = 129;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 14)
-                        {
-                            ////shoes
-                            armorWeenie = 132;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 15)
-                        {
-                            ////slippers
-                            armorWeenie = 133;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 16)
-                        {
-                            ////steel toed boots
-                            armorWeenie = 7897;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(6, 1);
-                        }
-                        else if (armorPiece == 17)
-                        {
-                            ////buckler
-                            armorWeenie = 44;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 18)
-                        {
-                            ////kite shield
-                            armorWeenie = 91;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 19)
-                        {
-                            ////large Kite Shield
-                            armorWeenie = 92;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 20)
-                        {
-                            ////Circlet
-                            armorWeenie = 29528;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 21)
-                        {
-                            ////Armet
-                            armorWeenie = 8488;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 22)
-                        {
-                            ////Baigha
-                            armorWeenie = 550;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 23)
-                        {
-                            ////Heaume
-                            armorWeenie = 74;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 24)
-                        {
-                            ////Helmet
-                            armorWeenie = 75;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 25)
-                        //{
-                        //    ////Horned Helm
-                        //    armorWeenie = 92;
-                        //    armorPieceType = 5;
-                        //    spellArray = 10;
-                        //    cantripArray = 10;
-                        //}
-                        else if (armorPiece == 25)
-                        {
-                            ////Kabuton
-                            armorWeenie = 77;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 26)
-                        {
-                            ////sollerets
-                            armorWeenie = 107;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 27)
-                        {
-                            ////viamontian laced boots
-                            armorWeenie = 28611;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 28)
-                        {
-                            ////RTower Shield
-                            armorWeenie = 95;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 29)
-                        //{
-                        //    ////Signet Crown
-                        //    armorWeenie = 31868;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44801;
-                        //    equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Faran Over-Robe
-                        //    armorWeenie = 44799;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Dho Vest and  Over-Robe
-                        //    armorWeenie = 44800;
-                        //    equipSetId = 14;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 33)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44802;
-                        //    ////equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 34)
-                        //{
-                        //    ////Coronet
-                        //    armorWeenie = 31866;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 35)
-                        //{
-                        //    ////Diadem
-                        //    armorWeenie = 31867;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        else
-                        {
-                            ////Round Shield
-                            armorWeenie = 93;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
+                            case 0:
+                                ////bandana
+                                armorWeenie = 28612;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 1:
+                                ////beret
+                                armorWeenie = 28605;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 2:
+                                ////Cloth Cap
+                                armorWeenie = 118;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 3:
+                                ////Cloth gloves
+                                armorWeenie = 121;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 4:
+                                ////Cowl
+                                armorWeenie = 119;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 5:
+                                ////crown
+                                armorWeenie = 296;
+                                armorPieceType = 1;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 6:
+                                ////Fez
+                                armorWeenie = 5894;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 7:
+                                ////hood
+                                armorWeenie = 5905;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 8:
+                                ////Kasa
+                                armorWeenie = 5901;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 9:
+                                ////Metal cap
+                                armorWeenie = 46;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 10:
+                                ////Horned Helm
+                                armorWeenie = 76;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 11:
+                                ////turban
+                                armorWeenie = 135;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 12:
+                                ////loafers
+                                armorWeenie = 28610;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 13:
+                                ////sandals
+                                armorWeenie = 129;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 14:
+                                ////shoes
+                                armorWeenie = 132;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 15:
+                                ////slippers
+                                armorWeenie = 133;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 16:
+                                ////steel toed boots
+                                armorWeenie = 7897;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(6, 1);
+                                break;
+                            case 17:
+                                ////buckler
+                                armorWeenie = 44;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 18:
+                                ////kite shield
+                                armorWeenie = 91;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 19:
+                                ////large Kite Shield
+                                armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////Circlet
+                                armorWeenie = 29528;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////Armet
+                                armorWeenie = 8488;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                ////Baigha
+                                armorWeenie = 550;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Heaume
+                                armorWeenie = 74;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Helmet
+                                armorWeenie = 75;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Kabuton
+                                armorWeenie = 77;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////sollerets
+                                armorWeenie = 107;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////viamontian laced boots
+                                armorWeenie = 28611;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////RTower Shield
+                                armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            default:
+                                ////Round Shield
+                                armorWeenie = 93;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
                         }
                     }
                     break;
-                ///////
-                ////
-
                 case 6:
                     lowSpellTier = 6;
                     highSpellTier = 7;
@@ -4936,554 +5106,504 @@ namespace ACE.Server.Factories
                     if (armorType == 1)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 14);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 554;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
+                            case 0:
+                                armorWeenie = 554;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 1:
+                                armorWeenie = 116;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                break;
+                            case 2:
+                                armorWeenie = 38;
+                                armorPieceType = 1;
+                                spellArray = 4;
+                                cantripArray = 4;
+                                break;
+                            case 3:
+                                armorWeenie = 42;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 4:
+                                armorWeenie = 48;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 5:
+                                armorWeenie = 723;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 6:
+                                armorWeenie = 53;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 7:
+                                armorWeenie = 59;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 8:
+                                armorWeenie = 63;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 9:
+                                armorWeenie = 68;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 10:
+                                armorWeenie = 68;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 11:
+                                armorWeenie = 89;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 12:
+                                armorWeenie = 99;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 13:
+                                armorWeenie = 105;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            default:
+                                armorWeenie = 112;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 116;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 38;
-                            armorPieceType = 1;
-                            spellArray = 4;
-                            cantripArray = 4;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 42;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 48;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 723;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 53;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            armorWeenie = 59;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            armorWeenie = 63;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            armorWeenie = 68;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            armorWeenie = 68;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            armorWeenie = 89;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            armorWeenie = 99;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            armorWeenie = 105;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else
-                        {
-                            armorWeenie = 112;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
+
                         materialType = GetMaterialType(5, 1);
                     }
                     ////Chainmail
                     if (armorType == 2)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 12);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 35;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
+                            case 0:
+                                armorWeenie = 35;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 1:
+                                armorWeenie = 413;
+                                armorPieceType = 1;
+                                spellArray = 4;
+                                cantripArray = 4;
+                                break;
+                            case 2:
+                                armorWeenie = 414;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 3:
+                                armorWeenie = 85;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 4:
+                                armorWeenie = 55;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 5:
+                                armorWeenie = 415;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 6:
+                                armorWeenie = 2605;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 7:
+                                armorWeenie = 71;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 8:
+                                armorWeenie = 80;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
+                            case 9:
+                                armorWeenie = 416;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 10:
+                                armorWeenie = 96;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 11:
+                                armorWeenie = 101;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            default:
+                                armorWeenie = 108;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 413;
-                            armorPieceType = 1;
-                            spellArray = 4;
-                            cantripArray = 4;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 414;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 85;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 55;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 415;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 2605;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            armorWeenie = 71;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            armorWeenie = 80;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            armorWeenie = 416;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            armorWeenie = 96;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            armorWeenie = 101;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else
-                        {
-                            armorWeenie = 108;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////Platemail
                     if (armorType == 3)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 10);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 40;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
+                            case 0:
+                                armorWeenie = 40;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 1:
+                                armorWeenie = 51;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 2:
+                                armorWeenie = 57;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 3:
+                                armorWeenie = 61;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 4:
+                                armorWeenie = 66;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 5:
+                                armorWeenie = 72;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 6:
+                                armorWeenie = 82;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 7:
+                                armorWeenie = 87;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 8:
+                                armorWeenie = 103;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 9:
+                                armorWeenie = 110;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
+                            default:
+                                armorWeenie = 114;
+                                armorPieceType = 1;
+                                spellArray = 4;
+                                cantripArray = 4;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 51;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 57;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 61;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 66;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 72;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 82;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            armorWeenie = 87;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            armorWeenie = 103;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            armorWeenie = 110;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
-                        else
-                        {
-                            armorWeenie = 114;
-                            armorPieceType = 1;
-                            spellArray = 4;
-                            cantripArray = 4;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////Scalemail
                     if (armorType == 4)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 13);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 552;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
+                            case 0:
+                                armorWeenie = 552;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 1:
+                                armorWeenie = 37;
+                                armorPieceType = 1;
+                                spellArray = 4;
+                                cantripArray = 4;
+                                break;
+                            case 2:
+                                armorWeenie = 41;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 3:
+                                armorWeenie = 793;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 4:
+                                armorWeenie = 52;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 5:
+                                armorWeenie = 58;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 6:
+                                armorWeenie = 62;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 7:
+                                armorWeenie = 67;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 8:
+                                armorWeenie = 73;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 9:
+                                armorWeenie = 83;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
+                            case 10:
+                                armorWeenie = 88;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 11:
+                                armorWeenie = 98;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 12:
+                                armorWeenie = 104;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            default:
+                                armorWeenie = 111;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 37;
-                            armorPieceType = 1;
-                            spellArray = 4;
-                            cantripArray = 4;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 41;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 793;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 52;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 58;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 62;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            armorWeenie = 67;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            armorWeenie = 73;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            armorWeenie = 83;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            armorWeenie = 88;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            armorWeenie = 98;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            armorWeenie = 104;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else
-                        {
-                            armorWeenie = 111;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////Yoroi
                     if (armorType == 5)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 7);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 43;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
+                            case 0:
+                                armorWeenie = 43;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 1:
+                                armorWeenie = 54;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 2:
+                                armorWeenie = 64;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 3:
+                                armorWeenie = 69;
+                                armorPieceType = 1;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 4:
+                                armorWeenie = 2437;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
+                            case 5:
+                                armorWeenie = 90;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 6:
+                                armorWeenie = 102;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            default:
+                                armorWeenie = 113;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 54;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 64;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 69;
-                            armorPieceType = 1;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 2437;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 90;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 102;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else
-                        {
-                            armorWeenie = 113;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////Diforsa
                     if (armorType == 6)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 12);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 28627;
-                            armorPieceType = 1;
-                            spellArray = 4;
-                            cantripArray = 4;
+                            case 0:
+                                armorWeenie = 28627;
+                                armorPieceType = 1;
+                                spellArray = 4;
+                                cantripArray = 4;
+                                break;
+                            case 1:
+                                armorWeenie = 28628;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 2:
+                                armorWeenie = 28630;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 3:
+                                armorWeenie = 28632;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 4:
+                                armorWeenie = 28633;
+                                armorPieceType = 1;
+                                spellArray = 6;
+                                cantripArray = 6;
+                                break;
+                            case 5:
+                                armorWeenie = 28634;
+                                armorPieceType = 31;
+                                spellArray = 8;
+                                cantripArray = 8;
+                                break;
+                            case 6:
+                                armorWeenie = 30948;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 7:
+                                armorWeenie = 28618;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            case 8:
+                                armorWeenie = 28621;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
+                            case 9:
+                                armorWeenie = 28623;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 10:
+                                armorWeenie = 30949;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
+                            case 11:
+                                armorWeenie = 28625;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                break;
+                            default:
+                                armorWeenie = 28626;
+                                armorPieceType = 1;
+                                spellArray = 7;
+                                cantripArray = 7;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 28628;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 28630;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 28632;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            armorWeenie = 28633;
-                            armorPieceType = 1;
-                            spellArray = 6;
-                            cantripArray = 6;
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            armorWeenie = 28634;
-                            armorPieceType = 31;
-                            spellArray = 8;
-                            cantripArray = 8;
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            armorWeenie = 30948;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            armorWeenie = 28618;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            armorWeenie = 28621;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            armorWeenie = 28623;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            armorWeenie = 30949;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            armorWeenie = 28625;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                        }
-                        else
-                        {
-                            armorWeenie = 28626;
-                            armorPieceType = 1;
-                            spellArray = 7;
-                            cantripArray = 7;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////celdon
@@ -5953,377 +6073,337 @@ namespace ACE.Server.Factories
                     //}
                     if (armorType == 15)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
-                        if (armorPiece == 0)
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
+                        switch (armorPiece)
                         {
-                            ////bandana
-                            armorWeenie = 28612;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 1)
-                        {
-                            ////beret
-                            armorWeenie = 28605;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            ////Cloth Cap
-                            armorWeenie = 118;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            ////Cloth gloves
-                            armorWeenie = 121;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            ////Cowl
-                            armorWeenie = 119;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            ////crown
-                            armorWeenie = 296;
-                            armorPieceType = 1;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            ////Fez
-                            armorWeenie = 5894;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            ////hood
-                            armorWeenie = 5905;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            ////Kasa
-                            armorWeenie = 5901;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            ////Metal cap
-                            armorWeenie = 46;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            ////Qafiya
-                            armorWeenie = 76;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            ////turban
-                            armorWeenie = 135;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            ////loafers
-                            armorWeenie = 28610;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            ////sandals
-                            armorWeenie = 129;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 14)
-                        {
-                            ////shoes
-                            armorWeenie = 132;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 15)
-                        {
-                            ////slippers
-                            armorWeenie = 133;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 16)
-                        {
-                            ////steel toed boots
-                            armorWeenie = 7897;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(6, 1);
-                        }
-                        else if (armorPiece == 17)
-                        {
-                            ////buckler
-                            armorWeenie = 44;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 18)
-                        {
-                            ////kite shield
-                            armorWeenie = 91;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 19)
-                        {
-                            ////large Kite Shield
-                            armorWeenie = 92;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 20)
-                        {
-                            ////Circlet
-                            armorWeenie = 29528;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 21)
-                        {
-                            ////Armet
-                            armorWeenie = 8488;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 22)
-                        {
-                            ////Baigha
-                            armorWeenie = 550;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 23)
-                        {
-                            ////Heaume
-                            armorWeenie = 74;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 24)
-                        {
-                            ////Helmet
-                            armorWeenie = 75;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 25)
-                        //{
-                        //    ////Horned Helm
-                        //    armorWeenie = 92;
-                        //    armorPieceType = 5;
-                        //    spellArray = 10;
-                        //    cantripArray = 10;
-                        //}
-                        else if (armorPiece == 25)
-                        {
-                            ////Kabuton
-                            armorWeenie = 77;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 26)
-                        {
-                            ////sollerets
-                            armorWeenie = 107;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 27)
-                        {
-                            ////viamontian laced boots
-                            armorWeenie = 28611;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 28)
-                        {
-                            ////RTower Shield
-                            armorWeenie = 95;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 29)
-                        //{
-                        //    ////Signet Crown
-                        //    armorWeenie = 31868;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44801;
-                        //    equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Faran Over-Robe
-                        //    armorWeenie = 44799;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Dho Vest and  Over-Robe
-                        //    armorWeenie = 44800;
-                        //    equipSetId = 14;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 33)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44802;
-                        //    ////equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Coronet
-                        //    armorWeenie = 31866;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Diadem
-                        //    armorWeenie = 31867;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Teardrop
-                        //    armorWeenie = 31864;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 37)
-                        //{
-                        //    ////Lyceum Hood
-                        //    armorWeenie = 44977;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 38)
-                        //{
-                        //    ////Empyrean Over-Robe
-                        //    armorWeenie = 43274;
-                        //    armorPieceType = 1;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        else
-                        {
-                            ////Round Shield
-                            armorWeenie = 93;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
+                            case 0:
+                                ////bandana
+                                armorWeenie = 28612;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 1:
+                                ////beret
+                                armorWeenie = 28605;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 2:
+                                ////Cloth Cap
+                                armorWeenie = 118;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 3:
+                                ////Cloth gloves
+                                armorWeenie = 121;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 4:
+                                ////Cowl
+                                armorWeenie = 119;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 5:
+                                ////crown
+                                armorWeenie = 296;
+                                armorPieceType = 1;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 6:
+                                ////Fez
+                                armorWeenie = 5894;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 7:
+                                ////hood
+                                armorWeenie = 5905;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 8:
+                                ////Kasa
+                                armorWeenie = 5901;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 9:
+                                ////Metal cap
+                                armorWeenie = 46;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 10:
+                                ////Horned Helm
+                                armorWeenie = 76;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 11:
+                                ////turban
+                                armorWeenie = 135;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 12:
+                                ////loafers
+                                armorWeenie = 28610;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 13:
+                                ////sandals
+                                armorWeenie = 129;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 14:
+                                ////shoes
+                                armorWeenie = 132;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 15:
+                                ////slippers
+                                armorWeenie = 133;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 16:
+                                ////steel toed boots
+                                armorWeenie = 7897;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(6, 1);
+                                break;
+                            case 17:
+                                ////buckler
+                                armorWeenie = 44;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 18:
+                                ////kite shield
+                                armorWeenie = 91;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 19:
+                                ////large Kite Shield
+                                armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////Circlet
+                                armorWeenie = 29528;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////Armet
+                                armorWeenie = 8488;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                ////Baigha
+                                armorWeenie = 550;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Heaume
+                                armorWeenie = 74;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Helmet
+                                armorWeenie = 75;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Kabuton
+                                armorWeenie = 77;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////sollerets
+                                armorWeenie = 107;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////viamontian laced boots
+                                armorWeenie = 28611;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////RTower Shield
+                                armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            default:
+                                ////Round Shield
+                                armorWeenie = 93;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
                         }
                     }
                     break;
@@ -7207,41 +7287,40 @@ namespace ACE.Server.Factories
                     if (armorType == 14)
                     {
                         int armorPiece = ThreadSafeRandom.Next(0, 4);
-                        if (armorPiece == 0)
+                        switch (armorPiece)
                         {
-                            armorWeenie = 30950;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
+                            case 0:
+                                armorWeenie = 30950;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                break;
+                            case 1:
+                                armorWeenie = 28629;
+                                armorPieceType = 1;
+                                spellArray = 2;
+                                cantripArray = 2;
+                                break;
+                            case 2:
+                                armorWeenie = 30951;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                break;
+                            case 3:
+                                armorWeenie = 28617;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                break;
+                            default:
+                                armorWeenie = 28620;
+                                armorPieceType = 1;
+                                spellArray = 3;
+                                cantripArray = 3;
+                                break;
                         }
-                        else if (armorPiece == 1)
-                        {
-                            armorWeenie = 28629;
-                            armorPieceType = 1;
-                            spellArray = 2;
-                            cantripArray = 2;
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            armorWeenie = 30951;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            armorWeenie = 28617;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                        }
-                        else
-                        {
-                            armorWeenie = 28620;
-                            armorPieceType = 1;
-                            spellArray = 3;
-                            cantripArray = 3;
-                        }
+
                         materialType = GetMaterialType(7, 1);
                     }
                     ////Knorr Academy Armor
@@ -7425,377 +7504,337 @@ namespace ACE.Server.Factories
                     //}
                     if (armorType == 15)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
-                        if (armorPiece == 0)
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
+                        switch (armorPiece)
                         {
-                            ////bandana
-                            armorWeenie = 28612;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 1)
-                        {
-                            ////beret
-                            armorWeenie = 28605;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 2)
-                        {
-                            ////Cloth Cap
-                            armorWeenie = 118;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 3)
-                        {
-                            ////Cloth gloves
-                            armorWeenie = 121;
-                            armorPieceType = 3;
-                            spellArray = 5;
-                            cantripArray = 5;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 4)
-                        {
-                            ////Cowl
-                            armorWeenie = 119;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 5)
-                        {
-                            ////crown
-                            armorWeenie = 296;
-                            armorPieceType = 1;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 6)
-                        {
-                            ////Fez
-                            armorWeenie = 5894;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 7)
-                        {
-                            ////hood
-                            armorWeenie = 5905;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 8)
-                        {
-                            ////Kasa
-                            armorWeenie = 5901;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 9)
-                        {
-                            ////Metal cap
-                            armorWeenie = 46;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 10)
-                        {
-                            ////Qafiya
-                            armorWeenie = 76;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 11)
-                        {
-                            ////turban
-                            armorWeenie = 135;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 12)
-                        {
-                            ////loafers
-                            armorWeenie = 28610;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 13)
-                        {
-                            ////sandals
-                            armorWeenie = 129;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 14)
-                        {
-                            ////shoes
-                            armorWeenie = 132;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 15)
-                        {
-                            ////slippers
-                            armorWeenie = 133;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(8, 1);
-                        }
-                        else if (armorPiece == 16)
-                        {
-                            ////steel toed boots
-                            armorWeenie = 7897;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(6, 1);
-                        }
-                        else if (armorPiece == 17)
-                        {
-                            ////buckler
-                            armorWeenie = 44;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 18)
-                        {
-                            ////kite shield
-                            armorWeenie = 91;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 19)
-                        {
-                            ////large Kite Shield
-                            armorWeenie = 92;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 20)
-                        {
-                            ////Circlet
-                            armorWeenie = 29528;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 21)
-                        {
-                            ////Armet
-                            armorWeenie = 8488;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 22)
-                        {
-                            ////Baigha
-                            armorWeenie = 550;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 23)
-                        {
-                            ////Heaume
-                            armorWeenie = 74;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 24)
-                        {
-                            ////Helmet
-                            armorWeenie = 75;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 25)
-                        //{
-                        //    ////Horned Helm
-                        //    armorWeenie = 92;
-                        //    armorPieceType = 5;
-                        //    spellArray = 10;
-                        //    cantripArray = 10;
-                        //}
-                        else if (armorPiece == 25)
-                        {
-                            ////Kabuton
-                            armorWeenie = 77;
-                            armorPieceType = 2;
-                            spellArray = 1;
-                            cantripArray = 1;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 26)
-                        {
-                            ////sollerets
-                            armorWeenie = 107;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 27)
-                        {
-                            ////viamontian laced boots
-                            armorWeenie = 28611;
-                            armorPieceType = 4;
-                            spellArray = 9;
-                            cantripArray = 9;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        else if (armorPiece == 28)
-                        {
-                            ////RTower Shield
-                            armorWeenie = 95;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
-                        }
-                        //else if (armorPiece == 29)
-                        //{
-                        //    ////Signet Crown
-                        //    armorWeenie = 31868;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44801;
-                        //    equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Faran Over-Robe
-                        //    armorWeenie = 44799;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Dho Vest and  Over-Robe
-                        //    armorWeenie = 44800;
-                        //    equipSetId = 14;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 33)
-                        //{
-                        //    ////Suikan Over-Robe
-                        //    armorWeenie = 44802;
-                        //    ////equipSetId = 15;
-                        //    armorPieceType = 5;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 30)
-                        //{
-                        //    ////Coronet
-                        //    armorWeenie = 31866;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 31)
-                        //{
-                        //    ////Diadem
-                        //    armorWeenie = 31867;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 32)
-                        //{
-                        //    ////Teardrop
-                        //    armorWeenie = 31864;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(7, 1);
-                        //}
-                        //else if (armorPiece == 37)
-                        //{
-                        //    ////Lyceum Hood
-                        //    armorWeenie = 44977;
-                        //    armorPieceType = 2;
-                        //    spellArray = 1;
-                        //    cantripArray = 1;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        //else if (armorPiece == 38)
-                        //{
-                        //    ////Empyrean Over-Robe
-                        //    armorWeenie = 43274;
-                        //    armorPieceType = 1;
-                        //    spellArray = 2;
-                        //    cantripArray = 2;
-                        //    materialType = GetMaterialType(8, 1);
-                        //}
-                        else
-                        {
-                            ////Round Shield
-                            armorWeenie = 93;
-                            armorPieceType = 5;
-                            spellArray = 10;
-                            cantripArray = 10;
-                            materialType = GetMaterialType(7, 1);
+                            case 0:
+                                ////bandana
+                                armorWeenie = 28612;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 1:
+                                ////beret
+                                armorWeenie = 28605;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 2:
+                                ////Cloth Cap
+                                armorWeenie = 118;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 3:
+                                ////Cloth gloves
+                                armorWeenie = 121;
+                                armorPieceType = 3;
+                                spellArray = 5;
+                                cantripArray = 5;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 4:
+                                ////Cowl
+                                armorWeenie = 119;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 5:
+                                ////crown
+                                armorWeenie = 296;
+                                armorPieceType = 1;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 6:
+                                ////Fez
+                                armorWeenie = 5894;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 7:
+                                ////hood
+                                armorWeenie = 5905;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 8:
+                                ////Kasa
+                                armorWeenie = 5901;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 9:
+                                ////Metal cap
+                                armorWeenie = 46;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 10:
+                                ////Horned Helm
+                                armorWeenie = 76;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 11:
+                                ////turban
+                                armorWeenie = 135;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 12:
+                                ////loafers
+                                armorWeenie = 28610;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 13:
+                                ////sandals
+                                armorWeenie = 129;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 14:
+                                ////shoes
+                                armorWeenie = 132;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 15:
+                                ////slippers
+                                armorWeenie = 133;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(8, 1);
+                                break;
+                            case 16:
+                                ////steel toed boots
+                                armorWeenie = 7897;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(6, 1);
+                                break;
+                            case 17:
+                                ////buckler
+                                armorWeenie = 44;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 18:
+                                ////kite shield
+                                armorWeenie = 91;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 19:
+                                ////large Kite Shield
+                                armorWeenie = 92;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 20:
+                                ////Circlet
+                                armorWeenie = 29528;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 21:
+                                ////Armet
+                                armorWeenie = 8488;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 22:
+                                ////Baigha
+                                armorWeenie = 550;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 23:
+                                ////Heaume
+                                armorWeenie = 74;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 24:
+                                ////Helmet
+                                armorWeenie = 75;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 25:
+                                ////Kabuton
+                                armorWeenie = 77;
+                                armorPieceType = 2;
+                                spellArray = 1;
+                                cantripArray = 1;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 26:
+                                ////sollerets
+                                armorWeenie = 107;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 27:
+                                ////viamontian laced boots
+                                armorWeenie = 28611;
+                                armorPieceType = 4;
+                                spellArray = 9;
+                                cantripArray = 9;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 28:
+                                ////RTower Shield
+                                armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            default:
+                                ////Round Shield
+                                armorWeenie = 93;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
                         }
                     }
                     break;
@@ -9099,7 +9138,7 @@ namespace ACE.Server.Factories
                     //}
                     if (armorType == 15)
                     {
-                        int armorPiece = ThreadSafeRandom.Next(0, 29);
+                        int armorPiece = ThreadSafeRandom.Next(0, 40);
                         switch (armorPiece)
                         {
                             case 0:
@@ -9183,7 +9222,7 @@ namespace ACE.Server.Factories
                                 materialType = GetMaterialType(7, 1);
                                 break;
                             case 10:
-                                ////Qafiya
+                                ////Horned Helm
                                 armorWeenie = 76;
                                 armorPieceType = 2;
                                 spellArray = 1;
@@ -9329,6 +9368,94 @@ namespace ACE.Server.Factories
                             case 28:
                                 ////RTower Shield
                                 armorWeenie = 95;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 29:
+                                ////shirt
+                                armorWeenie = 2587;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 30:
+                                ////pants
+                                armorWeenie = 2601;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 31:
+                                //// Poet's Shirt
+                                armorWeenie = 28608;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 32:
+                                ////Lace Shirt
+                                armorWeenie = 28607;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 33:
+                                ////Viamontian Pants
+                                armorWeenie = 28606;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 34:
+                                ////Smock
+                                armorWeenie = 2589;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 35:
+                                ////Tunic
+                                armorWeenie = 2592;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 36:
+                                ////Trousers
+                                armorWeenie = 2599;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 37:
+                                ////Pantaloons
+                                armorWeenie = 2600;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 38:
+                                ////Breeches
+                                armorWeenie = 2602;
+                                armorPieceType = 5;
+                                spellArray = 10;
+                                cantripArray = 10;
+                                materialType = GetMaterialType(7, 1);
+                                break;
+                            case 39:
+                                ////Qafiya
+                                armorWeenie = 128;
                                 armorPieceType = 5;
                                 spellArray = 10;
                                 cantripArray = 10;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -46,8 +46,8 @@ namespace ACE.Server.Factories
                         case 2:
                             weaponDefense = GetMaxDamageMod(tier, 18);
                             weaponOffense = GetMaxDamageMod(tier, 22);
-                            damage = GetMaxDamage(1, tier, wieldDiff, 1);
-                            damageVariance = GetVariance(1, 1);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Axe);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Axe);
                             break;
                         case 3:
                         case 4:
@@ -55,14 +55,14 @@ namespace ACE.Server.Factories
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
 
-                            damage = GetMaxDamage(1, tier, wieldDiff, 2);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Dagger);
 
                             if (heavyWeaponsType == 3)
-                                damageVariance = GetVariance(1, 2);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.Dagger);
                             if (heavyWeaponsType == 4 || heavyWeaponsType == 5)
                             {
-                                damage = GetMaxDamage(1, tier, wieldDiff, 3);
-                                damageVariance = GetVariance(1, 3);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.DaggerMulti);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.DaggerMulti);
                             }
                             break;
                         case 6:
@@ -71,23 +71,23 @@ namespace ACE.Server.Factories
                         case 9:
                             weaponDefense = GetMaxDamageMod(tier, 22);
                             weaponOffense = GetMaxDamageMod(tier, 18);
-                            damage = GetMaxDamage(1, tier, wieldDiff, 4);
-                            damageVariance = GetVariance(1, 4);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Mace);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Mace);
                             break;
                         case 10:
                         case 11:
                         case 12:
                             weaponDefense = GetMaxDamageMod(tier, 15);
                             weaponOffense = GetMaxDamageMod(tier, 25);
-                            damage = GetMaxDamage(1, tier, wieldDiff, 5);
-                            damageVariance = GetVariance(1, 5);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spear);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Spear);
                             break;
                         case 13:
                         case 14:
                             weaponDefense = GetMaxDamageMod(tier, 25);
                             weaponOffense = GetMaxDamageMod(tier, 15);
-                            damage = GetMaxDamage(1, tier, wieldDiff, 8);
-                            damageVariance = GetVariance(1, 6);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Staff);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Staff);
                             break;
                         case 15:
                         case 16:
@@ -98,21 +98,21 @@ namespace ACE.Server.Factories
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
 
-                            damage = GetMaxDamage(1, tier, wieldDiff, 6);
-                            damageVariance = GetVariance(1, 7);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Sword);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Sword);
 
                             if (heavyWeaponsType == 20)
                             {
-                                damage = GetMaxDamage(1, tier, wieldDiff, 7);
-                                damageVariance = GetVariance(1, 8);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.SwordMulti);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.SwordMulti);
                             }
                             break;
                         case 21:
                         default:
-                            damage = GetMaxDamage(1, tier, wieldDiff, 9);
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damageVariance = GetVariance(1, 9);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.UA);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.UA);
                             break;
                     }
                     break;
@@ -130,8 +130,8 @@ namespace ACE.Server.Factories
                         case 3:
                             weaponDefense = GetMaxDamageMod(tier, 18);
                             weaponOffense = GetMaxDamageMod(tier, 22);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 1);
-                            damageVariance = GetVariance(2, 1);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Axe);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Axe);
                             break;
                         case 4:
                         case 5:
@@ -140,14 +140,14 @@ namespace ACE.Server.Factories
 
                             if (lightWeaponsType == 4)
                             {
-                                damage = GetMaxDamage(2, tier, wieldDiff, 2);
-                                damageVariance = GetVariance(2, 2);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Dagger);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.Dagger);
                             }
 
                             if (lightWeaponsType == 5)
                             {
-                                damage = GetMaxDamage(2, tier, wieldDiff, 3);
-                                damageVariance = GetVariance(2, 3);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.DaggerMulti);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.DaggerMulti);
                             }
                             break;
                         case 6:
@@ -155,21 +155,21 @@ namespace ACE.Server.Factories
                         case 8:
                             weaponDefense = GetMaxDamageMod(tier, 22);
                             weaponOffense = GetMaxDamageMod(tier, 18);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 4);
-                            damageVariance = GetVariance(2, 4);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Mace);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Mace);
                             break;
                         case 9:
                         case 10:
                             weaponDefense = GetMaxDamageMod(tier, 15);
                             weaponOffense = GetMaxDamageMod(tier, 25);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 5);
-                            damageVariance = GetVariance(2, 6);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spear);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Spear);
                             break;
                         case 11:
                             weaponDefense = GetMaxDamageMod(tier, 25);
                             weaponOffense = GetMaxDamageMod(tier, 15);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 8);
-                            damageVariance = GetVariance(2, 7);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Staff);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Staff);
                             break;
                         case 12:
                         case 13:
@@ -180,21 +180,21 @@ namespace ACE.Server.Factories
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
 
-                            damage = GetMaxDamage(2, tier, wieldDiff, 6);
-                            damageVariance = GetVariance(2, 8);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Sword);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Sword);
 
                             if (lightWeaponsType == 14)
                             {
-                                damage = GetMaxDamage(2, tier, wieldDiff, 7);
-                                damageVariance = GetVariance(2, 9);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.SwordMulti);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.SwordMulti);
                             }
                             break;
                         case 18:
                         default:
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 9);
-                            damageVariance = GetVariance(2, 10);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.UA);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.UA);
                             break;
                     }
                     break;
@@ -211,21 +211,21 @@ namespace ACE.Server.Factories
                         case 2:
                             weaponDefense = GetMaxDamageMod(tier, 18);
                             weaponOffense = GetMaxDamageMod(tier, 22);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 1);
-                            damageVariance = GetVariance(2, 1);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Axe);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Axe);
                             break;
                         case 3:
                         case 4:
                         case 5:
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 2);
-                            damageVariance = GetVariance(2, 2);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Dagger);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Dagger);
 
                             if (finesseWeaponsType == 3 || finesseWeaponsType == 4)
                             {
-                                damageVariance = GetVariance(2, 3);
-                                damage = GetMaxDamage(2, tier, wieldDiff, 3);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.DaggerMulti);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.DaggerMulti);
                             }
                             break;
                         case 6:
@@ -235,25 +235,25 @@ namespace ACE.Server.Factories
                         case 10:
                             weaponDefense = GetMaxDamageMod(tier, 22);
                             weaponOffense = GetMaxDamageMod(tier, 18);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 4);
-                            damageVariance = GetVariance(2, 4);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Mace);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Mace);
 
                             if (finesseWeaponsType == 9)
-                                damageVariance = GetVariance(2, 5);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.Jitte);
                             break;
                         case 11:
                         case 12:
                             weaponDefense = GetMaxDamageMod(tier, 15);
                             weaponOffense = GetMaxDamageMod(tier, 25);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 5);
-                            damageVariance = GetVariance(2, 6);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spear);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Spear);
                             break;
                         case 13:
                         case 14:
                             weaponDefense = GetMaxDamageMod(tier, 25);
                             weaponOffense = GetMaxDamageMod(tier, 15);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 8);
-                            damageVariance = GetVariance(2, 7);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Staff);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Staff);
                             break;
                         case 15:
                         case 16:
@@ -263,21 +263,21 @@ namespace ACE.Server.Factories
                         case 20:
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 6);
-                            damageVariance = GetVariance(2, 8);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Sword);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.Sword);
 
                             if (finesseWeaponsType == 15)
                             {
-                                damage = GetMaxDamage(2, tier, wieldDiff, 7);
-                                damageVariance = GetVariance(2, 9);
+                                damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.SwordMulti);
+                                damageVariance = GetVariance(wieldSkillType, LootWeaponType.SwordMulti);
                             }
                             break;
                         case 21:
                         default:
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damage = GetMaxDamage(2, tier, wieldDiff, 9);
-                            damageVariance = GetVariance(2, 10);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.UA);
+                            damageVariance = GetVariance(wieldSkillType, LootWeaponType.UA);
                             break;
                     }
                     break;
@@ -287,8 +287,8 @@ namespace ACE.Server.Factories
                     int twoHandedWeaponsType = ThreadSafeRandom.Next(0, 11);
                     weaponWeenie = LootTables.TwoHandedWeaponsMatrix[twoHandedWeaponsType][eleType];
 
-                    damage = GetMaxDamage(3, tier, wieldDiff, 1);
-                    damageVariance = GetVariance(3, 1);
+                    damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Cleaving);
+                    damageVariance = GetVariance(wieldSkillType, LootWeaponType.TwoHanded);
 
                     switch (twoHandedWeaponsType)
                     {
@@ -297,7 +297,6 @@ namespace ACE.Server.Factories
                         case 2:
                             weaponDefense = GetMaxDamageMod(tier, 20);
                             weaponOffense = GetMaxDamageMod(tier, 20);
-                            damageVariance = GetVariance(2, 1);
                             break;
                         case 3:
                         case 4:
@@ -316,7 +315,7 @@ namespace ACE.Server.Factories
                         default:
                             weaponDefense = GetMaxDamageMod(tier, 15);
                             weaponOffense = GetMaxDamageMod(tier, 25);
-                            damage = GetMaxDamage(3, tier, wieldDiff, 2);
+                            damage = GetMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spears);
                             break;
                     }
                     break;
@@ -347,11 +346,13 @@ namespace ACE.Server.Factories
             wo.SetProperty(PropertyFloat.WeaponMissileDefense, missileD);
             wo.SetProperty(PropertyFloat.WeaponMagicDefense, magicD);
 
-            wo.SetProperty(PropertyInt.WieldDifficulty, wieldDiff);
-            wo.SetProperty(PropertyInt.WieldRequirements, (int)wieldRequirments);
-            wo.SetProperty(PropertyInt.WieldSkillType, (int)wieldSkillType);
-
-            if (wieldDiff == 0)
+            if (wieldDiff > 0)
+            {
+                wo.SetProperty(PropertyInt.WieldDifficulty, wieldDiff);
+                wo.SetProperty(PropertyInt.WieldRequirements, (int)wieldRequirments);
+                wo.SetProperty(PropertyInt.WieldSkillType, (int)wieldSkillType);
+            }
+            else
             {
                 wo.RemoveProperty(PropertyInt.WieldDifficulty);
                 wo.RemoveProperty(PropertyInt.WieldRequirements);

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -368,7 +368,6 @@ namespace ACE.Factories
             new int[] { 0, 2 },
             new int[] { 2, 3 },
             new int[] { 3, 4 },
-            new int[] { 3, 4 },
             new int[] { 4, 5 },
             new int[] { 5, 5 },
             new int[] { 5, 6 },


### PR DESCRIPTION
- Add shirts and pants to loot drop
- Change weapon damage to be based upon wield difficulty, instead of tier number
- Lower Essence drop rate to ~17%
- Convert a number of magic numbers to descriptive, enum based values
