### PR TITLE
NetworkSession.cachedPackets pruning

### DIFF
--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -10,6 +10,7 @@ using ACE.Database;
 using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
+using ACE.Server.Entity;
 using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
@@ -76,7 +77,7 @@ namespace ACE.Server.Network.Handlers
 
         private static void AccountSelectCallback(Account account, Session session, PacketInboundLoginRequest loginRequest)
         {
-            packetLog.DebugFormat("ConnectRequest TS: {0}", session.Network.ConnectionData.ServerTime);
+            packetLog.DebugFormat("ConnectRequest TS: {0}", Timers.PortalYearTicks);
 
             if (session.Network.ConnectionData.ServerSeed == null || session.Network.ConnectionData.ClientSeed == null)
             {
@@ -86,7 +87,7 @@ namespace ACE.Server.Network.Handlers
             }
 
             var connectRequest = new PacketOutboundConnectRequest(
-                session.Network.ConnectionData.ServerTime,
+                Timers.PortalYearTicks,
                 session.Network.ConnectionData.ConnectionCookie,
                 session.Network.ClientId,
                 session.Network.ConnectionData.ServerSeed,

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using log4net;
 
 using ACE.Common;
+using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
 using ACE.Server.Network.Packets;
@@ -154,7 +155,7 @@ namespace ACE.Server.Network.Managers
 
             // First we must send the connect request response
             var connectRequest = new PacketOutboundConnectRequest(
-                tempSession.Network.ConnectionData.ServerTime,
+                Timers.PortalYearTicks,
                 tempSession.Network.ConnectionData.ConnectionCookie,
                 tempSession.Network.ClientId,
                 tempSession.Network.ConnectionData.ServerSeed,

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -63,7 +63,7 @@ namespace ACE.Server.Network
         /// <summary>
         /// Number of seconds to retain cachedPackets
         /// </summary>
-        private const int cachedPacketRetentionTime = 60;
+        private const int cachedPacketRetentionTime = 120;
 
         /// <summary>
         /// This is referenced by multiple thread:<para />

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -581,7 +581,7 @@ namespace ACE.Server.Network
                     packet.Header.Sequence = ConnectionData.PacketSequence.NextValue;
                 packet.Header.Id = ServerId;
                 packet.Header.Iteration = 0x14;
-                packet.Header.Time = (ushort)ConnectionData.ServerTime;
+                packet.Header.Time = (ushort)Timers.PortalYearTicks;
 
                 if (packet.Header.Sequence >= 2u)
                     cachedPackets.TryAdd(packet.Header.Sequence, packet);
@@ -778,9 +778,9 @@ namespace ACE.Server.Network
             if (bundle.TimeSync) // 0x1000000
             {
                 packetHeader.Flags |= PacketHeaderFlags.TimeSync;
-                packetLog.DebugFormat("[{0}] Outgoing TimeSync TS: {1}", session.LoggingIdentifier, ConnectionData.ServerTime);
+                packetLog.DebugFormat("[{0}] Outgoing TimeSync TS: {1}", session.LoggingIdentifier, Timers.PortalYearTicks);
                 packet.InitializeBodyWriter();
-                packet.BodyWriter.Write(ConnectionData.ServerTime);
+                packet.BodyWriter.Write(Timers.PortalYearTicks);
             }
 
             if (bundle.ClientTime != -1f) // 0x4000000
@@ -789,7 +789,7 @@ namespace ACE.Server.Network
                 packetLog.DebugFormat("[{0}] Outgoing EchoResponse: {1}", session.LoggingIdentifier, bundle.ClientTime);
                 packet.InitializeBodyWriter();
                 packet.BodyWriter.Write(bundle.ClientTime);
-                packet.BodyWriter.Write((float)ConnectionData.ServerTime - bundle.ClientTime);
+                packet.BodyWriter.Write((float)Timers.PortalYearTicks - bundle.ClientTime);
             }
         }
 

--- a/Source/ACE.Server/Network/SessionConnectionData.cs
+++ b/Source/ACE.Server/Network/SessionConnectionData.cs
@@ -1,7 +1,6 @@
 using System;
 
 using ACE.Common.Cryptography;
-using ACE.Server.Entity;
 using ACE.Server.Network.Sequence;
 
 namespace ACE.Server.Network
@@ -55,12 +54,6 @@ namespace ACE.Server.Network
         /// Server->Client stream cipher
         /// </summary>
         public ISAAC IssacServer = null;
-
-        /// <summary>
-        /// This is just a wrapper around Timers.PortalYearTicks.<para />
-        /// In the future, we may want to consider removing this and referencing Timers.PortalYearTicks directly.
-        /// </summary>
-        public double ServerTime => Timers.PortalYearTicks;
 
         public SessionConnectionData()
         {


### PR DESCRIPTION
This should fix cachedPacket retention from clients with poor connections. Packet retention is now capped at 60s.

This also removes the SessionConnectionData wrapper:
public double ServerTime => Timers.PortalYearTicks;