### PR TITLE
Add support for LocalSignal emotes

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -743,6 +743,18 @@ namespace ACE.Server.Entity
             }
         }
 
+        public void EmitSignal(Player player, string message)
+        {
+            foreach (var wo in worldObjects.Values.Where(w => w.EmoteManager.HasAntennas).ToList())
+            {
+                if (player.IsWithinUseRadiusOf(wo, wo.UseRadius ?? 0))
+                {
+                    //Console.WriteLine($"{wo.Name}.EmoteManager.OnLocalSignal({player.Name}, {message})");
+                    wo.EmoteManager.OnLocalSignal(player, message);
+                }
+            }
+        }
+
         /// <summary>
         /// Check to see if we are close enough to interact.   Adds a fudge factor of 1.5f
         /// </summary>

--- a/Source/ACE.Server/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/Managers/EmoteManager.cs
@@ -79,6 +79,11 @@ namespace ACE.Server.Managers
                         var activationTarget = WorldObject.CurrentLandblock?.GetObject(WorldObject.ActivationTarget);
                         activationTarget?.OnActivate(WorldObject);
                     }
+                    else if (WorldObject.GeneratorId.HasValue && WorldObject.GeneratorId > 0) // Fallback to linked generator
+                    {
+                        var linkedGenerator = WorldObject.CurrentLandblock?.GetObject(WorldObject.GeneratorId ?? 0);
+                        linkedGenerator?.OnActivate(WorldObject);
+                    }
                     break;
 
                 case EmoteType.AddCharacterTitle:
@@ -672,6 +677,11 @@ namespace ACE.Server.Managers
                     break;
 
                 case EmoteType.LocalSignal:
+                    if (player != null)
+                    {
+                        if (player.CurrentLandblock != null)
+                            player.CurrentLandblock.EmitSignal(player, emote.Message);
+                    }
                     break;
 
                 case EmoteType.LockFellow:
@@ -1478,5 +1488,15 @@ namespace ACE.Server.Managers
         {
             ExecuteEmoteSet(EmoteCategory.ReceiveTalkDirect, message, player);
         }
+
+        /// <summary>
+        /// Called when this NPC receives a local signal from a player
+        /// </summary>
+        public void OnLocalSignal(Player player, string message)
+        {
+            ExecuteEmoteSet(EmoteCategory.ReceiveLocalSignal, message, player);
+        }
+
+        public bool HasAntennas => WorldObject.Biota.BiotaPropertiesEmote.Count(x => x.Category == (int)EmoteCategory.ReceiveLocalSignal) > 0;
     }
 }

--- a/Source/ACE.Server/WorldObjects/CraftTool.cs
+++ b/Source/ACE.Server/WorldObjects/CraftTool.cs
@@ -40,5 +40,10 @@ namespace ACE.Server.WorldObjects
             // fallback on recipe manager
             base.HandleActionUseOnTarget(player, target);
         }
+
+        public override void ActOnUse(WorldObject wo)
+        {
+            // Do nothing
+        }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # ACEmulator Change Log
 
+### 2019-07-04
+[Ripley]
+* Add DoNothing ActOnUse to CraftTool.
+* Adjust EmoteManager
+  - Wire up EmoteType.LocalSignal.
+  - Wire up EmoteCategory.ReceiveLocalSignal.
+  - Adjust EmoteType.Activate to fall back to linked generator if no activation target is specified.
+* Add Landblock.EmitSignal to support localized object interaction.
+
 ### 2019-07-01
 [Ripley]
 * Fix issue with converting books from JSON to SQL.


### PR DESCRIPTION
* Add DoNothing ActOnUse to CraftTool.
* Adjust EmoteManager
  - Wire up EmoteType.LocalSignal.
  - Wire up EmoteCategory.ReceiveLocalSignal.
  - Adjust EmoteType.Activate to fall back to linked generator if no activation target is specified.
* Add Landblock.EmitSignal to support localized object interaction.