### PR TITLE
Relocate landblock tick code and add more detailed landblock tick performance measurements

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
@@ -158,7 +158,7 @@ namespace ACE.Server.Command.Handlers
             var loadedLandblocks = LandblockManager.GetLoadedLandblocks();
 
             // Filter out landblocks that haven't recorded at least 1000 events
-            var sortedBy5mAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.AverageEventDuration).Take(10).ToList();
+            var sortedBy5mAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 10).OrderByDescending(r => r.Monitor5m.AverageEventDuration).Take(10).ToList();
             var sortedBy1hrAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.AverageEventDuration).Take(10).ToList();
 
             var combinedByAverage = sortedBy5mAverage.Concat(sortedBy1hrAverage).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.AverageEventDuration, r.Monitor1h.AverageEventDuration)).Take(10);
@@ -182,8 +182,8 @@ namespace ACE.Server.Command.Handlers
                           $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
             }
 
-            var sortedBy5mLong = loadedLandblocks.Where(r => r.Monitor5m.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.LongestEvent).Take(10);
-            var sortedBy1hrLong = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.LongestEvent).Take(10);
+            var sortedBy5mLong = loadedLandblocks.OrderByDescending(r => r.Monitor5m.LongestEvent).Take(10);
+            var sortedBy1hrLong = loadedLandblocks.OrderByDescending(r => r.Monitor1h.LongestEvent).Take(10);
 
             var combinedByLong = sortedBy5mLong.Concat(sortedBy1hrLong).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.LongestEvent, r.Monitor1h.LongestEvent)).Take(10);
 

--- a/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
@@ -158,12 +158,15 @@ namespace ACE.Server.Command.Handlers
             var loadedLandblocks = LandblockManager.GetLoadedLandblocks();
 
             // Filter out landblocks that haven't recorded at least 1000 events
-            var sortedByAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.AverageEventDuration).Take(10);
+            var sortedBy5mAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.AverageEventDuration).Take(10).ToList();
+            var sortedBy1hrAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.AverageEventDuration).Take(10).ToList();
+
+            var combinedByAverage = sortedBy5mAverage.Concat(sortedBy1hrAverage).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.AverageEventDuration, r.Monitor1h.AverageEventDuration));
 
             sb.Append($"Most Busy Landblock - By Average{'\n'}");
-            sb.Append($"~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
+            sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
 
-            foreach (var entry in sortedByAverage)
+            foreach (var entry in combinedByAverage)
             {
                 int players = 0, creatures = 0;
                 foreach (var worldObject in entry.GetAllWorldObjectsForDiagnostics())
@@ -174,16 +177,20 @@ namespace ACE.Server.Command.Handlers
                         creatures++;
                 }
 
-                sb.Append($"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
-                    $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
+                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} {((int)entry.Monitor5m.TotalSeconds).ToString().PadLeft(4)} - " +
+                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
+                          $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
             }
 
-            var sortedByLong = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.LongestEvent).Take(10);
+            var sortedBy5mLong = loadedLandblocks.Where(r => r.Monitor5m.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.LongestEvent).Take(10);
+            var sortedBy1hrLong = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.LongestEvent).Take(10);
+
+            var combinedByLong = sortedBy5mLong.Concat(sortedBy1hrLong).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.LongestEvent, r.Monitor1h.LongestEvent));
 
             sb.Append($"Most Busy Landblock - By Longest{'\n'}");
-            sb.Append($"~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
+            sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
 
-            foreach (var entry in sortedByLong)
+            foreach (var entry in combinedByLong)
             {
                 int players = 0, creatures = 0;
                 foreach (var worldObject in entry.GetAllWorldObjectsForDiagnostics())
@@ -194,7 +201,8 @@ namespace ACE.Server.Command.Handlers
                         creatures++;
                 }
 
-                sb.Append($"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
+                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} {((int)entry.Monitor5m.TotalSeconds).ToString().PadLeft(4)} - " +
+                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
                           $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
             }
 

