### PR TITLE
Fixing leather salvage

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -181,7 +181,6 @@ namespace ACE.Server.Managers
             var itemWorkmanship = target.Workmanship ?? 0;
 
             var tinkeredCount = target.NumTimesTinkered;
-            var attemptMod = TinkeringDifficulty[tinkeredCount];
 
             var materialType = tool.MaterialType.Value;
             var salvageMod = GetMaterialMod(materialType);
@@ -206,6 +205,8 @@ namespace ACE.Server.Managers
                 }
 
                 // thanks to Endy's Tinkering Calculator for this formula!
+                var attemptMod = TinkeringDifficulty[tinkeredCount];
+
                 var difficulty = (int)Math.Floor(((salvageMod * 5.0f) + (itemWorkmanship * salvageMod * 2.0f) - (toolWorkmanship * workmanshipMod * salvageMod / 5.0f)) * attemptMod);
 
                 successChance = SkillCheck.GetSkillChance((int)skill.Current, difficulty);
@@ -256,12 +257,12 @@ namespace ACE.Server.Managers
 
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(animLength);
-            actionChain.AddAction(player, () => DoTinkering(player, tool, target, (float)successChance, incItemTinkered));
+            actionChain.AddAction(player, () => DoTinkering(player, tool, target, recipe, (float)successChance, incItemTinkered));
             actionChain.AddAction(player, () => DoMotion(player, MotionCommand.Ready));
             actionChain.EnqueueChain();
         }
 
-        public static void DoTinkering(Player player, WorldObject tool, WorldObject target, float chance, bool incItemTinkered)
+        public static void DoTinkering(Player player, WorldObject tool, WorldObject target, Recipe recipe, float chance, bool incItemTinkered)
         {
             var success = ThreadSafeRandom.Next(0.0f, 1.0f) <= chance;
             var salvageMaterial = GetMaterialName(tool.MaterialType ?? 0);
@@ -277,7 +278,6 @@ namespace ACE.Server.Managers
             else
                 player.EnqueueBroadcast(new GameMessageSystemChat($"{player.Name} fails to apply the {salvageMaterial} Salvage (workmanship {(tool.Workmanship ?? 0):#.00}) to the {itemMaterial} {target.Name}. The target is destroyed.", ChatMessageType.Craft), 96.0f);
 
-            var recipe = GetRecipe(player, tool, target);
             CreateDestroyItems(player, recipe, tool, target, success);
 
             if (!player.GetCharacterOption(CharacterOption.UseCraftingChanceOfSuccessDialog)


### PR DESCRIPTION
This fixes bugs from leather/ivory salvage:

- If a player tried to apply leather/ivory salvage to an item that has already been tinkered 10 times, the server would crash when trying to index into TinkeringDifficulty

- The server would also crash with a null recipe exception after the item has been modified. It appears after the item has been modified, re-getting the recipe returns null, so the original recipe is passed in instead.