### PR TITLE
Add IOU trade in support

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -1933,5 +1933,23 @@ namespace ACE.Server.Command.Handlers
             WorldObject loot = LootGenerationFactory.CreateLootByWCID(weenieClassId, tier);
             session.Player.TryCreateInInventoryWithNetworking(loot);
         }
+
+        [CommandHandler("makeiou", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Make an IOU and put it in your inventory","<wcid>")]
+        public static void HandleMakeIOU(Session session, params string[] parameters)
+        {
+            string weenieClassDescription = parameters[0];
+            bool wcid = uint.TryParse(weenieClassDescription, out uint weenieClassId);
+
+            if (!wcid)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"WCID must be a valid weenie id", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var iou = PlayerFactory.CreateIOU(weenieClassId);
+
+            if (iou != null)
+                session.Player.TryCreateInInventoryWithNetworking(iou);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -104,26 +104,26 @@ namespace ACE.Server.Factories
                 if (hat != null)
                     player.TryEquipObject(hat, hat.ValidLocations ?? 0);
                 else
-                    player.TryAddToInventory(CreateIOU(player, sex.GetHeadgearWeenie(characterCreateInfo.Apperance.HeadgearStyle)));
+                    player.TryAddToInventory(CreateIOU(sex.GetHeadgearWeenie(characterCreateInfo.Apperance.HeadgearStyle)));
             }
 
             var shirt = GetClothingObject(sex.GetShirtWeenie(characterCreateInfo.Apperance.ShirtStyle), characterCreateInfo.Apperance.ShirtColor, characterCreateInfo.Apperance.ShirtHue);
             if (shirt != null)
                 player.TryEquipObject(shirt, shirt.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(player, sex.GetShirtWeenie(characterCreateInfo.Apperance.ShirtStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetShirtWeenie(characterCreateInfo.Apperance.ShirtStyle)));
 
             var pants = GetClothingObject(sex.GetPantsWeenie(characterCreateInfo.Apperance.PantsStyle), characterCreateInfo.Apperance.PantsColor, characterCreateInfo.Apperance.PantsHue);
             if (pants != null)
                 player.TryEquipObject(pants, pants.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(player, sex.GetPantsWeenie(characterCreateInfo.Apperance.PantsStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetPantsWeenie(characterCreateInfo.Apperance.PantsStyle)));
 
             var shoes = GetClothingObject(sex.GetFootwearWeenie(characterCreateInfo.Apperance.FootwearStyle), characterCreateInfo.Apperance.FootwearColor, characterCreateInfo.Apperance.FootwearHue);
             if (shoes != null)
                 player.TryEquipObject(shoes, shoes.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(player, sex.GetFootwearWeenie(characterCreateInfo.Apperance.FootwearStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetFootwearWeenie(characterCreateInfo.Apperance.FootwearStyle)));
 
             string templateName = heritageGroup.Templates[characterCreateInfo.TemplateOption].Name;
             //player.SetProperty(PropertyString.Title, templateName);
@@ -242,7 +242,7 @@ namespace ACE.Server.Factories
                         }
                         else
                         {
-                            player.TryAddToInventory(CreateIOU(player, item.WeenieId));
+                            player.TryAddToInventory(CreateIOU(item.WeenieId));
                         }
 
                         if (loot != null && player.TryAddToInventory(loot))
@@ -259,7 +259,7 @@ namespace ACE.Server.Factories
                                 }
                                 else
                                 {
-                                    player.TryAddToInventory(CreateIOU(player, item.WeenieId));
+                                    player.TryAddToInventory(CreateIOU(item.WeenieId));
                                 }
                             }
                         }
@@ -288,7 +288,7 @@ namespace ACE.Server.Factories
                             }
                             else
                             {
-                                player.TryAddToInventory(CreateIOU(player, item.WeenieId));
+                                player.TryAddToInventory(CreateIOU(item.WeenieId));
                             }
 
                             if (loot != null && player.TryAddToInventory(loot))
@@ -305,7 +305,7 @@ namespace ACE.Server.Factories
                                     }
                                     else
                                     {
-                                        player.TryAddToInventory(CreateIOU(player, item.WeenieId));
+                                        player.TryAddToInventory(CreateIOU(item.WeenieId));
                                     }
                                 }
                             }
@@ -453,7 +453,7 @@ namespace ACE.Server.Factories
             return worldObject;
         }
 