--- a/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
@@ -161,7 +161,7 @@ namespace ACE.Server.Command.Handlers
             var sortedBy5mAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.AverageEventDuration).Take(10).ToList();
             var sortedBy1hrAverage = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.AverageEventDuration).Take(10).ToList();
 
-            var combinedByAverage = sortedBy5mAverage.Concat(sortedBy1hrAverage).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.AverageEventDuration, r.Monitor1h.AverageEventDuration));
+            var combinedByAverage = sortedBy5mAverage.Concat(sortedBy1hrAverage).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.AverageEventDuration, r.Monitor1h.AverageEventDuration)).Take(10);
 
             sb.Append($"Most Busy Landblock - By Average{'\n'}");
             sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
@@ -185,7 +185,7 @@ namespace ACE.Server.Command.Handlers
             var sortedBy5mLong = loadedLandblocks.Where(r => r.Monitor5m.TotalEvents >= 1000).OrderByDescending(r => r.Monitor5m.LongestEvent).Take(10);
             var sortedBy1hrLong = loadedLandblocks.Where(r => r.Monitor1h.TotalEvents >= 1000).OrderByDescending(r => r.Monitor1h.LongestEvent).Take(10);
 
-            var combinedByLong = sortedBy5mLong.Concat(sortedBy1hrLong).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.LongestEvent, r.Monitor1h.LongestEvent));
+            var combinedByLong = sortedBy5mLong.Concat(sortedBy1hrLong).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.LongestEvent, r.Monitor1h.LongestEvent)).Take(10);
 
             sb.Append($"Most Busy Landblock - By Longest{'\n'}");
             sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");

--- a/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
@@ -164,7 +164,7 @@ namespace ACE.Server.Command.Handlers
             var combinedByAverage = sortedBy5mAverage.Concat(sortedBy1hrAverage).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.AverageEventDuration, r.Monitor1h.AverageEventDuration)).Take(10);
 
             sb.Append($"Most Busy Landblock - By Average{'\n'}");
-            sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
+            sb.Append($"~5m Hits   Avg  Long  Last - ~1h Hits   Avg  Long  Last - Location   Players  Creatures{'\n'}");
 
             foreach (var entry in combinedByAverage)
             {
@@ -177,8 +177,8 @@ namespace ACE.Server.Command.Handlers
                         creatures++;
                 }
 
-                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} {((int)entry.Monitor5m.TotalSeconds).ToString().PadLeft(4)} - " +
-                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
+                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} - " +
+                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} - " +
                           $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
             }
 
@@ -188,7 +188,7 @@ namespace ACE.Server.Command.Handlers
             var combinedByLong = sortedBy5mLong.Concat(sortedBy1hrLong).Distinct().OrderByDescending(r => Math.Max(r.Monitor5m.LongestEvent, r.Monitor1h.LongestEvent)).Take(10);
 
             sb.Append($"Most Busy Landblock - By Longest{'\n'}");
-            sb.Append($"~5m Hits   Avg  Long  Last  Tot - ~1h Hits   Avg  Long  Last  Tot - Location   Players  Creatures{'\n'}");
+            sb.Append($"~5m Hits   Avg  Long  Last - ~1h Hits   Avg  Long  Last - Location   Players  Creatures{'\n'}");
 
             foreach (var entry in combinedByLong)
             {
@@ -201,8 +201,8 @@ namespace ACE.Server.Command.Handlers
                         creatures++;
                 }
 
