### PR TITLE
starting to clean up /acecommands a bit

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -40,7 +40,7 @@ namespace ACE.Server.Command.Handlers
 
         // adminvision { on | off | toggle | check}
         [CommandHandler("adminvision", AccessLevel.Sentinel, CommandHandlerFlag.RequiresWorld, 1,
-            "Allows the admin to see admin - only visible items.", "{ on | off | toggle | check }\n" +
+            "Allows the admin to see admin-only visible items.", "{ on | off | toggle | check }\n" +
             "Controls whether or not the admin can see admin-only visible items. Note that if you turn this feature off, you will need to log out and back in before the visible items become invisible.")]
         public static void HandleAdminvision(Session session, params string[] parameters)
         {
@@ -564,7 +564,7 @@ namespace ACE.Server.Command.Handlers
 
         // myiid
         [CommandHandler("myiid", AccessLevel.Envoy, CommandHandlerFlag.RequiresWorld, 0,
-            "Displays your Instance ID(IID)")]
+            "Displays your Instance ID (IID)")]
         public static void HandleMyIID(Session session, params string[] parameters)
         {
             // @myiid - Displays your Instance ID(IID).
@@ -1585,7 +1585,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Displays how much experience the last appraised creature is worth when killed.
         /// </summary>
-        [CommandHandler("deathxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Displays how much experience the last appraised creature iw worth when killed.")]
+        [CommandHandler("deathxp", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Displays how much experience the last appraised creature is worth when killed.")]
         public static void HandleDeathxp(Session session, params string[] parameters)
         {
             var creature = CommandHandlerHelper.GetLastAppraisedObject(session);
@@ -1595,7 +1595,7 @@ namespace ACE.Server.Command.Handlers
         }
 
         // de_n name, text
-        [CommandHandler("de_n", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2)]
+        [CommandHandler("de_n", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2, "Sends text to named player, formatted exactly as entered.", "<name> <text>")]
         public static void Handlede_n(Session session, params string[] parameters)
         {
             // usage: @de_n name, text
@@ -1603,16 +1603,11 @@ namespace ACE.Server.Command.Handlers
             // Sends text to named player, formatted exactly as entered, with no prefix of any kind.
             // @direct_emote_name - Sends text to named player, formatted exactly as entered.
 
-            // usage: @de_s text
-            // usage: @direct_emote_select text
-            // Sends text to selected player, formatted exactly as entered, with no prefix of any kind.
-            // @direct_emote_select - Sends text to selected player, formatted exactly as entered.
-
             // TODO: output
         }
 
         // direct_emote_name name, text
-        [CommandHandler("direct_emote_name", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2)]
+        [CommandHandler("direct_emote_name", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 2, "Sends text to named player, formatted exactly as entered.", "<name> <text>")]
         public static void Handledirect_emote_name(Session session, params string[] parameters)
         {
             // usage: @de_n name, text
@@ -1620,23 +1615,13 @@ namespace ACE.Server.Command.Handlers
             // Sends text to named player, formatted exactly as entered, with no prefix of any kind.
             // @direct_emote_name - Sends text to named player, formatted exactly as entered.
 
-            // usage: @de_s text
-            // usage: @direct_emote_select text
-            // Sends text to selected player, formatted exactly as entered, with no prefix of any kind.
-            // @direct_emote_select - Sends text to selected player, formatted exactly as entered.
-
             // TODO: output
         }
 
         // de_s text
-        [CommandHandler("de_s", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
+        [CommandHandler("de_s", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Sends text to selected player, formatted exactly as entered, with no prefix of any kind.", "<text>")]
         public static void Handlede_s(Session session, params string[] parameters)
         {
-            // usage: @de_n name, text
-            // usage: @direct_emote_name name, text
-            // Sends text to named player, formatted exactly as entered, with no prefix of any kind.
-            // @direct_emote_name - Sends text to named player, formatted exactly as entered.
-
             // usage: @de_s text
             // usage: @direct_emote_select text
             // Sends text to selected player, formatted exactly as entered, with no prefix of any kind.
@@ -1646,7 +1631,7 @@ namespace ACE.Server.Command.Handlers
         }
 
         // direct_emote_select text
-        [CommandHandler("direct_emote_select", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1)]
+        [CommandHandler("direct_emote_select", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Sends text to selected player, formatted exactly as entered, with no prefix of any kind.", "<text>")]
         public static void Handledirect_emote_select(Session session, params string[] parameters)
         {
             // usage: @de_s text
@@ -1978,7 +1963,7 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("magic god", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
         public static void HandleMagicGod(Session session, params string[] parameters)
         {
-            // @magic god -Sets your magic stats to the specfied level.
+            // @magic god - Sets your magic stats to the specfied level.
 
             // TODO: output
 
@@ -1989,7 +1974,7 @@ namespace ACE.Server.Command.Handlers
 
         // heal
         [CommandHandler("heal", AccessLevel.Envoy, CommandHandlerFlag.RequiresWorld, 0,
-            "Heals yourself(or the selected creature)",
+            "Heals yourself (or the selected creature)",
             "\n" + "This command fully restores your(or the selected creature's) health, mana, and stamina")]
         public static void HandleHeal(Session session, params string[] parameters)
         {
@@ -2457,7 +2442,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Sets whether you lose items should you die.
         /// </summary>
-        [CommandHandler("sticky", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
+        [CommandHandler("sticky", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Sets whether you lose items should you die.", "<off/on>")]
         public static void HandleSticky(Session session, params string[] parameters)
         {
             bool sticky = !(parameters.Length > 0 && parameters[0] == "off");
@@ -2758,14 +2743,13 @@ namespace ACE.Server.Command.Handlers
             CommandHandlerHelper.WriteOutputInfo(session, "Successfully updated property description!", ChatMessageType.Help);
         }
 
-        [CommandHandler("resyncproperties", AccessLevel.Admin, CommandHandlerFlag.None, -1,
-            "Resync the properties database", "resyncproperties")]
+        [CommandHandler("resyncproperties", AccessLevel.Admin, CommandHandlerFlag.None, "Resync the properties database")]
         public static void HandleResyncServerProperties(Session session, params string[] parameters)
         {
             PropertyManager.ResyncVariables();
         }
 
-        [CommandHandler("fix-allegiances", AccessLevel.Admin, CommandHandlerFlag.None, 0, "Fixes the monarch data for allegiances", "")]
+        [CommandHandler("fix-allegiances", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, "Fixes the monarch data for allegiances")]
         public static void HandleFixAllegiances(Session session, params string[] parameters)
         {
             var players = PlayerManager.GetAllPlayers();
@@ -2833,7 +2817,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("show-allegiances", AccessLevel.Admin, CommandHandlerFlag.None, 0, "Shows all of the allegiance chains on the server.", "")]
+        [CommandHandler("show-allegiances", AccessLevel.Admin, CommandHandlerFlag.None, "Shows all of the allegiance chains on the server.")]
         public static void HandleShowAllegiances(Session session, params string[] parameters)
         {
             var players = PlayerManager.GetAllPlayers();
@@ -2849,7 +2833,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("verify-xp", AccessLevel.Admin, CommandHandlerFlag.None, 0, "fixes skill ranks from spec temple", "")]
+        [CommandHandler("verify-xp", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, "Fixes skill ranks from spec temple")]
         public static void HandleVerifySkill(Session session, params string[] parameters)
         {
             var players = PlayerManager.GetAllOffline();
@@ -2880,7 +2864,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("verify-skill-credits", AccessLevel.Admin, CommandHandlerFlag.None, 0, "fixes skill credits from asheron's castle", "")]
+        [CommandHandler("verify-skill-credits", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, "Verifies and fixes player skill credits from Asheron's Castle.")]
         public static void HandleVerifySkillCredits(Session session, params string[] parameters)
         {
             var players = PlayerManager.GetAllOffline();
@@ -3036,7 +3020,7 @@ namespace ACE.Server.Command.Handlers
             { 275, 46 }
         };
 
-        [CommandHandler("getenchantments", AccessLevel.Admin, CommandHandlerFlag.None, 0, "Shows the enchantments for the last appraised item", "")]
+        [CommandHandler("getenchantments", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, "Shows the enchantments for the last appraised item")]
         public static void HandleGetEnchantments(Session session, params string[] parameters)
         {
             var item = CommandHandlerHelper.GetLastAppraisedObject(session);
@@ -3053,16 +3037,14 @@ namespace ACE.Server.Command.Handlers
         }
       
         // cm <material type> <quantity> <ave. workmanship>
-        [CommandHandler("cm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 3)]
+        [CommandHandler("cm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
         public static void HandleCM(Session session, params string[] parameters)
         {
             // Format is: @cm <material type> <quantity> <ave. workmanship>
             HandleCISalvage(session);
-
-            // TODO: output
         }
 
-        [CommandHandler("cisalvage", AccessLevel.Admin, CommandHandlerFlag.None, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
+        [CommandHandler("cisalvage", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
         public static void HandleCISalvage(Session session, params string[] parameters)
         {
             if (!Enum.TryParse(parameters[0], true, out MaterialType materialType))

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -415,7 +415,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Debug command to spawn the Barber UI
         /// </summary>
-        [CommandHandler("barbershop", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("barbershop", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Displays the barber ui")]
         public static void BarberShop(Session session, params string[] parameters)
         {
             session.Network.EnqueueSend(new GameEventStartBarber(session));
@@ -950,7 +950,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Debug command to set player vitals to 1
         /// </summary>
-        [CommandHandler("harmself", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("harmself", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Sets all player vitals to 1")]
         public static void HarmSelf(Session session, params string[] parameters)
         {
             session.Player.UpdateVital(session.Player.Health, 1);
@@ -1450,7 +1450,7 @@ namespace ACE.Server.Command.Handlers
             Creature.ForcePos = enabled;
         }
 
-        [CommandHandler("lostest", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Tests for direct visibilty with latest appraised object", "lostest")]
+        [CommandHandler("lostest", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Tests for direct visibilty with latest appraised object")]
         public static void HandleVisible(Session session, params string[] parameters)
         {
             // get the last appraised object
@@ -1513,7 +1513,7 @@ namespace ACE.Server.Command.Handlers
                 Console.WriteLine(skill.Skill + ": " + skill.Current);
         }
 
-        [CommandHandler("givemana", AccessLevel.Developer, CommandHandlerFlag.None, 0, "Gives mana to the last appraised object", "givemana <amount>")]
+        [CommandHandler("givemana", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0, "Gives mana to the last appraised object", "<amount>")]
         public static void HandleGiveMana(Session session, params string[] parameters)
         {
             if (parameters.Length == 0) return;
@@ -1542,8 +1542,8 @@ namespace ACE.Server.Command.Handlers
             var dist = Vector3.Distance(sourcePos, targetPos);
             var dist2d = Vector2.Distance(new Vector2(sourcePos.X, sourcePos.Y), new Vector2(targetPos.X, targetPos.Y));
 
-            Console.WriteLine("Dist: " + dist);
-            Console.WriteLine("2D Dist: " + dist2d);
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Dist: {dist}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"2D Dist: {dist2d}", ChatMessageType.Broadcast));
         }
 
         /// <summary>
@@ -2015,13 +2015,13 @@ namespace ACE.Server.Command.Handlers
             session.Player.UpdateProperty(session.Player, PropertyInt.AetheriaBitfield, flags);
         }
 
-        [CommandHandler("debugchess", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Shows the chess move history for a player")]
+        [CommandHandler("debugchess", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the chess move history for a player")]
         public static void HandleDebugChess(Session session, params string[] parameters)
         {
             session.Player.ChessMatch?.DebugMove();
         }
 
-        [CommandHandler("debugboard", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, 0, "Shows the current chess board state")]
+        [CommandHandler("debugboard", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the current chess board state")]
         public static void HandleDebugBoard(Session session, params string[] parameters)
         {
             session.Player.ChessMatch?.Logic?.DebugBoard();
@@ -2030,7 +2030,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// Teleports directly to a dungeon by name or landblock
         /// </summary>
-        [CommandHandler("teledungeon", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "<dungeon name or landblock>")]
+        [CommandHandler("teledungeon", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Teleport to a dungeon", "<dungeon name or landblock>")]
         public static void HandleTeleDungeon(Session session, params string[] parameters)
         {
             var isBlock = true;
@@ -2200,7 +2200,7 @@ namespace ACE.Server.Command.Handlers
             log.Info($"Physics ObjMaint Audit Completed. Errors - objectTable: {objectTableErrors}, visibleObjectTable: {visibleObjectTableErrors}, voyeurTable: {voyeurTableErrors}");
         }
 
-        [CommandHandler("lootgen", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Generate a piece of loot from the LootGenerationFactory. Syntax is \"lootgen (wcid) <tier>\"")]
+        [CommandHandler("lootgen", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Generate a piece of loot from the LootGenerationFactory.", "<wcid> <tier>")]
         public static void HandleLootGen(Session session, params string[] parameters)
         {
             string weenieClassDescription = parameters[0];
@@ -2361,7 +2361,7 @@ namespace ACE.Server.Command.Handlers
         /// <summary>
         /// This is to add spells to items (whether loot or quest generated).  For making weapons to check damage from pcaps or other sources
         /// </summary>
-        [CommandHandler("additemspell", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "/additemspell <spell id> - adds a spell to the last appraised item. Ex /additemspell 6089 - adds Legendary Bloodthirst")]
+        [CommandHandler("additemspell", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Adds a spell to the last appraised item's spellbook.", "<spell id>")]
         public static void HandleAddItemSpell(Session session, params string[] parameters)
         {
             var obj = CommandHandlerHelper.GetLastAppraisedObject(session);
@@ -2385,7 +2385,7 @@ namespace ACE.Server.Command.Handlers
             session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} ({spell.Id}) {msg} {obj.Name}", ChatMessageType.Broadcast));
         }
 
-        [CommandHandler("pktimer", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 0)]
+        [CommandHandler("pktimer", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Sets your PK timer to the current time")]
         public static void HandlePKTimer(Session session, params string[] parameters)
         {
             session.Player.UpdatePKTimer();
@@ -2393,7 +2393,7 @@ namespace ACE.Server.Command.Handlers
             session.Network.EnqueueSend(new GameMessageSystemChat($"Updated PK timer", ChatMessageType.Broadcast));
         }
 
-        [CommandHandler("fellow-info", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("fellow-info", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows debug info for fellowships.")]
         public static void HandleFellowInfo(Session session, params string[] parameters)
         {
             var player = session.Player;
@@ -2543,7 +2543,7 @@ namespace ACE.Server.Command.Handlers
             }
         }
 
-        [CommandHandler("purchase-house", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("purchase-house", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Instantly purchase the house for the last appraised covenant crystal.")]
         public static void HandlePurchaseHouse(Session session, params string[] parameters)
         {
             var slumlord = CommandHandlerHelper.GetLastAppraisedObject(session) as SlumLord;
@@ -2557,7 +2557,7 @@ namespace ACE.Server.Command.Handlers
             session.Player.GiveDeed();
         }
 
-        [CommandHandler("barrier-test", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("barrier-test", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows debug information for house barriers")]
         public static void HandleBarrierTest(Session session, params string[] parameters)
         {
             var cell = session.Player.Location.Cell;
@@ -2580,15 +2580,15 @@ namespace ACE.Server.Command.Handlers
             Console.WriteLine($"Barrier: {barrier}");
         }
 
-        [CommandHandler("targetloc", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        [CommandHandler("targetloc", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the location of the last appraised object")]
         public static void HandleTargetLoc(Session session, params string[] parameters)
         {
             var wo = CommandHandlerHelper.GetLastAppraisedObject(session);
             if (wo == null)
                 return;
 
-            session.Network.EnqueueSend(new GameMessageSystemChat($"Location: {wo.Location.ToLOCString()}", ChatMessageType.Broadcast));
-            session.Network.EnqueueSend(new GameMessageSystemChat($"Physics : {wo.PhysicsObj.Position}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Location: {wo.Location?.ToLOCString()}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Physics : {wo.PhysicsObj?.Position}", ChatMessageType.Broadcast));
         }
 
         [CommandHandler("remove-vitae", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Removes vitae from last appraised player")]

--- a/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperDatabaseCommands.cs
@@ -38,7 +38,7 @@ namespace ACE.Server.Command.Handlers
             processor.RunAsync(session, biotasPerTest);
         }
 
-        [CommandHandler("fix-shortcut-bars", AccessLevel.Admin, CommandHandlerFlag.None, 0, "Outputs to console SQL scripting to fix the players with duplicate items on their shortcut bars.", "")]
+        [CommandHandler("fix-shortcut-bars", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, "Fixes the players with duplicate items on their shortcut bars.", "<execute>")]
         public static void HandleFixShortcutBars(Session session, params string[] parameters)
         {
             Console.WriteLine();

--- a/Source/ACE.Server/Command/Handlers/HelpCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/HelpCommands.cs
@@ -93,7 +93,7 @@ namespace ACE.Server.Command.Handlers
             if (parameters.Length > 0)
             {
                 var param = parameters[0];
-                if (Enum.TryParse(param, true, out AccessLevel pAccessLevel) && pAccessLevel < accessLevel)
+                if (Enum.TryParse(param, true, out AccessLevel pAccessLevel) && pAccessLevel <= accessLevel)
                 {
                     accessLevel = pAccessLevel;
                     exact = true;

--- a/Source/ACE.Server/Command/Handlers/HelpCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/HelpCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using ACE.Entity.Enum;
 using ACE.Server.Network;
@@ -74,10 +75,10 @@ namespace ACE.Server.Command.Handlers
         }
 
         // acecommands
-        [CommandHandler("acecommands", AccessLevel.Player, CommandHandlerFlag.None, 0, "Lists all commands.")]
+        [CommandHandler("acecommands", AccessLevel.Player, CommandHandlerFlag.None, 0, "Lists all commands.", "<access level>")]
         public static void HandleACECommands(Session session, params string[] parameters)
         {
-            List<String> commandList = new List<string>();
+            var commandList = new List<string>();
 
             var msgHeader = "Note: You may substitute a forward slash (/) for the at symbol (@).\n"
                           + "For more information, type @acehelp < command >.\n";
@@ -85,29 +86,32 @@ namespace ACE.Server.Command.Handlers
             if (session == null)            
                 Console.WriteLine("For more information, type acehelp < command >.");
 
-            foreach (var command in CommandManager.GetCommands())
+            var accessLevel = session != null ? session.AccessLevel : AccessLevel.Admin;
+            var exact = false;
+
+            if (parameters.Length > 0)
             {
-                if (session != null)
+                var param = parameters[0];
+                if (Enum.TryParse(param, true, out accessLevel))
                 {
-                    if (command.Attribute.Flags == CommandHandlerFlag.ConsoleInvoke) // Skip Console Commands
-                        continue;
-                    if (session.AccessLevel < command.Attribute.Access) // Skip Commands which are higher than your current access level
-                        continue;
-
-                    commandList.Add(string.Format("@{0} - {1}", command.Attribute.Command, command.Attribute.Description));
-                }
-                else
-                {
-                    if (command.Attribute.Flags == CommandHandlerFlag.RequiresWorld) // Skip Commands that only work in game
-                        continue;
-
-                    commandList.Add(string.Format("{0} - {1}", command.Attribute.Command, command.Attribute.Description));
+                    if (session != null && accessLevel > session.AccessLevel)
+                        accessLevel = session.AccessLevel;
+                    else
+                        exact = true;
                 }
             }
 
-            commandList.Sort();
+            var restrict = session != null ? CommandHandlerFlag.ConsoleInvoke : CommandHandlerFlag.RequiresWorld;
 
-            var msg = string.Join("\n", commandList.ToArray());
+            var commands = from cmd in CommandManager.GetCommands()
+                           where (exact ? cmd.Attribute.Access == accessLevel : cmd.Attribute.Access <= accessLevel) && cmd.Attribute.Flags != restrict
+                           orderby cmd.Attribute.Command
+                           select cmd;
+
+            foreach (var command in commands)
+                commandList.Add(string.Format("@{0} - {1}", command.Attribute.Command, command.Attribute.Description));
+
+            var msg = string.Join("\n", commandList);
 
             if (session != null)
                 session.Network.EnqueueSend(new GameMessageSystemChat(msgHeader + msg, ChatMessageType.Broadcast));


### PR DESCRIPTION
- Added an optional &lt;access level&gt; parameter to filter /acecommands
If this is specified, and the current user's access level is at least the requested level, the output will show the commands specifically for that access level.
ie., if an Admin types /acecommands developer, it will show them just the commands with AccessLevel.Developer
if a regular player types /acecommands developer, it will not show them the developer commands, and will just show them the regular commands they would see from /acecommands

- Added the ability search /acecommands by keyword. Ex., /acecommands house

- Started to clean up the text for all of the descriptions for display in-game. Some parameters that were directly in the descriptions were moved to the "parameters" section of the command.
The commands from the admin client that are still unimplemented were left with blank descriptions, to a) indicate in acecommands that these are still unimplemented, and b) make it easier for developers to see which commands still need to be implemented

- Fixed a few AccessLevels and CommandHandlerFlags, so typing acecommands from the console shows clean output again

TODO:

- Ensure the commands in the &lt;AccessLevel&gt;Commands.cs files match the actual AccessLevel of the command
- Review with the team the AccessLevels for some of the commands, and make sure the AccessLevels are set appropriately

Currently the 'Developer' AccessLevel has the most commands, and it is possible many of these commands could be moved to lower access levels