### PR TITLE
Optional assess creature mod

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -440,7 +440,7 @@ namespace ACE.Server.Managers
         public static readonly ReadOnlyDictionary<string, bool> DefaultBooleanProperties =
             DictOf(
                 ("advanced_combat_pets", false),    // (non-retail function) If enabled, Combat Pets can cast spells
-                ("assess_creature_mod", false),     // (non-retail function) If enabled, reenables former skill formula, when assess creature skill is five or less.
+                ("assess_creature_mod", false),     // (non-retail function) If enabled, re-enables former skill formula, when assess creature skill is not trained or spec'ed.
                 ("iou_trades", false),              // (non-retail function) If enabled, IOUs can be traded for objects that are missing in DB but added/restored later on.
                 ("chess_enabled", true),
                 ("corpse_destroy_pyreals", true),   // when player loses pyreals on death, should the pyreals be destroyed completely (end of retail),

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -440,6 +440,7 @@ namespace ACE.Server.Managers
         public static readonly ReadOnlyDictionary<string, bool> DefaultBooleanProperties =
             DictOf(
                 ("advanced_combat_pets", false),    // (non-retail function) If enabled, Combat Pets can cast spells
+                ("assess_creature_mod", false),     // (non-retail function) If enabled, reenables former skill formula, when assess creature skill is five or less.
                 ("iou_trades", false),              // (non-retail function) If enabled, IOUs can be traded for objects that are missing in DB but added/restored later on.
                 ("chess_enabled", true),
                 ("corpse_destroy_pyreals", true),   // when player loses pyreals on death, should the pyreals be destroyed completely (end of retail),

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -261,7 +261,8 @@ namespace ACE.Server.WorldObjects
                 var currentSkill = (int)GetCreatureSkill(skill).Current;
                 int difficulty = (int)creature.GetCreatureSkill(Skill.Deception).Current;
 
-                if (PropertyManager.GetBool("assess_creature_mod").Item && skill == Skill.AssessCreature && currentSkill <= 5)
+                if (PropertyManager.GetBool("assess_creature_mod").Item && skill == Skill.AssessCreature
+                        && Skills[Skill.AssessCreature].AdvancementClass < SkillAdvancementClass.Trained)
                     currentSkill = (int)((Focus.Current + Self.Current) / 2);
 
                 var chance = SkillCheck.GetSkillChance(currentSkill, difficulty);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -261,6 +261,9 @@ namespace ACE.Server.WorldObjects
                 var currentSkill = (int)GetCreatureSkill(skill).Current;
                 int difficulty = (int)creature.GetCreatureSkill(Skill.Deception).Current;
 
+                if (PropertyManager.GetBool("assess_creature_mod").Item && skill == Skill.AssessCreature && currentSkill <= 5)
+                    currentSkill = (int)((Focus.Current + Self.Current) / 2);
+
                 var chance = SkillCheck.GetSkillChance(currentSkill, difficulty);
 
                 if (difficulty == 0 || player != null && (!player.GetCharacterOption(CharacterOption.AttemptToDeceiveOtherPlayers) || player == this


### PR DESCRIPTION
- Add option for re-enabling the former skill formula for Assess Creature skill, when skill is untrained
