### PR TITLE
Assign armor level

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -305,14 +305,13 @@ namespace ACE.Server.Factories
                     case 1:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(20, 50);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(0, 29);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(0, 30);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(0, 10);
+                            armorModValue = ThreadSafeRandom.Next(0, 26);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = 0;
@@ -320,14 +319,13 @@ namespace ACE.Server.Factories
                     case 2:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(50, 80);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(29, 52);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(30, 54);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(10, 30);
+                            armorModValue = ThreadSafeRandom.Next(26, 50);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = 0;
@@ -335,14 +333,13 @@ namespace ACE.Server.Factories
                     case 3:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(80, 110);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(52, 75);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(54, 80);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(30, 60);
+                            armorModValue = ThreadSafeRandom.Next(50, 74);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(190, 210);
@@ -350,14 +347,13 @@ namespace ACE.Server.Factories
                     case 4:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(110, 140);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(75, 98);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(80, 106);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(60, 90);
+                            armorModValue = ThreadSafeRandom.Next(74, 98);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(210, 230);
@@ -365,14 +361,13 @@ namespace ACE.Server.Factories
                     case 5:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(140, 170);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(98, 121);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(106, 132);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(90, 120);
+                            armorModValue = ThreadSafeRandom.Next(98, 122);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(230, 250);
@@ -380,14 +375,13 @@ namespace ACE.Server.Factories
                     case 6:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(170, 200);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(121, 144);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(132, 158);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(120, 150);
+                            armorModValue = ThreadSafeRandom.Next(122, 146);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(250, 270);
@@ -395,14 +389,13 @@ namespace ACE.Server.Factories
                     case 7:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(200, 230);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(144, 167);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(158, 184);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(150, 180);
+                            armorModValue = ThreadSafeRandom.Next(146, 170);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(270, 290);
@@ -410,14 +403,13 @@ namespace ACE.Server.Factories
                     case 8:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(230, 260);
-                        if (wo.ArmorType == (int)ArmorType.Leather)
+                        if (wo.ArmorType == (int)ArmorType.Leather
+                            || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(167, 190);
-                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(184, 210);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(180, 204);
+                            armorModValue = ThreadSafeRandom.Next(170, 194);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(290, 310);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -277,164 +277,163 @@ namespace ACE.Server.Factories
             return wield;
         }
 
