### PR TITLE
fixing item proc sources and messages

### DIFF
--- a/Source/ACE.Server/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManager.cs
@@ -146,7 +146,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public virtual AddEnchantmentResult Add(Spell spell, WorldObject caster)
+        public virtual AddEnchantmentResult Add(Spell spell, WorldObject caster, bool equip = false)
         {
             var result = new AddEnchantmentResult();
 
@@ -156,7 +156,7 @@ namespace ACE.Server.Managers
             // if none, add new record
             if (entries.Count == 0)
             {
-                var newEntry = BuildEntry(spell, caster);
+                var newEntry = BuildEntry(spell, caster, equip);
                 newEntry.LayerId = 1;
                 WorldObject.Biota.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
                 WorldObject.ChangesDetected = true;
@@ -182,7 +182,7 @@ namespace ACE.Server.Managers
 
             if (refreshSpell == null)
             {
-                var newEntry = BuildEntry(spell, caster);
+                var newEntry = BuildEntry(spell, caster, equip);
                 newEntry.LayerId = result.NextLayerId;
                 WorldObject.Biota.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
 
@@ -215,7 +215,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Builds an enchantment registry entry from a spell ID
         /// </summary>
-        private BiotaPropertiesEnchantmentRegistry BuildEntry(Spell spell, WorldObject caster = null)
+        private BiotaPropertiesEnchantmentRegistry BuildEntry(Spell spell, WorldObject caster = null, bool equip = false)
         {
             var entry = new BiotaPropertiesEnchantmentRegistry();
 
@@ -237,7 +237,8 @@ namespace ACE.Server.Managers
             }
             else
             {
-                if (caster == null || caster.CurrentWieldedLocation == null && !caster.ItemSetContains(spell.Id))
+                //if (caster == null || caster.CurrentWieldedLocation == null && !caster.ItemSetContains(spell.Id))
+                if (!equip)
                 {
                     entry.Duration = spell.Duration;
                 }

--- a/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/Managers/EnchantmentManagerWithCaching.cs
@@ -36,9 +36,9 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public override AddEnchantmentResult Add(Spell spell, WorldObject caster)
+        public override AddEnchantmentResult Add(Spell spell, WorldObject caster, bool equip = false)
         {
-            var result = base.Add(spell, caster);
+            var result = base.Add(spell, caster, equip);
 
             ClearCache();
 

--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -127,7 +127,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Handles an item casting a spell on player or creature
+        /// Handles equipping an item casting a spell on player or creature
         /// </summary>
         public virtual EnchantmentStatus CreateItemSpell(WorldObject item, uint spellID)
         {
@@ -142,7 +142,7 @@ namespace ACE.Server.WorldObjects
             {
                 case MagicSchool.CreatureEnchantment:
 
-                    enchantmentStatus = CreatureMagic(this, spell, item);
+                    enchantmentStatus = CreatureMagic(this, spell, item, true);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(Guid, spell.TargetEffect, spell.Formula.Scale));
 
@@ -150,7 +150,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    LifeMagic(this, spell, out uint damage, out bool critical, out enchantmentStatus, item);
+                    LifeMagic(this, spell, out uint damage, out bool critical, out enchantmentStatus, item, true);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(Guid, spell.TargetEffect, spell.Formula.Scale));
 
@@ -159,9 +159,9 @@ namespace ACE.Server.WorldObjects
                 case MagicSchool.ItemEnchantment:
 
                     if (spell.HasItemCategory || spell.IsPortalSpell)
-                        enchantmentStatus = ItemMagic(this, spell, item);
+                        enchantmentStatus = ItemMagic(this, spell, item, true);
                     else
-                        enchantmentStatus = ItemMagic(item, spell, item);
+                        enchantmentStatus = ItemMagic(item, spell, item, true);
 
                     var playScript = spell.IsPortalSpell && spell.CasterEffect > 0 ? spell.CasterEffect : spell.TargetEffect;
                     EnqueueBroadcast(new GameMessageScript(Guid, playScript, spell.Formula.Scale));

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -245,7 +245,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Handles an item casting a spell on a player
+        /// Handles equipping an item casting a spell on a player
         /// </summary>
         public override EnchantmentStatus CreateItemSpell(WorldObject item, uint spellID)
         {
@@ -717,11 +717,11 @@ namespace ACE.Server.WorldObjects
                                 foreach (var item in items)
                                 {
                                     enchantmentStatus = ItemMagic(item, spell);
-                                    //EnqueueBroadcast(new GameMessageScript(player.Guid, spell.TargetEffect, spell.Formula.Scale));
-
                                     if (enchantmentStatus.Message != null)
                                         player.Session.Network.EnqueueSend(enchantmentStatus.Message);
                                 }
+                                if (items.Count() > 0)
+                                    EnqueueBroadcast(new GameMessageScript(player.Guid, spell.TargetEffect, spell.Formula.Scale));
                             }
                             else
                             {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -45,7 +45,7 @@ namespace ACE.Server.WorldObjects
                 return;*/
 
             // perform resistance check, if applicable
-            var resisted = tryResist ? TryResistSpell(spell, target) : false;
+            var resisted = tryResist ? TryResistSpell(spell, target, caster) : false;
             if (resisted)
                 return;
 
@@ -93,7 +93,7 @@ namespace ACE.Server.WorldObjects
         /// If this spell has a chance to be resisted, rolls for a chance
         /// Returns TRUE if spell is resistable and was resisted for this attempt
         /// </summary>
-        public bool TryResistSpell(Spell spell, WorldObject target)
+        public bool TryResistSpell(Spell spell, WorldObject target, WorldObject caster = null)
         {
             if (spell.IsBeneficial)
                 return false;
@@ -114,18 +114,22 @@ namespace ACE.Server.WorldObjects
                 case MagicSchool.CreatureEnchantment:
                     if (spell.NumProjectiles == 0)  // life magic projectiles
                     {
-                        bool? resisted = ResistSpell(target, spell);
+                        bool? resisted = ResistSpell(target, spell, caster);
                         if (resisted != null && resisted == true)
                             return true;
                     }
                     break;
                 case MagicSchool.ItemEnchantment:
-                    // ??
+                    {
+                        bool? resisted = ResistSpell(target, spell, caster);
+                        if (resisted != null && resisted == true)
+                            return true;
+                    }
                     break;
                 case MagicSchool.VoidMagic:
                     if (spell.NumProjectiles == 0)  // void magic projectiles
                     {
-                        bool? resisted = ResistSpell(target, spell);
+                        bool? resisted = ResistSpell(target, spell, caster);
                         if (resisted != null && resisted == true)
                             return true;
                     }
@@ -267,29 +271,42 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Performs the magic defense checks for spell attacks
         /// </summary>
-        public bool? ResistSpell(WorldObject target, Spell spell)
+        public bool? ResistSpell(WorldObject target, Spell spell, WorldObject caster = null)
         {
             uint magicSkill = 0;
-            var caster = this as Creature;
-            if (caster != null)
-                // Retrieve caster's skill level in the Magic School
-                magicSkill = caster.GetCreatureSkill(spell.School).Current;
-            else
-                // Retrieve casting item's spellcraft
-                magicSkill = (uint)(ItemSpellcraft ?? 0);
 
-            var player = caster as Player;
-            var targetPlayer = target as Player;
+            if (caster == null)
+                caster = this;
+
+            if (caster is Creature casterCreature)
+            {
+                // Retrieve caster's skill level in the Magic School
+                magicSkill = casterCreature.GetCreatureSkill(spell.School).Current;
+
+            }
+            else if (caster.ItemSpellcraft != null)
+            {
+                // Retrieve casting item's spellcraft
+                magicSkill = (uint)caster.ItemSpellcraft;
+            }
+            else if (caster.Wielder is Creature wielder)
+            {
+                // Receive wielder's skill level in the Magic School?
+                magicSkill = wielder.GetCreatureSkill(spell.School).Current;
+            }
 
             // only creatures can resist spells?
-            var creature = target as Creature;
-            if (creature == null) return null;
+            if (!(target is Creature targetCreature))
+                return null;
 
             // Retrieve target's Magic Defense Skill
-            var targetMagicDefenseSkill = creature.GetCreatureSkill(Skill.MagicDefense).Current;
+            var difficulty = targetCreature.GetCreatureSkill(Skill.MagicDefense).Current;
 
-            //Console.WriteLine($"{target.Name}.ResistSpell({Name}, {spell.Name}): magicSkill: {magicSkill}, difficulty: {targetMagicDefenseSkill}");
-            bool resisted = MagicDefenseCheck(magicSkill, targetMagicDefenseSkill);
+            //Console.WriteLine($"{target.Name}.ResistSpell({Name}, {spell.Name}): magicSkill: {magicSkill}, difficulty: {difficulty}");
+            bool resisted = MagicDefenseCheck(magicSkill, difficulty);
+
+            var player = this as Player;
+            var targetPlayer = target as Player;
 
             if (targetPlayer != null)
             {
@@ -302,16 +319,18 @@ namespace ACE.Server.WorldObjects
                     resisted = true;
                 }
             }
-            if (target == this)
+
+            if (caster == target)
                 resisted = false;
 
             if (resisted)
             {
                 if (player != null)
                 {
-                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{creature.Name} resists your spell", ChatMessageType.Magic));
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{targetCreature.Name} resists your spell", ChatMessageType.Magic));
                     player.Session.Network.EnqueueSend(new GameMessageSound(player.Guid, Sound.ResistSpell, 1.0f));
                 }
+
                 if (targetPlayer != null)
                 {
                     targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"You resist the spell cast by {Name}", ChatMessageType.Magic));
@@ -319,7 +338,6 @@ namespace ACE.Server.WorldObjects
 
                     Proficiency.OnSuccessUse(targetPlayer, targetPlayer.GetCreatureSkill(Skill.MagicDefense), magicSkill);
                 }
-                return resisted;
             }
             return resisted;
         }
@@ -327,7 +345,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a Life Magic spell
         /// </summary>
-        protected bool LifeMagic(WorldObject target, Spell spell, out uint damage, out bool critical, out EnchantmentStatus enchantmentStatus, WorldObject itemCaster = null)
+        protected bool LifeMagic(WorldObject target, Spell spell, out uint damage, out bool critical, out EnchantmentStatus enchantmentStatus, WorldObject itemCaster = null, bool equip = false)
         {
             critical = false;
             string srcVital, destVital;
@@ -621,9 +639,9 @@ namespace ACE.Server.WorldObjects
                 case SpellType.Enchantment:
                     damage = 0;
                     if (itemCaster != null)
-                        enchantmentStatus = CreateEnchantment(target, itemCaster, spell);
+                        enchantmentStatus = CreateEnchantment(target, itemCaster, spell, equip);
                     else
-                        enchantmentStatus = CreateEnchantment(target, this, spell);
+                        enchantmentStatus = CreateEnchantment(target, this, spell, equip);
                     break;
 
                 default:
@@ -666,7 +684,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Wrapper around CreateEnchantment for Creature Magic
         /// </summary>
-        protected EnchantmentStatus CreatureMagic(WorldObject target, Spell spell, WorldObject itemCaster = null)
+        protected EnchantmentStatus CreatureMagic(WorldObject target, Spell spell, WorldObject itemCaster = null, bool equip = false)
         {
             // redirect creature dispels to life magic
             if (spell.MetaSpellType == SpellType.Dispel)
@@ -674,20 +692,20 @@ namespace ACE.Server.WorldObjects
                 LifeMagic(target, spell, out uint damage, out bool critical, out var enchantmentStatus);
                 return enchantmentStatus;
             }
-            return CreateEnchantment(target, itemCaster ?? this, spell);
+            return CreateEnchantment(target, itemCaster ?? this, spell, equip);
         }
 
         /// <summary>
         /// Handles casting Item Magic spells
         /// </summary>
-        protected EnchantmentStatus ItemMagic(WorldObject target, Spell spell, WorldObject itemCaster = null)
+        protected EnchantmentStatus ItemMagic(WorldObject target, Spell spell, WorldObject itemCaster = null, bool equip = false)
         {
             var enchantmentStatus = new EnchantmentStatus(spell);
 
             // redirect item dispels to life magic
             if (spell.MetaSpellType == SpellType.Dispel)
             {
-                LifeMagic(target, spell, out uint damage, out bool critical, out enchantmentStatus);
+                LifeMagic(target, spell, out uint damage, out bool critical, out enchantmentStatus, itemCaster, equip);
                 return enchantmentStatus;
             }
 
@@ -1001,9 +1019,9 @@ namespace ACE.Server.WorldObjects
             else if (spell.MetaSpellType == SpellType.Enchantment)
             {
                 if (itemCaster != null)
-                    return CreateEnchantment(target, itemCaster, spell);
+                    return CreateEnchantment(target, itemCaster, spell, equip);
 
-                return CreateEnchantment(target, this, spell);
+                return CreateEnchantment(target, this, spell, equip);
             }
 
             enchantmentStatus.Success = true;
@@ -1216,16 +1234,14 @@ namespace ACE.Server.WorldObjects
         /// Creates an enchantment and interacts with the Enchantment registry.
         /// Used by Life, Creature, Item, and Void magic
         /// </summary>
-        public EnchantmentStatus CreateEnchantment(WorldObject target, WorldObject caster, Spell spell)
+        public EnchantmentStatus CreateEnchantment(WorldObject target, WorldObject caster, Spell spell, bool equip = false)
         {
             var enchantmentStatus = new EnchantmentStatus(spell);
 
             // create enchantment
-            var addResult = target.EnchantmentManager.Add(spell, caster);
+            var addResult = target.EnchantmentManager.Add(spell, caster, equip);
 
-            var player = this as Player;
             var playerTarget = target as Player;
-            var creatureTarget = target as Creature;
 
             // build message
             var suffix = "";
@@ -1261,14 +1277,18 @@ namespace ACE.Server.WorldObjects
                     message = null;
             }
 
-            if (target is Player)
+            if (playerTarget != null)
             {
                 playerTarget.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(playerTarget.Session, new Enchantment(playerTarget, addResult.Enchantment)));
 
                 playerTarget.HandleMaxVitalUpdate(spell);
 
                 if (playerTarget != this)
-                    playerTarget.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} cast {spell.Name} on you{suffix}", ChatMessageType.Magic));
+                    playerTarget.Session.Network.EnqueueSend(new GameMessageSystemChat($"{caster.Name} cast {spell.Name} on you{suffix}", ChatMessageType.Magic));
+            }
+            else if (caster != this && caster is Creature && target.Wielder is Player wielder)
+            {
+                wielder.Session.Network.EnqueueSend(new GameMessageSystemChat($"{caster.Name} cast {spell.Name} on {targetName}{suffix}", ChatMessageType.Magic));
             }
 
             if (message != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -716,7 +716,7 @@ namespace ACE.Server.WorldObjects
 
                 return;
             }
-            wielder.TryCastSpell(spell, target, wielder);
+            wielder.TryCastSpell(spell, target, this);
         }
     }
 }


