### PR TITLE
ObjMaint updates 1

### DIFF
--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -137,13 +137,8 @@ namespace ACE.Server.Physics.Common
             {
                 if (InitialClamp && !ObjectTable.ContainsKey(obj.ID))
                 {
-                    var wo = PhysicsObj.WeenieObj.WorldObject;
-                    var objWo = obj.WeenieObj.WorldObject;
+                    var distSq = PhysicsObj.Position.Distance2DSquared(obj.Position);
 
-                    if (wo == null || objWo == null)
-                        return false;
-
-                    var distSq = wo.Location.Distance2DSquared(objWo.Location);
                     if (distSq > InitialClamp_DistSq)
                         return false;
                 }
@@ -278,13 +273,8 @@ namespace ACE.Server.Physics.Common
             var dist = new List<PhysicsObj>();
             foreach (var obj in visibleObjs)
             {
-                var wo = PhysicsObj.WeenieObj.WorldObject;
-                var objWo = obj.WeenieObj.WorldObject;
+                var distSq = PhysicsObj.Position.Distance2DSquared(obj.Position);
 
-                if (wo == null || objWo == null)
-                    continue;
-
-                var distSq = wo.Location.Distance2DSquared(objWo.Location);
                 if (distSq <= InitialClamp_DistSq)
                     dist.Add(obj);
             }

--- a/Source/ACE.Server/Physics/Common/Position.cs
+++ b/Source/ACE.Server/Physics/Common/Position.cs
@@ -11,6 +11,12 @@ namespace ACE.Server.Physics.Common
         public uint ObjCellID;
         public AFrame Frame;
 
+        public uint Landblock => ObjCellID >> 16;
+
+        public uint LandblockX => ObjCellID >> 24;
+
+        public uint LandblockY => (ObjCellID >> 16) & 0xFF;
+
         public Position()
         {
             Init();
@@ -226,6 +232,25 @@ namespace ACE.Server.Physics.Common
             }
             //return LScape.get_landcell(newCell.Value);
             return newCell.Value;
+        }
+
+        /// <summary>
+        /// Returns the squared 2D distance between 2 positions
+        /// </summary>
+        public float Distance2DSquared(Position p)
+        {
+            if (Landblock == p.Landblock)
+            {
+                var dx = Frame.Origin.X - p.Frame.Origin.X;
+                var dy = Frame.Origin.Y - p.Frame.Origin.Y;
+                return dx * dx + dy * dy;
+            }
+            else
+            {
+                var dx = ((int)LandblockX - p.LandblockX) * 192 + Frame.Origin.X - p.Frame.Origin.X;
+                var dy = ((int)LandblockY - p.LandblockY) * 192 + Frame.Origin.Y - p.Frame.Origin.Y;
+                return dx * dx + dy * dy;
+            }
         }
 
         public bool Equals(Position pos)

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -228,7 +228,7 @@ namespace ACE.Server.Physics
                 return ObjCell.GetVisible(position.ObjCellID);
             }
 
-            var visibleCell = (Common.EnvCell)ObjCell.GetVisible(position.ObjCellID);
+            var visibleCell = (EnvCell)ObjCell.GetVisible(position.ObjCellID);
             if (visibleCell == null) return null;
 
             var point = position.LocalToGlobal(low_pt);
@@ -1632,8 +1632,8 @@ namespace ACE.Server.Physics
             var lbx_b = b >> 24;
             var lby_b = (b >> 16) & 0xFF;
 
-            var dx = (int)Math.Abs(lbx_a - lbx_b);
-            var dy = (int)Math.Abs(lby_a - lby_b);
+            var dx = (int)Math.Abs((int)lbx_a - lbx_b);
+            var dy = (int)Math.Abs((int)lby_a - lby_b);
 
             return Math.Max(dx, dy);
         }
@@ -2178,8 +2178,8 @@ namespace ACE.Server.Physics
 
         public void enqueue_objs(IEnumerable<PhysicsObj> newlyVisible)
         {
-            var player = WeenieObj.WorldObject as Player;
-            if (player == null) return;
+            if (!IsPlayer || !(WeenieObj.WorldObject is Player player))
+                return;
 
             foreach (var obj in newlyVisible)
             {
@@ -4028,6 +4028,11 @@ namespace ACE.Server.Physics
         public override int GetHashCode()
         {
             return ID.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"{Name} ({ID:X8})";
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -62,6 +62,8 @@ namespace ACE.Server.WorldObjects
 
             GagsTick();
 
+            PhysicsObj.ObjMaint.DestroyObjects();
+
             // Check if we're due for our periodic SavePlayer
             if (LastRequestedDatabaseSave == DateTime.MinValue)
                 LastRequestedDatabaseSave = DateTime.UtcNow;


### PR DESCRIPTION
This fixes some bugs and gaps in the object visibility system, without any major architectural changes

- Instead of calling handle_visible_cells() in the Player heartbeats if it hasn't been run in the past 5 seconds, only the DestructionQueue needs to be called. This ensures that even if a player hasn't changes cells recently, their destruction queue is still accurately maintained.

This prevents odd state situations where a previously known object re-enters visibility to a stationary player after 25s. This previously known object should be an unknown object at that time, and it should have been cleared out of the DestructionQueue (which it would on the next call to handle_visible_cells), but due to some odd state swapping with multiple operations happening on the same server frame, some logic was previously not running correctly in this situation.

- Physics.Position needs to implement its own GetDistance2DSquared instead of ACE.Position. This was causing some object visibility errors while teleporting, where ACE.Position was still in the pre-teleport position, and hadn't been updated yet.

These 2 relatively simple changes should fix a lot of the visibility errors that players have been finding