### PR TITLE
Remove attribute cantrips from jewelry.

### DIFF
--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -1705,14 +1705,12 @@ namespace ACE.Factories
             new int[] { 2554, 2519, 4232, 6059},
             ////Fealty
             new int[] { 2546, 2511, 4692, 6051},
+            ////Jump
+            new int[] { 2553, 2518, 4699, 6058},
+            ////Sprint
+            new int[] { 2564, 2529, 4710, 6071},
             ////Armor Self
             new int[] { 2578, 2571, 4911, 6102},
-            ////Regeneration
-            new int[] { 2626, 2623, 4680, 6077},
-            ////Rejuvenation
-            new int[] { 2628, 2625, 4682, 6076},
-            ////Mana Renewal
-            new int[] { 2627, 2624, 4681, 6078 },
             ////Armor Self
             new int[] { 2578, 2571, 4911, 6102},
             ////Acid Prot

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -1633,18 +1633,6 @@ namespace ACE.Factories
 
         public static readonly int[][] JewelryCantrips =
         {
-            ////Strength
-            new int[] { 2583, 2576, 3965, 6107},
-            ////Endurance
-            new int[] { 2580, 2573, 4226, 6104},
-            ////Coordination
-            new int[] { 2579, 2572, 3963, 6103},
-            ////Quickness
-            new int[] { 2582, 2575, 4019, 6106},
-            ////Focus
-            new int[] { 2581, 2574, 3964, 6105},
-            ////Willpower
-            new int[] { 2584, 2577, 4227, 6101},
             ////Invuln
             new int[] { 2550, 2515, 4696, 6055},
             ////Impreg


### PR DESCRIPTION
Further refining of the epic cantrips that are eligible for dropping on items to align with retail. Attributes should never be dropping on jewelry with the exception of rares.