### PR TITLE
Release NetworkSession resources when a session drops

### DIFF
--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -13,7 +13,6 @@ using ACE.Server.WorldObjects;
 using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
-using ACE.Server.Network.Packets;
 using ACE.Server.Network.GameMessages;
 
 
@@ -260,6 +259,11 @@ namespace ACE.Server.Network
             }
 
             WorldManager.RemoveSession(this);
+
+            // This is a temp fix to mark the Session.Network portion of the Session as released
+            // What this means is that we will release any network related resources, as well as avoid taking on additional resources
+            // In the future, we should set Network to null and funnel Network communication through Session, instead of accessing Session.Network directly.
+            Network.ReleaseResources();
         }
 
 


### PR DESCRIPTION
This is a simple patch to help CE mem usage. The proper fix is to funnel NetworkSession work through Session, so that Session can manage it's state directly.

What is happening now, and can/will happen in the future, is that Player references are being held, and thus, their Session and NetworkSession objects aren't being released.

Even after a Session drops, work can still be enqueued onto NetworkSession through ActionChains and other means. This PR will now ignore that work. Currently, in master, that work is received and held indefinitely (until Player/Session are released)

This also fixes the case where NetworkSession work was being enqueued after a session dropped, but before the Player was fully logged out of the world. Now, that work will be ignored.