### PR TITLE
fixing some gaps for swapping weapons after launching a projectile

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -143,11 +143,11 @@ namespace ACE.Server.Entity
             Attacker = attacker;
             Defender = defender;
 
-            CombatType = attacker.GetCombatType();
+            CombatType = damageSource.ProjectileSource == null ? attacker.GetCombatType() : CombatType.Missile;
 
             DamageSource = damageSource;
 
-            Weapon = attacker.GetEquippedWeapon();
+            Weapon = damageSource.ProjectileSource == null ? attacker.GetEquippedWeapon() : damageSource.ProjectileLauncher;
 
             AttackType = attacker.GetAttackType(Weapon, CombatManeuver);
             AttackHeight = attacker.AttackHeight ?? AttackHeight.Medium;
@@ -313,9 +313,8 @@ namespace ACE.Server.Entity
                 // handle prismatic arrows
                 if (DamageType == DamageType.Base)
                 {
-                    var weapon = attacker.GetEquippedWeapon();
-                    if (weapon != null && weapon.W_DamageType != DamageType.Undef)
-                        DamageType = weapon.W_DamageType;
+                    if (Weapon != null && Weapon.W_DamageType != DamageType.Undef)
+                        DamageType = Weapon.W_DamageType;
                     else
                         DamageType = DamageType.Pierce;
                 }
@@ -324,7 +323,7 @@ namespace ACE.Server.Entity
                 DamageType = attacker.GetDamageType();
 
             // TODO: combat maneuvers for player?
-            BaseDamageMod = attacker.GetBaseDamageMod();
+            BaseDamageMod = attacker.GetBaseDamageMod(DamageSource);
 
             if (DamageSource.ItemType == ItemType.MissileWeapon)
                 BaseDamageMod.ElementalBonus = WorldObject.GetMissileElementalDamageBonus(attacker, DamageType);
@@ -347,7 +346,7 @@ namespace ACE.Server.Entity
             BaseDamageMod = attacker.GetBaseDamage(AttackPart);
             BaseDamage = ThreadSafeRandom.Next(BaseDamageMod.MinDamage, BaseDamageMod.MaxDamage);
 
-            DamageType = attacker.GetDamageType(AttackPart);
+            DamageType = attacker.GetDamageType(AttackPart, CombatType);
 
             if (attacker is CombatPet combatPet)
                 DamageType = combatPet.DamageType;

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1051,7 +1051,7 @@ namespace ACE.Server.WorldObjects
         /// Returns the damage type for the currently equipped weapon / ammo
         /// </summary>
         /// <param name="multiple">If true, returns all of the damage types for the weapon</param>
-        public virtual DamageType GetDamageType(bool multiple = false)
+        public virtual DamageType GetDamageType(bool multiple = false, CombatType? combatType = null)
         {
             // old method, keeping intact for monsters
             var weapon = GetEquippedWeapon();
@@ -1060,7 +1060,8 @@ namespace ACE.Server.WorldObjects
             if (weapon == null)
                 return DamageType.Bludgeon;
 
-            var combatType = GetCombatType();
+            if (combatType == null)
+                combatType = GetCombatType();
 
             var damageSource = combatType == CombatType.Melee || ammo == null || !weapon.IsAmmoLauncher ? weapon : ammo;
 

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -70,12 +70,14 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a projectile from player to target
         /// </summary>
-        public WorldObject LaunchProjectile(WorldObject ammo, WorldObject target, out float time)
+        public WorldObject LaunchProjectile(WorldObject weapon, WorldObject ammo, WorldObject target, out float time)
         {
             var proj = WorldObjectFactory.CreateNewWorldObject(ammo.WeenieClassId);
 
             proj.ProjectileSource = this;
             proj.ProjectileTarget = target;
+
+            proj.ProjectileLauncher = weapon;
 
             var matchIndoors = Location.Indoors == target.Location.Indoors;
             var origin = matchIndoors ? Location.ToGlobal() : Location.Pos;

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -229,12 +229,12 @@ namespace ACE.Server.WorldObjects
             MaxRange = 0.0f;
         }
 
-        public DamageType GetDamageType(BiotaPropertiesBodyPart attackPart)
+        public DamageType GetDamageType(BiotaPropertiesBodyPart attackPart, CombatType? combatType = null)
         {
             var weapon = GetEquippedWeapon();
 
             if (weapon != null)
-                return GetDamageType();
+                return GetDamageType(false, combatType);
             else
             {
                 var damageType = (DamageType)attackPart.DType;

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -101,7 +101,7 @@ namespace ACE.Server.WorldObjects
 
                 if (AttackTarget != null)
                 {
-                    var projectile = LaunchProjectile(ammo, AttackTarget, out targetTime);
+                    var projectile = LaunchProjectile(weapon, ammo, AttackTarget, out targetTime);
                     UpdateAmmoAfterLaunch(ammo);
                 }
             });

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -296,12 +296,9 @@ namespace ACE.Server.WorldObjects
             Proficiency.OnSuccessUse(this, defenseSkill, difficulty);
         }
 
-        public BaseDamageMod GetBaseDamageMod()
+        public BaseDamageMod GetBaseDamageMod(WorldObject damageSource)
         {
-            var combatType = GetCombatType();
-            var damageSource = combatType == CombatType.Melee ? GetEquippedWeapon() : GetEquippedAmmo();
-
-            if (damageSource == null)
+            if (damageSource == this)
             {
                 if (AttackType == AttackType.Punch)
                     damageSource = HandArmor;
@@ -916,10 +913,11 @@ namespace ACE.Server.WorldObjects
         /// Returns the damage type for the currently equipped weapon / ammo
         /// </summary>
         /// <param name="multiple">If true, returns all of the damage types for the weapon</param>
-        public override DamageType GetDamageType(bool multiple = false)
+        public override DamageType GetDamageType(bool multiple = false, CombatType? combatType = null)
         {
             // player override
-            var combatType = GetCombatType();
+            if (combatType == null)
+                combatType = GetCombatType();
 
             var weapon = GetEquippedWeapon();
             var ammo = GetEquippedAmmo();

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -112,7 +112,7 @@ namespace ACE.Server.WorldObjects
                 UpdateVitalDelta(Stamina, -staminaCost);
 
                 float targetTime = 0.0f;
-                var projectile = LaunchProjectile(ammo, target, out targetTime);
+                var projectile = LaunchProjectile(weapon, ammo, target, out targetTime);
                 UpdateAmmoAfterLaunch(ammo);
             });
 

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -81,6 +81,8 @@ namespace ACE.Server.WorldObjects
         public WorldObject ProjectileSource;
         public WorldObject ProjectileTarget;
 
+        public WorldObject ProjectileLauncher;
+
         public WorldObject Wielder;
 
         public WorldObject() { }


### PR DESCRIPTION
This bug is showing up in the logs as DamageType.Undef when a monster launches its last projectile, and switches to melee combat while the projectile is in-flight, before it hits the target

A similar bug can also be reproed by the player, where you launch a prismatic arrow, and then dequip bow before the arrow hits the target