### PR TITLE
Add CMS setting if MotionTableId is present

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -269,7 +269,7 @@ namespace ACE.Server.WorldObjects
                 CurrentMotionState = new Motion(MotionStance.Invalid);
 
             if (WeenieType == WeenieType.Corpse)
-                HeartbeatInterval = 5;            
+                HeartbeatInterval = 5;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -265,9 +265,11 @@ namespace ACE.Server.WorldObjects
             if (Placement == null)
                 Placement = ACE.Entity.Enum.Placement.Resting;
 
-            //CurrentMotionState = new Motion(MotionStance.Invalid, new MotionItem(MotionCommand.Invalid));
+            if (MotionTableId != 0)
+                CurrentMotionState = new Motion(MotionStance.Invalid);
+
             if (WeenieType == WeenieType.Corpse)
-                HeartbeatInterval = 5;
+                HeartbeatInterval = 5;            
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes crashes, errors on Switches, Levers, random things with motion that aren't creatures