### PR TITLE
move IsBusy check to action, not consume

### DIFF
--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -47,6 +47,12 @@ namespace ACE.Server.WorldObjects
             var player = activator as Player;
             if (player == null) return;
 
+            if (activator.IsBusy)
+            {
+               player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.YoureTooBusy));
+                return;
+            }
+
             var buffType = Player.ConsumableBuffType.Stamina;
 
             if (BoostEnum != null)

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -876,8 +876,6 @@ namespace ACE.Server.WorldObjects
         /// <param name="spellDID">Id of the spell cast by the consumable; can be null, if buffType != ConsumableBuffType.Spell</param>
         public void ApplyConsumable(string consumableName, Sound sound, ConsumableBuffType buffType, uint? boostAmount, uint? spellDID)
         {
-            if (IsBusy) return;
-
             IsBusy = true;
 
             MotionCommand motionCommand;


### PR DESCRIPTION
moving the player.IsBusy check to the ActOnUse function prevents multiple food items in a stack from being used while the player is in a busy state