### PR TITLE
additional IsBusy checks

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -1368,7 +1368,7 @@ namespace ACE.Database.Models.Shard
             }
         }
 
-        public static bool TryRemoveKnownSpell(this Biota biota, int spell, out BiotaPropertiesSpellBook entity, ReaderWriterLockSlim rwLock)
+        public static bool TryRemoveKnownSpell(this Biota biota, int spell, out BiotaPropertiesSpellBook entity, ReaderWriterLockSlim rwLock, IDictionary<int, BiotaPropertiesSpellBook> cache)
         {
             rwLock.EnterUpgradeableReadLock();
             try
@@ -1379,6 +1379,8 @@ namespace ACE.Database.Models.Shard
                     rwLock.EnterWriteLock();
                     try
                     {
+                        cache.Remove(spell);
+
                         biota.BiotaPropertiesSpellBook.Remove(entity);
                         entity.Object = null;
                         return true;

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1187,13 +1187,30 @@ namespace ACE.Server.Command.Handlers
 
         // add <spell>
         [CommandHandler("addspell", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Adds the specified spell to your own spellbook.", "<spellid>")]
-        public static void HandleAdd(Session session, params string[] parameters)
+        public static void HandleAddSpell(Session session, params string[] parameters)
         {
             if (Enum.TryParse(parameters[0], true, out SpellId spellId))
             {
                 if (Enum.IsDefined(typeof(SpellId), spellId))
                     session.Player.LearnSpellWithNetworking((uint)spellId);
             }
+        }
+
+        [CommandHandler("removespell", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Removes the specified spell to your own spellbook.", "<spellid>")]
+        public static void HandleRemoveSpell(Session session, params string[] parameters)
+        {
+            if (!Enum.TryParse(parameters[0], true, out SpellId spellId))
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Unknown spell {parameters[0]}", ChatMessageType.Broadcast));
+                return;
+            }
+            if (session.Player.RemoveKnownSpell((uint)spellId))
+            {
+                var spell = new Entity.Spell(spellId, false);
+                session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} removed from spellbook.", ChatMessageType.Broadcast));
+            }
+            else
+                session.Network.EnqueueSend(new GameMessageSystemChat($"You don't know that spell!", ChatMessageType.Broadcast));
         }
 
         // adminhouse

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionAcceptTrade.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionAcceptTrade.cs
@@ -15,7 +15,7 @@ namespace ACE.Server.Network.GameAction.Actions
             bool initatorAccepts = Convert.ToBoolean(message.Payload.ReadUInt32());
             bool partnerAccepts = Convert.ToBoolean(message.Payload.ReadUInt32());
 
-            session.Player.HandleActionAcceptTrade(session, session.Player.Guid);
+            session.Player.HandleActionAcceptTrade();
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionAddToTrade.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionAddToTrade.cs
@@ -9,7 +9,7 @@ namespace ACE.Server.Network.GameAction.Actions
             var itemGuid = message.Payload.ReadUInt32();
             var tradeSlot = message.Payload.ReadUInt32();
 
-            session.Player.HandleActionAddToTrade(session, itemGuid, tradeSlot);
+            session.Player.HandleActionAddToTrade(itemGuid, tradeSlot);
         }
     }
 }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionCloseTradeNegotiations.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionCloseTradeNegotiations.cs
@@ -11,10 +11,10 @@ namespace ACE.Server.Network.GameAction.Actions
 
             if (target != null)
             {
-                session.Player.HandleActionCloseTradeNegotiations(session);
+                session.Player.HandleActionCloseTradeNegotiations();
 
                 //Close the trade window for the trade partner
-                target.HandleActionCloseTradeNegotiations(target.Session);
+                target.HandleActionCloseTradeNegotiations();
             }
         }
     }

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionResetTrade.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionResetTrade.cs
@@ -13,10 +13,10 @@ namespace ACE.Server.Network.GameAction.Actions
 
             if (target != null)
             {
-                session.Player.HandleActionResetTrade(session, whoReset);
+                session.Player.HandleActionResetTrade(whoReset);
 
                 //Send GameEvent to reset partner's trade window
-                target.HandleActionResetTrade(target.Session, whoReset);
+                target.HandleActionResetTrade(whoReset);
             }
         }
     }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -457,7 +457,7 @@ namespace ACE.Server.WorldObjects
                 var tradePartner = PlayerManager.GetOnlinePlayer(TradePartner);
 
                 if (tradePartner != null)
