### PR TITLE
Fix the inability to cast beneficial item spells on other characters

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -726,22 +726,25 @@ namespace ACE.Server.WorldObjects
                             else
                             {
                                 // targeting another player or monster
-                                var item = creatureTarget.EquippedObjects.Values.FirstOrDefault(i => i.IsShield && i.IsEnchantable);
+                                var items = creatureTarget.EquippedObjects.Values.Where(i => (i.WeenieType == WeenieType.Clothing || i.IsShield) && i.IsEnchantable);
 
-                                if (item != null)
+                                foreach (var item in items)
                                 {
-                                    enchantmentStatus = ItemMagic(item, spell);
-                                    EnqueueBroadcast(new GameMessageScript(item.Guid, spell.TargetEffect, spell.Formula.Scale));
-                                    if (enchantmentStatus.Message != null)
-                                        player.Session.Network.EnqueueSend(enchantmentStatus.Message);
-                                }
-                                else
-                                {
-                                    // 'fails to affect'?
-                                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You fail to affect {creatureTarget.Name} with {spell.Name}", ChatMessageType.Magic));
+                                    if (item != null)
+                                    {
+                                        enchantmentStatus = ItemMagic(item, spell);
+                                        EnqueueBroadcast(new GameMessageScript(item.Guid, spell.TargetEffect, spell.Formula.Scale));
+                                        if (enchantmentStatus.Message != null)
+                                            player.Session.Network.EnqueueSend(enchantmentStatus.Message);
+                                    }
+                                    else
+                                    {
+                                        // 'fails to affect'?
+                                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You fail to affect {creatureTarget.Name} with {spell.Name}", ChatMessageType.Magic));
 
-                                    if (targetPlayer != null)
-                                        targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} fails to affect you with {spell.Name}", ChatMessageType.Magic));
+                                        if (targetPlayer != null)
+                                            targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} fails to affect you with {spell.Name}", ChatMessageType.Magic));
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This PR resolves the problem where players are unable to cast beneficial item spells on others due to the error: "You fail to affect <<Name>> with <<Spell>>"

I believe this functionality was permitted in retail, and was permitted in ACE up until a recent PR. If I am mis-remembering and this was not permitted in retail, then I will withdraw my PR.