### PR TITLE
Add multi-homed internet support

### DIFF
--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -16,7 +16,7 @@ namespace ACE.Server.Network
 
         public Socket Socket { get; private set; }
 
-        private IPEndPoint listenerEndpoint;
+        public IPEndPoint ListenerEndpoint { get; private set; }
 
         private readonly uint listeningPort;
 
@@ -36,10 +36,10 @@ namespace ACE.Server.Network
             log.DebugFormat("Starting ConnectionListener, host {0} port {1}", listeningHost, listeningPort);
             try
             {
-                listenerEndpoint = new IPEndPoint(listeningHost, (int)listeningPort);
+                ListenerEndpoint = new IPEndPoint(listeningHost, (int)listeningPort);
                 Socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                 Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-                Socket.Bind(listenerEndpoint);
+                Socket.Bind(ListenerEndpoint);
                 Listen();
             }
             catch (Exception exception)
@@ -91,14 +91,14 @@ namespace ACE.Server.Network
                 if (packetLog.IsDebugEnabled)
                 {
                     StringBuilder sb = new StringBuilder();
-                    sb.AppendLine($"Received Packet (Len: {data.Length}) [{ipEndpoint.Address}:{ipEndpoint.Port}=>{listenerEndpoint.Address}:{listenerEndpoint.Port}]");
+                    sb.AppendLine($"Received Packet (Len: {data.Length}) [{ipEndpoint.Address}:{ipEndpoint.Port}=>{ListenerEndpoint.Address}:{ListenerEndpoint.Port}]");
                     sb.AppendLine(data.BuildPacketString());
                     packetLog.Debug(sb.ToString());
                 }
 
                 var packet = new ClientPacket(data);
                 if (packet.IsValid)
-                    NetworkManager.ProcessPacket(packet, ipEndpoint, listenerEndpoint);
+                    NetworkManager.ProcessPacket(this, packet, ipEndpoint);
             }
             catch (SocketException socketException)
             {

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -28,6 +28,7 @@ namespace ACE.Server.Network
         private const int timeBetweenAck = 2000; // 2s
 
         private readonly Session session;
+        private readonly ConnectionListener connectionListener;
 
         private readonly Object[] currentBundleLocks = new Object[(int)GameMessageGroup.QueueMax];
         private readonly NetworkBundle[] currentBundles = new NetworkBundle[(int)GameMessageGroup.QueueMax];
@@ -84,11 +85,14 @@ namespace ACE.Server.Network
         public ushort ClientId { get; }
         public ushort ServerId { get; }
 
-        public NetworkSession(Session session, ushort clientId, ushort serverId)
+        public NetworkSession(Session session, ConnectionListener connectionListener, ushort clientId, ushort serverId)
         {
             this.session = session;
+            this.connectionListener = connectionListener;
+
             ClientId = clientId;
             ServerId = serverId;
+
             // New network auth session timeouts will always be low.
             TimeoutTick = DateTime.UtcNow.AddSeconds(AuthenticationHandler.DefaultAuthTimeout).Ticks;
 
@@ -614,7 +618,7 @@ namespace ACE.Server.Network
 
             try
             {
-                Socket socket = SocketManager.GetMainSocket();
+                var socket = connectionListener.Socket;
 
                 packet.CreateReadyToSendPacket(buffer, out var size);
 

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -53,10 +53,10 @@ namespace ACE.Server.Network
         public string BootSessionReason { get; private set; }
 
 
-        public Session(IPEndPoint endPoint, ushort clientId, ushort serverId)
+        public Session(ConnectionListener connectionListener, IPEndPoint endPoint, ushort clientId, ushort serverId)
         {
             EndPoint = endPoint;
-            Network = new NetworkSession(this, clientId, serverId);
+            Network = new NetworkSession(this, connectionListener, clientId, serverId);
         }
 
 


### PR DESCRIPTION
This allows you to bind ACE to multiple interfaces via the Config.js.

For most configurations, on a single-homed machine, your Config.js would have:
      "Host": "0.0.0.0",

However, in the event you have a server with multiple NIC's, or, a software based VPN, you may want to expose your server to the internet via both of those ip addresses, using the VPN for your public clients and your actual address for your personal clients.

You can now do something like this:
      "Host": "10.1.2.3,192.1.2.3",

The PR seems like it's a lot of changes, but it's mainly just a few renamed. The difference now is we pass the ConnectionListener to the NetworkSession and use the ConnectionListener that was initially used to connect to transmit our return packets.