-                    tradePartner.HandleActionCloseTradeNegotiations(tradePartner.Session);
+                    tradePartner.HandleActionCloseTradeNegotiations();
             }
 
             if (!clientSessionTerminatedAbruptly)

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -181,15 +181,16 @@ namespace ACE.Server.WorldObjects
         /// <param name="items"></param>
         public void HandleActionBuyItem(uint vendorGuid, List<ItemProfile> items)
         {
-            var vendor = CurrentLandblock?.GetObject(vendorGuid) as Vendor;
-
-            if (vendor == null)
+            if (IsBusy)
             {
-                SendUseDoneEvent();
+                SendUseDoneEvent(WeenieError.YoureTooBusy);
                 return;
             }
 
-            vendor.BuyItems_ValidateTransaction(items, this);
+            var vendor = CurrentLandblock?.GetObject(vendorGuid) as Vendor;
+
+            if (vendor != null)
+                vendor.BuyItems_ValidateTransaction(items, this);
 
             SendUseDoneEvent();
         }
@@ -315,6 +316,12 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionSellItem(List<ItemProfile> itemprofiles, uint vendorGuid)
         {
+            if (IsBusy)
+            {
+                SendUseDoneEvent(WeenieError.YoureTooBusy);
+                return;
+            }
+
             var vendor = CurrentLandblock?.GetObject(vendorGuid) as Vendor;
 
             if (vendor == null)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -601,6 +601,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionPutItemInContainer(uint itemGuid, uint containerGuid, int placement = 0)
         {
+            if (IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, itemGuid));
+                return;
+            }
+
             OnPutItemInContainer(itemGuid, containerGuid, placement);
 
             var item = FindObject(itemGuid, SearchLocations.LocationsICanMove, out _, out var itemRootOwner, out var itemWasEquipped);
@@ -1913,6 +1920,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionGiveObjectRequest(uint targetGuid, uint itemGuid, int amount)
         {
+            if (IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, itemGuid));
+                return;
+            }
+
             if (amount <= 0)
             {
                 log.WarnFormat("Player 0x{0:X8}:{1} tried to give item with invalid amount ({3}) 0x{2:X8}.", Guid.Full, Name, itemGuid, amount);

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -30,6 +30,14 @@ namespace ACE.Server.WorldObjects
             return spellAdded;
         }
 
+        /// <summary>
+        /// Removes a known spell from the player's spellbook
+        /// </summary>
+        public bool RemoveKnownSpell(uint spellId)
+        {
+            return Biota.TryRemoveKnownSpell((int)spellId, out _, BiotaDatabaseLock, BiotaPropertySpells);
+        }
+
         public void LearnSpellWithNetworking(uint spellId, bool uiOutput = true)
         {
             var spells = DatManager.PortalDat.SpellTable;

--- a/Source/ACE.Server/WorldObjects/Player_Trade.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Trade.cs
@@ -16,10 +16,14 @@ namespace ACE.Server.WorldObjects
     partial class Player
     {
         public List<ObjectGuid> ItemsInTradeWindow = new List<ObjectGuid>();
-        private bool TradeAccepted { get; set; } = false;
-        private bool IsTrading = false;
-        private bool TradeTransferInProgress { get; set; } = false;
+
         public ObjectGuid TradePartner;
+
+        private bool IsTrading;
+
+        private bool TradeAccepted;
+
+        public bool TradeTransferInProgress;
 
         public void HandleActionOpenTradeNegotiations(uint tradePartnerGuid, bool initiator = false)
         {
@@ -88,69 +92,70 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public void HandleActionCloseTradeNegotiations(Session session, EndTradeReason endTradeReason = EndTradeReason.Normal)
+        public void HandleActionCloseTradeNegotiations(EndTradeReason endTradeReason = EndTradeReason.Normal)
         {
-            if (session.Player.TradeTransferInProgress) return;
+            if (TradeTransferInProgress) return;
 
-            session.Player.IsTrading = false;
-            session.Player.TradeAccepted = false;
-            session.Player.TradeTransferInProgress = false;
-            session.Player.ItemsInTradeWindow.Clear();
-            session.Player.TradePartner = ObjectGuid.Invalid;
+            IsTrading = false;
+            TradeAccepted = false;
+            TradeTransferInProgress = false;
+            ItemsInTradeWindow.Clear();
+            TradePartner = ObjectGuid.Invalid;
 
-            session.Network.EnqueueSend(new GameEventCloseTrade(session, endTradeReason));
-            session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeClosed));
+            Session.Network.EnqueueSend(new GameEventCloseTrade(Session, endTradeReason));
+            Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.TradeClosed));
         }
 
