### PR TITLE
adjust aetheria drop rates, fixing drop rate mods

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -95,21 +95,25 @@ namespace ACE.Server.Factories
 
             if (itemChance <= profile.MagicItemChance)
             {
-                int aetheriaDropChance;
-                bool aetheriaGenerated = false;
                 numItems = ThreadSafeRandom.Next(profile.MagicItemMinAmount, profile.MagicItemMaxAmount);
+
+                bool aetheriaGenerated = false;
+                bool generateAetheria = false;
+                double dropRate = PropertyManager.GetDouble("aetheria_drop_rate").Item;
+                double dropRateMod = 1.0 / dropRate;
+
                 for (var i = 0; i < numItems; i++)
                 {
                     // Coalesced Aetheria doesn't drop in loot tiers less than 5
                     // According to wiki, Weapon Mana Forge chests don't drop Aetheria, also
                     // a loot role will only drop one Coealesced Aetheria per call into loot system, as I don't remember there
                     // being multiples, and I didn't find any written mention of it.
-                    if (aetheriaGenerated == false && profile.Tier > 4 && lootBias != LootBias.Weapons)
-                        aetheriaDropChance = ThreadSafeRandom.Next(1, (int)(100));
+                    if (!aetheriaGenerated && profile.Tier > 4 && lootBias != LootBias.Weapons && dropRate > 0)
+                        generateAetheria = ThreadSafeRandom.Next(1, (int)(10 * dropRateMod)) == 1;  // 10% of all magical items generated are Aetheria? this seems extremely high...
                     else
-                        aetheriaDropChance = 0;
+                        generateAetheria = false;
 
-                    if (aetheriaDropChance > 90 )  // Default set for a 10% chance drop rate
+                    if (generateAetheria)
                     {
                         lootWorldObject = CreateAetheria(profile.Tier);
                         if (lootWorldObject != null)
@@ -1879,18 +1883,18 @@ namespace ACE.Server.Factories
             int numLegendaries = 0;
 
             if (tier < 8)
-                return numLegendaries;
+                return 0;
 
-            double dropRateSkew = PropertyManager.GetDouble("legendary_cantrip_drop_rate_mod").Item;
-            if (dropRateSkew <= 0)
-                dropRateSkew = 1;
+            var dropRate = PropertyManager.GetDouble("legendary_cantrip_drop_rate").Item;
+            if (dropRate <= 0)
+                return 0;
 
-            int legendaryCantripChance = ThreadSafeRandom.Next(1, (int)(5000 * dropRateSkew));
+            var dropRateMod = 1.0 / dropRate;
 
             // 1% chance for a legendary, 0.02% chance for 2 legendaries
-            if (legendaryCantripChance <= 50)
+            if (ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1)
                 numLegendaries = 1;
-            if (legendaryCantripChance <= 1)
+            if (ThreadSafeRandom.Next(1, (int)(500 * dropRateMod)) == 1)
                 numLegendaries = 2;
 
             return numLegendaries;
@@ -1901,23 +1905,23 @@ namespace ACE.Server.Factories
             int numEpics = 0;
 
             if (tier < 7)
-                return numEpics;
+                return 0;
 
-            double dropRateSkew = PropertyManager.GetDouble("epic_cantrip_drop_rate_mod").Item;
-            if (dropRateSkew <= 0)
-                dropRateSkew = 1;
+            var dropRate = PropertyManager.GetDouble("epic_cantrip_drop_rate").Item;
+            if (dropRate <= 0)
+                return 0;
 
-            int epicCantripChance = ThreadSafeRandom.Next(1, (int)(1000000 * dropRateSkew));
+            var dropRateMod = 1.0 / dropRate;
 
             // 0.1% chance for 1 Epic, 0.01% chance for 2 Epics,
             // 0.001% chance for 3 Epics, 0.0001% chance for 4 Epics 
-            if (epicCantripChance <= 1000)
+            if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
                 numEpics = 1;
-            if (epicCantripChance <= 100)
+            if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
                 numEpics = 2;
-            if (epicCantripChance <= 10)
+            if (ThreadSafeRandom.Next(1, (int)(100000 * dropRateMod)) == 1)
                 numEpics = 3;
-            if (epicCantripChance <= 1)
+            if (ThreadSafeRandom.Next(1, (int)(1000000 * dropRateMod)) == 1)
                 numEpics = 4;
 
             return numEpics;
@@ -1927,9 +1931,11 @@ namespace ACE.Server.Factories
         {
             int numMajors = 0;
 
-            double dropRateSkew = PropertyManager.GetDouble("major_cantrip_drop_rate_mod").Item;
-            if (dropRateSkew <= 0)
-                dropRateSkew = 1;
+            var dropRate = PropertyManager.GetDouble("major_cantrip_drop_rate").Item;
+            if (dropRate <= 0)
+                return 0;
+
+            var dropRateMod = 1.0 / dropRate;
 
             switch (tier)
             {
@@ -1937,30 +1943,30 @@ namespace ACE.Server.Factories
                     numMajors = 0;
                     break;
                 case 2:
-                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateMod)) == 1)
                         numMajors = 1;
                     break;
                 case 3:
-                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateMod)) == 1)
                         numMajors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
                         numMajors = 2;
                     break;
                 case 4:
                 case 5:
                 case 6:
