### PR TITLE
Separate Armor from MiscClothing in loot gen

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -237,31 +237,35 @@ namespace ACE.Server.Factories
                     type = 2;
                     break;
                 case LootBias.Weapons:
-                    type = 3;
-                    break;
-                case LootBias.Jewelry:
                     type = 4;
                     break;
+                case LootBias.Jewelry:
+                    type = 5;
+                    break;
                 default:
-                    type = ThreadSafeRandom.Next(1, 4);
+                    type = ThreadSafeRandom.Next(1, 5);
                     break;
             }
 
             switch (type)
             {
                 case 1:
-                    //jewels
+                    // jewels
                     wo = CreateJewels(tier, isMagical);
                     return wo;
                 case 2:
-                    //armor
-                    wo = CreateArmor(tier, isMagical, lootBias);
+                    // armor
+                    wo = CreateArmor(tier, isMagical, true, lootBias);
                     return wo;
                 case 3:
-                    //weapons
-                    wo = CreateWeapon(tier, isMagical);
+                    // shirts/pants
+                    wo = CreateArmor(tier, isMagical, false, lootBias);
                     return wo;
                 case 4:
+                    // weapons
+                    wo = CreateWeapon(tier, isMagical);
+                    return wo;
+                case 5:
                 default:
                     //jewelry
                     wo = CreateJewelry(tier, isMagical);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -6,9 +6,9 @@ namespace ACE.Server.Factories
 {
     public static partial class LootGenerationFactory
     {
-        private static WorldObject CreateArmor(int tier, bool isMagical, LootBias lootBias = LootBias.UnBiased)
+        private static WorldObject CreateArmor(int tier, bool isMagical, bool isArmor, LootBias lootBias = LootBias.UnBiased)
         {
-            var minType = LootTables.ArmorType.MiscClothing;
+            var minType = LootTables.ArmorType.Helms;
             var maxType = new LootTables.ArmorType();
 
             switch (tier)
@@ -33,14 +33,14 @@ namespace ACE.Server.Factories
                 case 7:
                 case 8:
                     maxType = LootTables.ArmorType.OlthoiAlduressaArmor;
-
-                    // armor Mana Forge Chests don't include clothing type items
-                    if (lootBias == LootBias.Armor)
-                        minType = LootTables.ArmorType.Helms;
                     break;
             }
 
-            var armorType = (LootTables.ArmorType)ThreadSafeRandom.Next((int)minType, (int)maxType);
+            LootTables.ArmorType armorType;
+            if (isArmor == true)
+                armorType = (LootTables.ArmorType)ThreadSafeRandom.Next((int)minType, (int)maxType);
+            else
+                armorType = LootTables.ArmorType.MiscClothing;
 
             int[] table = LootTables.GetLootTable(armorType);
 


### PR DESCRIPTION
Separate MiscClothing items out from being lumped into armor in general, without creating code duplication, by adding a flag to CreateArmor() that specifies either one or the other.  MiscClothing items should now have a fixed one in five chances of being generated, instead of a variable 1 in 6 to 1 in 28 chances, depending upon loot tier.

Code compiles but have not run/play tested