### PR DESCRIPTION
this pr resolves https://github.com/ACEmulator/ACE/issues/1922

the code in this pr got a little hairy, in particular the 'bool equipping' that EnchantmentManager seems to require, and the way it needs to be passed through many of the magic functions

i think that maybe these -1 duration spells from equipping items could all be the SpellType.Enchantment, but with the way spells are first passed to Creature/Item/Life Magic, and each one handling SpellType.Enchantment and further passing to CreateEnchantment, required passing this 'equip' bool through many of these functions unfortunately.

the logic in EnchantmentManager that determines if a duration should be -1 used to be a sticking point in the past, but it really seems to boil down to something simple: if i am equipping an item that casts a spell, that spell should most likely be duration -1 to my current understanding. if there are any exceptions to this, please let me know!

Aetheria is an example of how this gets tricky -- it casts item set spells on the wielder when equipped, which are -1 duration. But it also procs spells on both the wielder and target. These procs have a duration. So the logic could be something tricky like a combination of checks like it was performing previously, but to do it the safest and clearest way, i think it really just boils down to this 'equipping' bool

CreateItemSpell() is the function that gets called when an item is casting a spell from equipping it (and only for this case), so this is the only place equip bool gets set to true. Everywhere else in the system, it defaults to false (duration), so hopefully this should limit the types of 'infinite duration' errors that arose in the system awhile ago, and also make the logic much clearer

