### PR TITLE
add valid skills hashset, check valid skills entering godmode

### DIFF
--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 
 using ACE.Entity;
+using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 
 namespace ACE.Database.Models.Shard
@@ -1170,9 +1171,18 @@ namespace ACE.Database.Models.Shard
                 try
                 {
                     entity = new BiotaPropertiesSkill { ObjectId = biota.Id, Type = type, Object = biota };
-                    biota.BiotaPropertiesSkill.Add(entity);
-                    skillAdded = true;
-                    return entity;
+
+                    if (SkillHelper.ValidSkills.Contains((Skill)type))
+                    {
+                        biota.BiotaPropertiesSkill.Add(entity);
+                        skillAdded = true;
+                        return entity;
+                    }
+                    else
+                    {
+                        skillAdded = false;
+                        return entity;
+                    }
                 }
                 finally
                 {

--- a/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 
 using ACE.Entity;
-using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 
 namespace ACE.Database.Models.Shard
@@ -1171,18 +1170,9 @@ namespace ACE.Database.Models.Shard
                 try
                 {
                     entity = new BiotaPropertiesSkill { ObjectId = biota.Id, Type = type, Object = biota };
-
-                    if (SkillHelper.ValidSkills.Contains((Skill)type))
-                    {
-                        biota.BiotaPropertiesSkill.Add(entity);
-                        skillAdded = true;
-                        return entity;
-                    }
-                    else
-                    {
-                        skillAdded = false;
-                        return entity;
-                    }
+                    biota.BiotaPropertiesSkill.Add(entity);
+                    skillAdded = true;
+                    return entity;
                 }
                 finally
                 {

--- a/Source/ACE.Entity/Enum/Skill.cs
+++ b/Source/ACE.Entity/Enum/Skill.cs
@@ -5,7 +5,8 @@ namespace ACE.Entity.Enum
 {
     /// <summary>
     /// note: even though these are unnumbered, order is very important.  values of "none" or commented
-    /// as retired or unused CANNOT be removed
+    /// as retired or unused --ABSOLUTELY CANNOT-- be removed. Skills that are none, retired, or not
+    /// implemented have been removed from the SkillHelper.ValidSkills hashset below.
     /// </summary>
     public enum Skill
     {
@@ -102,6 +103,48 @@ namespace ACE.Entity.Enum
 
     public static class SkillHelper
     {
+        public static HashSet<Skill> ValidSkills = new HashSet<Skill>
+        {
+            Skill.MeleeDefense,
+            Skill.MissileDefense,
+            Skill.ArcaneLore,
+            Skill.MagicDefense,
+            Skill.ManaConversion,
+            Skill.ItemTinkering,
+            Skill.AssessPerson,
+            Skill.Deception,
+            Skill.Healing,
+            Skill.Jump,
+            Skill.Lockpick,
+            Skill.Run,
+            Skill.AssessCreature,
+            Skill.WeaponTinkering,
+            Skill.ArmorTinkering,
+            Skill.MagicItemTinkering,
+            Skill.CreatureEnchantment,
+            Skill.ItemEnchantment,
+            Skill.LifeMagic,
+            Skill.WarMagic,
+            Skill.Leadership,
+            Skill.Loyalty,
+            Skill.Fletching,
+            Skill.Alchemy,
+            Skill.Cooking,
+            Skill.Salvaging,
+            Skill.TwoHandedCombat,
+            Skill.VoidMagic,
+            Skill.HeavyWeapons,
+            Skill.LightWeapons,
+            Skill.FinesseWeapons,
+            Skill.MissileWeapons,
+            Skill.Shield,
+            Skill.DualWield,
+            Skill.Recklessness,
+            Skill.SneakAttack,
+            Skill.DirtyFighting,
+            Skill.Summoning
+        };
+
         public static HashSet<Skill> AttackSkills = new HashSet<Skill>
         {
             Skill.Axe,

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1768,32 +1768,43 @@ namespace ACE.Server.Command.Handlers
                 returnState += $"1={session.Player.TotalExperience}=2={session.Player.AvailableExperience}=";
 
                 // need all attributes
+                // 1 through 6 str, end, coord, quick, focus, self
                 foreach (var att in biota.BiotaPropertiesAttribute)
                 {
-                    returnState += $"{att.Type}=";
-                    returnState += $"{att.InitLevel}=";
-                    returnState += $"{att.LevelFromCP}=";
-                    returnState += $"{att.CPSpent}=";
+                    if(att.Type > 0 && att.Type <= 6)
+                    {
+                        returnState += $"{att.Type}=";
+                        returnState += $"{att.InitLevel}=";
+                        returnState += $"{att.LevelFromCP}=";
+                        returnState += $"{att.CPSpent}=";
+                    }
                 }
 
                 // need all vitals
+                // 1, 3, 5 H,S,M (2,4,6 are current values and are not stored since they will be maxed entering/exiting godmode)
                 foreach (var attSec in biota.BiotaPropertiesAttribute2nd)
                 {
-                    returnState += $"{attSec.Type}=";
-                    returnState += $"{attSec.InitLevel}=";
-                    returnState += $"{attSec.LevelFromCP}=";
-                    returnState += $"{attSec.CPSpent}=";
-                    returnState += $"{attSec.CurrentLevel}=";
+                    if(attSec.Type == 1 || attSec.Type == 3 || attSec.Type == 5)
+                    {
+                        returnState += $"{attSec.Type}=";
+                        returnState += $"{attSec.InitLevel}=";
+                        returnState += $"{attSec.LevelFromCP}=";
+                        returnState += $"{attSec.CPSpent}=";
+                        returnState += $"{attSec.CurrentLevel}="; 
+                    }
                 }
 
                 // need all skills
                 foreach (var sk in biota.BiotaPropertiesSkill)
                 {
-                    returnState += $"{sk.Type}=";
-                    returnState += $"{sk.LevelFromPP}=";
-                    returnState += $"{sk.SAC}=";
-                    returnState += $"{sk.PP}=";
-                    returnState += $"{sk.InitLevel}=";
+                    if (SkillHelper.ValidSkills.Contains((Skill)sk.Type))
+                    {
+                        returnState += $"{sk.Type}=";
+                        returnState += $"{sk.LevelFromPP}=";
+                        returnState += $"{sk.SAC}=";
+                        returnState += $"{sk.PP}=";
+                        returnState += $"{sk.InitLevel}=";
+                    }
                 }
 
                 // Check string is correctly formatted before altering stats
@@ -1810,8 +1821,6 @@ namespace ACE.Server.Command.Handlers
                 session.Player.SetProperty(PropertyString.GodState, returnState);
                 session.Player.SaveBiotaToDatabase(); 
             }
-
-            
 
             // Begin Godly Stats Increase
 
@@ -1878,7 +1887,6 @@ namespace ACE.Server.Command.Handlers
         {
             // @ungod - Returns skills and attributues to pre-god levels.
             Player currentPlayer = session.Player;
-            Biota biota = currentPlayer.Biota;
             string returnString = session.Player.GodState;
             
             if (returnString == null)


### PR DESCRIPTION
added a valid skills hashset to the skillhelper so that it could be checked against when entering godmode. also added hard coded checks against the attribute and attribute 2nd types... figured they didnt need a helper

this change will only add entries to the godstring if they are valid. 

According to ripley, the bug is with the GetOrAddSkill function that adds a skill to a players biota_properties_skill table when checking for invalid skill types. if a player had an invalid skill (typically this was a skill with type 0) the string would be too long and cause the error. now when entering godmode invalid skill and attribute values will be ignored and everything should work as intended

the only way an error when attempting to god/ungod should happen now is if the db is externally corrupted or manually changed... or until the next bug is uncovered :)