### PR TITLE
Fixed issue with Recipe Manager CopyFromSourceToResult not using the player as the source.

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -1051,7 +1051,7 @@ namespace ACE.Server.Managers
                     target.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);
                     break;
                 case ModificationOperation.CopyFromSourceToResult:
-                    result.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);     // ??
+                    result.SetProperty(prop, player.GetProperty(prop) ?? 0);     // ??
                     break;
                 case ModificationOperation.AddSpell:
                     if (value != -1)
@@ -1088,7 +1088,7 @@ namespace ACE.Server.Managers
                     target.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);
                     break;
                 case ModificationOperation.CopyFromSourceToResult:
-                    result.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);
+                    result.SetProperty(prop, player.GetProperty(prop) ?? 0);
                     break;
                 default:
                     log.Warn($"RecipeManager.ModifyFloat({source.Name}, {target.Name}): unhandled operation {op}");
@@ -1114,7 +1114,7 @@ namespace ACE.Server.Managers
                     target.SetProperty(prop, sourceMod.GetProperty(prop) ?? sourceMod.Name);
                     break;
                 case ModificationOperation.CopyFromSourceToResult:
-                    result.SetProperty(prop, sourceMod.GetProperty(prop) ?? sourceMod.Name);
+                    result.SetProperty(prop, player.GetProperty(prop) ?? player.Name);
                     break;
                 default:
                     log.Warn($"RecipeManager.ModifyString({source.Name}, {target.Name}): unhandled operation {op}");
@@ -1140,7 +1140,7 @@ namespace ACE.Server.Managers
                     target.SetProperty(prop, ModifyInstanceIDRuleSet(prop, sourceMod, targetMod));
                     break;
                 case ModificationOperation.CopyFromSourceToResult:
-                    result.SetProperty(prop, ModifyInstanceIDRuleSet(prop, sourceMod, targetMod));     // ??
+                    result.SetProperty(prop, ModifyInstanceIDRuleSet(prop, player, targetMod));     // ??
                     break;
                 default:
                     log.Warn($"RecipeManager.ModifyInstanceID({source.Name}, {target.Name}): unhandled operation {op}");
@@ -1180,7 +1180,7 @@ namespace ACE.Server.Managers
                     target.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);
                     break;
                 case ModificationOperation.CopyFromSourceToResult:
-                    result.SetProperty(prop, sourceMod.GetProperty(prop) ?? 0);
+                    result.SetProperty(prop, player.GetProperty(prop) ?? 0);
                     break;
                 default:
                     log.Warn($"RecipeManager.ModifyDataID({source.Name}, {target.Name}): unhandled operation {op}");

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-06-27
+[OptimShi]
+* Fixed issue with Recipe Manager "CopyFromSourceToResult" not using the player as the source.
+
 ### 2019-06-23
 [Ripley]
 * Fix issue of weenie cache corruption, setting the weenie's weenietype instead of biota's weenietype


### PR DESCRIPTION
Given the small handful of recipes that use this enum and based on the properties involved, it's apparent the "source" should always be the player/crafter and not the "source" per the Recipe.

These are the only properties affected:
* ALLOWED_ACTIVATOR_IID
* ALLOWED_WIELDER_IID
* CRAFTSMAN_NAME_STRING