### PR TITLE
hotfix for objmaint v2 references

### DIFF
--- a/Source/ACE.Server/WorldObjects/CombatPet.cs
+++ b/Source/ACE.Server/WorldObjects/CombatPet.cs
@@ -150,6 +150,11 @@ namespace ACE.Server.WorldObjects
 
                 monsters.Add(creature);
             }
+
+            // hack fixed in v3
+            PhysicsObj.ObjMaint.ObjectTable.Clear();
+            PhysicsObj.ObjMaint.VisibleObjectTable.Clear();
+
             return monsters;
         }
 

--- a/Source/ACE.Server/WorldObjects/CombatPet.cs
+++ b/Source/ACE.Server/WorldObjects/CombatPet.cs
@@ -152,8 +152,8 @@ namespace ACE.Server.WorldObjects
             }
 
             // hack fixed in v3
-            PhysicsObj.ObjMaint.ObjectTable.Clear();
-            PhysicsObj.ObjMaint.VisibleObjectTable.Clear();
+            //PhysicsObj.ObjMaint.ObjectTable.Clear();
+            //PhysicsObj.ObjMaint.VisibleObjectTable.Clear();
 
             return monsters;
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -255,8 +255,12 @@ namespace ACE.Server.WorldObjects
                     continue;
 
                 players.Add(creature);
-
             }
+
+            // hack fixed in v3
+            PhysicsObj.ObjMaint.ObjectTable.Clear();
+            PhysicsObj.ObjMaint.VisibleObjectTable.Clear();
+
             return players;
         }
 


### PR DESCRIPTION
This is fixed in a much better way in https://github.com/ACEmulator/ACE/pull/2086, but this fixes the current memory leak in v2

Thanks for @Mag-nus for tracking this bug down