### PR TITLE
fix bug with level proportional xp

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -355,8 +355,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void GrantLevelProportionalXp(double percent, ulong max, bool shareable = false)
         {
-            var maxLevel = GetMaxLevel();
-
             var nextLevelXP = GetXPBetweenLevels(Level.Value, Level.Value + 1);
             var scaledXP = (long)Math.Min(nextLevelXP * percent, max);
 

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -356,7 +356,6 @@ namespace ACE.Server.WorldObjects
         public void GrantLevelProportionalXp(double percent, ulong max, bool shareable = false)
         {
             var maxLevel = GetMaxLevel();
-            if (Level >= maxLevel) return;
 
             var nextLevelXP = GetXPBetweenLevels(Level.Value, Level.Value + 1);
             var scaledXP = (long)Math.Min(nextLevelXP * percent, max);


### PR DESCRIPTION
This fixes a bug where EmoteType.AwardLevelProportionalXP -> GrantLevelProportionalXp() doesn't award any XP for max level players

This bug was fixed in GetXPBetweenLevels() awhile ago, where for max level players it uses the XP between 274-275, but there was still an if check in GrantLevelProportionalXp() lingering around
