### PR TITLE
Move WorldObject specific managers to a different folder

### DIFF
--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
+
 using ACE.Database.Models.Shard;
-using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Entity
 {

--- a/Source/ACE.Server/Entity/EnchantmentStatus.cs
+++ b/Source/ACE.Server/Entity/EnchantmentStatus.cs
@@ -1,5 +1,6 @@
-using ACE.Server.Managers;
+
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Entity
 {

--- a/Source/ACE.Server/Managers/EventManager.cs
+++ b/Source/ACE.Server/Managers/EventManager.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
+
 using log4net;
 
 namespace ACE.Server.Managers
 {
-    public class EventManager
+    public static class EventManager
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventSendClientContractTrackerTable.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventSendClientContractTrackerTable.cs
@@ -1,5 +1,5 @@
-using ACE.Server.Managers;
 using ACE.Server.Network.Structure;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Network.GameEvent.Events
 {

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -6,8 +6,8 @@ using ACE.Database.Models.Shard;
 using ACE.DatLoader.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
-using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Network.Structure
 {

--- a/Source/ACE.Server/Network/Structure/EnchantmentRegistry.cs
+++ b/Source/ACE.Server/Network/Structure/EnchantmentRegistry.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using ACE.Common.Extensions;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
-using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Network.Structure
 {

--- a/Source/ACE.Server/Network/Structure/SquelchDB.cs
+++ b/Source/ACE.Server/Network/Structure/SquelchDB.cs
@@ -7,6 +7,7 @@ using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Network.Structure
 {

--- a/Source/ACE.Server/WorldObjects/Armor.cs
+++ b/Source/ACE.Server/WorldObjects/Armor.cs
@@ -1,7 +1,8 @@
 using System;
+
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
-using ACE.Server.Managers;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -6,7 +6,7 @@ using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
-using ACE.Server.Managers;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/Managers/ConfirmationManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/ConfirmationManager.cs
@@ -1,12 +1,12 @@
 using System.Collections.Concurrent;
+
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
 using ACE.Server.Network.GameEvent.Events;
-using ACE.Server.WorldObjects;
 
 using log4net;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
     public class ConfirmationManager
     {

--- a/Source/ACE.Server/WorldObjects/Managers/ContractManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/ContractManager.cs
@@ -1,18 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using log4net;
-using ACE.Database.Models.Shard;
-using ACE.Server.Network.GameEvent.Events;
-using ACE.Server.WorldObjects;
 using System.IO;
-using ACE.Server.Network.Structure;
+
+using log4net;
+
+using ACE.Database.Models.Shard;
 using ACE.DatLoader;
 using ACE.DatLoader.Entity;
-using ACE.Server.Network.GameMessages.Messages;
 using ACE.Entity.Enum;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.Network.Structure;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
     public class ContractManager
     {

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -15,18 +15,18 @@ using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
+using ACE.Server.Managers;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
-using ACE.Server.WorldObjects;
 
 using log4net;
 
 using Position = ACE.Entity.Position;
 using Spell = ACE.Server.Entity.Spell;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
-    public partial class EmoteManager
+    public class EmoteManager
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 
@@ -9,14 +8,13 @@ using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
+using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.Structure;
-using ACE.Server.Physics;
-using ACE.Server.WorldObjects;
 using ACE.Server.WorldObjects.Entity;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
     public enum StackType
     {

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -5,11 +5,9 @@ using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
-using ACE.Server.Network.Structure;
-using ACE.Server.WorldObjects;
 using ACE.Server.WorldObjects.Entity;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
     public class EnchantmentManagerWithCaching : EnchantmentManager
     {

--- a/Source/ACE.Server/WorldObjects/Managers/SquelchManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/SquelchManager.cs
@@ -8,9 +8,9 @@ using ACE.Server.Entity;
 using ACE.Server.Network.Structure;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
-using ACE.Server.WorldObjects;
+using ACE.Server.Managers;
 
-namespace ACE.Server.Managers
+namespace ACE.Server.WorldObjects.Managers
 {
     public class SquelchManager
     {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using ACE.Database;
 using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
@@ -21,9 +22,9 @@ using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Structure;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
+using ACE.Server.WorldObjects.Managers;
 
 using MotionTable = ACE.DatLoader.FileTypes.MotionTable;
-using ACE.Database;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -8,6 +8,7 @@ using log4net;
 
 using ACE.Common;
 using ACE.Common.Extensions;
+using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
@@ -24,10 +25,10 @@ using ACE.Server.Physics;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Util;
+using ACE.Server.WorldObjects.Managers;
 
 using Landblock = ACE.Server.Entity.Landblock;
 using Position = ACE.Entity.Position;
-using ACE.Database;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -17,6 +17,7 @@ using ACE.Server.Network.Structure;
 using ACE.Server.Managers;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Physics;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.WorldObjects
 {


### PR DESCRIPTION
This helps better visualize the manager usage between
- server wide
- world object localized

I'm doing this because as I travel down the rabbit hole of server-wide thread safety, these types of separations help make it easier to understand what managers need more attention for thread safety vs world object localized managers that sould be thread safe because their parent wo should be thread safe (key word *should*)

I'll be adding thread safety to these server-wide managers and want to organize them better first to reduce the size of the multi-threading PR. This makes it easier to read, and easier to roll back if needed.

QuestManager remains in the server wide folder because it is used for both WorldObjects and Fellowships.