### PR TITLE
More Generator Adjustments

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1130,12 +1130,12 @@ namespace ACE.Server.Command.Handlers
                         {
                             if (item.WeenieClassId == 0)
                             {
-                                msg += $"{((DestinationType)item.DestinationType).ToString()}: {item.Shade,6:P2} - {item.WeenieClassId,5} - Nothing\n";
+                                msg += $"{((DestinationType)item.DestinationType).ToString()}: {item.Shade,7:P2} - {item.WeenieClassId,5} - Nothing\n";
                                 continue;
                             }
 
                             var weenie = DatabaseManager.World.GetCachedWeenie(item.WeenieClassId);
-                            msg += $"{((DestinationType)item.DestinationType).ToString()}: {item.Shade,6:P2} - {item.WeenieClassId,5} - {weenie.ClassName} - {weenie.GetProperty(PropertyString.Name)}\n";
+                            msg += $"{((DestinationType)item.DestinationType).ToString()}: {item.Shade,7:P2} - {item.WeenieClassId,5} - {weenie.ClassName} - {weenie.GetProperty(PropertyString.Name)}\n";
                         }
                     }
                     else
@@ -1151,6 +1151,9 @@ namespace ACE.Server.Command.Handlers
                     else
                         msg += "Creature has no wielded items to drop.\n";
                 }
+                else
+                    msg = $"{wo.Name} (0x{wo.Guid}) has no trophies.";
+
                 session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.System));
             }
         }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -251,6 +251,16 @@ namespace ACE.Server.Entity
                 if (sortCell != null && sortCell.has_building())
                     continue;
 
+                if (PropertyManager.GetBool("override_encounter_spawn_rates").Item)
+                {
+                    wo.RegenerationInterval = PropertyManager.GetDouble("encounter_regen_interval").Item;
+
+                    foreach (var profile in wo.Biota.BiotaPropertiesGenerator)
+                    {
+                        profile.Delay = (float)PropertyManager.GetDouble("encounter_delay").Item;
+                    }
+                }
+
                 actionQueue.EnqueueAction(new ActionEventDelegate(() =>
                 {
                     AddWorldObject(wo);

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -452,6 +452,7 @@ namespace ACE.Server.Managers
                 ("house_purchase_requirements", true),
                 ("house_rent_enabled", true),
                 ("log_audit", true),                        // if disabled, audit channel is not logged.
+                ("override_encounter_spawn_rates", false),  // if enabled, landblock encounter spawns are overidden by double properties below.
                 ("player_receive_immediate_save", false),   // if enabled, when the player receives items from an NPC, they will be saved immediately
                 ("pk_server", false),               // set this to TRUE for darktide servers
                 ("quest_info_enabled", false),      // toggles the /myquests player command
@@ -473,6 +474,8 @@ namespace ACE.Server.Managers
         public static readonly ReadOnlyDictionary<string, double> DefaultDoubleProperties =
             DictOf(
                 ("chess_ai_start_time", -1.0),      // the number of seconds for the chess ai to start. defaults to -1 (disabled)
+                ("encounter_delay", 1800),          // the number of seconds a generator profile for regions is delayed from returning to free slots
+                ("encounter_regen_interval", 600),  // the number of seconds a generator for regions at which spawns its next set of objects.
                 ("luminance_modifier", 1.0),        // scales the amount of luminance received by players
                 ("vendor_unique_rot_time", 300),    // the number of seconds before unique items sold to vendors disappear
                 ("vitae_penalty", 0.05),            // the amount of vitae penalty a player gets per death

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -664,8 +664,8 @@ namespace ACE.Server.WorldObjects
 
                 if (Generator.GeneratorId.HasValue && Generator.GeneratorId > 0) // Generator is controlled by another generator.
                 {
-                    if (Generator.InitCreate > 0 && (Generator.CurrentCreate - removeQueueTotal) == 0) // Generator's complete spawn count has been wiped out
-                        Generator.Destroy();
+                    if (Generator is GenericObject && Generator.Visibility && Generator.InitCreate > 0 && (Generator.CurrentCreate - removeQueueTotal) == 0) // Parent generator is basic generator, not visible to players
+                        Generator.Destroy(); // Generator's complete spawn count has been wiped out
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -129,6 +129,21 @@ namespace ACE.Server.WorldObjects
                     if (profile.MaxObjectsSpawned)
                         continue;
 
+                    if (profile.RegenLocationType.HasFlag(RegenLocationType.Treasure))
+                    {
+                        if (profile.Biota.InitCreate > 1)
+                        {
+                            log.Warn($"0x{Guid} {Name}.SelectProfilesInit(): profile[{i}].RegenLocationType({profile.RegenLocationType}), profile.Biota.WCID({profile.Biota.WeenieClassId}), profile.Biota.InitCreate({profile.Biota.InitCreate}) > 1, set to 1. WCID: {WeenieClassId} - LOC: {Location.ToLOCString()}");
+                            profile.Biota.InitCreate = 1;
+                        }
+
+                        if (profile.Biota.MaxCreate > 1)
+                        {
+                            log.Warn($"0x{Guid} {Name}.SelectProfilesInit(): profile[{i}].RegenLocationType({profile.RegenLocationType}), profile.Biota.WCID({profile.Biota.WeenieClassId}), profile.Biota.MaxCreate({profile.Biota.MaxCreate}) > 1, set to 1. WCID: {WeenieClassId} - LOC: {Location.ToLOCString()}");
+                            profile.Biota.MaxCreate = 1;
+                        }
+                    }
+
                     var probability = rng_selected ? GetAdjustedProbability(i) : profile.Biota.Probability;
 
                     if (rng < probability || probability == -1)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -654,8 +654,19 @@ namespace ACE.Server.WorldObjects
 
             if (!Generator.GeneratorDisabled)
             {
+                var removeQueueTotal = 0;
+
                 foreach (var generator in Generator.GeneratorProfiles)
+                {
                     generator.NotifyGenerator(Guid, regenerationType);
+                    removeQueueTotal += generator.RemoveQueue.Count;
+                }
+
+                if (Generator.GeneratorId.HasValue && Generator.GeneratorId > 0) // Generator is controlled by another generator.
+                {
+                    if (Generator.InitCreate > 0 && (Generator.CurrentCreate - removeQueueTotal) == 0) // Generator's complete spawn count has been wiped out
+                        Generator.Destroy();
+                }
             }
 
             Generator = null;


### PR DESCRIPTION
* Adjust some debug output
* Add overridden properties for region encounter generators
  - override_encounter_spawn_rates
     - encounter_regen_interval
     - encounter_delay
* Allow camp generators to despawn 
  - When a full "camp" is wiped, if the camp has a parent generator, destroy it so the parent generator can roll the slot again