### PR TITLE
improved pk/pklite top damager detection

### DIFF
--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -58,18 +58,16 @@ namespace ACE.Server.Entity
         /// Returns the WorldObject that did the most damage to this WorldObject
         /// Used to determine corpse looting rights
         /// </summary>
-        public WorldObject TopDamager
-        {
-            get
-            {
-                var sorted = TotalDamage.OrderByDescending(wo => wo.Value.Value);
-                var topDamager = sorted.FirstOrDefault().Value;
-                //var topDamagerName = topDamager != null ? topDamager.Name : null;
-                //Console.WriteLine($"DamageHistory.TopDamager: {topDamagerName}");
-                return topDamager?.TryGetWorldObject();
-            }
-        }
+        public WorldObject TopDamager => GetTopDamager();
 
+        public WorldObject GetTopDamager(bool includeSelf = true)
+        {
+            var sorted = TotalDamage.Values.Where(wo => includeSelf || wo.Guid != Creature.Guid).OrderByDescending(wo => wo.Value);
+
+            var topDamager = sorted.FirstOrDefault();
+
+            return topDamager?.TryGetWorldObject();
+        }
 
         /// <summary>
         /// Constructs a new DamageHistory for a Player / Creature

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -610,7 +610,7 @@ namespace ACE.Server.WorldObjects
 
         public bool IsPKDeath(uint? killerGuid)
         {
-            return PlayerKillerStatus.HasFlag(PlayerKillerStatus.PK) && new ObjectGuid(killerGuid ?? 0).IsPlayer();
+            return PlayerKillerStatus.HasFlag(PlayerKillerStatus.PK) && new ObjectGuid(killerGuid ?? 0).IsPlayer() && killerGuid != Guid.Full;
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace ACE.Server.WorldObjects
 
         public bool IsPKLiteDeath(uint? killerGuid)
         {
-            return PlayerKillerStatus.HasFlag(PlayerKillerStatus.PKLite) && new ObjectGuid(killerGuid ?? 0).IsPlayer();
+            return PlayerKillerStatus.HasFlag(PlayerKillerStatus.PKLite) && new ObjectGuid(killerGuid ?? 0).IsPlayer() && killerGuid != Guid.Full;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -33,7 +33,9 @@ namespace ACE.Server.WorldObjects
         /// <param name="damageType">The damage type for the death message</param>
         public override DeathMessage OnDeath(WorldObject lastDamager, DamageType damageType, bool criticalHit = false)
         {
-            if (DamageHistory.TopDamager is Player pkPlayer)
+            var topDamager = DamageHistory.GetTopDamager(false);
+
+            if (topDamager is Player pkPlayer)
             {
                 if (IsPKDeath(pkPlayer))
                 {
@@ -135,6 +137,14 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         protected override void Die(WorldObject lastDamager, WorldObject topDamager)
         {
+            if (topDamager == this && IsPKType)
+            {
+                var topDamagerOther = DamageHistory.GetTopDamager(false);
+
+                if (topDamagerOther is Player)
+                    topDamager = topDamagerOther;
+            }
+
             UpdateVital(Health, 0);
             NumDeaths++;
             suicideInProgress = false;


### PR DESCRIPTION
a new function has been added, DamageHistory.GetTopDamager(bool includeSelf)

new logic has been added to prevent the following scenarios:
- a player should not be able to suicide during a pk battle and have themselves detected as the top damager (jumping off a cliff, harm self to death).
if a player is pk / pklite, and they are their own TopDamager, GetTopDamager(includeSelf = false) is called, to check if it is another player. If so, that player becomes the effective TopDamager, and is awarded the looting rights.
- if a pk / pklite is their own top damager, and the next highest damager is not another player, then the player remains their own effective top damager.

after this 'effective top damager' is determined, the IsPKDeath(topDamager) / IsPKLiteDeath(topDamager) calls also have logic added to ensure a true suicide is not considered death from a PK/PKLite battle