### PR TITLE
Add configuration for number of threads

### DIFF
--- a/Source/ACE.Common/ThreadConfiguration.cs
+++ b/Source/ACE.Common/ThreadConfiguration.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ACE.Common
+{
+    /// <summary>
+    /// We determine the number of available threads using Environment.ProcessCount
+    /// We allocate(int)Math.Max(Environment.ProcessorCount * multiplier, 1) to the World, and the remainder to the database.
+    /// </summary>
+    public static class ThreadConfiguration
+    {
+        /*
+         * Multiplier of 0.34:
+         * 1 vCPU = 1 thread world, 1 thread database
+         * 2 vCPU = 1 thread world, 1 thread database
+         * 3 vCPU = 1 thread world, 2 thread database
+         * 4 vCPU = 1 thread world, 3 thread database
+         * 5 vCPU = 1 thread world, 4 thread database
+         * 6 vCPU = 2 thread world, 4 thread database
+         * 7 vCPU = 2 thread world, 5 thread database
+         * 8 vCPU = 2 thread world, 6 thread database
+         * 9 vCPU = 3 thread world, 6 thread database
+         * 10 vCPU = 3 thread world, 7 thread database
+         */
+
+        /// <summary>
+        /// This is the number of threads used for World (Non Databae) operations
+        /// </summary>
+        public const double Multiplier = 0.34;
+
+
+
+        // World Thread Management
+
+        public static readonly int WorldThreadCount = (int)Math.Max(Environment.ProcessorCount * Multiplier, 1);
+
+        public static readonly int LandblockManagerThreadCount = WorldThreadCount;
+        public static readonly ParallelOptions LandblockManagerParallelOptions = new ParallelOptions { MaxDegreeOfParallelism = LandblockManagerThreadCount };
+
+        public static readonly int NetworkManagerThreadCount = WorldThreadCount;
+        public static readonly ParallelOptions NetworkManagerParallelOptions = new ParallelOptions { MaxDegreeOfParallelism = NetworkManagerThreadCount };
+
+
+        // Database Thread Management
+
+        public static readonly int DatabaseThreadCount = Math.Max(Environment.ProcessorCount - WorldThreadCount, 1);
+        public static readonly ParallelOptions DatabaseParallelOptions = new ParallelOptions { MaxDegreeOfParallelism = DatabaseThreadCount };
+    }
+}

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 using log4net;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database.Entity;
 using ACE.Database.Models.Shard;
@@ -23,8 +24,6 @@ namespace ACE.Database
     public class ShardDatabase
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-        private static readonly ParallelOptions parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = (int)Math.Max(Environment.ProcessorCount - (int)Math.Max(Environment.ProcessorCount * .34, 1), 1) };
 
         public bool Exists(bool retryUntilFound)
         {
@@ -371,7 +370,7 @@ namespace ACE.Database
         {
             var result = true;
 
-            Parallel.ForEach(biotas, parallelOptions, biota =>
+            Parallel.ForEach(biotas, ThreadConfiguration.DatabaseParallelOptions, biota =>
             {
                 if (!SaveBiota(biota.biota, biota.rwLock))
                     result = false;
@@ -434,7 +433,7 @@ namespace ACE.Database
         {
             var result = true;
 
-            Parallel.ForEach(biotas, parallelOptions, biota =>
+            Parallel.ForEach(biotas, ThreadConfiguration.DatabaseParallelOptions, biota =>
             {
                 if (!RemoveBiota(biota.biota, biota.rwLock))
                     result = false;
@@ -480,7 +479,7 @@ namespace ACE.Database
                     .Where(r => r.Type == (ushort)PropertyInstanceId.Container && r.Value == parentId)
                     .ToList();
 
-                Parallel.ForEach(results, parallelOptions, result =>
+                Parallel.ForEach(results, ThreadConfiguration.DatabaseParallelOptions, result =>
                 {
                     var biota = GetBiota(result.ObjectId);
 
@@ -514,7 +513,7 @@ namespace ACE.Database
                     .Where(r => r.Type == (ushort)PropertyInstanceId.Wielder && r.Value == parentId)
                     .ToList();
 
-                Parallel.ForEach(results, parallelOptions, result =>
+                Parallel.ForEach(results, ThreadConfiguration.DatabaseParallelOptions, result =>
                 {
                     var biota = GetBiota(result.ObjectId);
 
@@ -566,7 +565,7 @@ namespace ACE.Database
 
                 var results = context.Biota.Where(b => b.Id >= min && b.Id <= max).ToList();
 
-                Parallel.ForEach(results, parallelOptions, result =>
+                Parallel.ForEach(results, ThreadConfiguration.DatabaseParallelOptions, result =>
                 {
                     var biota = GetBiota(result.Id);
                     staticObjects.Add(biota);
@@ -625,7 +624,7 @@ namespace ACE.Database
                     .Where(p => p.PositionType == 1 && p.ObjCellId >= min && p.ObjCellId <= max && p.ObjectId >= 0x80000000)
                     .ToList();
 
-                Parallel.ForEach(results, parallelOptions, result =>
+                Parallel.ForEach(results, ThreadConfiguration.DatabaseParallelOptions, result =>
                 {
                     var biota = GetBiota(result.ObjectId);
 

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -292,8 +292,6 @@ namespace ACE.Server.Network.Managers
             }
         }
 
-        private static readonly ParallelOptions parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = (int)Math.Max(Environment.ProcessorCount * .34, 1) };
-
         /// <summary>
         /// Processes all inbound GameAction messages.<para />
         /// Dispatches all outgoing messages.<para />
@@ -308,7 +306,7 @@ namespace ACE.Server.Network.Managers
             {
                 // The session tick outbound processes pending actions and handles outgoing messages
                 ServerPerformanceMonitor.RegisterEventStart(ServerPerformanceMonitor.MonitorType.DoSessionWork_TickOutbound);
-                Parallel.ForEach(sessionMap, parallelOptions, s => s?.TickOutbound());
+                Parallel.ForEach(sessionMap, ThreadConfiguration.NetworkManagerParallelOptions, s => s?.TickOutbound());
                 ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.DoSessionWork_TickOutbound);
 
                 // Removes sessions in the NetworkTimeout state, including sessions that have reached a timeout limit.


### PR DESCRIPTION
This doesn't persist to the actual .config yet, but still provides a local way to manage thread count allocation.