### PR TITLE
MoreNetworkFixes

### DIFF
--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -105,7 +105,8 @@ namespace ACE.Server.Network
                 // If we get "Connection has been forcibly closed..." error, just eat the exception and continue on
                 // This gets sent when the remote host terminates the connection (on UDP? interesting...)
                 // TODO: There might be more, should keep an eye out. Logged message will help here.
-                if (socketException.SocketErrorCode == SocketError.NetworkReset ||
+                if (socketException.SocketErrorCode == SocketError.MessageSize ||
+                    socketException.SocketErrorCode == SocketError.NetworkReset ||
                     socketException.SocketErrorCode == SocketError.ConnectionReset)
                 {
                     log.DebugFormat("ConnectionListener.OnDataReceieve() has thrown {0}: {1} from client {2}", socketException.SocketErrorCode, socketException.Message, clientEndPoint != null ? clientEndPoint.ToString() : "Unknown");

--- a/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
+++ b/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
@@ -4,6 +4,7 @@ namespace ACE.Server.Network.Enum
     {
         None,
         PacketHeaderDisconnect,
+        AccountInformationInvalid,
         AccountSelectCallbackException,
         NetworkTimeout,
         /// <summary>
@@ -32,6 +33,7 @@ namespace ACE.Server.Network.Enum
         {
             "",
             "PacketHeader Disconnect",
+            "Account Information Invalid",
             "AccountSelectCallback threw an exception.",
             "Network Timeout",
             "client sent network error disconnect",

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -34,6 +34,14 @@ namespace ACE.Server.Network.Handlers
             try
             {
                 PacketInboundLoginRequest loginRequest = new PacketInboundLoginRequest(packet);
+
+                if (loginRequest.Account.Length > 50)
+                {
+                    NetworkManager.SendLoginRequestReject(session, CharacterError.AccountInvalid);
+                    session.Terminate(SessionTerminationReason.AccountInformationInvalid);
+                    return;
+                }
+
                 Task t = new Task(() => DoLogin(session, loginRequest));
                 t.Start();
             }

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -153,20 +153,25 @@ namespace ACE.Server.Network.Managers
         {
             var tempSession = new Session(connectionListener, endPoint, (ushort)(sessionMap.Length + 1), ServerId);
 
+            SendLoginRequestReject(tempSession, error);
+        }
+
+        public static void SendLoginRequestReject(Session session, CharacterError error)
+        {
             // First we must send the connect request response
             var connectRequest = new PacketOutboundConnectRequest(
                 Timers.PortalYearTicks,
-                tempSession.Network.ConnectionData.ConnectionCookie,
-                tempSession.Network.ClientId,
-                tempSession.Network.ConnectionData.ServerSeed,
-                tempSession.Network.ConnectionData.ClientSeed);
-            tempSession.Network.ConnectionData.DiscardSeeds();
-            tempSession.Network.EnqueueSend(connectRequest);
+                session.Network.ConnectionData.ConnectionCookie,
+                session.Network.ClientId,
+                session.Network.ConnectionData.ServerSeed,
+                session.Network.ConnectionData.ClientSeed);
+            session.Network.ConnectionData.DiscardSeeds();
+            session.Network.EnqueueSend(connectRequest);
 
             // Then we send the error
-            tempSession.SendCharacterError(error);
+            session.SendCharacterError(error);
 
-            tempSession.Network.Update();
+            session.Network.Update();
         }
 
         public static int GetSessionCount()


### PR DESCRIPTION
Fix exceptions from account names that exceed the database column limit.

Fix another exception caused by fragments that are too large