ResistSpell() has been changed up very slightly, and is now being passed the additional 'caster' parameter that is common in many of the other magic methods. This is done for a few reasons, but now follows a consistent pattern as the other methods: when the current player has an item that casts a spell, instead of calling item.CastSpell() through the pipeline, player.CastSpell(itemSource) is instead used, which remains consistent with the current implementation of the rest of the magic system. The references to both the item caster and wielder are useful here, so it's useful to have references to them both. This could probably eventually be refactored / cleaned up further, but for now having ResistSpell() similar to the other magic methods is useful for consistency.

so for the Phials (thrown weapons w/ item procs), throughout the magic casting pipeline, wielder.TryCastSpell(target, item) is the method used (last param updated), which then calls wielder.TryResistSpell(target, item). Item is being passed for the 'item caster' param, which is used for various operations if not null. For example, in ResistSpell(), it determines the caster from either the item caster or the wielder, and now has the appropriate logic to get magicSkill. If an item caster was passed in, it tries to use its ItemSpellcraft (this part was already there). One part that was missing, if an item caster's ItemSpellcraft is null, it checks if the item is being wielded by a creature, and if so, uses the wielder's magic skill for the spell.

A clear distinction between player and item caster is also useful for determining all of the proper messages:

```
Source:

Target resists your spell
Pyreal Phial of Imperil casts Imperil Other V on Target

Target:

You resist the spell cast by Source
Pyreal Phial of Imperil cast Imperil Other V on you
```

For resists, I think the player names are always used, but for the successful cast messages, i think the item names are used there. Haven't confirmed the resist messages yet, but using item names for resists could result in some odd messages

Since these changes touched slightly on a lot of different methods, I went through and re-tested almost every possible magic casting setup, to ensure all the existing functionality was left intact. I tested all the Phials with both monster and player targets, Aetheria item set spells and both types of procs (self and target), item set spells for rare armor, casting all of the different types of magic school spells, a bunch of different wielded items with built-in spells, and also various spell traps. Everything appears to be functioning as expected, but careful review and feedback and additional playtesting is always a good thing