-                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} {((int)entry.Monitor5m.TotalSeconds).ToString().PadLeft(4)} - " +
-                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} {((int)entry.Monitor1h.TotalSeconds).ToString().PadLeft(4)} - " +
+                sb.Append($"{entry.Monitor5m.TotalEvents.ToString().PadLeft(7)} {entry.Monitor5m.AverageEventDuration:N4} {entry.Monitor5m.LongestEvent:N3} {entry.Monitor5m.LastEvent:N3} - " +
+                          $"{entry.Monitor1h.TotalEvents.ToString().PadLeft(7)} {entry.Monitor1h.AverageEventDuration:N4} {entry.Monitor1h.LongestEvent:N3} {entry.Monitor1h.LastEvent:N3} - " +
                           $"0x{entry.Id.Raw:X8} {players.ToString().PadLeft(7)}  {creatures.ToString().PadLeft(9)}{'\n'}");
             }
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -127,6 +127,9 @@ namespace ACE.Server.Entity
         public List<ModelMesh> Scenery { get; private set; }
 
 
+        public readonly RateMonitor Monitor5m = new RateMonitor();
+        private readonly TimeSpan last5mClearInteval = TimeSpan.FromMinutes(5);
+        private DateTime last5mClear;
         public readonly RateMonitor Monitor1h = new RateMonitor();
         private readonly TimeSpan last1hClearInteval = TimeSpan.FromHours(1);
         private DateTime last1hClear;
@@ -352,6 +355,9 @@ namespace ACE.Server.Entity
 
         public void TickPhysics(double portalYearTicks, ConcurrentBag<WorldObject> movedObjects)
         {
+            Monitor5m.RegisterEventStart();
+            Monitor1h.RegisterEventStart();
+
             foreach (WorldObject wo in GetWorldObjectsForPhysicsHandling())
             {
                 // set to TRUE if object changes landblock
@@ -377,6 +383,9 @@ namespace ACE.Server.Entity
                 if (landblockUpdate)
                     movedObjects.Add(wo);
             }
+
+            Monitor5m.PauseEvent();
+            Monitor1h.PauseEvent();
         }
 
         /// <summary>
@@ -399,7 +408,8 @@ namespace ACE.Server.Entity
 
         public void Tick(double currentUnixTime)
         {
-            Monitor1h.RegisterEventStart();
+            Monitor5m.ResumeEvent();
+            Monitor1h.ResumeEvent();
 
             ServerPerformanceMonitor.ResumeEvent(ServerPerformanceMonitor.MonitorType.Landblock_Tick_RunActions);
             actionQueue.RunActions();
@@ -537,7 +547,14 @@ namespace ACE.Server.Entity
             }
             ServerPerformanceMonitor.PauseEvent(ServerPerformanceMonitor.MonitorType.Landblock_Tick_Database_Save);
 
+            Monitor5m.RegisterEventEnd();
             Monitor1h.RegisterEventEnd();
+
+            if (DateTime.UtcNow - last5mClear >= last5mClearInteval)
+            {
+                Monitor5m.ClearEventHistory();
+                last5mClear = DateTime.UtcNow;
+            }
 
             if (DateTime.UtcNow - last1hClear >= last1hClearInteval)
             {

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -155,11 +155,11 @@ namespace ACE.Server.Managers
             0x5369FFFF
         };
 
-        public static void Tick(double tickTime)
+        public static void Tick(double portalYearTicks)
         {
             // update positions through physics engine
             ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.LandblockManager_TickPhysics);
-            TickPhysics(Timers.PortalYearTicks);
+            TickPhysics(portalYearTicks);
             ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.LandblockManager_TickPhysics);
 
             // Tick all of our Landblocks and WorldObjects

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -155,6 +155,54 @@ namespace ACE.Server.Managers
             0x5369FFFF
         };
 
