### PR TITLE
Generator system tweaks

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2265,6 +2265,7 @@ namespace ACE.Server.Command.Handlers
                         msg += $"WhenCreate: {((RegenerationType)profile.Biota.WhenCreate).ToString()} | WhereCreate: {((RegenLocationType)profile.Biota.WhereCreate).ToString()}\n";
                         msg += $"StackSize: {profile.Biota.StackSize} | PaletteId: {profile.Biota.PaletteId} | Shade: {profile.Biota.Shade}\n";
                         msg += $"CurrentCreate: {profile.CurrentCreate} | Spawned.Count: {profile.Spawned.Count} | SpawnQueue.Count: {profile.SpawnQueue.Count} | RemoveQueue.Count: {profile.RemoveQueue.Count}\n";
+                        msg += $"GeneratedTreasureItem: {profile.GeneratedTreasureItem}\n";
                         msg += $"--====--\n";
                         if (profile.Spawned.Count > 0)
                         {

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2291,7 +2291,25 @@ namespace ACE.Server.Command.Handlers
                             msg += "Pending Removed Objects:\n";
                             foreach (var spawn in profile.RemoveQueue)
                             {
-                                msg += $"0x{spawn.objectGuid:X8} removed at {spawn.time.ToLocalTime()}\n";
+                                var action = "";
+                                switch((RegenerationType)profile.Biota.WhenCreate)
+                                {
+                                    case RegenerationType.Death:
+                                        action = "died";
+                                        break;
+                                    case RegenerationType.Destruction:
+                                        action = "destroyed";
+                                        break;
+                                    case RegenerationType.PickUp:
+                                        action = "picked up";
+                                        break;
+                                    case RegenerationType.Undef:
+                                    default:
+                                        action = "despawned";
+                                        break;
+                                }
+
+                                msg += $"0x{spawn.objectGuid:X8} {action} at {spawn.time.AddSeconds(-profile.Delay).ToLocalTime()} and will be removed from profile at {spawn.time.ToLocalTime()}\n";
                             }
                             msg += $"--====--\n";
                         }

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -50,9 +50,28 @@ namespace ACE.Server.Entity
         public bool IsPlaceholder { get => Biota.WeenieClassId == 3666; }
 
         /// <summary>
+        /// TRUE if this Profile generated treasure using TreasureGenerator
+        /// </summary>
+        public bool GeneratedTreasureItem { get; private set; } = false;
+
+        /// <summary>
         /// The total # of active spawned objects + awaiting spawning
         /// </summary>
-        public int CurrentCreate { get => Spawned.Count + SpawnQueue.Count; }
+        public int CurrentCreate
+        {
+            get
+            {
+                if (!GeneratedTreasureItem)
+                    return Spawned.Count + SpawnQueue.Count;
+                else
+                {
+                    if ((Spawned.Count + SpawnQueue.Count) > 0)
+                        return 1;
+                    else
+                        return 0;
+                }
+            }
+        }
 
         /// <summary>
         /// Returns the MaxCreate for this generator profile
@@ -137,7 +156,7 @@ namespace ACE.Server.Entity
         /// Enqueues 1 or multiple objects from this generator profile
         /// adds these items to the spawn queue
         /// </summary>
-        public void Enqueue(int numObjects = 1, bool initialSpawn = true)
+        public void Enqueue(int numObjects = 1)
         {
             for (var i = 0; i < numObjects; i++)
             {
@@ -147,8 +166,6 @@ namespace ACE.Server.Entity
                     break;
                 }*/
                 SpawnQueue.Add(GetSpawnTime());
-                if (initialSpawn)
-                    Generator.CurrentCreate++;
             }
         }
 
@@ -186,10 +203,6 @@ namespace ACE.Server.Entity
                             Spawned.Add(obj.Guid.Full, woi);
                         }
                     }
-                    else
-                    {
-                        //_generator.CurrentCreate--;
-                    }
                 }
                 else
                 {
@@ -212,7 +225,10 @@ namespace ACE.Server.Entity
             {
                 objects = TreasureGenerator();
                 if (objects.Count > 0)
+                {
                     Generator.GeneratedTreasureItem = true;
+                    GeneratedTreasureItem = true;
+                }
             }
             else
             {
@@ -434,15 +450,12 @@ namespace ACE.Server.Entity
 
             if (woi == null) return;
 
-            if (woi.WeenieClassId != Biota.WeenieClassId) return;
-
             RemoveQueue.Enqueue((DateTime.UtcNow.AddSeconds(Delay), woi.Guid.Full));
         }
 
         public void FreeSlot(uint objectGuid)
         {
-            if (Spawned.Remove(objectGuid))
-                Generator.CurrentCreate--;
+            Spawned.Remove(objectGuid);
         }
     }
 }

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -52,7 +52,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// TRUE if this Profile generated treasure using TreasureGenerator
         /// </summary>
