### PR TITLE
Make Dat SubPalette and TextureMapChanges properties public

### DIFF
--- a/Source/ACE.DatLoader/Entity/SubPalette.cs
+++ b/Source/ACE.DatLoader/Entity/SubPalette.cs
@@ -5,9 +5,9 @@ namespace ACE.DatLoader.Entity
     // TODO: refactor to use existing PaletteOverride object
     public class SubPalette : IUnpackable
     {
-        public uint SubID { get; private set; }
-        public uint Offset { get; private set; }
-        public uint NumColors { get; private set; }
+        public uint SubID { get; set; }
+        public uint Offset { get; set; }
+        public uint NumColors { get; set; }
 
         public void Unpack(BinaryReader reader)
         {

--- a/Source/ACE.DatLoader/Entity/TextureMapChange.cs
+++ b/Source/ACE.DatLoader/Entity/TextureMapChange.cs
@@ -5,9 +5,9 @@ namespace ACE.DatLoader.Entity
     // TODO: refactor to merge with existing TextureMapOverride object
     public class TextureMapChange : IUnpackable
     {
-        public byte PartIndex { get; private set; }
-        public uint OldTexture { get; private set; }
-        public uint NewTexture { get; private set; }
+        public byte PartIndex { get; set; }
+        public uint OldTexture { get; set; }
+        public uint NewTexture { get; set; }
 
         public void Unpack(BinaryReader reader)
         {


### PR DESCRIPTION
This allows other tools to instantiate these objects and set new values.

This is used by OptimShis Palette decoder and my retail character importer.

I was always on the fence about these dat properties being public. The risk is that a developer could modify a property in ACE. That property would then persist to the cached at object, and would be re-used until ACE was restarted.

This happens because dat objects are cached, and that same instance is returned on subsequent requests.

However, if we are ever to have 3rd party Dat editor tools, these properties will need to be public anyway.