### PR TITLE
fixing bug for multiple items leveling simultaneously

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -854,15 +854,24 @@ namespace ACE.Server.Command.Handlers
             var item = CommandHandlerHelper.GetLastAppraisedObject(session);
             if (item == null) return;
 
-            if (!item.HasItemLevel)
+            if (item is Player player)
             {
-                session.Network.EnqueueSend(new GameMessageSystemChat($"{item.Name} is not a levelable item.", ChatMessageType.Broadcast));
-                return;
+                player.GrantItemXP(amount);
+
+                foreach (var i in player.EquippedObjects.Values.Where(i => i.HasItemLevel))
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{amount:N0} experience granted to {i.Name}.", ChatMessageType.Broadcast));
             }
+            else
+            {
+                if (item.HasItemLevel)
+                {
+                    session.Player.GrantItemXP(item, amount);
 
-            session.Player.GrantItemXP(item, amount);
-
-            session.Network.EnqueueSend(new GameMessageSystemChat($"{amount:N0} experience granted to {item.Name}.", ChatMessageType.Broadcast));
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{amount:N0} experience granted to {item.Name}.", ChatMessageType.Broadcast));
+                }
+                else
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{item.Name} is not a levelable item.", ChatMessageType.Broadcast));
+            }
         }
 
         [CommandHandler("spendallxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Spend all available XP on Attributes, Vitals and Skills.")]

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -56,6 +56,8 @@ namespace ACE.Server.WorldObjects
             HandleAllegianceOnLogin();
             HandleHouseOnLogin();
 
+            AuditItemSpells();
+
             if (PlayerKillerStatus == PlayerKillerStatus.PKLite)
             {
                 var actionChain = new ActionChain();

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
+using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
 using ACE.Server.Network.GameEvent.Events;
@@ -145,6 +146,57 @@ namespace ACE.Server.WorldObjects
             var spells = GetSpellSet((EquipmentSet)item.EquipmentSetId, setItems);
 
             EquipDequipItemFromSet(item, spells, prevSpells);
+        }
+
+        public void AuditItemSpells()
+        {
+            // cleans up bugged chars with dangling item set spells
+            // from previous bugs
+
+            // get active item enchantments
+            var enchantments = Biota.GetEnchantments(BiotaDatabaseLock).Where(i => i.Duration == -1).ToList();
+
+            foreach (var enchantment in enchantments)
+            {
+                // if this item is not equipped, remove enchantment
+                if (!EquippedObjects.TryGetValue(new ObjectGuid(enchantment.CasterObjectId), out var item))
+                {
+                    var spell = new Spell(enchantment.SpellId, false);
+                    log.Error($"{Name}.AuditItemSpells(): removing spell {spell.Name} from non-equipped item");
+
+                    EnchantmentManager.Dispel(enchantment);
+                    continue;
+                }
+
+                // is this item part of a set?
+                if (!item.HasItemSet)
+                    continue;
+
+                // get all of the equipped items in this set
+                var setItems = EquippedObjects.Values.Where(i => i.HasItemSet && i.EquipmentSetId == item.EquipmentSetId).ToList();
+
+                // get all of the spells currently active from this set
+                var currentSpells = GetSpellSet((EquipmentSet)item.EquipmentSetId, setItems);
+
+                // get all of the spells possible for this item set
+                var possibleSpells = GetSpellSetAll((EquipmentSet)item.EquipmentSetId);
+
+                // get the difference between them
+                var inactiveSpells = possibleSpells.Except(currentSpells).ToList();
+
+                // remove any item set spells that shouldn't be active
+                foreach (var inactiveSpell in inactiveSpells)
+                {
+                    var removeSpells = enchantments.Where(i => i.SpellSetId == (uint)item.EquipmentSetId && i.SpellId == inactiveSpell.Id).ToList();
+
+                    foreach (var removeSpell in removeSpells)
+                    {
+                        log.Error($"{Name}.AuditItemSpells(): removing spell {inactiveSpell.Name} from {item.EquipmentSetId}");
+
+                        EnchantmentManager.Dispel(removeSpell);
+                    }
+                }
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -407,6 +407,8 @@ namespace ACE.Server.WorldObjects
             var newItemLevel = item.ItemLevel.Value;
             if (newItemLevel > prevItemLevel)
             {
+                OnItemLevelUp(item, prevItemLevel);
+
                 var actionChain = new ActionChain();
                 actionChain.AddAction(this, () =>
                 {
@@ -414,9 +416,6 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
 
                     EnqueueBroadcast(new GameMessageScript(Guid, ACE.Entity.Enum.PlayScript.AetheriaLevelUp));
-
-                    OnItemLevelUp(item, prevItemLevel);
-
                 });
                 actionChain.EnqueueChain();
             }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Set.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Set.cs
@@ -120,6 +120,30 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// Returns all spells from all levels in the item set
+        /// </summary>
+        public static List<Spell> GetSpellSetAll(EquipmentSet equipmentSet)
+        {
+            var spells = new List<Spell>();
+
+            if (!DatManager.PortalDat.SpellTable.SpellSet.TryGetValue((uint)equipmentSet, out var spellSet))
+                return spells;
+
+            var spellIds = new HashSet<uint>();
+
+            foreach (var level in spellSet.SpellSetTiers.Values)
+            {
+                foreach (var spell in level.Spells)
+                    spellIds.Add(spell);
+            }
+
+            foreach (var spellId in spellIds)
+                spells.Add(new Spell(spellId, false));
+
+            return spells;
+        }
+
+        /// <summary>
         /// Returns the item set spells for a particular level
         /// </summary>
         public static List<Spell> GetSpellSet(EquipmentSet equipmentSet, List<WorldObject> setItems, int levelDiff = 0)


### PR DESCRIPTION
Repro steps:

- set a bunch of aetheria in the same item set to ItemTotalXp 0, equip them
- appraise player, /grantitemxp 5000000000
- dequip aetheria

Expected:

no spells from aetheria item set active

Actual:

spells from aetheria item set active

The error was placing OnItemLevelUp() inside of the ActionChain. Simply moving this method call outside of the action chain fixes the bug

To fix existing players in this bugged state is a bit more complicated, and the AuditItemSpells() method was added to handle this
