### PR TITLE
additional healing kit refactoring

### DIFF
--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -15,12 +15,6 @@ namespace ACE.Server.WorldObjects
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public PropertyAttribute2nd BoostEnum
-        {
-            get => (PropertyAttribute2nd)(GetProperty(PropertyInt.BoosterEnum) ?? 0);
-            set { if (value == 0) RemoveProperty(PropertyInt.BoosterEnum); else SetProperty(PropertyInt.BoosterEnum, (int)value); }
-        }
-
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
         /// </summary>
@@ -101,7 +95,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void ApplyConsumable(Player player)
         {
-            var buffType = (ConsumableBuffType)BoostEnum;
+            var buffType = (ConsumableBuffType)BoosterEnum;
             GameMessageSystemChat buffMessage = null;
 
             // spells
@@ -122,28 +116,26 @@ namespace ACE.Server.WorldObjects
             // vitals
             else
             {
-                var maxVital = BoostEnum - 1;
+                var vital = player.GetCreatureVital(BoosterEnum);
 
-                if (player.Vitals.TryGetValue(maxVital, out var vital))
+                if (vital != null)
                 {
-                    var boostAmount = Boost ?? 0;
+                    var vitalChange = (uint)Math.Abs(player.UpdateVitalDelta(vital, BoostValue));
 
-                    var vitalChange = (uint)Math.Abs(player.UpdateVitalDelta(vital, boostAmount));
-
-                    if (BoostEnum == PropertyAttribute2nd.Health)
+                    if (BoosterEnum == PropertyAttribute2nd.Health)
                     {
-                        if (boostAmount >= 0)
+                        if (BoostValue >= 0)
                             player.DamageHistory.OnHeal(vitalChange);
                         else
                             player.DamageHistory.Add(this, DamageType.Health, vitalChange);
                     }
 
-                    var verb = boostAmount >= 0 ? "restores" : "takes";
-                    buffMessage = new GameMessageSystemChat($"The {Name} {verb} {vitalChange} points of your {BoostEnum}.", ChatMessageType.Broadcast);
+                    var verb = BoostValue >= 0 ? "restores" : "takes";
+                    buffMessage = new GameMessageSystemChat($"The {Name} {verb} {vitalChange} points of your {BoosterEnum}.", ChatMessageType.Broadcast);
                 }
                 else
                 {
-                    buffMessage = new GameMessageSystemChat($"{Name} ({Guid}) contains invalid vital {BoostEnum}", ChatMessageType.Broadcast);
+                    buffMessage = new GameMessageSystemChat($"{Name} ({Guid}) contains invalid vital {BoosterEnum}", ChatMessageType.Broadcast);
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -16,6 +16,8 @@ namespace ACE.Server.WorldObjects
 {
     public class Healer : WorldObject
     {
+        // TODO: change structure / maxstructure to int,
+        // cast to ushort at network level
         public ushort? UsesLeft
         {
             get => Structure;
@@ -57,11 +59,23 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            // Validate healing attribute against maxValue
-            CreatureVital vital = GetVitalsByKitType(BoosterEnum, targetPlayer).Item2;
+            // ensure target player vital < MaxValue
+            var vital = targetPlayer.GetCreatureVital(BoosterEnum);
+
             if (vital.Current == vital.MaxValue)
             {
-                healer.Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(healer.Session, WeenieErrorWithString._IsAtFullHealth, target.Name));
+                switch (vital.Vital)
+                {
+                    case PropertyAttribute2nd.MaxHealth:
+                        healer.Session.Network.EnqueueSend(new GameEventWeenieErrorWithString(healer.Session, WeenieErrorWithString._IsAtFullHealth, target.Name));
+                        break;
+                    case PropertyAttribute2nd.MaxStamina:
+                        healer.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(healer.Session, $"{target.Name} is already at full stamina!"));
+                        break;
+                    case PropertyAttribute2nd.MaxMana:
+                        healer.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(healer.Session, $"{target.Name} is already at full mana!"));
+                        break;
+                }
                 healer.SendUseDoneEvent();
                 return;
             }
@@ -97,7 +111,7 @@ namespace ACE.Server.WorldObjects
             actionChain.AddDelaySeconds(animLength);
             actionChain.AddAction(healer, () =>
             {
-                // check windup move distance cap
+                // check healing move distance cap
                 var endPos = new Position(healer.Location);
                 var dist = startPos.DistanceTo(endPos);
 
@@ -119,34 +133,40 @@ namespace ACE.Server.WorldObjects
 
         public void DoHealing(Player healer, Player target)
         {
-            var remainingMsg = $"Your {Name} has {--UsesLeft} uses left.";
+            var remainingMsg = "";
+
+            if (!UnlimitedUse)
+            {
+                UsesLeft--;
+                var s = UsesLeft == 1 ? "" : "s";
+                remainingMsg = UsesLeft > 0 ? $" Your {Name} has {UsesLeft} use{s} left." : $" Your {Name} is used up.";
+            }
+
             var stackSize = new GameMessagePublicUpdatePropertyInt(this, PropertyInt.Structure, UsesLeft.Value);
             var targetName = healer == target ? "yourself" : target.Name;
-            var vitals = GetVitalsByKitType(BoosterEnum, target);
 
-            Vital vital = vitals.Item1;
-            CreatureVital creatureVital = vitals.Item2;
+            var vital = target.GetCreatureVital(BoosterEnum);
 
             // skill check
             var difficulty = 0;
-            var skillCheck = DoSkillCheck(healer, target, ref difficulty);
+            var skillCheck = DoSkillCheck(healer, target, vital, ref difficulty);
             if (!skillCheck)
             {
-                var failMsg = new GameMessageSystemChat($"You fail to heal {targetName}. {remainingMsg}", ChatMessageType.Broadcast);
+                var failMsg = new GameMessageSystemChat($"You fail to heal {targetName}.{remainingMsg}", ChatMessageType.Broadcast);
                 healer.Session.Network.EnqueueSend(failMsg, stackSize);
                 if (healer != target)
                     target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{healer.Name} fails to heal you.", ChatMessageType.Broadcast));
-                if (UsesLeft <= 0)
+                if (UsesLeft <= 0 && !UnlimitedUse)
                     healer.TryConsumeFromInventoryWithNetworking(this, 1);
                 return;
             }
 
             // heal up
-            var healAmount = GetHealAmount(healer, target, creatureVital, out var critical, out var staminaCost);
+            var healAmount = GetHealAmount(healer, target, vital, out var critical, out var staminaCost);
 
-            healer.UpdateVitalDelta(healer.Stamina, (int)(-staminaCost));
-            target.UpdateVitalDelta(creatureVital, healAmount);
-            if (vital == Vital.Health)
+            healer.UpdateVitalDelta(healer.Stamina, (int)-staminaCost);
+            target.UpdateVitalDelta(vital, healAmount);
+            if (vital.Vital == PropertyAttribute2nd.MaxHealth)
                 target.DamageHistory.OnHeal(healAmount);
 
             //if (target.Fellowship != null)
@@ -155,29 +175,22 @@ namespace ACE.Server.WorldObjects
             var healingSkill = healer.GetCreatureSkill(Skill.Healing);
             Proficiency.OnSuccessUse(healer, healingSkill, difficulty);
 
-            var updateHealth = new GameMessagePrivateUpdateAttribute2ndLevel(target, vital, creatureVital.Current);
             var crit = critical ? "expertly " : "";
-            GameMessageSystemChat message = null;
-
-            if (UsesLeft <= 0)
-                message = new GameMessageSystemChat($"You {crit}heal {targetName} for {healAmount} {BoosterEnum.ToString()} points with {Name}. Your {Name} is used up.", ChatMessageType.Broadcast);
-            else
-                message = new GameMessageSystemChat($"You {crit}heal {targetName} for {healAmount} {BoosterEnum.ToString()} points. {remainingMsg}", ChatMessageType.Broadcast);
+            var message = new GameMessageSystemChat($"You {crit}heal {targetName} for {healAmount} {BoosterEnum.ToString()} points.{remainingMsg}", ChatMessageType.Broadcast);
 
             healer.Session.Network.EnqueueSend(message, stackSize);
-            target.Session.Network.EnqueueSend(updateHealth);
 
             if (healer != target)
                 target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{healer.Name} heals you for {healAmount} {BoosterEnum.ToString()} points.", ChatMessageType.Broadcast));
 
-            if (UsesLeft <= 0)
+            if (UsesLeft <= 0 && !UnlimitedUse)
                 healer.TryConsumeFromInventoryWithNetworking(this, 1);
         }
 
         /// <summary>
         /// Determines if healer successfully heals target for attempt
         /// </summary>
-        public bool DoSkillCheck(Player healer, Player target, ref int difficulty)
+        public bool DoSkillCheck(Player healer, Player target, CreatureVital vital, ref int difficulty)
         {
             // skill check:
             // (healing skill + healing kit boost) * trainedMod
@@ -187,8 +200,8 @@ namespace ACE.Server.WorldObjects
 
             var combatMod = healer.CombatMode == CombatMode.NonCombat ? 1.0f : 1.1f;
 
-            var effectiveSkill = (int)Math.Round(healingSkill.Current + (Boost ?? 0) * trainedMod);
-            difficulty = (int)Math.Round((target.Health.MaxValue - target.Health.Current) * 2 * combatMod);
+            var effectiveSkill = (int)Math.Round(healingSkill.Current + BoostValue * trainedMod);
+            difficulty = (int)Math.Round((vital.MaxValue - vital.Current) * 2 * combatMod);
 
             var skillCheck = SkillCheck.GetSkillChance(effectiveSkill, difficulty);
             return skillCheck >= ThreadSafeRandom.Next(0.0f, 1.0f);
@@ -219,15 +232,15 @@ namespace ACE.Server.WorldObjects
             criticalHeal = ThreadSafeRandom.Next(0.0f, 1.0f) < 0.1f;
             if (criticalHeal) healAmount *= 2;
 
-            // cap to missing health
-            var missingHealth = vital.MaxValue - vital.Current;
-            if (healAmount > missingHealth)
-                healAmount = missingHealth;
+            // cap to missing vital
+            var missingVital = vital.MaxValue - vital.Current;
+            if (healAmount > missingVital)
+                healAmount = missingVital;
 
             // stamina check? On the Q&A board a dev posted that stamina directly effects the amount of damage you can heal
-            // low stam = less health healed. I don't have exact numbers for it. Working through forum archive.
+            // low stam = less vital healed. I don't have exact numbers for it. Working through forum archive.
 
-            // stamina cost: 1 stamina per 5 health
+            // stamina cost: 1 stamina per 5 vital healed 
             staminaCost = (uint)Math.Round(healAmount / 5.0f);
             if (staminaCost > healer.Stamina.Current)
             {
@@ -235,39 +248,6 @@ namespace ACE.Server.WorldObjects
                 healAmount = staminaCost * 5;
             }
             return (uint)Math.Round(healAmount);
-        }
-
-        public PropertyAttribute2nd BoosterEnum
-        {
-            get => (PropertyAttribute2nd)(GetProperty(PropertyInt.BoosterEnum) ?? (int)PropertyAttribute2nd.Undef);
-            set { if (value == 0) RemoveProperty(PropertyInt.BoosterEnum); else SetProperty(PropertyInt.BoosterEnum, (int)value); }
-        }
-
-        /// <summary>
-        /// Returns the appropriate Vital and CreatureVital for a given healing kit type
-        /// </summary>
-        private Tuple<Vital, CreatureVital> GetVitalsByKitType(PropertyAttribute2nd type, Player target)
-        {
-            Vital vital = Vital.Undefined;
-            CreatureVital creatureVital = null;
-            switch (BoosterEnum)
-            {
-                case PropertyAttribute2nd.Health:
-                    goto default;
-                case PropertyAttribute2nd.Stamina:
-                    vital = Vital.Stamina;
-                    creatureVital = target.Stamina;
-                    break;
-                case PropertyAttribute2nd.Mana:
-                    vital = Vital.Mana;
-                    creatureVital = target.Mana;
-                    break;
-                default:
-                    vital = Vital.Health;
-                    creatureVital = target.Health;
-                    break;
-            }
-            return Tuple.Create(vital, creatureVital);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Vitals.cs
@@ -246,5 +246,21 @@ namespace ACE.Server.WorldObjects
 
             return vitalUpdate;
         }
+
+        public CreatureVital GetCreatureVital(PropertyAttribute2nd vital)
+        {
+            switch (vital)
+            {
+                case PropertyAttribute2nd.Health:
+                    return Health;
+                case PropertyAttribute2nd.Stamina:
+                    return Stamina;
+                case PropertyAttribute2nd.Mana:
+                    return Mana;
+                default:
+                    log.Error($"{Name}.GetCreatureVital({vital}): unexpected vital");
+                    return null;
+            }
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1855,10 +1855,22 @@ namespace ACE.Server.WorldObjects
             set { if (value == null) RemoveProperty(PropertyString.Use); else SetProperty(PropertyString.Use, value); }
         }
 
-        public int? Boost
+        public int BoostValue
         {
-            get => GetProperty(PropertyInt.BoostValue);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.BoostValue); else SetProperty(PropertyInt.BoostValue, value.Value); }
+            get => GetProperty(PropertyInt.BoostValue) ?? 0;
+            set { if (value == 0) RemoveProperty(PropertyInt.BoostValue); else SetProperty(PropertyInt.BoostValue, value); }
+        }
+
+        public PropertyAttribute2nd BoosterEnum
+        {
+            get => (PropertyAttribute2nd)(GetProperty(PropertyInt.BoosterEnum) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt.BoosterEnum); else SetProperty(PropertyInt.BoosterEnum, (int)value); }
+        }
+
+        public bool UnlimitedUse
+        {
+            get => GetProperty(PropertyBool.UnlimitedUse) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.UnlimitedUse); else SetProperty(PropertyBool.UnlimitedUse, value); }
         }
 
         public uint? SpellDID


### PR DESCRIPTION
- removed duplicate BoostEnum/BoosterEnum properties in Food/Healer, moved to WorldObject_Properties using original name
- refactored Food."BoostEnum - 1" and Healer.GetVitalsByKitType() into common GetCreatureVital(PropertyAttribute2nd)
- left a note for Structure/MaxStructure ushort/int inconsistency for future refactoring
- Added TransientMessages for '&lt;target&gt; is already at full &lt;vital&gt;!' for stamina/mana (doesn't appear to be werrors for those)
- Added logic for UnlimitedUse kits
- Updated remainingMsg to match retail: removed double space, '1 use', 'Your &lt;kitName&gt; is used up.' also sent on failure, omitting message for UnlimitedUse
- Fixed a bug where Healer.DoSkillCheck() was using target.MissingHealth instead of target.MissingVital
- Ensure UnlimitedUse kits are never consumed
- Removed redundant GameMessagePrivateUpdateAttribute2ndLevel network message, already sent in UpdateVitalDelta
- cleaned up comments