-        public void HandleActionAddToTrade(Session session, uint itemGuid, uint tradeWindowSlotNumber)
+        public void HandleActionAddToTrade(uint itemGuid, uint tradeWindowSlotNumber)
         {
-            if (session.Player.TradeTransferInProgress) return;
+            if (TradeTransferInProgress)
+                return;
 
-            var target = PlayerManager.GetOnlinePlayer(session.Player.TradePartner);
+            TradeAccepted = false;
 
-            session.Player.TradeAccepted = false;
+            var target = PlayerManager.GetOnlinePlayer(TradePartner);
 
-            if (itemGuid != 0 && target != null)
+            if (target == null || itemGuid == 0)
+                return;
+
+            target.TradeAccepted = false;
+
+            WorldObject wo = GetInventoryItem(itemGuid);
+
+            if (wo == null)
+                return;
+
+            if (wo.IsAttunedOrContainsAttuned)
             {
-                target.TradeAccepted = false;
-
-                WorldObject wo = GetInventoryItem(itemGuid);
-
-                if (wo != null)
-                {
-                    if ((wo.Attuned ?? 0) >= 1)
-                    {
-                        session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "You cannot trade that!"));
-                        session.Network.EnqueueSend(new GameEventTradeFailure(session, itemGuid, WeenieError.AttunedItem));
-                    }
-                    else
-                    {
-                        session.Player.ItemsInTradeWindow.Add(new ObjectGuid(itemGuid));
-
-                        session.Network.EnqueueSend(new GameEventAddToTrade(session, itemGuid, TradeSide.Self));
-
-                        target.TrackObject(wo);
-
-                        var actionChain = new ActionChain();
-                        actionChain.AddDelaySeconds(0.001f);
-                        actionChain.AddAction(target, () =>
-                        {
-                            target.Session.Network.EnqueueSend(new GameEventAddToTrade(target.Session, itemGuid, TradeSide.Partner));
-                        });
-                        actionChain.EnqueueChain();
-                    }
-                }
+                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You cannot trade that!"));
+                Session.Network.EnqueueSend(new GameEventTradeFailure(Session, itemGuid, WeenieError.AttunedItem));
+                return;
             }
+
+            ItemsInTradeWindow.Add(new ObjectGuid(itemGuid));
+
+            Session.Network.EnqueueSend(new GameEventAddToTrade(Session, itemGuid, TradeSide.Self));
+
+            target.TrackObject(wo);
+
+            var actionChain = new ActionChain();
+            actionChain.AddDelaySeconds(0.001f);
+            actionChain.AddAction(target, () =>
+            {
+                target.Session.Network.EnqueueSend(new GameEventAddToTrade(target.Session, itemGuid, TradeSide.Partner));
+            });
+            actionChain.EnqueueChain();
         }
 
-        public void HandleActionResetTrade(Session session, ObjectGuid whoReset)
+        public void HandleActionResetTrade(ObjectGuid whoReset)
         {
-            if (session.Player.TradeTransferInProgress) return;
+            if (TradeTransferInProgress)
+                return;
 
-            session.Player.ItemsInTradeWindow.Clear();
-            session.Player.TradeAccepted = false;
+            ItemsInTradeWindow.Clear();
+            TradeAccepted = false;
 
-            session.Network.EnqueueSend(new GameEventResetTrade(session, whoReset));
+            Session.Network.EnqueueSend(new GameEventResetTrade(Session, whoReset));
         }
 
         public void ClearTradeAcceptance()
@@ -161,123 +166,72 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameEventClearTradeAcceptance(Session));
         }
 
-        public void HandleActionAcceptTrade(Session session, ObjectGuid whoAccepted)
+        public void HandleActionAcceptTrade()
         {
-            if (session.Player.TradeTransferInProgress) return;
+            if (TradeTransferInProgress)
+                return;
 
-            session.Player.TradeAccepted = true;
+            TradeAccepted = true;
 
-            session.Network.EnqueueSend(new GameEventAcceptTrade(session, whoAccepted));
+            Session.Network.EnqueueSend(new GameEventAcceptTrade(Session, Guid));
+            Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You have accepted the offer"));
 
-            if (whoAccepted == session.Player.Guid)
-                session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "You have accepted the offer"));
+            var target = PlayerManager.GetOnlinePlayer(TradePartner);
 
