### PR TITLE
Add ComponentCheck to player spell casting

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2112,5 +2112,29 @@ namespace ACE.Server.Command.Handlers
                     session.Network.EnqueueSend(new GameMessageSystemChat($"Session is null for {player.Name} which shouldn't occur.", ChatMessageType.Broadcast));
             }
         }
+
+        [CommandHandler("requirecomps", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1,
+            "Sets whether spell components are required to cast spells.",
+            "[ on | off ]\n"
+            + "This command sets whether spell components are required to cast spells..\n When turned on, spell components are required.\n When turned off, spell components are ignored.")]
+        public static void HandleRequireComps(Session session, params string[] parameters)
+        {
+            var param = parameters[0];
+
+            switch (param)
+            {
+                case "off":
+                    session.Player.SpellComponentsRequired = false;
+                    session.Player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyBool(session.Player, PropertyBool.SpellComponentsRequired, session.Player.SpellComponentsRequired));
+                    session.Network.EnqueueSend(new GameMessageSystemChat("You can now cast spells without components.", ChatMessageType.Broadcast));
+                    break;
+                case "on":
+                default:
+                    session.Player.SpellComponentsRequired = true;
+                    session.Player.EnqueueBroadcast(new GameMessagePublicUpdatePropertyBool(session.Player, PropertyBool.SpellComponentsRequired, session.Player.SpellComponentsRequired));
+                    session.Network.EnqueueSend(new GameMessageSystemChat("You can no longer cast spells without components.", ChatMessageType.Broadcast));
+                    break;
+            }
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -366,7 +366,7 @@ namespace ACE.Server.WorldObjects
             var difficulty = spell.Power;
 
             // is this needed? should talismans remain the same, regardless of player spell formula?
-            spell.Formula.GetPlayerFormula(player);
+            //spell.Formula.GetPlayerFormula(player);
 
             var castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
 
@@ -417,7 +417,7 @@ namespace ACE.Server.WorldObjects
             Proficiency.OnSuccessUse(player, player.GetCreatureSkill(Skill.ManaConversion), spell.PowerMod);
 
             // begin spellcasting
-            spell.Formula.GetPlayerFormula(player);
+            //spell.Formula.GetPlayerFormula(player);
 
             string spellWords = spell._spellBase.GetSpellWords(DatManager.PortalDat.SpellComponentsTable);
             if (!string.IsNullOrWhiteSpace(spellWords) && !isWeaponSpell)
@@ -778,7 +778,7 @@ namespace ACE.Server.WorldObjects
             Proficiency.OnSuccessUse(this, GetCreatureSkill(Skill.ManaConversion), spell.PowerMod);
 
             // begin spellcasting
-            spell.Formula.GetPlayerFormula(this);
+            //spell.Formula.GetPlayerFormula(this);
 
             string spellWords = spell._spellBase.GetSpellWords(DatManager.PortalDat.SpellComponentsTable);
             if (!string.IsNullOrWhiteSpace(spellWords))
@@ -1122,10 +1122,10 @@ namespace ACE.Server.WorldObjects
         }
 
         public bool HasComponentsForSpell(Spell spell)
