### PR TITLE
updating outdoor house references for unloaded landblocks

### DIFF
--- a/Source/ACE.Server/WorldObjects/House.cs
+++ b/Source/ACE.Server/WorldObjects/House.cs
@@ -390,7 +390,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (_dungeonLandblockID == null)
                 {
-                    var rootHouseBlock = RootHouse.CurrentLandblock.Id.Raw | 0xFFFF;
+                    var rootHouseBlock = RootHouse.Location.LandblockId.Raw | 0xFFFF;
 
                     var housePortals = GetHousePortals();
 
@@ -474,7 +474,11 @@ namespace ACE.Server.WorldObjects
                 if (_rootGuid != null)
                     return _rootGuid.Value;
 
-                if (!CurrentLandblock.IsDungeon)
+                // CurrentLandblock == null should only happen when the player is in a villa/mansion dungeon basement,
+                // and the outdoor house landblock is still unloaded. the reference to the outdoor House will be a shallow reference at that point,
+                // and this should only happen for outdoor landblocks
+
+                if (CurrentLandblock == null || !CurrentLandblock.IsDungeon)
                 {
                     _rootGuid = Guid;
                     return Guid;


### PR DESCRIPTION
this fixes something that was working originally, but then was broken again when OnProperty and DungeonLandblockID were updated

this updates those properties so everything works as expected with shallow references to outdoor houses on unloaded landblocks