-            var target = PlayerManager.GetOnlinePlayer(session.Player.TradePartner);
+            if (target == null)
+                return;
 
-            if (target != null)
+            target.Session.Network.EnqueueSend(new GameEventAcceptTrade(target.Session, Guid));
+            target.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(target.Session, $"{Name} has accepted the offer"));
+
+            if (target.TradeAccepted)
+                FinalizeTrade(target);
+        }
+
+        private void FinalizeTrade(Player target)
+        {
+            if (!VerifyTrade_BusyState(target) || !VerifyTrade_Inventory(target))
+                return;
+
+            TradeTransferInProgress = true;
+            target.TradeTransferInProgress = true;
+
+            Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "The items are being traded"));
+            target.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(target.Session, "The items are being traded"));
+
+            var tradedItems = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
+
+            foreach (ObjectGuid itemGuid in ItemsInTradeWindow)
             {
-                target.Session.Network.EnqueueSend(new GameEventAcceptTrade(target.Session, whoAccepted));
-
-                if (whoAccepted == session.Player.Guid)
-                    target.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(target.Session, $"{session.Player.Name} has accepted the offer"));
-
-                if (session.Player.TradeAccepted && target.TradeAccepted)
+                if (TryRemoveFromInventoryWithNetworking(itemGuid, out var wo, RemoveFromInventoryAction.TradeItem) || TryDequipObjectWithNetworking(itemGuid, out wo, DequipObjectAction.TradeItem))
                 {
-                    var playerAitems = GetItemsInTradeWindow(session.Player);
-                    var playerBitems = GetItemsInTradeWindow(target);
+                    target.TryCreateInInventoryWithNetworking(wo);
 
-                    var playerACanAddToInventory = session.Player.CanAddToInventory(playerBitems, out var playerAIsTooEnumbered, out var playerANotEnoughFreeSlots);
-                    var playerBCanAddToInventory = target.CanAddToInventory(playerAitems, out var playerBIsTooEnumbered, out var playerBNotEnoughFreeSlots);
-
-                    if (!playerACanAddToInventory || !playerBCanAddToInventory)
-                    {
-                        var playerAreason = "";
-                        var playerBreason = "";
-
-                        if (!playerACanAddToInventory)
-                        {
-                            playerAreason = "You ";
-                            playerBreason = "Your trading partner ";
-
-                            if (playerAIsTooEnumbered)
-                            {
-                                playerAreason += "are too encumbered to complete the trade!";
-                                playerBreason += "is too encumbered to complete the trade!";
-                            }
-                            else if (playerANotEnoughFreeSlots)
-                            {
-                                playerAreason += "do not have enough free slots to complete the trade!";
-                                playerBreason += "does not have enough free slots to complete the trade!";
-                            }
-                        }
-                        else if (!playerBCanAddToInventory)
-                        {                            
-                            playerAreason = "Your trading partner ";
-                            playerBreason = "You ";
-
-                            if (playerBIsTooEnumbered)
-                            {                                
-                                playerAreason += "is too encumbered to complete the trade!";
-                                playerBreason += "are too encumbered to complete the trade!";
-                            }
-                            else if (playerBNotEnoughFreeSlots)
-                            {                                
-                                playerAreason += "does not have enough free slots to complete the trade!";
-                                playerBreason += "do not have enough free slots to complete the trade!";
-                            }
-                        }
-
-                        session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, playerAreason));
-                        session.Player.ClearTradeAcceptance();
-                        target.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(target.Session, playerBreason));
-                        target.ClearTradeAcceptance();
-
-                        return;
-                    }
-
-                    session.Player.TradeTransferInProgress = true;
-                    target.TradeTransferInProgress = true;
-
-                    session.Network.EnqueueSend(new GameEventCommunicationTransientString(session, "The items are being traded"));
-                    target.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(target.Session, "The items are being traded"));
-
-                    var tradedItems = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();
-
-                    foreach (ObjectGuid itemGuid in session.Player.ItemsInTradeWindow)
-                    {
-                        if (session.Player.TryRemoveFromInventoryWithNetworking(itemGuid, out var wo, RemoveFromInventoryAction.TradeItem) || session.Player.TryDequipObjectWithNetworking(itemGuid, out wo, DequipObjectAction.TradeItem))
-                        {
-                            target.TryCreateInInventoryWithNetworking(wo);
-
-                            tradedItems.Add((wo.Biota, wo.BiotaDatabaseLock));
-                        }
-                    }
-
-                    foreach (ObjectGuid itemGuid in target.ItemsInTradeWindow)
-                    {
-                        if (target.TryRemoveFromInventoryWithNetworking(itemGuid, out var wo, RemoveFromInventoryAction.TradeItem) || target.TryDequipObjectWithNetworking(itemGuid, out wo, DequipObjectAction.TradeItem))
-                        {
-                            session.Player.TryCreateInInventoryWithNetworking(wo);
-
-                            tradedItems.Add((wo.Biota, wo.BiotaDatabaseLock));
-                        }
-                    }
-
-                    session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeComplete));
-                    target.Session.Network.EnqueueSend(new GameEventWeenieError(target.Session, WeenieError.TradeComplete));
-
-                    //session.Player.HandleActionResetTrade(session, ObjectGuid.Invalid);
-                    //target.HandleActionResetTrade(target.Session, ObjectGuid.Invalid);
-
-                    session.Player.TradeTransferInProgress = false;
-                    target.TradeTransferInProgress = false;
-
-                    DatabaseManager.Shard.SaveBiotasInParallel(tradedItems, null);
-
-                    session.Player.HandleActionResetTrade(session, Guid);
-                    target.HandleActionResetTrade(target.Session, target.Guid);
+                    tradedItems.Add((wo.Biota, wo.BiotaDatabaseLock));
                 }
             }
