### PR TITLE
fixing StackSize 0 bug in WieldedTreasure

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -95,7 +95,7 @@ namespace ACE.Server.WorldObjects
                 var hasVariance = item.StackSizeVariance > 0;
                 if (hasVariance)
                 {
-                    var minStack = (int)Math.Round(item.StackSize * item.StackSizeVariance);
+                    var minStack = (int)Math.Max(Math.Round(item.StackSize * item.StackSizeVariance), 1);
                     var maxStack = item.StackSize;
                     stackSize = ThreadSafeRandom.Next(minStack, maxStack);
                 }


### PR DESCRIPTION
This fixes a bug that can occur with Throwing Clubs for example, where StackSize=4 and StackSizeVariance=0.1

MinStackSize is set to Math.Round(0.4) in this case, which becomes 0. This ensures the minimum stack size cannot fall below 1

This also points to another issue in the WieldedTreasure StackSizeVariance code, where MinStackSize should actually be defined as StackSize * (1.0f - StackSizeVariance). However, due to monsters lacking the logic where they decide to switch between ranged and melee, this code currently provides a reasonable counterbalance for now