### PR TITLE
Revert "PlacementPosition is not an enum type. It's an inventory order (index)"

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -723,6 +723,8 @@ namespace ACE.Entity.Enum.Properties
                     return System.Enum.GetName(typeof(ArmorType), value);
                 case PropertyInt.ParentLocation:
                     return System.Enum.GetName(typeof(ParentLocation), value);
+                case PropertyInt.PlacementPosition:
+                    return System.Enum.GetName(typeof(Placement), value);
                 case PropertyInt.HouseStatus:
                     return System.Enum.GetName(typeof(HouseStatus), value);
 


### PR DESCRIPTION
Reverts ACEmulator/ACE#2069

PlacementPosition references enum Placement, See [LongBow](https://github.com/ACEmulator/ACE-World-16PY/blob/master/Database/3-Core/9%20WeenieDefaults/SQL/MissileLauncher/MissileWeapon/00306%20Longbow.sql) and other MissileLaunchers for example.