+        /// <summary>
+        /// Assign a final AL value based upon tier
+        /// Based upon http://acpedia.org/wiki/Loot/Tier_7_Pre2013#Max_Armor_Levels
+        /// and http://acpedia.org/wiki/Loot/Tier_8#Maximum_Armor_Levels given the base AL values on the weenies
+        /// </summary>
+        /// <param name="wo"></param>
+        /// <param name="tier"></param>
+        /// <param name="armorType"></param>
+        /// <returns></returns>
         private static WorldObject AssignArmorLevel(WorldObject wo, int tier, LootTables.ArmorType armorType)
         {
             var baseArmorLevel = wo.GetProperty(PropertyInt.ArmorLevel) ?? 0;
 
-            if (baseArmorLevel > 0)
+            if (wo.ArmorType != null && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear)
             {
-                int adjustedArmorLevel = baseArmorLevel + GetArmorLevelModifier(tier, armorType);
+                int armorModValue = 0;
+
+                // Accouting for Olthoi armor types in ACE-World dbs that have not been reduced to true base levels, similar to other loot clothing
+                var version = wo.GetProperty(PropertyInt.Version) ?? 1;
+                if (armorType > LootTables.ArmorType.HaebreanArmor && armorType <= LootTables.ArmorType.OlthoiAlduressaArmor && version < 3)
+                {
+                    if (armorType != LootTables.ArmorType.OlthoiAlduressaArmor)
+                    {
+                        switch (tier)
+                        {
+                            case 7:
+                                armorModValue = ThreadSafeRandom.Next(0, 40);
+                                break;
+                            case 8:
+                                armorModValue = ThreadSafeRandom.Next(160, 200);
+                                break;
+                            default:
+                                armorModValue = 0;
+                                break;
+                        }
+                    }
+                }
+                else
+                {
+                    // Sets AL variations based on weenie ArmorType field, such as cloth, leather, metal, etc.
+                    switch (tier)
+                    {
+                        case 1:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(20, 50);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(50, 70);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(0, 10);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = 0;
+                            break;
+                        case 2:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(50, 80);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(70, 100);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(10, 30);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = 0;
+                            break;
+                        case 3:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(80, 110);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(100, 130);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(30, 60);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(190, 210);
+                            break;
+                        case 4:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(110, 140);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(120, 150);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(60, 90);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(210, 230);
+                            break;
+                        case 5:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(140, 170);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(150, 180);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(90, 120);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(230, 250);
+                            break;
+                        case 6:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(170, 200);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(180, 210);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(120, 150);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(250, 270);
+                            break;
+                        case 7:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(200, 230);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(210, 240);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(150, 180);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(270, 290);
+                            break;
+                        case 8:
+                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                                armorModValue = ThreadSafeRandom.Next(230, 260);
+                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                                armorModValue = ThreadSafeRandom.Next(240, 270);
+                            if (wo.ArmorType == (int)ArmorType.Metal
+                                || wo.ArmorType == (int)ArmorType.Chainmail
+                                || wo.ArmorType == (int)ArmorType.Scalemail)
+                                armorModValue = ThreadSafeRandom.Next(180, 210);
+                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                                armorModValue = ThreadSafeRandom.Next(290, 310);
+                            break;
+                    }
+                }
+
+                int adjustedArmorLevel = baseArmorLevel + armorModValue;
                 wo.SetProperty(PropertyInt.ArmorLevel, adjustedArmorLevel);
             }
 
+            if (wo.ArmorType == null)
+                log.Warn($"[LOOT] Missing PropertyInt.ArmorType on loot item {wo.WeenieClassId} - {wo.Name}");
+
             return wo;
-        }
-
-        private static int GetArmorLevelModifier(int tier, LootTables.ArmorType armorType)
-        {
-            // fixed in pending update synced w/ db
-            if (armorType > LootTables.ArmorType.HaebreanArmor && armorType < LootTables.ArmorType.OlthoiAlduressaArmor)
-            {
-                switch (tier)
-                {
-                    case 7:
-                        return ThreadSafeRandom.Next(0, 40);
-
-                    case 8:
-                        return ThreadSafeRandom.Next(160, 200);
-
-                    default:
-                        return 0;
-                }
-            }
-
-            switch (tier)
-            {
-                case 1:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(0, 27);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(0, 23);
-
-                    else
-                        return ThreadSafeRandom.Next(0, 40);
-
-                case 2:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(27, 54);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(23, 46);
-
-                    else
-                        return ThreadSafeRandom.Next(40, 80);
-
-                case 3:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(54, 81);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(46, 69);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(90, 130);
-
-                    else
-                        return ThreadSafeRandom.Next(80, 120);
-
-                case 4:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(81, 108);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(69, 92);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(130, 170);
-
-                    else
-                        return ThreadSafeRandom.Next(120, 160);
-
-                case 5:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(108, 135);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(92, 115);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(170, 210);
-
-                    else
-                        return ThreadSafeRandom.Next(160, 200);
-
-                case 6:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(135, 162);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(115, 138);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(210, 250);
-
-                    else
-                        return ThreadSafeRandom.Next(200, 240);
-
-                case 7:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(162, 189);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                          || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(138, 161);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(250, 290);
-
-                    else
-                        return ThreadSafeRandom.Next(240, 280);
-
-                case 8:
-                    if (armorType == LootTables.ArmorType.StuddedLeatherArmor
-                     || armorType == LootTables.ArmorType.Helms
-                     || armorType == LootTables.ArmorType.Shields)
-                        return ThreadSafeRandom.Next(189, 216);
-
-                    else if (armorType == LootTables.ArmorType.LeatherArmor
-                        || armorType == LootTables.ArmorType.MiscClothing)
-                        return ThreadSafeRandom.Next(161, 184);
-
-                    else if (armorType == LootTables.ArmorType.CovenantArmor)
-                        return ThreadSafeRandom.Next(290, 330);
-
-                    else
-                        return ThreadSafeRandom.Next(280, 320);
-
-                default:
-                    return 0;
-            }
         }
     }
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -295,17 +295,19 @@ namespace ACE.Server.Factories
                 int armorModValue = 0;
 
                 // Account for ACE World Databases that have not yet been updated
