### PR TITLE
Fix some issues with CombatPets

### DIFF
--- a/Source/ACE.Server/WorldObjects/CombatPet.cs
+++ b/Source/ACE.Server/WorldObjects/CombatPet.cs
@@ -51,6 +51,10 @@ namespace ACE.Server.WorldObjects
             GeneratorProfiles.Clear();            
 
             DeathTreasureType = null;
+            WieldedTreasureType = null;
+
+            if (Biota.WeenieType != (int)WeenieType.CombatPet) // Combat Pets are currently being made from real creatures
+                Biota.WeenieType = (int)WeenieType.CombatPet;
         }
 
         public void Init(Player player, DamageType damageType, PetDevice petDevice)

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -74,10 +74,14 @@ namespace ACE.Server.WorldObjects
 
             if (!(this is Player))
             {
-                GenerateWieldList();
-                GenerateWieldedTreasure();
+                if (!(this is CombatPet)) //combat pets normally wouldn't have these items, but due to subbing in code currently, sometimes they do. this skips them for now.
+                {
+                    GenerateWieldList();
+                    GenerateWieldedTreasure();
 
-                EquipInventoryItems();
+
+                    EquipInventoryItems();
+                }
 
                 // TODO: fix tod data
                 Health.Current = Health.MaxValue;

--- a/Source/ACE.Server/WorldObjects/PetDevice.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice.cs
@@ -143,9 +143,6 @@ namespace ACE.Server.WorldObjects
                 return false;
             }
 
-            if (weenie.Type != (int)WeenieType.CombatPet) // Combat Pets are currently being made from real creatures
-                weenie.Type = (int)WeenieType.CombatPet;
-
             var combatPet = new CombatPet(weenie, GuidManager.NewDynamicGuid());
             if (combatPet == null)
             {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2019-06-23
+[Ripley]
+* Fix issue of weenie cache corruption, setting the weenie's weenietype instead of biota's weenietype
+* Ensure subbed combatpets are always melee-ing by not spawning any inventory/weapons.
+
 ### 2019-06-22
 [Ripley]
 * Expand `qst` command.


### PR DESCRIPTION
* Fix issue of weenie cache corruption, setting the weenie's type instead of biota's weenietype
* Ensure subbed combatpets are always melee by depriving them of inventory