### PR TITLE
EmoteManager AddDelaySeconds() only when > 0

### DIFF
--- a/Source/ACE.Server/Entity/Actions/ActionChain.cs
+++ b/Source/ACE.Server/Entity/Actions/ActionChain.cs
@@ -119,6 +119,9 @@ namespace ACE.Server.Entity.Actions
             return this;
         }
 
+        /// <summary>
+        /// If timeInSeconds &lt;= 0, no action will be added. If you must wait for one tick, use AddDelayForOneTick() 
+        /// </summary>
         public ActionChain AddDelaySeconds(double timeInSeconds)
         {
             if (Double.IsNaN(timeInSeconds))
@@ -127,7 +130,19 @@ namespace ACE.Server.Entity.Actions
                 return this;
             }
 
+            if (timeInSeconds <= 0)
+                return this;
+
             AddAction(WorldManager.DelayManager, new DelayAction(timeInSeconds));
+
+            return this;
+        }
+
+        public ActionChain AddDelayForOneTick()
+        {
+            // TODO: This should be expanded to gaurantee that a full world tick actually completes
+            // TODO: If this gets called before the WorldObject.Tick->RunActions(), then it can end up executing on the same tick.
+            AddAction(WorldManager.DelayManager, new DelayAction(0.001f));
 
             return this;
         }


### PR DESCRIPTION
This will help OnDeath emotes with 0 delay run on the next tick. This also has the added benefit of not deferring action chains 1 tick when delays are 0. For that specific scenario, another stub function has been added.

It's more difficult to run them on the same tick due to the way Emotes tick. If you want to ensure OnDeath emotes are run on the same tick, you can modify EmoteManager (ExecuteEmoteSet or Enqueue) to execute the emote right away instead of enqueueing it.