### PR TITLE
Fix Existing Jewelry objects in Shard DB

### DIFF
--- a/Database/Updates/Shard/2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql
+++ b/Database/Updates/Shard/2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql
@@ -1,0 +1,6 @@
+USE `ace_shard`;
+
+UPDATE biota
+INNER JOIN biota_properties_int on biota.weenie_Class_Id = biota_properties_int.object_Id
+SET biota.weenie_Type = 1
+WHERE biota.id > 0 AND biota.weenie_Type = 2 AND biota_properties_int.`type` = 1 AND biota_properties_int.`value` = 8;

--- a/Database/Updates/Shard/2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql
+++ b/Database/Updates/Shard/2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql
@@ -1,6 +1,6 @@
 USE `ace_shard`;
 
 UPDATE biota
-INNER JOIN biota_properties_int on biota.weenie_Class_Id = biota_properties_int.object_Id
+INNER JOIN biota_properties_int on biota.id = biota_properties_int.object_Id
 SET biota.weenie_Type = 1
 WHERE biota.id > 0 AND biota.weenie_Type = 2 AND biota_properties_int.`type` = 1 AND biota_properties_int.`value` = 8;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2019-05-03
+[Ripley]
+* Add fix up SQL script (2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql) for existing servers to run to correct jewelry WeenieType on existing items.
+  - This script will only need to be run once and only fixes incorrect objects.
+
 ### 2019-05-02
 [Ripley]
 * Changed House Warning Messages filter.


### PR DESCRIPTION
* Add fix up SQL script (2019-05-03-00-Fix_Biota_Jewelry_WeenieType.sql) for existing servers to run to correct jewelry WeenieType on existing items.
  - This script will only need to be run once and only fixes incorrect objects.