### PR TITLE
re-adjusting epic cantrip rates

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1913,15 +1913,15 @@ namespace ACE.Server.Factories
 
             var dropRateMod = 1.0 / dropRate;
 
-            // 0.1% chance for 1 Epic, 0.01% chance for 2 Epics,
-            // 0.001% chance for 3 Epics, 0.0001% chance for 4 Epics 
-            if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
+            // 1% chance for 1 Epic, 0.1% chance for 2 Epics,
+            // 0.01% chance for 3 Epics, 0.001% chance for 4 Epics 
+            if (ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1)
                 numEpics = 1;
-            if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
+            if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
                 numEpics = 2;
-            if (ThreadSafeRandom.Next(1, (int)(100000 * dropRateMod)) == 1)
+            if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
                 numEpics = 3;
-            if (ThreadSafeRandom.Next(1, (int)(1000000 * dropRateMod)) == 1)
+            if (ThreadSafeRandom.Next(1, (int)(100000 * dropRateMod)) == 1)
                 numEpics = 4;
 
             return numEpics;

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1913,16 +1913,20 @@ namespace ACE.Server.Factories
 
             var dropRateMod = 1.0 / dropRate;
 
-            // 1% chance for 1 Epic, 0.1% chance for 2 Epics,
-            // 0.01% chance for 3 Epics, 0.001% chance for 4 Epics 
-            if (ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1)
-                numEpics = 1;
-            if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
-                numEpics = 2;
-            if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
-                numEpics = 3;
-            if (ThreadSafeRandom.Next(1, (int)(100000 * dropRateMod)) == 1)
-                numEpics = 4;
+            // 25% base chance for no epics for tier 7
+            if (ThreadSafeRandom.Next(1, 4) > 1)
+            {
+                // 1% chance for 1 Epic, 0.1% chance for 2 Epics,
+                // 0.01% chance for 3 Epics, 0.001% chance for 4 Epics 
+                if (ThreadSafeRandom.Next(1, (int)(100 * dropRateMod)) == 1)
+                    numEpics = 1;
+                if (ThreadSafeRandom.Next(1, (int)(1000 * dropRateMod)) == 1)
+                    numEpics = 2;
+                if (ThreadSafeRandom.Next(1, (int)(10000 * dropRateMod)) == 1)
+                    numEpics = 3;
+                if (ThreadSafeRandom.Next(1, (int)(100000 * dropRateMod)) == 1)
+                    numEpics = 4;
+            }
 
             return numEpics;
         }


### PR DESCRIPTION
When comparing https://github.com/ACEmulator/ACE/pull/1892 to current, there appears to be a 200x gap to cover here

There appears to be a missing factor from 1892 where there would be a pre-roll, where T7 would have 25% chance to drop no epics. So that would reduce the gap to 150x

Prior to https://github.com/ACEmulator/ACE/pull/2101, the rates were briefly bumped up, and this version was well-received from the CE player feedback. This version would further reduce the gap to 15x

This PR sets the default rates back to the pre-2101 rates, which seem to be a good balance currently