+        public static void Tick(double tickTime)
+        {
+            // update positions through physics engine
+            ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.LandblockManager_TickPhysics);
+            TickPhysics(Timers.PortalYearTicks);
+            ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.LandblockManager_TickPhysics);
+
+            // Tick all of our Landblocks and WorldObjects
+            ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.LandblockManager_Tick);
+            Tick();
+            ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.LandblockManager_Tick);
+
+            // clean up inactive landblocks
+            UnloadLandblocks();
+        }
+
+        /// <summary>
+        /// Processes physics objects in all active landblocks for updating
+        /// </summary>
+        private static void TickPhysics(double portalYearTicks)
+        {
+            var activeLandblocks = GetActiveLandblocks();
+
+            var movedObjects = new ConcurrentBag<WorldObject>();
+
+            foreach (var landblock in activeLandblocks)
+                landblock.TickPhysics(portalYearTicks, movedObjects);
+
+            // iterate through objects that have changed landblocks
+            foreach (var movedObject in movedObjects)
+            {
+                // NOTE: The object's Location can now be null, if a player logs out, or an item is picked up
+                if (movedObject.Location == null)
+                    continue;
+
+                // assume adjacency move here?
+                RelocateObjectForPhysics(movedObject, true);
+            }
+        }
+
+        private static void Tick()
+        {
+            var loadedLandblocks = GetLoadedLandblocks();
+
+            foreach (var landblock in loadedLandblocks)
+                landblock.Tick(Time.GetUnixTime());
+        }
+
         /// <summary>
         /// Adds a WorldObject to the landblock defined by the object's location
         /// </summary>

--- a/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
+++ b/Source/ACE.Server/Managers/ServerPerformanceMonitor.cs
@@ -23,9 +23,8 @@ namespace ACE.Server.Managers
 
             // These are all found in WorldManager.UpdateGameWorld()
             UpdateGameWorld_Entire,
-            UpdateGameWorld_HandlePhysics,
-            UpdateGameWorld_RelocateObjectForPhysics,
-            UpdateGameWorld_landblock_Tick,
+            LandblockManager_TickPhysics,
+            LandblockManager_Tick,
 
             // These are all found in Landblock.Tick()
             Landblock_Tick_RunActions,
@@ -261,7 +260,7 @@ namespace ACE.Server.Managers
             AddMonitorOutputToStringBuilder(monitors5m[(int)MonitorType.UpdateGameWorld_Entire], monitors1h[(int)MonitorType.UpdateGameWorld_Entire], monitors24h[(int)MonitorType.UpdateGameWorld_Entire], MonitorType.UpdateGameWorld_Entire, sb);
 
             sb.Append($"Calls from WorldManager.UpdateGameWorld(){'\n'}");
-            for (int i = (int)MonitorType.UpdateGameWorld_HandlePhysics; i <= (int)MonitorType.UpdateGameWorld_landblock_Tick; i++)
+            for (int i = (int)MonitorType.LandblockManager_TickPhysics; i <= (int)MonitorType.LandblockManager_Tick; i++)
                 AddMonitorOutputToStringBuilder(monitors5m[i], monitors1h[i], monitors24h[i], (MonitorType)i, sb);
 
             sb.Append($"Calls from Landblock.Tick() - Cumulative over a single UpdateGameWorld Tick{'\n'}");

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -28,8 +28,6 @@ namespace ACE.Server.Managers
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static bool Concurrency = false;
-
         private static readonly PhysicsEngine Physics;
 
         public static bool WorldActive { get; private set; }

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Threading.Tasks;
 
 using log4net;
 
@@ -23,7 +20,6 @@ using ACE.Server.Network.Managers;
 using ACE.Server.Physics;
 using ACE.Server.Physics.Common;
 
-using Landblock = ACE.Server.Entity.Landblock;
 using Position = ACE.Entity.Position;
 
 namespace ACE.Server.Managers
@@ -372,33 +368,7 @@ namespace ACE.Server.Managers
 
             ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_Entire);
 
