### PR TITLE
enabling magic absorption for missile/magic weapons

### DIFF
--- a/Database/Updates/Shard/2019-10-31-00-Fix-Magic-Absorption.sql
+++ b/Database/Updates/Shard/2019-10-31-00-Fix-Magic-Absorption.sql
@@ -1,0 +1,1 @@
+update biota_properties_float set value=0.25 where `type`=159 and value=1;

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -1000,7 +1000,7 @@ namespace ACE.Server.Managers
                     // 	Fetish of the Dark Idols
                     case 0x38000046:
                         AddImbuedEffect(player, target, ImbuedEffectType.IgnoreSomeMagicProjectileDamage);
-                        target.SetProperty(PropertyFloat.AbsorbMagicDamage, 1);
+                        target.SetProperty(PropertyFloat.AbsorbMagicDamage, 0.25f);
                         break;
                 }
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -371,7 +371,7 @@ namespace ACE.Server.WorldObjects
                     criticalHit = true;
             }
 
-            var shieldMod = GetShieldMod(target);
+            var absorbMod = GetAbsorbMod(target);
 
             bool isPVP = sourcePlayer != null && targetPlayer != null;
 
@@ -393,7 +393,7 @@ namespace ACE.Server.WorldObjects
                 if (criticalHit)
                     damageBonus = lifeMagicDamage * 0.5f * GetWeaponCritDamageMod(sourceCreature, attackSkill, target);
 
-                finalDamage = (lifeMagicDamage + damageBonus) * elementalDmgBonus * slayerBonus * shieldMod;
+                finalDamage = (lifeMagicDamage + damageBonus) * elementalDmgBonus * slayerBonus * absorbMod;
                 return finalDamage;
             }
             // war/void magic projectiles
@@ -436,26 +436,50 @@ namespace ACE.Server.WorldObjects
 
                 finalDamage = baseDamage + damageBonus + warSkillBonus;
                 finalDamage *= target.GetResistanceMod(resistanceType, null, weaponResistanceMod)
-                    * elementalDmgBonus * slayerBonus * shieldMod;
+                    * elementalDmgBonus * slayerBonus * absorbMod;
 
                 return finalDamage;
             }
         }
 
+        public float GetAbsorbMod(Creature target)
+        {
+            switch (target.CombatMode)
+            {
+                case CombatMode.Melee:
+
+                    // does target have shield equipped?
+                    var shield = target.GetEquippedShield();
+                    if (shield != null && shield.AbsorbMagicDamage != null)
+                        return GetShieldMod(target, shield);
+
+                    break;
+
+                case CombatMode.Missile:
+
+                    var weapon = target.GetEquippedMissileWeapon();
+                    if (weapon != null && weapon.AbsorbMagicDamage != null)
+                        return AbsorbMagic(target, weapon);
+
+                    break;
+
+                case CombatMode.Magic:
+
+                    weapon = target.GetEquippedWand();
+                    if (weapon != null && weapon.AbsorbMagicDamage != null)
+                        return AbsorbMagic(target, weapon);
+
+                    break;
+            }
+            return 1.0f;
+        }
+
         /// <summary>
         /// Calculates the amount of damage a shield absorbs from magic projectile
         /// </summary>