+
+            foreach (ObjectGuid itemGuid in target.ItemsInTradeWindow)
+            {
+                if (TryRemoveFromInventoryWithNetworking(itemGuid, out var wo, RemoveFromInventoryAction.TradeItem) || target.TryDequipObjectWithNetworking(itemGuid, out wo, DequipObjectAction.TradeItem))
+                {
+                    TryCreateInInventoryWithNetworking(wo);
+
+                    tradedItems.Add((wo.Biota, wo.BiotaDatabaseLock));
+                }
+            }
+
+            Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.TradeComplete));
+            target.Session.Network.EnqueueSend(new GameEventWeenieError(target.Session, WeenieError.TradeComplete));
+
+            TradeTransferInProgress = false;
+            target.TradeTransferInProgress = false;
+
+            DatabaseManager.Shard.SaveBiotasInParallel(tradedItems, null);
+
+            HandleActionResetTrade(Guid);
+            target.HandleActionResetTrade(target.Guid);
+
         }
 
         private List<WorldObject> GetItemsInTradeWindow(Player player)
@@ -323,14 +277,90 @@ namespace ACE.Server.WorldObjects
                 var target = PlayerManager.GetOnlinePlayer(session.Player.TradePartner);
 
                 session.Network.EnqueueSend(new GameEventWeenieError(session, WeenieError.TradeNonCombatMode));
-                session.Player.HandleActionCloseTradeNegotiations(session, EndTradeReason.EnteredCombat);
+                session.Player.HandleActionCloseTradeNegotiations(EndTradeReason.EnteredCombat);
 
                 if (target != null)
                 {
                     target.Session.Network.EnqueueSend(new GameEventWeenieError(target.Session, WeenieError.TradeNonCombatMode));
-                    target.HandleActionCloseTradeNegotiations(target.Session, EndTradeReason.EnteredCombat);
+                    target.HandleActionCloseTradeNegotiations(EndTradeReason.EnteredCombat);
                 }
             }