-                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateMod)) == 1)
                         numMajors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateMod)) == 1)
                         numMajors = 2;
                     break;
                 case 7:
                 default:
-                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(500 * dropRateMod)) == 1)
                         numMajors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateMod)) == 1)
                         numMajors = 2;
-                    if (ThreadSafeRandom.Next(1, (int)(15000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(15000 * dropRateMod)) == 1)
                         numMajors = 3;
                     break;
             }
@@ -1972,42 +1978,44 @@ namespace ACE.Server.Factories
         {
             int numMinors = 0;
 
-            double dropRateSkew = PropertyManager.GetDouble("minor_cantrip_drop_rate_mod").Item;
-            if (dropRateSkew <= 0)
-                dropRateSkew = 1;
+            var dropRate = PropertyManager.GetDouble("minor_cantrip_drop_rate").Item;
+            if (dropRate <= 0)
+                return 0;
+
+            var dropRateMod = 1.0 / dropRate;
 
             switch (tier)
             {
                 case 1:
-                    if (ThreadSafeRandom.Next(1, (int)(100 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1)
                         numMinors = 1;
                     break;
                 case 2:
                 case 3:
-                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateMod)) == 1)
                         numMinors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateMod)) == 1)
                         numMinors = 2;
                     break;
                 case 4:
                 case 5:
-                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateMod)) == 1)
                         numMinors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateMod)) == 1)
                         numMinors = 2;
-                    if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
                         numMinors = 3;
                     break;
                 case 6:
                 case 7:
                 default:
-                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(50 * dropRateMod)) == 1)
                         numMinors = 1;
-                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(250 * dropRateMod)) == 1)
                         numMinors = 2;
-                    if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
                         numMinors = 3;
-                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateSkew)) == 1)
+                    if (ThreadSafeRandom.Next(1, (int)(5000 * dropRateMod)) == 1)
                         numMinors = 4;
                     break;
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -109,7 +109,7 @@ namespace ACE.Server.Factories
                     // a loot role will only drop one Coealesced Aetheria per call into loot system, as I don't remember there
                     // being multiples, and I didn't find any written mention of it.
                     if (!aetheriaGenerated && profile.Tier > 4 && lootBias != LootBias.Weapons && dropRate > 0)
-                        generateAetheria = ThreadSafeRandom.Next(1, (int)(10 * dropRateMod)) == 1;  // 10% of all magical items generated are Aetheria? this seems extremely high...
+                        generateAetheria = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1;     // base 1% of all magical items aetheria?
                     else
                         generateAetheria = false;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
@@ -49,32 +49,34 @@ namespace ACE.Server.Factories
                 return null;
 
 
-            // Initial role for an Aetheria level 1 through 3
-            wo.ItemMaxLevel = ThreadSafeRandom.Next(1, 3);
+            // Initial roll for an Aetheria level 1 through 3
+            wo.ItemMaxLevel = 1;
 
