### PR TITLE
adding support for PropertyBool.OpensAnyLock

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1560,7 +1560,7 @@ namespace ACE.Server.Command.Handlers
 
                     if (!string.IsNullOrWhiteSpace(lockCode))
                     {
-                        res = @lock.Unlock(session.Player.Guid.Full, lockCode);
+                        res = @lock.Unlock(session.Player.Guid.Full, null, lockCode);
                         ChatPacket.SendServerMessage(session, $"Crack {wo.WeenieType} via {lockCode} result: {res}.{opening}", ChatMessageType.Broadcast);
                     }
                     else if (resistLockpick.HasValue && resistLockpick > 0)

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -283,9 +283,9 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Used for unlocking a chest via a key
         /// </summary>
-        public UnlockResults Unlock(uint unlockerGuid, string keyCode)
+        public UnlockResults Unlock(uint unlockerGuid, Key key, string keyCode = null)
         {
-            var result = LockHelper.Unlock(this, keyCode);
+            var result = LockHelper.Unlock(this, key, keyCode);
 
             if (result == UnlockResults.UnlockSuccess)
                 LastUnlocker = unlockerGuid;

--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -182,9 +182,9 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Used for unlocking a door via a key
         /// </summary>
-        public UnlockResults Unlock(uint unlockerGuid, string keyCode)
+        public UnlockResults Unlock(uint unlockerGuid, Key key, string keyCode = null)
         {
-            return LockHelper.Unlock(this, keyCode);
+            return LockHelper.Unlock(this, key, keyCode);
         }
 
         public override void SetLinkProperties(WorldObject wo)

--- a/Source/ACE.Server/WorldObjects/Key.cs
+++ b/Source/ACE.Server/WorldObjects/Key.cs
@@ -36,6 +36,12 @@ namespace ACE.Server.WorldObjects
             set { if (value == null) RemoveProperty(PropertyString.KeyCode); else SetProperty(PropertyString.KeyCode, value); }
         }
 
+        public bool OpensAnyLock
+        {
+            get => GetProperty(PropertyBool.OpensAnyLock) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.OpensAnyLock); else SetProperty(PropertyBool.OpensAnyLock, value); }
+        }
+
         public override void HandleActionUseOnTarget(Player player, WorldObject target)
         {
             UnlockerHelper.UseUnlocker(player, this, target);

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -22,7 +22,7 @@ namespace ACE.Server.WorldObjects
     }
     public interface Lock
     {
-        UnlockResults Unlock(uint unlockerGuid, string keyCode);
+        UnlockResults Unlock(uint unlockerGuid, Key key, string keyCode = null);
         UnlockResults Unlock(uint unlockerGuid, uint playerLockpickSkillLvl, ref int difficulty);
     }
     public class UnlockerHelper
@@ -81,7 +81,7 @@ namespace ACE.Server.WorldObjects
                                 return;
                             }
                         }
-                        result = @lock.Unlock(player.Guid.Full, woKey.KeyCode);
+                        result = @lock.Unlock(player.Guid.Full, woKey);
                     }
 
                     switch (result)
@@ -180,15 +180,18 @@ namespace ACE.Server.WorldObjects
                 myLockCode = woChest.LockCode;
             return myLockCode;
         }
-        public static UnlockResults Unlock(WorldObject target, string keyCode)
+        public static UnlockResults Unlock(WorldObject target, Key key, string keyCode = null)
         {
+            if (keyCode == null)
+                keyCode = key?.KeyCode;
+
             string myLockCode = GetLockCode(target);
             if (myLockCode == null) return UnlockResults.IncorrectKey;
 
             if (target.IsOpen)
                 return UnlockResults.Open;
 
-            if (keyCode.Equals(myLockCode, StringComparison.OrdinalIgnoreCase))
+            if (keyCode != null && keyCode.Equals(myLockCode, StringComparison.OrdinalIgnoreCase) || (key?.OpensAnyLock == true))
             {
                 if (!target.IsLocked)
                     return UnlockResults.AlreadyUnlocked;

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -29,11 +29,14 @@ namespace ACE.Server.WorldObjects
     {
         public static void ConsumeUnlocker(Player player, WorldObject unlocker)
         {
-            if ((unlocker.GetProperty(PropertyBool.UnlimitedUse) ?? false))
+            // is Sonic Screwdriver supposed to be consumed on use?
+            // it doesn't have a Structure, and it doesn't have PropertyBool.UnlimitedUse
+            if (unlocker.Structure == null || (unlocker.GetProperty(PropertyBool.UnlimitedUse) ?? false))
             {
                 player.SendUseDoneEvent();
                 return;
             }
+
             unlocker.Structure--;
             if (unlocker.Structure < 1)
                 player.TryConsumeFromInventoryWithNetworking(unlocker, 1);
@@ -191,7 +194,17 @@ namespace ACE.Server.WorldObjects
             if (target.IsOpen)
                 return UnlockResults.Open;
 
-            if (keyCode != null && keyCode.Equals(myLockCode, StringComparison.OrdinalIgnoreCase) || (key?.OpensAnyLock == true))
+            // there is only 1 instance of an 'opens all' key in PY16 data, 'keysonicscrewdriver'
+            // which uses keyCode '_bohemund's_magic_key_'
+
+            // when LSD added the rare skeleton key (keyrarevolatileuniversal),
+            // they used PropertyBool.OpensAnyLock, which appears to have been used for something else in retail on Writables:
+
+            // https://github.com/ACEmulator/ACE-World-16PY/blob/master/Database/3-Core/9%20WeenieDefaults/SQL/Key/Key/09181%20Sonic%20Screwdriver.sql
+            // https://github.com/ACEmulator/ACE-World-16PY/search?q=OpensAnyLock
+
+            if (keyCode != null && (keyCode.Equals(myLockCode, StringComparison.OrdinalIgnoreCase) || keyCode.Equals("_bohemund's_magic_key_")) ||
+                    key != null && key.OpensAnyLock)
             {
                 if (!target.IsLocked)
                     return UnlockResults.AlreadyUnlocked;


### PR DESCRIPTION
also fixes a crash when using keyrarevolatileuniversal in current master