### PR TITLE
Fix issue with creatures dropping their wieldables to corpses

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -100,8 +100,8 @@ namespace ACE.Server.WorldObjects
 
             dieChain.AddAction(this, () =>
             {
-                Destroy();
                 CreateCorpse(topDamager);
+                Destroy();
             });
 
             dieChain.EnqueueChain();
@@ -347,10 +347,13 @@ namespace ACE.Server.WorldObjects
                     continue;
 
                 if (TryDequipObjectWithBroadcasting(item.Guid, out var wo, out var wieldedLocation))
-                    TryAddToInventory(wo);
+                    EnqueueBroadcast(new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Wielder, ObjectGuid.Invalid));
 
                 if (corpse != null)
+                {
                     corpse.TryAddToInventory(item);
+                    EnqueueBroadcast(new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, corpse.Guid), new GameMessagePickupEvent(item));
+                }
                 else
                     droppedItems.Add(item);
             }


### PR DESCRIPTION
This fixes the unable to move errors that occur for 25 seconds after death, as well as requiring reloading the corpse to see the items after they disappear the first time