### PR TITLE
Include material in give item message

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -233,14 +233,13 @@ namespace ACE.Server.Managers
                     var truncated = percent.Truncate(decimalPlaces);
 
                     var toolMaterial = GetMaterialName(tool.MaterialType ?? 0);
-                    var targetMaterial = GetMaterialName(target.MaterialType ?? 0);
 
                     // TODO: retail messages
                     // You determine that you have a 100 percent chance to succeed.
                     // You determine that you have a 99 percent chance to succeed.
                     // You determine that you have a 38 percent chance to succeed. 5 percent is due to your augmentation.
 
-                    var templateMsg = $"You have a % chance of using {toolMaterial} {tool.Name} on {targetMaterial} {target.Name}.";
+                    var templateMsg = $"You have a % chance of using {toolMaterial} {tool.Name} on {target.NameWithMaterial}.";
                     var floorMsg = templateMsg.Replace("%", (int)percent + "%");
                     var truncateMsg = templateMsg.Replace("%", Math.Round(truncated, decimalPlaces) + "%");
                     var exactMsg = templateMsg.Replace("%", percent + "%");
@@ -273,7 +272,6 @@ namespace ACE.Server.Managers
         {
             var success = ThreadSafeRandom.Next(0.0f, 1.0f) <= chance;
             var salvageMaterial = GetMaterialName(tool.MaterialType ?? 0);
-            var itemMaterial = GetMaterialName(target.MaterialType ?? 0);
 
             if (success)
             {
@@ -281,10 +279,10 @@ namespace ACE.Server.Managers
 
                 // send local broadcast
                 if (incItemTinkered)
-                    player.EnqueueBroadcast(new GameMessageSystemChat($"{player.Name} successfully applies the {salvageMaterial} Salvage (workmanship {(tool.Workmanship ?? 0):#.00}) to the {itemMaterial} {target.Name}.", ChatMessageType.Craft), 96.0f);
+                    player.EnqueueBroadcast(new GameMessageSystemChat($"{player.Name} successfully applies the {salvageMaterial} Salvage (workmanship {(tool.Workmanship ?? 0):#.00}) to the {target.NameWithMaterial}.", ChatMessageType.Craft), 96.0f);
             }
             else if (incItemTinkered)
-                player.EnqueueBroadcast(new GameMessageSystemChat($"{player.Name} fails to apply the {salvageMaterial} Salvage (workmanship {(tool.Workmanship ?? 0):#.00}) to the {itemMaterial} {target.Name}. The target is destroyed.", ChatMessageType.Craft), 96.0f);
+                player.EnqueueBroadcast(new GameMessageSystemChat($"{player.Name} fails to apply the {salvageMaterial} Salvage (workmanship {(tool.Workmanship ?? 0):#.00}) to the {target.NameWithMaterial}. The target is destroyed.", ChatMessageType.Craft), 96.0f);
 
             CreateDestroyItems(player, recipe, tool, target, success, !incItemTinkered);
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -2135,15 +2135,16 @@ namespace ACE.Server.WorldObjects
 
                 var stackMsg = stackSize > 1 ? $"{stackSize} " : "";
                 var itemName = stackSize > 1 ? itemToGive.GetPluralName() : itemToGive.Name;
+                string itemMaterial = item.MaxStackSize == null && item.MaterialType != null ? string.Format("{0} ", RecipeManager.GetMaterialName(item.MaterialType ?? 0)) : "";
 
-                Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemName}.", ChatMessageType.Broadcast));
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
                 Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
 
                 // send DO to source player if not splitting a stack
                 if (item == itemToGive)
                     Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
 
-                target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} gives you {stackMsg}{itemName}.", ChatMessageType.Broadcast));
+                target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} gives you {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
                 target.Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
             });
 
@@ -2183,6 +2184,8 @@ namespace ACE.Server.WorldObjects
             {
                 if (acceptAll || result.Category == (uint)EmoteCategory.Give)
                 {
+                    string itemMaterial = item.MaxStackSize == null && item.MaterialType != null ? string.Format("{0} ", RecipeManager.GetMaterialName(item.MaterialType ?? 0)) : "";
+
                     // for NPCs that accept items with EmoteCategory.Give,
                     // if stacked item, only give 1
                     if (!acceptAll && RemoveItemForGive(item, itemFoundInContainer, itemWasEquipped, itemRootOwner, 1, out WorldObject itemToGive, true))
@@ -2203,7 +2206,7 @@ namespace ACE.Server.WorldObjects
 
                             var stackMsg = stackSize > 1 ? $"{stackSize} " : "";
                             var itemName = stackSize > 1 ? item.GetPluralName() : item.Name;
-                            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemName}.", ChatMessageType.Broadcast));
+                            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
                             Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
                         }
                         else

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -2134,17 +2134,16 @@ namespace ACE.Server.WorldObjects
                 var stackSize = itemToGive.StackSize ?? 1;
 
                 var stackMsg = stackSize > 1 ? $"{stackSize} " : "";
