### PR TITLE
fixing inventory stack bugs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1714,6 +1714,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            if (!CanAddToInventory(sourceStack))
+            {
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, sourceStack.Guid.Full, WeenieError.None));
+                return;
+            }
+
             if ((sourceStackRootOwner == this && targetStackRootOwner != this)  || (sourceStackRootOwner != this && targetStackRootOwner == this)) // Movement is between the player and the world
             {
                 if (sourceStackRootOwner is Vendor)
@@ -1818,7 +1824,7 @@ namespace ACE.Server.WorldObjects
                 }
                 else if (sourceStackRootOwner != null)
                 {
-                    if (!sourceStackRootOwner.TryRemoveFromInventory(sourceStack.Guid, out _))
+                    if (!sourceStackRootOwner.TryRemoveFromInventory(sourceStack.Guid, out _) && (!(sourceStackRootOwner is Player playerContainer) || !playerContainer.TryDequipObjectWithNetworking(sourceStack.Guid, out _, DequipObjectAction.DequipToPack)))
                     {
                         Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "TryRemoveFromInventory failed!")); // Custom error message
                         Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, sourceStack.Guid.Full));


### PR DESCRIPTION
This PR fixes 2 types of inventory stack bugs:

Bug 1:

- Have a partial stack of an item (249/250 stack size, for example) in your main pack
- Have a partial stack of the same item in the landblock, where merging the stacks would exceed the MaxStackSize
- Have the main pack full
- Attempt to pick up the partial stack from the landblock

Result before patch:

 - Error, and the landblock stack poofs completely

Bug 2:

- Have a partial stack of a wielded item, such as arrows or phials wielded
- Have another partial stack of the same item in main pack, where merging the 2 stacks would still be < MaxStackSize
- Try to dequip the wielded stack by double clicking on it

Result before patch:

The client sends a packet to try to merge the wielded stack into the inventory stack, which resulted in an error before, from the equipped source stack not being found in inventory