### PR TITLE
Fix CommandParser for Multiple Encapsulated Arguments

### DIFF
--- a/Source/ACE.Server/Command/CommandManager.cs
+++ b/Source/ACE.Server/Command/CommandManager.cs
@@ -137,23 +137,25 @@ namespace ACE.Server.Command
                 var listParameters = new List<string>();
 
                 for (int start = 0; start < parameters.Length; start++)
-                    if (!parameters[start].StartsWith("\""))
-                        listParameters.Add(parameters[start]);
+                {
+                    if (!parameters[start].StartsWith("\"") || parameters[start].EndsWith("\"")) // Make sure we catch parameters like: "someParam"
+                        listParameters.Add(parameters[start].Replace("\"", ""));
                     else
                     {
                         listParameters.Add(parameters[start].Replace("\"", ""));
                         for (int end = start + 1; end < parameters.Length; end++)
                         {
                             if (!parameters[end].EndsWith("\""))
-                                listParameters[start] = listParameters[start] + " " + parameters[end];
+                                listParameters[listParameters.Count - 1] += " " + parameters[end];
                             else
                             {
-                                listParameters[start] = listParameters[start] + " " + parameters[end].Replace("\"", "");
+                                listParameters[listParameters.Count - 1] += " " + parameters[end].Replace("\"", "");
                                 start = end;
                                 break;
                             }
                         }
                     }
+                }
                 Array.Resize(ref parameters, listParameters.Count);
                 parameters = listParameters.ToArray();
             }


### PR DESCRIPTION
Fixes for things like
/command "Param1" "Param 2"