-        public float GetShieldMod(Creature target)
+        public float GetShieldMod(Creature target, WorldObject shield)
         {
-            // ensure combat stance
-            if (target.CombatMode == CombatMode.NonCombat)
-                return 1.0f;
-
-            // does the player have a shield equipped?
-            var shield = target.GetEquippedShield();
-            if (shield == null || shield.GetProperty(PropertyFloat.AbsorbMagicDamage) == null) return 1.0f;
-
-            // is spell projectile in front of player,
+            // is spell projectile in front of creature target,
             // within shield effectiveness area?
             var effectiveAngle = 180.0f;
             var angle = target.GetAngle(this);
@@ -489,8 +513,43 @@ namespace ACE.Server.WorldObjects
 
             var reduction = (cap * specMod * baseSkill * 0.003f) - (cap * specMod * 0.3f);
 
-            var shieldMod = 1.0f - reduction;
+            var shieldMod = Math.Min(1.0f, 1.0f - reduction);
             return shieldMod;
+        }
+
+        /// <summary>
+        /// Calculates the damage reduction modifier for bows and casters
+        /// with 'Magic Absorbing' property
+        /// </summary>
+        public float AbsorbMagic(Creature target, WorldObject item)
+        {
+            // https://asheron.fandom.com/wiki/Category:Magic_Absorbing
+
+            // Tomes and Bows
+            // The formula to determine magic absorption for Tomes and the Fetish of the Dark Idols:
+            // - For a 25% maximum item: (magic absorbing %) = 25 - (0.1 * (319 - base magic defense))
+            // - For a 10% maximum item: (magic absorbing %) = 10 - (0.04 * (319 - base magic defense))
+
+            // wiki currently has what is likely at typo for the 10% formula
+            // where it has a factor of 0.4 instead of 0.04
+            // with 0.4, the 10% items would not start to become effective until base magic defense 294
+            // with 0.04, both formulas start to become effective at base magic defense 69
+
+            // using an equivalent formula that produces the correct results for 10% and 25%,
+            // and also produces the correct results for any %
+
+            if (item.AbsorbMagicDamage == null)
+                return 1.0f;
+
+            var maxPercent = item.AbsorbMagicDamage.Value;
+
+            var baseCap = 319;
+            var magicDefBase = target.GetCreatureSkill(Skill.MagicDefense).Base;
+            var diff = Math.Max(0, baseCap - magicDefBase);
+
+            var percent = maxPercent - maxPercent * diff * 0.004f;
+
+            return Math.Min(1.0f, 1.0f - (float)percent);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -530,7 +530,7 @@ namespace ACE.Server.WorldObjects
             // - For a 25% maximum item: (magic absorbing %) = 25 - (0.1 * (319 - base magic defense))
             // - For a 10% maximum item: (magic absorbing %) = 10 - (0.04 * (319 - base magic defense))
 
-            // wiki currently has what is likely at typo for the 10% formula
+            // wiki currently has what is likely a typo for the 10% formula,
             // where it has a factor of 0.4 instead of 0.04
             // with 0.4, the 10% items would not start to become effective until base magic defense 294
             // with 0.04, both formulas start to become effective at base magic defense 69

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1691,6 +1691,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.ArmorModVsNether); else SetProperty(PropertyFloat.ArmorModVsNether, value.Value); }
         }
 
+        public double? AbsorbMagicDamage
+        {
+            get => GetProperty(PropertyFloat.AbsorbMagicDamage);
+            set { if (value.HasValue) RemoveProperty(PropertyFloat.AbsorbMagicDamage); else SetProperty(PropertyFloat.AbsorbMagicDamage, value.Value); }
+        }
+
         public int? ArmorType
         {
             get => GetProperty(PropertyInt.ArmorType);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1694,7 +1694,7 @@ namespace ACE.Server.WorldObjects
         public double? AbsorbMagicDamage
         {
             get => GetProperty(PropertyFloat.AbsorbMagicDamage);
-            set { if (value.HasValue) RemoveProperty(PropertyFloat.AbsorbMagicDamage); else SetProperty(PropertyFloat.AbsorbMagicDamage, value.Value); }
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.AbsorbMagicDamage); else SetProperty(PropertyFloat.AbsorbMagicDamage, value.Value); }
         }
 
         public int? ArmorType


### PR DESCRIPTION
Warning: there are currently items in the database that incorrectly have PropertyFloat.AbsorbMagicDamage=1.0, instead of the correct percentage for magic damage they can absorb. These items need to be fixed in sync with this code update -- ie. for any existing players on the servers that already have items with AbsorbMagicDamage=1.0, the data for these items needs to be fixed in tandem with this code change.

Please do not check in this code change before all of the data corrections have been added

Updated: this PR now contains recipe fix (was code-based instead of data-based), and the above-mentioned SQL fix. Please notify server operators to be sure to run the sql shard update when they update to this version of the code.

This fixes https://github.com/ACEmulator/ACE/issues/2373