### PR TITLE
removing max velocity estimated, not found in pcaps

### DIFF
--- a/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/SentinelCommands.cs
@@ -51,7 +51,7 @@ namespace ACE.Server.Command.Handlers
 
                     session.Player.SetProperty(PropertyInt.CloakStatus, (int)CloakStatus.On);
 
-                    CommandHandlerHelper.WriteOutputInfo(session, $"You are now cloaked.\nYou are now etheral and can pass through doors.", ChatMessageType.Broadcast);
+                    CommandHandlerHelper.WriteOutputInfo(session, $"You are now cloaked.\nYou are now ethereal and can pass through doors.", ChatMessageType.Broadcast);
                     break;
                 case "player":
                     if (session.AccessLevel > AccessLevel.Envoy)

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -56,7 +56,7 @@ namespace ACE.Server.Network.Structure
             WeaponLength = weapon.GetProperty(PropertyFloat.WeaponLength) ?? 1.0f;
             MaxVelocity = weapon.GetProperty(PropertyFloat.MaximumVelocity) ?? 1.0f;
             WeaponOffense = GetWeaponOffense(weapon, wielder);
-            MaxVelocityEstimated = (uint)Math.Round(MaxVelocity);   // ??
+            //MaxVelocityEstimated = (uint)Math.Round(MaxVelocity);   // not found in pcaps?
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/House.cs
+++ b/Source/ACE.Server/WorldObjects/House.cs
@@ -476,7 +476,7 @@ namespace ACE.Server.WorldObjects
         {
             get
             {
-                if (HouseType == ACE.Entity.Enum.HouseType.Apartment || HouseType == ACE.Entity.Enum.HouseType.Cottage)
+                if (HouseType == HouseType.Apartment || HouseType == HouseType.Cottage)
                 {
                     _rootGuid = Guid;
                     return Guid;


### PR DESCRIPTION
This removes the (based on STRENGTH 100) display in the client for missile weapons

Searched the retail pcaps for any instances where MaxVelocityEstimated != 0, and couldn't find any examples. If this is supposed to be set for things like Thrown Weapons, not sure what values to place in here