### PR TITLE
Fix RegenOnClose

### DIFF
--- a/Source/ACE.Server/Entity/Generator.cs
+++ b/Source/ACE.Server/Entity/Generator.cs
@@ -102,16 +102,24 @@ namespace ACE.Server.Entity
         }
 
         /// <summary>
-        /// Called every ~5 seconds for generator
+        /// Called every ~5 seconds for generator<para />
+        /// Processes the RemoveQueue
         /// </summary>
-        public void HeartBeat()
+        public void Maintenance_HeartBeat()
         {
             while (RemoveQueue.TryPeek(out var result) && result.time <= DateTime.UtcNow)
             {
                 RemoveQueue.Dequeue();
                 FreeSlot(result.objectGuid);
             }
+        }
 
+        /// <summary>
+        /// Called every ~5 seconds for generator based on conditions<para />
+        /// Processes the SpawnQueue
+        /// </summary>
+        public void Spawn_HeartBeat()
+        {
             if (SpawnQueue.Count > 0)
                 ProcessQueue();
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -532,7 +532,8 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Called every ~5 seconds for object generators
+        /// Called every [RegenerationInterval] seconds<para />
+        /// Also called from EmoteManager, Chest.Reset(), WorldObject.OnGenerate()
         /// </summary>
         public void Generator_HeartBeat()
         {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -541,6 +541,9 @@ namespace ACE.Server.WorldObjects
             if (!FirstEnterWorldDone)
                 FirstEnterWorldDone = true;
 
+            foreach (var generator in GeneratorProfiles)
+                generator.Maintenance_HeartBeat();
+
             CheckGeneratorStatus();
 
             if (!GeneratorEnteredWorld)
@@ -562,7 +565,7 @@ namespace ACE.Server.WorldObjects
             }
 
             foreach (var generator in GeneratorProfiles)
-                generator.HeartBeat();
+                generator.Spawn_HeartBeat();
         }
     }
 }


### PR DESCRIPTION
This fixes the issue were chests weren't calling their profiles generator.HeartBeat() because chest.ResetGenerator was false.

The fix is to process maintenance for generator profiles always, but only the spawn heartbeats conditionally.

This was tested using /crack and the pathwarden chest.