### PR TITLE
Fix the GetWield method for magic casters

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -374,10 +374,7 @@ namespace ACE.Server.Factories
                         case 1:
                         case 2:
                         case 3:
-                            if (chance < 80)
-                                wield = 0;
-                            else
-                                wield = 290;
+                            wield = 0;
                             break;
                         case 4:
                             if (chance < 60)


### PR DESCRIPTION
- According to loot tier breakdowns, tiers 1 through 3 should not have a chance for a wield requirement on the caster; ref. http://acpedia.org/wiki/Loot