-                if (wo.ArmorType != (int)ArmorType.Cloth && wo.GetProperty(PropertyInt.Version) < 3)
+                if (wo.ArmorType != (int)ArmorType.Cloth && (wo.GetProperty(PropertyInt.Version) == null || wo.GetProperty(PropertyInt.Version) < 3))
                     return AssignArmorLevelCompat(wo, tier, armorType);
 
                 // Sets AL variations based on weenie ArmorType field, such as cloth, leather, metal, etc.
                 switch (tier)
                 {
                     case 1:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(20, 50);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(0, 29);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(50, 70);
+                            armorModValue = ThreadSafeRandom.Next(0, 30);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -315,10 +317,12 @@ namespace ACE.Server.Factories
                             armorModValue = 0;
                         break;
                     case 2:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(50, 80);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(29, 52);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(70, 100);
+                            armorModValue = ThreadSafeRandom.Next(30, 54);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -328,10 +332,12 @@ namespace ACE.Server.Factories
                             armorModValue = 0;
                         break;
                     case 3:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(80, 110);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(52, 75);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(100, 130);
+                            armorModValue = ThreadSafeRandom.Next(54, 80);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -341,10 +347,12 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(190, 210);
                         break;
                     case 4:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(110, 140);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(75, 98);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(120, 150);
+                            armorModValue = ThreadSafeRandom.Next(80, 106);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -354,10 +362,12 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(210, 230);
                         break;
                     case 5:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(140, 170);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(98, 121);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(150, 180);
+                            armorModValue = ThreadSafeRandom.Next(106, 132);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -367,10 +377,12 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(230, 250);
                         break;
                     case 6:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(170, 200);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(121, 144);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(180, 210);
+                            armorModValue = ThreadSafeRandom.Next(132, 158);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -380,10 +392,12 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(250, 270);
                         break;
                     case 7:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(200, 230);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(144, 167);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(210, 240);
+                            armorModValue = ThreadSafeRandom.Next(158, 184);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
@@ -393,14 +407,16 @@ namespace ACE.Server.Factories
                             armorModValue = ThreadSafeRandom.Next(270, 290);
                         break;
                     case 8:
-                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                        if (wo.ArmorType == (int)ArmorType.Cloth)
                             armorModValue = ThreadSafeRandom.Next(230, 260);
+                        if (wo.ArmorType == (int)ArmorType.Leather)
+                            armorModValue = ThreadSafeRandom.Next(167, 190);
                         if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                            armorModValue = ThreadSafeRandom.Next(240, 270);
+                            armorModValue = ThreadSafeRandom.Next(184, 210);
                         if (wo.ArmorType == (int)ArmorType.Metal
                             || wo.ArmorType == (int)ArmorType.Chainmail
                             || wo.ArmorType == (int)ArmorType.Scalemail)
-                            armorModValue = ThreadSafeRandom.Next(180, 210);
+                            armorModValue = ThreadSafeRandom.Next(180, 204);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(290, 310);
@@ -419,7 +435,7 @@ namespace ACE.Server.Factories
 
         private static WorldObject AssignArmorLevelCompat(WorldObject wo, int tier, LootTables.ArmorType armorType)
         {
-            log.Warn($"[LOOT] Using AL Assignment Compatibility layer for item {wo.WeenieClassId} - {wo.Name}. Please update ACE-World Database");
+            log.Warn($"[LOOT] Using AL Assignment Compatibility layer for item {wo.WeenieClassId} - {wo.Name}.");
 
             var baseArmorLevel = wo.GetProperty(PropertyInt.ArmorLevel) ?? 0;
 
@@ -427,7 +443,7 @@ namespace ACE.Server.Factories
             {
                 int armorModValue = 0;
 
-                if (armorType > LootTables.ArmorType.HaebreanArmor && armorType < LootTables.ArmorType.OlthoiAlduressaArmor)
+                if (armorType > LootTables.ArmorType.HaebreanArmor && armorType <= LootTables.ArmorType.OlthoiAlduressaArmor)
                 {
                     switch (tier)
                     {

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -437,7 +437,7 @@ namespace ACE.Server.Factories
                 wo.SetProperty(PropertyInt.ArmorLevel, adjustedArmorLevel);
             }
 
-            if (wo.GetProperty(PropertyInt.ArmorLevel) >= 340 && (wo.ResistMagic != null && wo.ResistMagic == 9999))
+            if ((wo.ResistMagic == null || wo.ResistMagic < 9999) && wo.GetProperty(PropertyInt.ArmorLevel) >= 340)
                 log.Warn($"[LOOT] Standard armor item exceeding upper AL threshold {wo.WeenieClassId} - {wo.Name}");
 
             if (wo.ArmorType == null)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -279,9 +279,8 @@ namespace ACE.Server.Factories
 
         /// <summary>
         /// Assign a final AL value based upon tier
-        /// Used values given at http://acpedia.org/wiki/Loot/Tier_7_Pre2013#Max_Armor_Levels
-        /// and http://acpedia.org/wiki/Loot/Tier_8#Maximum_Armor_Levels for setting the AL mod values
-        /// so as to not exceed the values listed on those tables
+        /// Used values given at https://asheron.fandom.com/wiki/Loot#Armor_Levels for setting the AL mod values
+        /// so as to not exceed the values listed in that table
         /// </summary>
         /// <param name="wo"></param>
         /// <param name="tier"></param>
@@ -304,7 +303,7 @@ namespace ACE.Server.Factories
                 {
                     case 1:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(20, 50);
+                            armorModValue = ThreadSafeRandom.Next(0, 25);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(0, 29);
@@ -313,12 +312,15 @@ namespace ACE.Server.Factories
                             || wo.ArmorType == (int)ArmorType.Scalemail)
                             armorModValue = ThreadSafeRandom.Next(0, 26);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        // Does not drop at this tier level
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = 0;
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(5, 22);
                         break;
                     case 2:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(50, 80);
+                            armorModValue = ThreadSafeRandom.Next(25, 50);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(29, 52);
@@ -327,12 +329,15 @@ namespace ACE.Server.Factories
                             || wo.ArmorType == (int)ArmorType.Scalemail)
                             armorModValue = ThreadSafeRandom.Next(26, 50);
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        // Does not drop at this tier level
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = 0;
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(22, 39);
                         break;
                     case 3:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(80, 110);
+                            armorModValue = ThreadSafeRandom.Next(50, 75);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(52, 75);
@@ -343,10 +348,12 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(190, 210);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(39, 56);
                         break;
                     case 4:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(110, 140);
+                            armorModValue = ThreadSafeRandom.Next(75, 100);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(75, 98);
@@ -357,10 +364,12 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(210, 230);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(56, 73);
                         break;
                     case 5:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(140, 170);
+                            armorModValue = ThreadSafeRandom.Next(100, 125);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(98, 121);
@@ -371,10 +380,12 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(230, 250);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(73, 90);
                         break;
                     case 6:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(170, 200);
+                            armorModValue = ThreadSafeRandom.Next(125, 150);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(121, 144);
@@ -385,10 +396,12 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(250, 270);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(90, 107);
                         break;
                     case 7:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(200, 230);
+                            armorModValue = ThreadSafeRandom.Next(150, 175);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(144, 167);
@@ -399,10 +412,12 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(270, 290);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(107, 124);
                         break;
                     case 8:
                         if (wo.ArmorType == (int)ArmorType.Cloth)
-                            armorModValue = ThreadSafeRandom.Next(230, 260);
+                            armorModValue = ThreadSafeRandom.Next(175, 200);
                         if (wo.ArmorType == (int)ArmorType.Leather
                             || wo.ArmorType == (int)ArmorType.StuddedLeather)
                             armorModValue = ThreadSafeRandom.Next(167, 190);
@@ -413,12 +428,17 @@ namespace ACE.Server.Factories
                         // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
                         if (wo.ResistMagic != null && wo.ResistMagic == 9999)
                             armorModValue = ThreadSafeRandom.Next(290, 310);
+                        if (wo.IsShield)
+                            armorModValue = ThreadSafeRandom.Next(124, 141);
                         break;
                 }
 
                 int adjustedArmorLevel = baseArmorLevel + armorModValue;
                 wo.SetProperty(PropertyInt.ArmorLevel, adjustedArmorLevel);
             }
+
+            if (wo.GetProperty(PropertyInt.ArmorLevel) >= 340 && (wo.ResistMagic != null && wo.ResistMagic == 9999))
+                log.Warn($"[LOOT] Standard armor item exceeding upper AL threshold {wo.WeenieClassId} - {wo.Name}");
 
             if (wo.ArmorType == null)
                 log.Warn($"[LOOT] Missing PropertyInt.ArmorType on loot item {wo.WeenieClassId} - {wo.Name}");

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -279,8 +279,9 @@ namespace ACE.Server.Factories
 
         /// <summary>
         /// Assign a final AL value based upon tier
-        /// Based upon http://acpedia.org/wiki/Loot/Tier_7_Pre2013#Max_Armor_Levels
-        /// and http://acpedia.org/wiki/Loot/Tier_8#Maximum_Armor_Levels given the base AL values on the weenies
+        /// Used values given at http://acpedia.org/wiki/Loot/Tier_7_Pre2013#Max_Armor_Levels
+        /// and http://acpedia.org/wiki/Loot/Tier_8#Maximum_Armor_Levels for setting the AL mod values
+        /// so as to not exceed the values listed on those tables
         /// </summary>
         /// <param name="wo"></param>
         /// <param name="tier"></param>
@@ -445,13 +446,15 @@ namespace ACE.Server.Factories
 
                 if (armorType > LootTables.ArmorType.HaebreanArmor && armorType <= LootTables.ArmorType.OlthoiAlduressaArmor)
                 {
+                    // Even if most are not using T8, made a change to that outcome to ensure that Olthoi Alduressa doesn't go way out of spec
+                    // Side effect is that Haebrean to Olthoi Celdon may suffer
                     switch (tier)
                     {
                         case 7:
                             armorModValue = ThreadSafeRandom.Next(0, 40);
                             break;
                         case 8:
-                            armorModValue = ThreadSafeRandom.Next(160, 200);
+                            armorModValue = ThreadSafeRandom.Next(91, 115); 
                             break;
                         default:
                             armorModValue = 0;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -294,136 +294,117 @@ namespace ACE.Server.Factories
             {
                 int armorModValue = 0;
 
-                // Accouting for Olthoi armor types in ACE-World dbs that have not been reduced to true base levels, similar to other loot clothing
-                var version = wo.GetProperty(PropertyInt.Version) ?? 1;
-                if (armorType > LootTables.ArmorType.HaebreanArmor && armorType <= LootTables.ArmorType.OlthoiAlduressaArmor && version < 3)
+                // Account for ACE World Databases that have not yet been updated
+                if (wo.ArmorType != (int)ArmorType.Cloth && wo.GetProperty(PropertyInt.Version) < 3)
+                    return AssignArmorLevelCompat(wo, tier, armorType);
+
+                // Sets AL variations based on weenie ArmorType field, such as cloth, leather, metal, etc.
+                switch (tier)
                 {
-                    if (armorType != LootTables.ArmorType.OlthoiAlduressaArmor)
-                    {
-                        switch (tier)
-                        {
-                            case 7:
-                                armorModValue = ThreadSafeRandom.Next(0, 40);
-                                break;
-                            case 8:
-                                armorModValue = ThreadSafeRandom.Next(160, 200);
-                                break;
-                            default:
-                                armorModValue = 0;
-                                break;
-                        }
-                    }
-                }
-                else
-                {
-                    // Sets AL variations based on weenie ArmorType field, such as cloth, leather, metal, etc.
-                    switch (tier)
-                    {
-                        case 1:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(20, 50);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(50, 70);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(0, 10);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = 0;
-                            break;
-                        case 2:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(50, 80);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(70, 100);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(10, 30);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = 0;
-                            break;
-                        case 3:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(80, 110);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(100, 130);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(30, 60);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(190, 210);
-                            break;
-                        case 4:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(110, 140);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(120, 150);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(60, 90);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(210, 230);
-                            break;
-                        case 5:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(140, 170);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(150, 180);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(90, 120);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(230, 250);
-                            break;
-                        case 6:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(170, 200);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(180, 210);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(120, 150);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(250, 270);
-                            break;
-                        case 7:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(200, 230);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(210, 240);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(150, 180);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(270, 290);
-                            break;
-                        case 8:
-                            if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
-                                armorModValue = ThreadSafeRandom.Next(230, 260);
-                            if (wo.ArmorType == (int)ArmorType.StuddedLeather)
-                                armorModValue = ThreadSafeRandom.Next(240, 270);
-                            if (wo.ArmorType == (int)ArmorType.Metal
-                                || wo.ArmorType == (int)ArmorType.Chainmail
-                                || wo.ArmorType == (int)ArmorType.Scalemail)
-                                armorModValue = ThreadSafeRandom.Next(180, 210);
-                            // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
-                            if (wo.ResistMagic != null && wo.ResistMagic == 9999)
-                                armorModValue = ThreadSafeRandom.Next(290, 310);
-                            break;
-                    }
+                    case 1:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(20, 50);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(50, 70);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(0, 10);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = 0;
+                        break;
+                    case 2:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(50, 80);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(70, 100);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(10, 30);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = 0;
+                        break;
+                    case 3:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(80, 110);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(100, 130);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(30, 60);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(190, 210);
+                        break;
+                    case 4:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(110, 140);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(120, 150);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(60, 90);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(210, 230);
+                        break;
+                    case 5:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(140, 170);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(150, 180);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(90, 120);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(230, 250);
+                        break;
+                    case 6:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(170, 200);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(180, 210);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(120, 150);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(250, 270);
+                        break;
+                    case 7:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(200, 230);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(210, 240);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(150, 180);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(270, 290);
+                        break;
+                    case 8:
+                        if (wo.ArmorType == (int)ArmorType.Leather || wo.ArmorType == (int)ArmorType.Cloth)
+                            armorModValue = ThreadSafeRandom.Next(230, 260);
+                        if (wo.ArmorType == (int)ArmorType.StuddedLeather)
+                            armorModValue = ThreadSafeRandom.Next(240, 270);
+                        if (wo.ArmorType == (int)ArmorType.Metal
+                            || wo.ArmorType == (int)ArmorType.Chainmail
+                            || wo.ArmorType == (int)ArmorType.Scalemail)
+                            armorModValue = ThreadSafeRandom.Next(180, 210);
+                        // Covenant and Olthoi Armor (not Amuli, Celdon, Koujia, or Alduressa types of Olthoi Armor)
+                        if (wo.ResistMagic != null && wo.ResistMagic == 9999)
+                            armorModValue = ThreadSafeRandom.Next(290, 310);
+                        break;
                 }
 
                 int adjustedArmorLevel = baseArmorLevel + armorModValue;
@@ -432,6 +413,170 @@ namespace ACE.Server.Factories
 
             if (wo.ArmorType == null)
                 log.Warn($"[LOOT] Missing PropertyInt.ArmorType on loot item {wo.WeenieClassId} - {wo.Name}");
+
+            return wo;
+        }
+
+        private static WorldObject AssignArmorLevelCompat(WorldObject wo, int tier, LootTables.ArmorType armorType)
+        {
+            log.Warn($"[LOOT] Using AL Assignment Compatibility layer for item {wo.WeenieClassId} - {wo.Name}. Please update ACE-World Database");
+
+            var baseArmorLevel = wo.GetProperty(PropertyInt.ArmorLevel) ?? 0;
+
+            if (baseArmorLevel > 0)
+            {
+                int armorModValue = 0;
+
+                if (armorType > LootTables.ArmorType.HaebreanArmor && armorType < LootTables.ArmorType.OlthoiAlduressaArmor)
+                {
+                    switch (tier)
+                    {
+                        case 7:
+                            armorModValue = ThreadSafeRandom.Next(0, 40);
+                            break;
+                        case 8:
+                            armorModValue = ThreadSafeRandom.Next(160, 200);
+                            break;
+                        default:
+                            armorModValue = 0;
+                            break;
+                    }
+                }
+                else
+                {
+                    switch (tier)
+                    {
+                        case 1:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(0, 27);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(0, 23);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(0, 40);
+                            break;
+                        case 2:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(27, 54);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(23, 46);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(40, 80);
+                            break;
+                        case 3:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(54, 81);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(46, 69);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(90, 130);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(80, 120);
+                            break;
+                        case 4:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(81, 108);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(69, 92);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(130, 170);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(120, 160);
+                            break;
+                        case 5:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(108, 135);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(92, 115);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(170, 210);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(160, 200);
+                            break;
+                        case 6:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(135, 162);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(115, 138);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(210, 250);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(200, 240);
+                            break;
+                        case 7:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(162, 189);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                  || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(138, 161);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(250, 290);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(240, 280);
+                            break;
+                        case 8:
+                            if (armorType == LootTables.ArmorType.StuddedLeatherArmor
+                             || armorType == LootTables.ArmorType.Helms
+                             || armorType == LootTables.ArmorType.Shields)
+                                armorModValue = ThreadSafeRandom.Next(189, 216);
+
+                            else if (armorType == LootTables.ArmorType.LeatherArmor
+                                || armorType == LootTables.ArmorType.MiscClothing)
+                                armorModValue = ThreadSafeRandom.Next(161, 184);
+
+                            else if (armorType == LootTables.ArmorType.CovenantArmor)
+                                armorModValue = ThreadSafeRandom.Next(290, 330);
+
+                            else
+                                armorModValue = ThreadSafeRandom.Next(280, 320);
+                            break;
+                        default:
+                            armorModValue = 0;
+                            break;
+                    }
+                }
+
+                int adjustedArmorLevel = baseArmorLevel + armorModValue;
+                wo.SetProperty(PropertyInt.ArmorLevel, adjustedArmorLevel);
+            }
 
             return wo;
         }


### PR DESCRIPTION
- Update AssignArmorLevel() to account for updated base AL weenie values and align AL mod with armor type, ie, cloth, leather, chainmail, metal, etc.
- Maintains original AssignArmorLevel code for a compatibility layer for databases that have not been updated, yet
- Should be paired with an [update](https://github.com/ACEmulator/ACE-World-16PY-Patches/pull/253) to ACE-World-Patches but should be safe to use without updated armor objects
