### PR TITLE
applying TransferCap to both srcVital and destVital for life transfer spells

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -481,27 +481,30 @@ namespace ACE.Server.WorldObjects
                     var drainMod = isDrain ? (float)source.GetResistanceMod(GetDrainResistanceType(spell.Source)) : 1.0f;
 
                     srcVitalChange = (uint)Math.Round(source.GetCreatureVital(spell.Source).Current * spell.Proportion * drainMod);
-
-                    if (spell.TransferCap != 0)
-                    {
-                        if (srcVitalChange > spell.TransferCap)
-                            srcVitalChange = (uint)spell.TransferCap;
-                    }
-
                     // should healing resistances be applied here?
                     var boostMod = isDrain ? (float)destination.GetResistanceMod(GetBoostResistanceType(spell.Destination)) : 1.0f;
+
+                    // TransferCap caps both srcVitalChange and destVitalChange
+                    // https://asheron.fandom.com/wiki/Announcements_-_2003/01_-_The_Slumbering_Giant#Letter_to_the_Players
+
+                    if (spell.TransferCap != 0 && srcVitalChange > spell.TransferCap)
+                        srcVitalChange = (uint)spell.TransferCap;
 
                     destVitalChange = (uint)Math.Round(srcVitalChange * (1.0f - spell.LossPercent) * boostMod);
 
                     // scale srcVitalChange to destVitalChange?
                     var missingDest = destination.GetCreatureVital(spell.Destination).Missing;
 
-                    if (destVitalChange > missingDest)
+                    var maxDestVitalChange = missingDest;
+                    if (spell.TransferCap != 0 && maxDestVitalChange > spell.TransferCap)
+                        maxDestVitalChange = (uint)spell.TransferCap;
+
+                    if (destVitalChange > maxDestVitalChange)
                     {
-                        var scalar = (float)missingDest / destVitalChange;
+                        var scalar = (float)maxDestVitalChange / destVitalChange;
 
                         srcVitalChange = (uint)Math.Round(srcVitalChange * scalar);
-                        destVitalChange = missingDest;
+                        destVitalChange = maxDestVitalChange;
                     }
 
                     // Apply the change in vitals to the source

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -481,14 +481,15 @@ namespace ACE.Server.WorldObjects
                     var drainMod = isDrain ? (float)source.GetResistanceMod(GetDrainResistanceType(spell.Source)) : 1.0f;
 
                     srcVitalChange = (uint)Math.Round(source.GetCreatureVital(spell.Source).Current * spell.Proportion * drainMod);
-                    // should healing resistances be applied here?
-                    var boostMod = isDrain ? (float)destination.GetResistanceMod(GetBoostResistanceType(spell.Destination)) : 1.0f;
 
                     // TransferCap caps both srcVitalChange and destVitalChange
                     // https://asheron.fandom.com/wiki/Announcements_-_2003/01_-_The_Slumbering_Giant#Letter_to_the_Players
 
                     if (spell.TransferCap != 0 && srcVitalChange > spell.TransferCap)
                         srcVitalChange = (uint)spell.TransferCap;
+
+                    // should healing resistances be applied here?
+                    var boostMod = isDrain ? (float)destination.GetResistanceMod(GetBoostResistanceType(spell.Destination)) : 1.0f;
 
                     destVitalChange = (uint)Math.Round(srcVitalChange * (1.0f - spell.LossPercent) * boostMod);
 


### PR DESCRIPTION
thanks to Yeonan for spotting this one:

https://asheron.fandom.com/wiki/Announcements_-_2003/01_-_The_Slumbering_Giant#Letter_to_the_Players

Example 1 - A mage is taking damage and would like to recover some health quickly. Using the level 1 health transfer spell, he takes 30 points away from a monster attacking him and receives 60 points in return. He does this a few times to help keep him alive while he tries to make a speedy retreat.

Example 2 - A mage has taken some damage, but well within what she can handle. She targets a nearby creature that has quite a bit of health. Using the level 7 health transfer spell, she takes 180 points of health away from the creature, and receives 90 in return.