-            // update positions through physics engine
-            ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_HandlePhysics);
-            var movedObjects = HandlePhysics(Timers.PortalYearTicks);
-            ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_HandlePhysics);
-
-            // iterate through objects that have changed landblocks
-            ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_RelocateObjectForPhysics);
-            foreach (var movedObject in movedObjects)
-            {
-                // NOTE: The object's Location can now be null, if a player logs out, or an item is picked up
-                if (movedObject.Location == null) continue;
-
-                // assume adjacency move here?
-                LandblockManager.RelocateObjectForPhysics(movedObject, true);
-            }
-            ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_RelocateObjectForPhysics);
-
-            // Tick all of our Landblocks and WorldObjects
-            ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_landblock_Tick);
-            var loadedLandblocks = LandblockManager.GetLoadedLandblocks();
-
-            foreach (var landblock in loadedLandblocks)
-                landblock.Tick(Time.GetUnixTime());
-            ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.UpdateGameWorld_landblock_Tick);
-
-            // clean up inactive landblocks
-            LandblockManager.UnloadLandblocks();
+            LandblockManager.Tick(Timers.PortalYearTicks);
 
             HouseManager.Tick();
 
@@ -411,85 +381,5 @@ namespace ACE.Server.Managers
         /// Function to begin ending the operations inside of an active world.
         /// </summary>
         public static void StopWorld() { pendingWorldStop = true; }
-
-        /// <summary>
-        /// Processes physics objects in all active landblocks for updating
-        /// </summary>
-        private static IEnumerable<WorldObject> HandlePhysics(double timeTick)
-        {
-            ConcurrentQueue<WorldObject> movedObjects = new ConcurrentQueue<WorldObject>();
-            try
-            {
-                var activeLandblocks = LandblockManager.GetActiveLandblocks();
-
-                if (Concurrency)
-                {
-                    // Access ActiveLandblocks should be safe here, but sometimes crashes with
-                    // System.InvalidOperationException: 'Collection was modified; enumeration operation may not execute.'
-                    Parallel.ForEach(activeLandblocks, landblock =>
-                    {
-                        HandlePhysicsLandblock(landblock, timeTick, movedObjects);
-                    });
-                }
-                else
-                {
-                    foreach (var landblock in activeLandblocks)
-                        HandlePhysicsLandblock(landblock, timeTick, movedObjects);
-                }
-            }
-            catch (Exception e)
-            {
-                log.Error(e);
-            }
-            return movedObjects;
-        }
-
-        private static void HandlePhysicsLandblock(Landblock landblock, double timeTick, ConcurrentQueue<WorldObject> movedObjects)
-        {
-            foreach (WorldObject wo in landblock.GetWorldObjectsForPhysicsHandling())
-            {
-                // set to TRUE if object changes landblock
-                var landblockUpdate = false;
-
-                // detect player movement
-                // TODO: handle players the same as everything else
-                if (wo is Player player)
-                {
-                    wo.InUpdate = true;
-
-                    var newPosition = HandlePlayerPhysics(player, timeTick);
-
-                    // update position through physics engine
-                    if (newPosition != null)
-                        landblockUpdate = wo.UpdatePlayerPhysics(newPosition);
-
-                    wo.InUpdate = false;
-                }
-                else
-                    landblockUpdate = wo.UpdateObjectPhysics();
-
-                if (landblockUpdate)
-                    movedObjects.Enqueue(wo);
-            }
-        }
-
-        /// <summary>
-        /// Detects if player has moved through ForcedLocation or RequestedLocation
-        /// </summary>
-        private static Position HandlePlayerPhysics(Player player, double timeTick)
-        {
-            Position newPosition = null;
-
-            if (player.ForcedLocation != null)
-                newPosition = player.ForcedLocation;
-
-            else if (player.RequestedLocation != null)
-                newPosition = player.RequestedLocation;
-
-            if (newPosition != null)
-                player.ClearRequestedPositions();
-
-            return newPosition;
-        }
     }
 }


### PR DESCRIPTION
Landblock tick management has been moved from WorldManager to LandblockManager

Individual landblock physics ticking has been moved all the way down to Landblock

Landblock now includes a 5m rate monitor in addition to the 1hr it already had

landblockperformance /allstats now reports a combined report from both 5m and 1hr rate monitoring.