### PR TITLE
Unattackable until exited from portal space

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -135,7 +135,7 @@ namespace ACE.Server.WorldObjects
                 if (player != null && creature is Player && player.CheckPKStatusVsTarget(player, creature, null) != null)
                     continue;
 
-                if (!creature.Attackable)
+                if (!creature.Attackable || creature.Teleporting)
                     continue;
 
                 if (creature is CombatPet && (player != null || this is CombatPet))

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -239,7 +239,7 @@ namespace ACE.Server.WorldObjects
                 if (creature == null) continue;
 
                 // ensure attackable
-                if (!creature.Attackable) continue;
+                if (!creature.Attackable || creature.Teleporting) continue;
 
                 // ensure within 'detection radius' ?
                 var chaseDistSq = creature == AttackTarget ? MaxChaseRangeSq : RadiusAwarenessSquared;
@@ -321,7 +321,7 @@ namespace ACE.Server.WorldObjects
             {
                 var creature = visibleTarget.WeenieObj.WorldObject as Creature;
 
-                if (creature == null || creature is Player player && (!player.Attackable || (player.Hidden ?? false)))
+                if (creature == null || creature is Player player && (!player.Attackable || player.Teleporting || (player.Hidden ?? false)))
                     continue;
 
                 var distSq = Location.SquaredDistanceTo(creature.Location);

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -436,13 +436,12 @@ namespace ACE.Server.WorldObjects
             ReportCollisions = true;
             IgnoreCollisions = false;
             Hidden = false;
-
+            Teleporting = false;
+            
             CheckMonsters();
             CheckHouse();
 
             EnqueueBroadcastPhysicsState();
-
-            Teleporting = false;
         }
 
         public void NotifyLandblocks()

--- a/Source/ACE.Server/WorldObjects/Player_Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Monster.cs
@@ -16,7 +16,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void CheckMonsters(float rangeSquared = RadiusAwarenessSquared)
         {
-            if (!Attackable) return;
+            if (!Attackable || Teleporting) return;
 
             var visibleObjs = PhysicsObj.ObjMaint.VisibleObjects.Values;
 


### PR DESCRIPTION
Right now it is possible to attack players, and to gain aggro on mobs, while you are still in portal space. Retail behavior was that you were considered unattackable while in portal space, meaning nothing would aggro you and all attempts to attack would fail to do any damage.

This PR adds a check for the Teleporting flag in a few places where we determine whether a target can be attacked, namely a player, since this is not applicable for mobs.