### PR TITLE
add a check before entering godmode

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1796,10 +1796,22 @@ namespace ACE.Server.Command.Handlers
                     returnState += $"{sk.InitLevel}=";
                 }
 
+                // Check string is correctly formatted before altering stats
+                // correctly formatted return string should have 240 entries
+                // if the construction of the string changes - this will need to be updated to match
+                if (returnState.Split("=").Length != 240)
+                {
+                    ChatPacket.SendServerMessage(session, "Godmode is not available at this time.", ChatMessageType.Broadcast);
+                    Console.WriteLine($"Player {session.Player.Name} tried to enter god mode but there was an error with the godString length. (length = {returnState.Split("=").Length}) Godmode not available.");
+                    return;
+                }
+
                 // save return state to db in property string
                 session.Player.SetProperty(PropertyString.GodState, returnState);
                 session.Player.SaveBiotaToDatabase(); 
             }
+
+            
 
             // Begin Godly Stats Increase
 


### PR DESCRIPTION
recently players were reporting errors with their godString... after examining the strings it seems as if sometimes an extra blank 'skill' is inserted into the string

i havent worked out exactly why but i added a check to the process so you wont be able to enter godmode if the string is not the proper length. this should prevent characters being stuck in godmode after entering with an incorrect string length