-        public bool GeneratedTreasureItem { get; private set; } = false;
+        public bool GeneratedTreasureItem { get; private set; }
 
         /// <summary>
         /// The total # of active spawned objects + awaiting spawning

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -233,7 +233,6 @@ namespace ACE.Server.WorldObjects
                 {
                     generator.Spawned.Clear();
                     generator.SpawnQueue.Clear();
-                    CurrentCreate--;
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -717,6 +717,7 @@ namespace ACE.Server.WorldObjects
                 profile.AnglesX = link.AnglesX;
                 profile.AnglesY = link.AnglesY;
                 profile.AnglesZ = link.AnglesZ;
+                profile.Delay = profileTemplate.Biota.Delay;
                 profile.Probability = profileTemplate.Biota.Probability;
                 profile.InitCreate = profileTemplate.Biota.InitCreate;
                 profile.MaxCreate = profileTemplate.Biota.MaxCreate;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -68,8 +68,7 @@ namespace ACE.Server.WorldObjects
         /// The number of currently spawned objects +
         /// the number of objects currently in the spawn queue
         /// </summary>
-        //public int CurrentCreate { get => GeneratorProfiles.Select(i => i.CurrentCreate).Sum(); }
-        public int CurrentCreate;   // maintained directly
+        public int CurrentCreate { get => GeneratorProfiles.Select(i => i.CurrentCreate).Sum(); }
 
         /// <summary>
         /// A list of indices into GeneratorProfiles where CurrentCreate > 0
@@ -108,7 +107,6 @@ namespace ACE.Server.WorldObjects
             //History.Add($"[{DateTime.UtcNow}] - SelectProfilesInit()");
 
             bool rng_selected = false;
-            //bool campSpawned = false;
 
             while (true)
             {
@@ -133,44 +131,8 @@ namespace ACE.Server.WorldObjects
 
                     if (rng < probability || probability == -1)
                     {
-                        //if (!profile.RegenLocationType.HasFlag(RegenLocationType.Treasure))
-                        //{
-                        //    if (profile.Biota.WeenieClassId > 0)
-                        //    {
-                        //        //Console.WriteLine($"{Name} ({WeenieClassId}): CurrentCreate = {CurrentCreate} | profile.Biota.WeenieClassId = {profile.Biota.WeenieClassId}");
-                        //        var profileSpawn = WorldObjectFactory.CreateWorldObject(DatabaseManager.World.GetCachedWeenie(profile.Biota.WeenieClassId), new ACE.Entity.ObjectGuid(0));
-                        //        if (profileSpawn != null)
-                        //        {
-                        //            //Console.WriteLine($"{Name} ({WeenieClassId}): CurrentCreate = {CurrentCreate} | profile.Biota.WeenieClassId = {profile.Biota.WeenieClassId} | profileSpawn.Name: {profileSpawn.Name} | profileSpawn.IsGenerator: {profileSpawn.IsGenerator}");
-                        //            if (profileSpawn.IsGenerator && !(profileSpawn.WeenieType == WeenieType.Container || profileSpawn.WeenieType == WeenieType.Chest) && probability != -1 && profileSpawn.InitCreate > 1)
-                        //            {
-                        //                if (!campSpawned)
-                        //                {
-                        //                    profile.Enqueue(1);
-                        //                    CurrentCreate = MaxCreate;
-                        //                    campSpawned = true;
-                        //                    //return;
-                        //                }
-                        //                else
-                        //                    continue;
-                        //            }
-                        //            else
-                        //            {
-                        //                //var numObjects = GetMaxObjects(profile);
-                        //                var numObjects = GetRNGInitToMaxObjects(profile);
-                        //                profile.Enqueue(numObjects);
-                        //            }
-                        //        }
-                        //    }
-                        //}
-                        //else
-                        //{
-                        //    //Console.WriteLine($"{Name} ({WeenieClassId}): CurrentCreate = {CurrentCreate} | profile.Biota.WeenieClassId = {profile.Biota.WeenieClassId} | profile.RegenLocationType = {profile.RegenLocationType.ToString()}");
-                        //    //var numObjects = GetInitObjects(profile);
-                              //var numObjects = GetRNGInitToMaxObjects(profile);
                         var numObjects = GetInitObjects(profile);
                         profile.Enqueue(numObjects);
-                        //}
 
                         //var rng_str = probability == -1 ? "" : "RNG ";
                         //History.Add($"[{DateTime.UtcNow}] - SelectProfilesInit() - {rng_str}selected slot {i} to spawn, adding {numObjects} objects ({profile.CurrentCreate}/{profile.MaxCreate})");
@@ -647,7 +609,6 @@ namespace ACE.Server.WorldObjects
 
                         generator.Spawned.Clear();
                         generator.SpawnQueue.Clear();
-                        CurrentCreate = 0;
                     }
                     break;
                 case GeneratorDestruct.Destroy:
@@ -665,7 +626,6 @@ namespace ACE.Server.WorldObjects
 
                         generator.Spawned.Clear();
                         generator.SpawnQueue.Clear();
-                        CurrentCreate = 0;
                     }
                     break;
                 case GeneratorDestruct.Nothing:
@@ -807,7 +767,6 @@ namespace ACE.Server.WorldObjects
 
                 generator.Spawned.Clear();
                 generator.SpawnQueue.Clear();
-                CurrentCreate = 0;
             }
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # ACEmulator Change Log
 
+### 2019-06-23
+[Ripley]
+* Generator system tweaks
+  - Carry over Delay from profile template correctly.
+  - Update RemoveQueue info in GeneratorDump.
+  - Adjust CurrentCreate to be calculated to prevent out-of-sync issues.
+
 ### 2019-06-22
 [Ripley]
 * Expand `qst` command.


### PR DESCRIPTION
* Generator system tweaks
  - Carry over Delay from profile template correctly.
  - Update RemoveQueue info in GeneratorDump.
  - Adjust CurrentCreate to be calculated to prevent out-of-sync issues.
     - Added GeneratedTreasureItem to GeneratorProfile to track when TreasureGenerator is used (random, mutated lootgen)