### PR TITLE
possible fix for rare damage spikes

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -226,8 +226,8 @@ namespace ACE.Server.Entity
                 // select random body part @ current attack height
                 GetBodyPart(AttackHeight);
 
-                // get armor pieces
-                Armor = attacker.GetArmorLayers(BodyPart);    // this uses attacker.AttackTarget
+                // get player armor pieces
+                Armor = attacker.GetArmorLayers(playerDefender, BodyPart);
 
                 // get armor modifiers
                 ArmorMod = attacker.GetArmorMod(DamageType, Armor, DamageSource, armorRendingMod);

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -276,10 +276,8 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the creature armor for a body part
         /// </summary>
-        public List<WorldObject> GetArmorLayers(BodyPart bodyPart)
+        public List<WorldObject> GetArmorLayers(Player target, BodyPart bodyPart)
         {
-            var target = AttackTarget as Creature;
-
             //Console.WriteLine("BodyPart: " + bodyPart);
             //Console.WriteLine("===");
 


### PR DESCRIPTION
This looks like it might fix the bug where some players were occasionally getting hit in rare instances for 400+ by Olthoi Rippers and Biakas

GetArmorLayers() is a very old function, and was originally written to use the current AttackTarget of the monster. I left a comment in DamageEvent when I realized this might be unsafe, but now we might see some possible ramifications of this

When the monster AI was updated much later for switching targets in functions like FindNextTarget(), the current execution of this target switching might need to be more tightly clamped to certain states. What I think is happening is, monsters are switching targets in the middle of an attack (ie. maybe they start swinging at a player, and then maybe they re-target a nearby summoned mob before their attack hits the player). DamageEvent.PlayerDefender would still be the original intended target in this case, but Monster.AttackTarget would be pointing to the new target, and this discrepancy might lead to errors

The monster AI code should eventually be reviewed to see anywhere else it might use AttackTarget after an actionchain delay, and either update those portions, or have more state conditions in FindNextTarget, as mention previously