### PR TITLE
fixing magic pickup issue

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -47,6 +47,14 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            // fix bug in magic combat mode after walking to target,
+            // crouch animation steps out of range
+            if (useRadius == null)
+                useRadius = target.UseRadius ?? 0.6f;
+
+            if (CombatMode == CombatMode.Magic)
+                useRadius = Math.Max(0.0f, useRadius.Value - 0.2f);
+
             // already within use distance?
             var withinUseRadius = CurrentLandblock.WithinUseRadius(this, target.Guid, out var targetValid, useRadius);
             if (withinUseRadius)


### PR DESCRIPTION
This fixes a bug that only appears while looting containers in magic combat mode:

- Start in magic combat mode
- Double click a landblock container (chest, corpse) while you are just outside the max looting range, so that your player walks (not runs) to the container
- Attempt to loot an item from the container

Expected:

Item is successfully looted, and container inventory window stays up

Actual:

Item is looted, although with some odd client errors such as 'can only move 1 item at a time', and the most important bug: the container inventory window is automatically closed on the client

This happens because magic combat mode appears to be the only stance where the player takes a small step back during the crouch down animation. This step back is just enough to move outside of max looting range, so the client automatically closes the window.

This causes many issues for magic casters trying to loot, esp. when they are trying to loot important quest items, and the chests automatically close/lock on them