### PR TITLE
Picking up null Burden items

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -49,11 +49,8 @@ namespace ACE.Server.WorldObjects
 
         public bool HasEnoughBurdenToAddToInventory(WorldObject worldObject)
         {
-            if (worldObject.EncumbranceVal.HasValue)
-                return (EncumbranceVal + worldObject.EncumbranceVal <= (GetEncumbranceCapacity() * 3));
-            else
-                // Some items have a null EncumbranceVal but can still be picked up (assuming player is not at 300%)
-                return (EncumbranceVal <= (GetEncumbranceCapacity() * 3));
+            // We can still pick up null items, for some reason, we have the conditional for that
+            return (EncumbranceVal + (worldObject.EncumbranceVal ?? 0) <= (GetEncumbranceCapacity() * 3));
         }
 
         public bool HasEnoughBurdenToAddToInventory(int totalEncumbranceToCheck)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -49,7 +49,11 @@ namespace ACE.Server.WorldObjects
 
         public bool HasEnoughBurdenToAddToInventory(WorldObject worldObject)
         {
-            return (EncumbranceVal + worldObject.EncumbranceVal <= (GetEncumbranceCapacity() * 3));
+            if (worldObject.EncumbranceVal.HasValue)
+                return (EncumbranceVal + worldObject.EncumbranceVal <= (GetEncumbranceCapacity() * 3));
+            else
+                // Some items have a null EncumbranceVal but can still be picked up (assuming player is not at 300%)
+                return (EncumbranceVal <= (GetEncumbranceCapacity() * 3));
         }
 
         public bool HasEnoughBurdenToAddToInventory(int totalEncumbranceToCheck)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2019-07-25
+[OptimShi]
+* Fix to allow *null* EncumberanceVal items to be carried.
+
 ### 2019-07-24
 [OptimShi]
 * Added support for proper visual display of Layered Armor (Tailoring) and Reduced Armor (Tailoring) as well as future items such as Over-Robes.


### PR DESCRIPTION
Fixes an issue where you were unable to pick up null EncumberanceVal items. Specifically, the Gelidite Dais, but possibly others, too.
Testing Steps: 
-	Proceed to 0x546302A5 [216.357574 -70.013016 -5.995000] 0.667876 0.000000 0.000000 -0.744273
-	Pick up the Gelidite Dais.
-	Pick up another. And another. BECAUSE YOU CAN!
-	Reference: https://asheron.fandom.com/wiki/Gelidite_Dais
