### PR TITLE
Changes related to Event Generators

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -84,6 +84,9 @@ namespace ACE.Server.WorldObjects
             // their effects won't be seen if they broadcast from themselves
             if (target != null && spell.TargetEffect != 0)
                 target.EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
+
+            if (caster != null && spell.CasterEffect != 0)
+                caster.EnqueueBroadcast(new GameMessageScript(caster.Guid, spell.CasterEffect, spell.Formula.Scale));
         }
 
         /// <summary>


### PR DESCRIPTION
* Changed loot to drop to ground if NoCorpse is true for creatures
* Broadcast CasterEffect if spell has one for all to see (if creature is visible)
* Change Generators enable/disable to staged: change occurs on 2nd heartbeat, 1st detects the change and arms.