### PR TITLE
Add busy checks for recall/PKL commands

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -895,7 +895,8 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.OnlyNonPKsMayEnterPKLite));
                 return;
             }
-            if (IsBusy || EmoteManager.IsBusy)
+
+            if (TooBusyToRecall)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -895,6 +895,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.OnlyNonPKsMayEnterPKLite));
                 return;
             }
+            if (IsBusy || EmoteManager.IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                return;
+            }
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is looking for a fight!", ChatMessageType.Broadcast));
 
@@ -907,8 +912,10 @@ namespace ACE.Server.WorldObjects
 
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(animLength);
+            IsBusy = true;
             actionChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 UpdateProperty(this, PropertyInt.PlayerKillerStatus, (int)PlayerKillerStatus.PKLite, true);
 
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YouAreNowPKLite));

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -52,7 +52,7 @@ namespace ACE.Server.WorldObjects
 
         public bool TooBusyToRecall
         {
-            get => IsBusy || EmoteManager.IsBusy || Teleporting;
+            get => IsBusy || Teleporting;
         }
 
         public void HandleActionTeleToHouse()
@@ -102,8 +102,10 @@ namespace ACE.Server.WorldObjects
             // Then do teleport
             var animLength = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.HouseRecall);
             actionChain.AddDelaySeconds(animLength);
+            IsBusy = true;
             actionChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 var endPos = new Position(Location);
                 if (startPos.SquaredDistanceTo(endPos) > RecallMoveThresholdSq)
                 {
@@ -165,9 +167,11 @@ namespace ACE.Server.WorldObjects
             ActionChain lifestoneChain = new ActionChain();
 
             // Then do teleport
+            IsBusy = true;
             lifestoneChain.AddDelaySeconds(DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.LifestoneRecall));
             lifestoneChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 var endPos = new Position(Location);
                 if (startPos.SquaredDistanceTo(endPos) > RecallMoveThresholdSq)
                 {

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -121,6 +121,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.ExitTrainingAcademyToUseCommand));
                 return;
             }
+            if (IsBusy || EmoteManager.IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                return;
+            }
 
             if (Sanctuary == null)
             {
@@ -180,6 +185,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            if (IsBusy || EmoteManager.IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                return;
+            }
+
             var updateCombatMode = new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat);
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall), 96.0f);
@@ -195,8 +206,10 @@ namespace ACE.Server.WorldObjects
             mpChain.AddDelaySeconds(14);
 
             // Then do teleport
+            IsBusy = true;
             mpChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 var endPos = new Position(Location);
                 if (startPos.SquaredDistanceTo(endPos) > RecallMoveThresholdSq)
                 {
@@ -241,6 +254,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YourAllegianceDoesNotHaveHometown));
                 return;
             }
+            if (IsBusy || EmoteManager.IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                return;
+            }
 
             if (CombatMode != CombatMode.NonCombat)
             {
@@ -259,10 +277,12 @@ namespace ACE.Server.WorldObjects
             var actionChain = new ActionChain();
 
             // Then do teleport
+            IsBusy = true;
             var animLength = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.AllegianceHometownRecall);
             actionChain.AddDelaySeconds(animLength);
             actionChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 var endPos = new Position(Location);
                 if (startPos.SquaredDistanceTo(endPos) > RecallMoveThresholdSq)
                 {
@@ -293,6 +313,11 @@ namespace ACE.Server.WorldObjects
             if (RecallsDisabled)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.ExitTrainingAcademyToUseCommand));
+                return;
+            }
+            if (IsBusy || EmoteManager.IsBusy)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;
             }
 
@@ -343,8 +368,11 @@ namespace ACE.Server.WorldObjects
             // Then do teleport
             var animLength = DatManager.PortalDat.ReadFromDat<MotionTable>(MotionTableId).GetAnimationLength(MotionCommand.HouseRecall);
             actionChain.AddDelaySeconds(animLength);
+
+            IsBusy = true;
             actionChain.AddAction(this, () =>
             {
+                IsBusy = false;
                 var endPos = new Position(Location);
                 if (startPos.SquaredDistanceTo(endPos) > RecallMoveThresholdSq)
                 {

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -50,6 +50,11 @@ namespace ACE.Server.WorldObjects
         public static float RecallMoveThreshold = 8.0f;
         public static float RecallMoveThresholdSq = RecallMoveThreshold * RecallMoveThreshold;
 
+        public bool TooBusyToRecall
+        {
+            get => IsBusy || EmoteManager.IsBusy || Teleporting;
+        }
+
         public void HandleActionTeleToHouse()
         {
             if (PKTimerActive)
@@ -61,6 +66,12 @@ namespace ACE.Server.WorldObjects
             if (RecallsDisabled)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.ExitTrainingAcademyToUseCommand));
+                return;
+            }
+
+            if (TooBusyToRecall)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;
             }
 
@@ -121,7 +132,8 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.ExitTrainingAcademyToUseCommand));
                 return;
             }
-            if (IsBusy || EmoteManager.IsBusy)
+
+            if (TooBusyToRecall)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;
@@ -185,7 +197,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (IsBusy || EmoteManager.IsBusy)
+            if (TooBusyToRecall)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;
@@ -242,6 +254,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            if (TooBusyToRecall)
+            {
+                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
+                return;
+            }
+
             // check if player is in an allegiance
             if (Allegiance == null)
             {
@@ -252,11 +270,6 @@ namespace ACE.Server.WorldObjects
             if (Allegiance.Sanctuary == null)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YourAllegianceDoesNotHaveHometown));
-                return;
-            }
-            if (IsBusy || EmoteManager.IsBusy)
-            {
-                Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;
             }
 
@@ -315,7 +328,8 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.ExitTrainingAcademyToUseCommand));
                 return;
             }
-            if (IsBusy || EmoteManager.IsBusy)
+
+            if (TooBusyToRecall)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.YoureTooBusy));
                 return;


### PR DESCRIPTION
Right now it is possible to use multiple recall commands as well as the PKL command simultaneously. You can test on the master branch by typing /mp and then immediately typing /pkl. You will notice that you become PKL just before you teleport to marketplace. You can use these commands while teleporting in portal space which will begin the timer for the action concurrently with the current teleport/action.

This PR adds a common check to determine whether a recall (or entering PKL) is possible at that time. It checks for whether the character is busy or is already teleporting.