### PR TITLE
Buy/Sell input validation

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -154,7 +154,7 @@ namespace ACE.Server.WorldObjects
             }
 
             var totalAmount = items.Sum(r => r.Amount);
-            if (totalAmount > 10000)  // Make sure total amount doesn't exceed 10,000, which can be 10 stacks of 1000 (think tapers)
+            if (totalAmount > 5000)  // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't buy that many total items!")); // Custom message
                 log.Warn($"{Name} tried to buy too many total items, totalAmount: {totalAmount:N0}, from 0x{vendor.Guid.Full:X8}:{vendor.Name}");
@@ -346,7 +346,7 @@ namespace ACE.Server.WorldObjects
             }
 
             var totalAmount = items.Sum(r => r.Amount);
-            if (totalAmount > 10000)  // Make sure total amount doesn't exceed 10,000, which can be 10 stacks of 1000 (think tapers)
+            if (totalAmount > 10000)  // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't sell that many total items!")); // Custom message
                 log.Warn($"{Name} tried to sell too many total items, totalAmount: {totalAmount:N0}, from 0x{vendor.Guid.Full:X8}:{vendor.Name}");

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -146,15 +146,20 @@ namespace ACE.Server.WorldObjects
 
         private bool ValidateBuyItems(Vendor vendor, List<ItemProfile> items)
         {
-            if (items.Count > 20) // Allow this many unique items per trasnaction
+            // Allow this many unique items per trasnaction
+            // Max found in retail pcaps: 20
+            if (items.Count > 40)
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't buy that many unique items!")); // Custom message
                 log.Warn($"{Name} tried to buy too many unique items, items.count: {items.Count}, from 0x{vendor.Guid}:{vendor.Name}");
                 return false;
             }
 
+            // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
+            // Max single item stack size found in pcaps: 5000
+            // Max total items found in pcaps: 5000
             var totalAmount = items.Sum(r => r.Amount);
-            if (totalAmount > 5000)  // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
+            if (totalAmount > 10000)
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't buy that many total items!")); // Custom message
                 log.Warn($"{Name} tried to buy too many total items, totalAmount: {totalAmount:N0}, from 0x{vendor.Guid}:{vendor.Name}");
@@ -352,15 +357,20 @@ namespace ACE.Server.WorldObjects
 
         private bool ValidateSellItems(List<ItemProfile> items, Vendor vendor)
         {
-            if (items.Count > 40) // Allow this many unique items per trasnaction
+            // Allow this many unique items per trasnaction
+            // Max found in retail pcaps: 49
+            if (items.Count > 100)
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't sell that many unique items!")); // Custom message
                 log.Warn($"{Name} tried to sell too many unique items, items.count: {items.Count}, from 0x{vendor.Guid}:{vendor.Name}");
                 return false;
             }
 
+            // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
+            // Max single item stack size found in pcaps: 1000
+            // Max total items found in pcaps: 1000
             var totalAmount = items.Sum(r => r.Amount);
-            if (totalAmount > 10000)  // Make sure total amount doesn't exceed this value. Think # of stacks at MaxStackSize
+            if (totalAmount > 10000)
             {
                 Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You can't sell that many total items!")); // Custom message
                 log.Warn($"{Name} tried to sell too many total items, totalAmount: {totalAmount:N0}, from 0x{vendor.Guid}:{vendor.Name}");

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -302,33 +302,30 @@ namespace ACE.Server.WorldObjects
                     wo.Shade = itemprofile.Shade;
 
                 // can we stack this ?
-                if (wo.MaxStackSize.HasValue)
+                if (wo.MaxStackSize.HasValue && wo.MaxStackSize.Value > 0)
                 {
-                    if ((wo.MaxStackSize.Value != 0) & (wo.MaxStackSize.Value <= itemprofile.Amount))
+                    if (wo.MaxStackSize.Value <= itemprofile.Amount)
                     {
                         wo.SetStackSize(wo.MaxStackSize.Value);
                         worldobjects.Add(wo);
-                        itemprofile.Amount = itemprofile.Amount - wo.MaxStackSize.Value;
+                        itemprofile.Amount -= wo.MaxStackSize.Value;
                     }
-                    else // we cant stack this but its not a single item
+                    else 
                     {
                         wo.SetStackSize((int)itemprofile.Amount);
                         worldobjects.Add(wo);
-                        itemprofile.Amount = itemprofile.Amount - itemprofile.Amount;
+                        itemprofile.Amount = 0;
                     }
                 }
-                else
+                else // if there multiple items of the same  type.. 
                 {
-                    // if there multiple items of the same  type.. 
-                    if (itemprofile.Amount > 0)
-                    {
-                        // single item with no stack options. 
-                        itemprofile.Amount = itemprofile.Amount - 1;
-                        wo.StackSize = null;
-                        worldobjects.Add(wo);
-                    }
+                    // single item with no stack options. 
+                    wo.StackSize = null;
+                    worldobjects.Add(wo);
+                    itemprofile.Amount -= 1;
                 }
             }
+
             return worldobjects;
         }
 


### PR DESCRIPTION
Selling is limited to 20 unique items per transaction

Selling is limited to 5,000 total items per transaction
- think a transaction of 1 stack of 1000 tapers plus other stacks of 100 scarabs

Buying is limited to 40 unique items per transaction
- think players selling junk for pyreals

Selling is limited to 10,000 total items per transaction
- think a transaction of 10 stacks of 1000 tapers

This also changes the existing VerifySellItems function that would prune corrupt/invalid entries to now being a hard fail on the total transaction if any errors are detected.

Logging is added for transactions that fail these conditions, and these numbers may need to be modified if players exceed them during normal play.