### PR TITLE
Guid Recycle Redux

### DIFF
--- a/Source/ACE.Server/Managers/GuidManager.cs
+++ b/Source/ACE.Server/Managers/GuidManager.cs
@@ -286,7 +286,7 @@ namespace ACE.Server.Managers
             // todo: fix this so things don't look funky to clients
             // todo: What was reported was that items would spawn in looking like couches, or other dynamic items
             // todo: Figure out how long the sequence gaps, then change the recycle limit to that threshold
-            //dynamicAlloc.Recycle(guid.Full);
+            dynamicAlloc.Recycle(guid.Full);
         }
 
 

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -672,9 +672,31 @@ namespace ACE.Server.WorldObjects
             player.Session.Network.EnqueueSend(itemsToSend.ToArray());
         }
 
+        private void SendDeletesForMyInventory(Player player)
+        {
+            // send deleteobjects for all objects in this container's inventory to player
+            var itemsToSend = new List<GameMessage>();
+
+            foreach (var item in Inventory.Values)
+            {
+                // FIXME: only send messages for known objects
+                itemsToSend.Add(new GameMessageDeleteObject(item));
+
+                if (item is Container container)
+                {
+                    foreach (var containerItem in container.Inventory.Values)
+                        itemsToSend.Add(new GameMessageDeleteObject(containerItem));
+                }
+            }
+
+            player.Session.Network.EnqueueSend(itemsToSend.ToArray());
+        }
+
         public virtual void Close(Player player)
         {
             if (!IsOpen) return;
+
+            SendDeletesForMyInventory(player);
 
             var animTime = DoOnCloseMotionChanges();
 

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -696,8 +696,6 @@ namespace ACE.Server.WorldObjects
         {
             if (!IsOpen) return;
 
-            SendDeletesForMyInventory(player);
-
             var animTime = DoOnCloseMotionChanges();
 
             if (animTime <= 0)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -880,8 +880,7 @@ namespace ACE.Server.WorldObjects
                 NotifyOfEvent(RegenerationType.Destruction);
 
             CurrentLandblock?.RemoveWorldObject(Guid);
-            if (CurrentLandblock == null)
-                EnqueueBroadcast(new GameMessageDeleteObject(this));
+
             RemoveBiotaFromDatabase();
 
             if (Guid.IsDynamic())

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -880,6 +880,8 @@ namespace ACE.Server.WorldObjects
                 NotifyOfEvent(RegenerationType.Destruction);
 
             CurrentLandblock?.RemoveWorldObject(Guid);
+            if (CurrentLandblock == null)
+                EnqueueBroadcast(new GameMessageDeleteObject(this));
             RemoveBiotaFromDatabase();
 
             if (Guid.IsDynamic())


### PR DESCRIPTION
- Added code to send DestroyObject messages from objects being destroyed to those that know about it when it is not on a landblock (Corpse/Chest/Container)
- Re-enabled Guid Recycling