### PR TITLE
Add refresh from world db scripts

### DIFF
--- a/Database/Optional/Shard/2019-07-12-00-Match_World_Spells_In_Biota_Enchantment_Registry.sql
+++ b/Database/Optional/Shard/2019-07-12-00-Match_World_Spells_In_Biota_Enchantment_Registry.sql
@@ -1,0 +1,5 @@
+UPDATE ace_shard.biota_properties_enchantment_registry enchantment
+INNER JOIN ace_world.spell ON spell.id=enchantment.spell_Id
+AND spell.stat_Mod_Type IS NOT NULL AND spell.stat_Mod_Key IS NOT NULL
+SET enchantment.stat_Mod_Type=spell.stat_Mod_Type, enchantment.stat_Mod_Key=spell.stat_Mod_Key
+WHERE enchantment.object_Id > 0;

--- a/Database/Optional/Shard/2019-08-04-00-Match_World_WeenieType_In_Biota.sql
+++ b/Database/Optional/Shard/2019-08-04-00-Match_World_WeenieType_In_Biota.sql
@@ -1,0 +1,6 @@
+SET @OLD_SQL_SAFE_UPDATES=@@SQL_SAFE_UPDATES, SQL_SAFE_UPDATES=0;
+UPDATE ace_shard.biota AS biota
+INNER JOIN ace_world.weenie AS weenie ON biota.weenie_Class_Id=weenie.class_Id
+SET biota.weenie_Type=weenie.`type`
+WHERE biota.id > 0 AND weenie.`type` <> biota.weenie_Type;
+SET SQL_SAFE_UPDATES=@OLD_SQL_SAFE_UPDATES;


### PR DESCRIPTION
Server operators can run these scripts to periodically re-sync with newer database changes.