+        }
+
+        private bool VerifyTrade_BusyState(Player partner)
+        {
+            if (!IsBusy && !partner.IsBusy)
+                return true;
+
+            var selfBusy = "You are too busy to complete the trade!";
+            var otherBusy = "Your trading partner is too busy to complete the trade!";
+
+            var selfMsg = IsBusy ? selfBusy : otherBusy;
+            var partnerMsg = IsBusy ? selfBusy : otherBusy;
+
+            Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, selfMsg));
+            partner.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(partner.Session, partnerMsg));
+
+            ClearTradeAcceptance();
+            partner.ClearTradeAcceptance();
+
+            return false;
+        }
+
+        private bool VerifyTrade_Inventory(Player partner)
+        {
+            var self_items = GetItemsInTradeWindow(this);
+            var partner_items = GetItemsInTradeWindow(partner);
+
+            var playerACanAddToInventory = CanAddToInventory(partner_items, out var selfEncumbered, out var selfPackSpace);
+            var playerBCanAddToInventory = partner.CanAddToInventory(self_items, out var partnerEncumbered, out var partnerPackSpace);
+
+            if (playerACanAddToInventory && playerBCanAddToInventory)
+                return true;
+
+            var selfReason = "";
+            var partnerReason = "";
+
+            if (!playerACanAddToInventory)
+            {
+                selfReason = "You ";
+                partnerReason = "Your trading partner ";
+
+                if (selfEncumbered)
+                {
+                    selfReason += "are too encumbered to complete the trade!";
+                    partnerReason += "is too encumbered to complete the trade!";
+                }
+                else if (selfPackSpace)
+                {
+                    selfReason += "do not have enough free slots to complete the trade!";
+                    partnerReason += "does not have enough free slots to complete the trade!";
+                }
+            }
+            else if (!playerBCanAddToInventory)
+            {
+                selfReason = "Your trading partner ";
+                partnerReason = "You ";
+
+                if (partnerEncumbered)
+                {
+                    selfReason += "is too encumbered to complete the trade!";
+                    partnerReason += "are too encumbered to complete the trade!";
+                }
+                else if (partnerPackSpace)
+                {
+                    selfReason += "does not have enough free slots to complete the trade!";
+                    partnerReason += "do not have enough free slots to complete the trade!";
+                }
+            }
+
+            Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, selfReason));
+            partner.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(partner.Session, partnerReason));
+
+            ClearTradeAcceptance();
+            partner.ClearTradeAcceptance();
+
+            return false;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Trade.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Trade.cs
@@ -296,7 +296,7 @@ namespace ACE.Server.WorldObjects
             var otherBusy = "Your trading partner is too busy to complete the trade!";
 
             var selfMsg = IsBusy ? selfBusy : otherBusy;
-            var partnerMsg = IsBusy ? selfBusy : otherBusy;
+            var partnerMsg = IsBusy ? otherBusy : selfBusy;
 
             Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, selfMsg));
             partner.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(partner.Session, partnerMsg));

--- a/Source/ACE.Server/WorldObjects/Scroll.cs
+++ b/Source/ACE.Server/WorldObjects/Scroll.cs
@@ -71,9 +71,12 @@ namespace ACE.Server.WorldObjects
             }
 
             var animTime = player.EnqueueMotion(actionChain, MotionCommand.Reading);
+            player.LastUseTime += animTime;
 
-            actionChain.AddDelaySeconds(2.0f);
-            player.LastUseTime += 2.0f;
+            var readTime = 1.0f;
+
+            actionChain.AddDelaySeconds(readTime);
+            player.LastUseTime += readTime;
 
             actionChain.AddAction(player, () =>
             {
@@ -106,9 +109,13 @@ namespace ACE.Server.WorldObjects
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat("The scroll is destroyed.", ChatMessageType.Broadcast));
             });
 
+
+            // FIXME: return stance time
+            player.EnqueueMotion(actionChain, MotionCommand.Ready);
+
             player.LastUseTime += animTime;     // return stance
 
-            player.EnqueueMotion(actionChain, MotionCommand.Ready);
+            actionChain.AddDelaySeconds(animTime);
 
             actionChain.AddAction(player, () => player.IsBusy = false);
 


### PR DESCRIPTION
This fixes additional bugs while reading scrolls, where it was possible to give the scroll to another player, move it to a landblock container, sell it to a vendor, or trade it to another player while the scroll was being read, thereby bypassing the original player's TryRemoveFromInventory

This has been known about for some time, and was originally fixed with dropping into the landblock originally. IsBusy checks have been added for all of these possible scenarios. 

/removespell <spell id> has been added to complement /addspell, and removes a spell from the player's  known spells / spellbook. This was used during testing to repeatedly learn/unlearn the same spell

The client actually prevents an item from being used while it is in the trade window, but it was still possible to start reading the scoll, add it to the trade window, and then for both players to accept the trade before the scroll reading completed.

Trade has also been refactored to remove the redundant 'session' parameters that were being passed to all of the functions.

Some small changes to Scrolls were also backported from https://github.com/ACEmulator/ACE/pull/1991, notably reducing the scroll reading time from 2s -> 1s to match retail, and an additional bug fix for the IsBusy state ending early from the return stance time not being factored in, similar to issues with EnqueueMotion that Consumables had