-            // Perform an additional role check for a chance at a higher Aetheria level for tiers 6+
+            var rng = ThreadSafeRandom.Next(1, 7);
+
+            if (rng > 4)
+            {
+                if (rng > 6)
+                    wo.ItemMaxLevel = 3;
+                else
+                    wo.ItemMaxLevel = 2;
+            }
+
+            // Perform an additional roll check for a chance at a higher Aetheria level for tiers 6+
             if (tier > 5)
             {
+                // FIXME
                 double dropRateSkew = PropertyManager.GetDouble("aetheria_level_drop_rate_mod").Item;
                 if (dropRateSkew <= 0)
                     dropRateSkew = 1;
 
-                int aetheriaHigherLevelChance = ThreadSafeRandom.Next(1, (int)(100 * dropRateSkew));
-                switch (tier)
+                if (ThreadSafeRandom.Next(1, (int)(50 * dropRateSkew)) == 1)
                 {
-                    case 6:
-                        if (aetheriaHigherLevelChance <= 10)
-                            wo.ItemMaxLevel = 4;
-                        break;
-                    case 7:
-                    case 8:
-                        if (aetheriaHigherLevelChance <= 10)
-                            wo.ItemMaxLevel = 4;
-                        if (aetheriaHigherLevelChance <= 5)
-                            wo.ItemMaxLevel = 5;
-                        break;
-                    default:
-                        break;
+                    wo.ItemMaxLevel = 4;
+                    if (tier > 6 && ThreadSafeRandom.Next(1, 5) == 1)
+                    {
+                        wo.ItemMaxLevel = 5;
+                    }
                 }
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
@@ -65,12 +65,7 @@ namespace ACE.Server.Factories
             // Perform an additional roll check for a chance at a higher Aetheria level for tiers 6+
             if (tier > 5)
             {
-                // FIXME
-                double dropRateSkew = PropertyManager.GetDouble("aetheria_level_drop_rate_mod").Item;
-                if (dropRateSkew <= 0)
-                    dropRateSkew = 1;
-
-                if (ThreadSafeRandom.Next(1, (int)(50 * dropRateSkew)) == 1)
+                if (ThreadSafeRandom.Next(1, 50) == 1)
                 {
                     wo.ItemMaxLevel = 4;
                     if (tier > 6 && ThreadSafeRandom.Next(1, 5) == 1)

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -478,7 +478,7 @@ namespace ACE.Server.Managers
                 ("major_cantrip_drop_rate", 1.0),
                 ("epic_cantrip_drop_rate", 1.0),
                 ("legendary_cantrip_drop_rate", 1.0),
-                ("aethera_drop_rate", 1.0),
+                ("aetheria_drop_rate", 1.0),
                 ("chess_ai_start_time", -1.0),      // the number of seconds for the chess ai to start. defaults to -1 (disabled)
                 ("encounter_delay", 1800),          // the number of seconds a generator profile for regions is delayed from returning to free slots
                 ("encounter_regen_interval", 600),  // the number of seconds a generator for regions at which spawns its next set of objects.

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -474,11 +474,11 @@ namespace ACE.Server.Managers
 
         public static readonly ReadOnlyDictionary<string, double> DefaultDoubleProperties =
             DictOf(
-                ("minor_cantrip_drop_rate_mod", 1.0),      // Default of one sets drop rates to coded values; 
-                ("major_cantrip_drop_rate_mod", 1.0),      // greater than one decreases drop rate,
-                ("epic_cantrip_drop_rate_mod", 1.0),       // less than one increases drop rate
-                ("legendary_cantrip_drop_rate_mod", 1.0),
-                ("aetheria_level_drop_rate_mod", 1.0),
+                ("minor_cantrip_drop_rate", 1.0),
+                ("major_cantrip_drop_rate", 1.0),
+                ("epic_cantrip_drop_rate", 1.0),
+                ("legendary_cantrip_drop_rate", 1.0),
+                ("aethera_drop_rate", 1.0),
                 ("chess_ai_start_time", -1.0),      // the number of seconds for the chess ai to start. defaults to -1 (disabled)
                 ("encounter_delay", 1800),          // the number of seconds a generator profile for regions is delayed from returning to free slots
                 ("encounter_regen_interval", 600),  // the number of seconds a generator for regions at which spawns its next set of objects.


### PR DESCRIPTION
This adjusts the Aetheria drop rates to be better aligned with retail data, and from community feedback from knowledgeable players

Previously, level 1-3 Aetheria all had an equal chance of dropping, and level 4-5 Aetheria both had the same chance of dropping

Some initial retail data (albeit very sparse, esp. for level 4-5) can be found here:

https://cdn.discordapp.com/attachments/417074022237601802/600013535510003712/aetheria_stats.csv

Drop chances for the previous code per magical item generated (100m simulated rolls):

```
at least level 1: 1 in 10
at least level 2: 1 in 10
at least level 3: 1 in 10
at least level 4: 1 in 100
at least level 5: 1 in 100
```

Drop chances for the updated code:

```
at least level 1: 1 in 100
at least level 2: 1 in 200
at least level 3: 1 in 400
at least level 4: 1 in 5000
at least level 5: 1 in 25000
```

These numbers can be continued to be further adjusted

The server admin options for cantrip and Aetheria drop rates have also been adjusted. If the server admin sets a 2x drop rate, the items should drop at 2x the rate (previously > 1.0 was lower rate)