-        {
-            if (!SpellComponentsRequired) return true;
-
+        {            
             spell.Formula.GetPlayerFormula(this);
+
+            if (!SpellComponentsRequired) return true;
 
             var requiredComps = spell.Formula.CurrentFormula;
             if (requiredComps.Count == 0) return true;

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1171,7 +1171,7 @@ namespace ACE.Server.WorldObjects
 
             foreach (var component in usedComps)
             {
-                var compAmountRequired = usedComps[component.Key];
+                var compAmountRequired = component.Value;
                 var compWcid = wcidComps[component.Key];
                 var compAmountAvailable = GetNumInventoryItemsOfWCID(compWcid);
                 if (compAmountRequired > compAmountAvailable)

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1131,6 +1131,7 @@ namespace ACE.Server.WorldObjects
             if (requiredComps.Count == 0) return true;
 
             var usedComps = new Dictionary<uint, int>();
+            var wcidComps = new Dictionary<uint, uint>();
 
             // check spell components
             foreach (var component in requiredComps)
@@ -1142,7 +1143,13 @@ namespace ACE.Server.WorldObjects
                 }
 
                 var wcid = Spell.GetComponentWCID(component);
-                if (wcid == 0) continue;
+                if (wcid == 0)
+                {
+                    Console.WriteLine($"{Name}.HasComponentsForSpell(): Couldn't find wcid for SpellComponent {component}");
+                    continue;
+                }
+                else
+                    wcidComps.TryAdd(component, wcid);
 
                 var item = GetInventoryItemsOfWCID(wcid).FirstOrDefault();
                 if (item == null)
@@ -1154,16 +1161,21 @@ namespace ACE.Server.WorldObjects
                     if (usedComps.ContainsKey(component))
                     {
                         usedComps[component]++;
-                        var compAmountRequired = usedComps[component];
-                        var compAmountAvailable = GetNumInventoryItemsOfWCID(wcid);
-                        if (compAmountRequired > compAmountAvailable)
-                            return false;
                     }
                     else
                     {
                         usedComps.Add(component, 1);
                     }
                 }
+            }
+
+            foreach (var component in usedComps)
+            {
+                var compAmountRequired = usedComps[component.Key];
+                var compWcid = wcidComps[component.Key];
+                var compAmountAvailable = GetNumInventoryItemsOfWCID(compWcid);
+                if (compAmountRequired > compAmountAvailable)
+                    return false;
             }
 
             return true;

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -226,6 +226,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.HouseRentTimestamp); else SetProperty(PropertyInt.HouseRentTimestamp, value.Value); }
         }
 
+        public bool SpellComponentsRequired
+        {
+            get => GetProperty(PropertyBool.SpellComponentsRequired) ?? true;
+            set { if (value) RemoveProperty(PropertyBool.SpellComponentsRequired); else SetProperty(PropertyBool.SpellComponentsRequired, value); }
+        }
+
 
         // ========================================
         // ===== Player Properties - Titles========

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2171,13 +2171,6 @@ namespace ACE.Server.WorldObjects
             set { SetPosition(PositionType.TeleportedCharacter, value); }
         }
 
-
-        public bool SpellComponentsRequired
-        {
-            get => GetProperty(PropertyBool.SpellComponentsRequired) ?? true;
-            set { SetProperty(PropertyBool.SpellComponentsRequired, value); }
-        }
-
         public uint? CurrentCombatTarget
         {
             get => GetProperty(PropertyInstanceId.CurrentCombatTarget);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2172,6 +2172,12 @@ namespace ACE.Server.WorldObjects
         }
 
 
+        public bool SpellComponentsRequired
+        {
+            get => GetProperty(PropertyBool.SpellComponentsRequired) ?? true;
+            set { SetProperty(PropertyBool.SpellComponentsRequired, value); }
+        }
+
         public uint? CurrentCombatTarget
         {
             get => GetProperty(PropertyInstanceId.CurrentCombatTarget);

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ### 2019-06-09
 [Ripley]
 * Add `requirecomps` command.
+* Add SpellComponentsRequired property.
+* Add HasComponentsForSpell.
+* Add HasComponentsForSpell checks to Player.CreatePlayerSpell for targeted and untargeted spells.
 
 ### 2019-06-08
 [Ripley]

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-06-09
+[Ripley]
+* Add `requirecomps` command.
+
 ### 2019-06-08
 [Ripley]
 * Add LightSource Weenie class.


### PR DESCRIPTION
* Add `requirecomps` command.
* Add SpellComponentsRequired property.
* Add HasComponentsForSpell.
* Add HasComponentsForSpell checks to Player.CreatePlayerSpell for targeted and untargeted spells.