-        public static WorldObject CreateIOU(Player player, uint missingWeenieId)
+        public static WorldObject CreateIOU(uint missingWeenieId)
         {
             var iou = (Book)WorldObjectFactory.CreateNewWorldObject("parchment");
 
@@ -462,6 +462,8 @@ namespace ACE.Server.Factories
             iou.Bonded = (int)BondedStatus.Bonded;
             iou.Attuned = (int)AttunedStatus.Attuned;
             iou.SetProperty(PropertyBool.IsSellable, false);
+            iou.Value = 0;
+            iou.EncumbranceVal = 0;
 
             return iou;
         }

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -326,7 +326,7 @@ namespace ACE.Server.Managers
                             }
                         }
                         else
-                            item = PlayerFactory.CreateIOU(player, (uint)emote.WeenieClassId);
+                            item = PlayerFactory.CreateIOU((uint)emote.WeenieClassId);
 
                         success = player.TryCreateInInventoryWithNetworking(item);
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -439,6 +439,7 @@ namespace ACE.Server.Managers
 
         public static readonly ReadOnlyDictionary<string, bool> DefaultBooleanProperties =
             DictOf(
+                ("iou_trades", false),              // (non-retail function) If enabled, IOUs can be traded for objects that are missing in DB but added/restored later on.
                 ("chess_enabled", true),
                 ("corpse_destroy_pyreals", true),   // when player loses pyreals on death, should the pyreals be destroyed completely (end of retail),
                 ("gateway_ties_summonable", true),        // if disabled, players cannot summon ties from gateways. defaults to enabled, as in retail

--- a/Source/ACE.Server/WorldObjects/Book.cs
+++ b/Source/ACE.Server/WorldObjects/Book.cs
@@ -175,5 +175,12 @@ namespace ACE.Server.WorldObjects
 
             return true;
         }
+
+        public BiotaPropertiesBookPageData GetPage(uint pageId)
+        {
+            var page = Biota.GetBookPageData(Guid.Full, pageId, BiotaDatabaseLock);
+
+            return page;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -663,5 +663,13 @@ namespace ACE.Server.WorldObjects
         }
 
         public virtual MotionCommand MotionPickup => MotionCommand.Pickup;
+
+        /// <summary>
+        /// Mainly used to mark containers (corpse) inventory loaded for proper decay rules
+        /// </summary>
+        public void MarkAsInventoryLoaded()
+        {
+            InventoryLoaded = true;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -257,6 +257,7 @@ namespace ACE.Server.WorldObjects
             if (CanGenerateRare && killer != null)
                 corpse.GenerateRare(killer);
 
+            corpse.MarkAsInventoryLoaded();
             corpse.EnterWorld();
 
             if (this is Player p)

--- a/Source/ACE.Server/WorldObjects/House.cs
+++ b/Source/ACE.Server/WorldObjects/House.cs
@@ -380,6 +380,10 @@ namespace ACE.Server.WorldObjects
                 if (_dungeonLandblockID == null)
                 {
                     var housePortal = GetHousePortals();
+
+                    if (housePortal.Count == 0)
+                        return 0;
+
                     _dungeonLandblockID = housePortal[0].ObjCellId | 0xFFFF;
                 }
                 return _dungeonLandblockID.Value;
@@ -395,6 +399,10 @@ namespace ACE.Server.WorldObjects
                 if (_dungeonHouseGuid == null)
                 {
                     var housePortals = GetHousePortals();
+
+                    if (housePortals.Count == 0)
+                        return 0;
+
                     _dungeonHouseGuid = housePortals[0].Id;
 
                 }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1905,6 +1905,8 @@ namespace ACE.Server.WorldObjects
 
                                     if (PropertyManager.GetBool("player_receive_immediate_save").Item)
                                         RushNextPlayerSave(5);
+
+                                    log.Info($"{Name} traded in a IOU (0x{iouToTurnIn.Guid.Full:X8}) for {wcid} which became {item.Name} (0x{item.Guid.Full:X8}).");
                                 }
                                 return;
                             }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1906,7 +1906,7 @@ namespace ACE.Server.WorldObjects
                                     if (PropertyManager.GetBool("player_receive_immediate_save").Item)
                                         RushNextPlayerSave(5);
 
-                                    log.Info($"{Name} traded in a IOU (0x{iouToTurnIn.Guid.Full:X8}) for {wcid} which became {item.Name} (0x{item.Guid.Full:X8}).");
+                                    log.Info($"{Name} (0x{Guid:X8}) traded in a IOU (0x{iouToTurnIn.Guid.Full:X8}) for {wcid} which became {item.Name} (0x{item.Guid.Full:X8}).");
                                 }
                                 return;
                             }


### PR DESCRIPTION
* `iou_trades` property must be enabled (true)
* Hand any IOU to a Town Crier and it will turn it into real item if that item is now in DB
* also fix corpse decay for empty corpses