### PR TITLE
Add support for lower armor reduction kit applied to leggings

### DIFF
--- a/Source/ACE.Server/Entity/Tailoring.cs
+++ b/Source/ACE.Server/Entity/Tailoring.cs
@@ -266,6 +266,11 @@ namespace ACE.Server.Entity
                         player.UpdateProperty(target, PropertyInt.ValidLocations, (int)EquipMask.LowerArmArmor);
                         clothingPriority = CoverageMask.OuterwearLowerArms;
                     }
+                    else if (validLocations.HasFlag(EquipMask.UpperLegArmor))
+                    {
+                        player.UpdateProperty(target, PropertyInt.ValidLocations, (int)EquipMask.LowerLegArmor);
+                        clothingPriority = CoverageMask.OuterwearLowerLegs;
+                    }
                     break;
 
                 case ArmorMiddleReductionTool:


### PR DESCRIPTION
This adds support for the Armor Lower Reduction Kit to reduce leggings to lower legs (greaves) only. It currently only works for Arms -> Lower Arms (bracers).