### PR TITLE
add percentages for jewelry slot drops, move jewelry items to LootTables.cs

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -109,19 +109,13 @@ namespace ACE.Server.Factories
             switch (jewelrySlot)
             {
                 case int n when (n <= ringPercent):
-                    // 297 ring, 624 ring
-                    int[] ringItems = { 297, 624 };
-                    jewelType = ringItems[ThreadSafeRandom.Next(0, ringItems.Length - 1)];
+                    jewelType = LootTables.ringItems[ThreadSafeRandom.Next(0, LootTables.ringItems.Length - 1)];
                     break;
                 case int n when (n <= ringPercent + braceletPercent && n > ringPercent):
-                    // 621 heavy bracelet, 295 bracelet
-                    int[] braceletItems = { 621, 295 };
-                    jewelType = braceletItems[ThreadSafeRandom.Next(0, braceletItems.Length - 1)];
+                    jewelType = LootTables.braceletItems[ThreadSafeRandom.Next(0, LootTables.braceletItems.Length - 1)];
                     break;
                 case int n when (n <= ringPercent + braceletPercent + necklacePercent && n > ringPercent + braceletPercent):
-                    // 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
-                    int[] necklaceItems = { 294, 623, 622, 2367 };
-                    jewelType = necklaceItems[ThreadSafeRandom.Next(0, necklaceItems.Length - 1)];
+                    jewelType = LootTables.necklaceItems[ThreadSafeRandom.Next(0, LootTables.necklaceItems.Length - 1)];
                     break;
                 default:
                     return null;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -98,11 +98,36 @@ namespace ACE.Server.Factories
         private static WorldObject CreateJewelry(int tier, bool isMagical)
         {
 
+            // 35% chance ring, 35% chance bracelet, 30% chance necklace
+            // 621 heavy bracelet, 295 bracelet, 297 ring, 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
+
+            int jewelrySlot = ThreadSafeRandom.Next(0, 100);
+            int jewelType;
+
+            switch (jewelrySlot)
+            {
+                case int n when (n <= 35):
+                    // 297 ring, 624 ring
+                    int[] ringItems = { 297, 624 };
+                    jewelType = ringItems[ThreadSafeRandom.Next(0, ringItems.Length - 1)];
+                    break;
+                case int n when (n <= 70 && n > 35):
+                    // 621 heavy bracelet, 295 bracelet
+                    int[] braceletItems = { 621, 295 };
+                    jewelType = braceletItems[ThreadSafeRandom.Next(0, braceletItems.Length - 1)];
+                    break;
+                case int n when (n <= 100 && n > 70):
+                    // 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
+                    int[] necklaceItems = { 294, 623, 622, 2367 };
+                    jewelType = necklaceItems[ThreadSafeRandom.Next(0, necklaceItems.Length - 1)];
+                    break;
+                default:
+                    return null;
+            }
+
             int[][] JewelrySpells = LootTables.JewelrySpells;
             int[][] JewelryCantrips = LootTables.JewelryCantrips;
-            int[] jewelryItems = { 621, 295, 297, 294, 623, 622 };
-            int jewelType = jewelryItems[ThreadSafeRandom.Next(0, jewelryItems.Length - 1)];
-
+                        
             //int rank = 0;
             //int skill_level_limit = 0;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -99,24 +99,26 @@ namespace ACE.Server.Factories
         {
 
             // 35% chance ring, 35% chance bracelet, 30% chance necklace
-            // 621 heavy bracelet, 295 bracelet, 297 ring, 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
+            int ringPercent = 35;
+            int braceletPercent = 35;
+            int necklacePercent = 30;
 
-            int jewelrySlot = ThreadSafeRandom.Next(0, 100);
+            int jewelrySlot = ThreadSafeRandom.Next(0, ringPercent + braceletPercent + necklacePercent);
             int jewelType;
 
             switch (jewelrySlot)
             {
-                case int n when (n <= 35):
+                case int n when (n <= ringPercent):
                     // 297 ring, 624 ring
                     int[] ringItems = { 297, 624 };
                     jewelType = ringItems[ThreadSafeRandom.Next(0, ringItems.Length - 1)];
                     break;
-                case int n when (n <= 70 && n > 35):
+                case int n when (n <= ringPercent + braceletPercent && n > ringPercent):
                     // 621 heavy bracelet, 295 bracelet
                     int[] braceletItems = { 621, 295 };
                     jewelType = braceletItems[ThreadSafeRandom.Next(0, braceletItems.Length - 1)];
                     break;
-                case int n when (n <= 100 && n > 70):
+                case int n when (n <= ringPercent + braceletPercent + necklacePercent && n > ringPercent + braceletPercent):
                     // 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
                     int[] necklaceItems = { 294, 623, 622, 2367 };
                     jewelType = necklaceItems[ThreadSafeRandom.Next(0, necklaceItems.Length - 1)];

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -1925,7 +1925,6 @@ namespace ACE.Factories
         };
 
         public static readonly int[] necklaceItems =
-            // 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
         {
             294,    // amulet
             622,    // necklace

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -1912,6 +1912,27 @@ namespace ACE.Factories
             44975  // Hood
         };
 
+        public static readonly int[] ringItems =
+        {
+            297,    // ring type 1
+            624     // ring type 2
+        };
+
+        public static readonly int[] braceletItems =
+        {
+            295,    // bracelet
+            621     // heavy bracelet
+        };
+
+        public static readonly int[] necklaceItems =
+            // 294 amulet, 623 heavy necklace, 622 necklace, 2367 gorget
+        {
+            294,    // amulet
+            622,    // necklace
+            623,    // heavy necklace
+            2367    // gorget
+        };
+
         public static readonly int[] Helms =
         {
             46, // Metal Cap


### PR DESCRIPTION
adds percentage chance for jewelry drops based on slot, not type of jewelry

as of right now i set 35% rings, 35% bracelets, 30% necklaces.... this can easily be adjusted by altering the percentage variables

there are more types of necklaces and they were dropping at a higher percentage

also adds gorgets and the second type of ring to loot