### PR TITLE
Ensure that Impen spell is present on magical Covenant Armor

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -942,8 +942,10 @@ namespace ACE.Server.Factories
             return -manaRate;
         }
 
-        private static WorldObject AssignMagic(WorldObject wo, int tier)
+        private static WorldObject AssignMagic(WorldObject wo, int tier, bool covenantArmor = false)
         {
+            const int armorSpellImpenIndex = 47; // 47th row in the LootTables.ArmorSpells array, starting from zero
+
             int[][] spells;
             int[][] cantrips;
 
@@ -1012,6 +1014,26 @@ namespace ACE.Server.Factories
                 {
                     int col = ThreadSafeRandom.Next(lowSpellTier - 1, highSpellTier - 1);
                     int spellID = spells[shuffledValues[a]][col];
+                    wo.Biota.GetOrAddKnownSpell(spellID, wo.BiotaDatabaseLock, wo.BiotaPropertySpells, out _);
+                }
+            }
+
+            // From a discussion on LSD, determined in that if covenant armor includes spells, the armor piece will have at least Impen
+            if (covenantArmor == true)
+            {
+                // Ensure that one of the Impen spells was not already added
+                bool impenFound = false;
+                for (int a = 0; a < 8; a++)
+                {
+                    impenFound = wo.Biota.SpellIsKnown(LootTables.ArmorSpells[armorSpellImpenIndex][a], wo.BiotaDatabaseLock);
+                    if (impenFound == true)
+                        break;
+                }
+
+                if (impenFound == false)
+                {
+                    int col = ThreadSafeRandom.Next(lowSpellTier - 1, highSpellTier - 1);
+                    int spellID = LootTables.ArmorSpells[armorSpellImpenIndex][col];
                     wo.Biota.GetOrAddKnownSpell(spellID, wo.BiotaDatabaseLock, wo.BiotaPropertySpells, out _);
                 }
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories
             }
 
             var armorType = (LootTables.ArmorType)ThreadSafeRandom.Next((int)minType, (int)maxType);
-            armorType = LootTables.ArmorType.CovenantArmor;
+
             int[] table = LootTables.GetLootTable(armorType);
 
             int rng = ThreadSafeRandom.Next(0, table.Length - 1);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories
             }
 
             var armorType = (LootTables.ArmorType)ThreadSafeRandom.Next((int)minType, (int)maxType);
-
+            armorType = LootTables.ArmorType.CovenantArmor;
             int[] table = LootTables.GetLootTable(armorType);
 
             int rng = ThreadSafeRandom.Next(0, table.Length - 1);
@@ -129,7 +129,10 @@ namespace ACE.Server.Factories
             wo = AssignEquipmentSetId(wo, tier);
 
             if (isMagical)
-                wo = AssignMagic(wo, tier);
+            {
+                bool covenantArmor = false || (armorType == LootTables.ArmorType.CovenantArmor || armorType == LootTables.ArmorType.OlthoiArmor);
+                wo = AssignMagic(wo, tier, covenantArmor);
+            }
             else
             {
                 wo.RemoveProperty(PropertyInt.ItemManaCost);


### PR DESCRIPTION
Per a discussion on LSD discord, it was determined that Covenant Armor that contains spells will have Impenetrability as one of them.  While I tested the added code in game, it should probably be tested by others before merging to ensure that I didn't miss something, especially in regards to array indexing, if the added code is deemed acceptable.