-                var itemName = stackSize > 1 ? itemToGive.GetPluralName() : itemToGive.Name;
-                string itemMaterial = item.MaxStackSize == null && item.MaterialType != null ? string.Format("{0} ", RecipeManager.GetMaterialName(item.MaterialType ?? 0)) : "";
+                var itemName = stackSize > 1 ? itemToGive.GetPluralName() : itemToGive.NameWithMaterial;
 
-                Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
+                Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemName}.", ChatMessageType.Broadcast));
                 Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
 
                 // send DO to source player if not splitting a stack
                 if (item == itemToGive)
                     Session.Network.EnqueueSend(new GameMessageDeleteObject(item));
 
-                target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} gives you {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
+                target.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name} gives you {stackMsg}{itemName}.", ChatMessageType.Broadcast));
                 target.Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
             });
 
@@ -2184,8 +2183,6 @@ namespace ACE.Server.WorldObjects
             {
                 if (acceptAll || result.Category == (uint)EmoteCategory.Give)
                 {
-                    string itemMaterial = item.MaxStackSize == null && item.MaterialType != null ? string.Format("{0} ", RecipeManager.GetMaterialName(item.MaterialType ?? 0)) : "";
-
                     // for NPCs that accept items with EmoteCategory.Give,
                     // if stacked item, only give 1
                     if (!acceptAll && RemoveItemForGive(item, itemFoundInContainer, itemWasEquipped, itemRootOwner, 1, out WorldObject itemToGive, true))
@@ -2193,7 +2190,7 @@ namespace ACE.Server.WorldObjects
                         if (itemToGive == null)
                             Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(Session, item, target));
 
-                        Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.Name}.", ChatMessageType.Broadcast));
+                        Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {item.NameWithMaterial}.", ChatMessageType.Broadcast));
                         Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
                     }
                     else
@@ -2205,8 +2202,8 @@ namespace ACE.Server.WorldObjects
                             var stackSize = item.StackSize ?? 1;
 
                             var stackMsg = stackSize > 1 ? $"{stackSize} " : "";
-                            var itemName = stackSize > 1 ? item.GetPluralName() : item.Name;
-                            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemMaterial}{itemName}.", ChatMessageType.Broadcast));
+                            var itemName = stackSize > 1 ? item.GetPluralName() : item.NameWithMaterial;
+                            Session.Network.EnqueueSend(new GameMessageSystemChat($"You give {target.Name} {stackMsg}{itemName}.", ChatMessageType.Broadcast));
                             Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.ReceiveItem));
                         }
                         else
@@ -2218,7 +2215,7 @@ namespace ACE.Server.WorldObjects
                 else if (result.Category == (uint)EmoteCategory.Refuse)
                 {
                     // Item rejected by npc
-                    Session.Network.EnqueueSend(new GameMessageSystemChat($"You allow {target.Name} to examine your {item.Name}.", ChatMessageType.Broadcast));
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"You allow {target.Name} to examine your {item.NameWithMaterial}.", ChatMessageType.Broadcast));
                     Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full, WeenieError.TradeAiRefuseEmote));
                 }
             }
@@ -2231,7 +2228,7 @@ namespace ACE.Server.WorldObjects
 
         private void HandleIOUTurnIn(WorldObject target, WorldObject iouToTurnIn)
         {
-            Session.Network.EnqueueSend(new GameMessageSystemChat($"You allow {target.Name} to examine your {iouToTurnIn.Name}.", ChatMessageType.Broadcast));
+            Session.Network.EnqueueSend(new GameMessageSystemChat($"You allow {target.Name} to examine your {iouToTurnIn.NameWithMaterial}.", ChatMessageType.Broadcast));
             Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, iouToTurnIn.Guid.Full, WeenieError.TradeAiRefuseEmote));
 
             if (iouToTurnIn is Book book)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -824,6 +824,15 @@ namespace ACE.Server.WorldObjects
             set => SetProperty(PropertyString.Name, value);
         }
 
+        public String NameWithMaterial
+        {
+            get
+            {
+                string itemMaterial = MaxStackSize == null && MaterialType != null ? string.Format("{0} ", RecipeManager.GetMaterialName(MaterialType ?? 0)) : "";
+                return String.Format("{0}{1}", itemMaterial, Name);
+            }
+        }
+
         public string DisplayName
         {
             get => GetProperty(PropertyString.DisplayName);


### PR DESCRIPTION
Right now whenever you give an item to a player or an NPC, it omits the material name prefix. This material name prefix should be present at all times when passing around or tinkering items with a material type. This PR adjusts the text to include the material name, but ensures that the item is neither stackable (which should never have a valid material) and that it has a material name specified, prior to including it in the output.