### PR TITLE
Account In Use changes

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -477,6 +477,7 @@ namespace ACE.Server.Managers
 
         public static readonly ReadOnlyDictionary<string, Property<bool>> DefaultBooleanProperties =
             DictOf(
+                ("account_login_boots_in_use", new Property<bool>(true, "if FALSE, oldest connection to account is not booted when new connection occurs.")),
                 ("advanced_combat_pets", new Property<bool>(false, "(non-retail function) If enabled, Combat Pets can cast spells")),
                 ("assess_creature_mod", new Property<bool>(false, "(non-retail function) If enabled, re-enables former skill formula, when assess creature skill is not trained or spec'ed.")),
                 ("fellow_kt_killer", new Property<bool>(true, "if FALSE, fellowship kill tasks will share with the fellowship, even if the killer doesn't have the quest")),

--- a/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
+++ b/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
@@ -25,7 +25,8 @@ namespace ACE.Server.Network.Enum
         ClientConnectionFailure,
         SendToSocketException,
         WorldClosed,
-        AbnormalSequenceReceived
+        AbnormalSequenceReceived,
+        AccountLoggedIn
     }
     public static class SessionTerminationReasonHelper
     {
@@ -34,7 +35,7 @@ namespace ACE.Server.Network.Enum
             "",
             "PacketHeader Disconnect",
             "Account Information Invalid",
-            "AccountSelectCallback threw an exception.",
+            "AccountSelectCallback threw an exception",
             "Network Timeout",
             "client sent network error disconnect",
             "Account Booted",
@@ -42,13 +43,14 @@ namespace ACE.Server.Network.Enum
             "Pong sent, closing connection.",
             "Not Authorized: No password or GlsTicket included in login request",
             "Not Authorized: Account Not Found",
-            "Account In Use: Found another session already logged in for this account.",
-            "Not Authorized: Password does not match.",
+            "Account In Use: Found another session already logged in for this account",
+            "Not Authorized: Password does not match",
             "Not Authorized: GlsTicket is not implemented to process login request",
             "Client connection failure",
             "MainSocket.SendTo exception occured",
             "World is closed",
-            "Client supplied an abnormal sequence"
+            "Client supplied an abnormal sequence",
+            "Account was logged in, booting currently connected account in favor of new connection"
         };
         public static string GetDescription(this SessionTerminationReason reason)
         {

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -140,10 +140,13 @@ namespace ACE.Server.Network.Handlers
                 return;
             }
 
-            if (NetworkManager.Find(account.AccountName) != null)
+            if (!PropertyManager.GetBool("account_login_boots_in_use").Item)
             {
-                session.Terminate(SessionTerminationReason.AccountInUse, new GameMessageCharacterError(CharacterError.ServerCrash1));
-                return;
+                if (NetworkManager.Find(account.AccountName) != null)
+                {
+                    session.Terminate(SessionTerminationReason.AccountInUse, new GameMessageCharacterError(CharacterError.ServerCrash1));
+                    return;
+                }
             }
 
             if (loginRequest.NetAuthType == NetAuthType.AccountPassword)
@@ -161,6 +164,16 @@ namespace ACE.Server.Network.Handlers
                     // exponential duration of lockout for targeted account
 
                     return;
+                }
+
+                if (PropertyManager.GetBool("account_login_boots_in_use").Item)
+                {
+                    var previouslyConnectedAccount = NetworkManager.Find(account.AccountName);
+
+                    if (previouslyConnectedAccount != null)
+                    {
+                        previouslyConnectedAccount.Terminate(SessionTerminationReason.AccountLoggedIn, new GameMessageCharacterError(CharacterError.Logon));
+                    }
                 }
 
                 if (WorldManager.WorldStatus == WorldManager.WorldStatusState.Open)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ACEmulator Change Log
 
+### 2019-08-04
+[Ripley]
+* Update AuthenticationHandler to boot oldest connection to account when new one connects with valid login/password.
+ - Added new server configurable property `account_login_boots_in_use`, enabled by default retail rule.
+
 ### 2019-08-03
 [Ripley]
 * Add support for AdminEnvirons


### PR DESCRIPTION
* Update AuthenticationHandler to boot oldest connection to account when new one connects with valid login/password.
   - Added new server configurable property `account_login_boots_in_use`, enabled by default retail rule.