### PR TITLE
Added NoAccess as an AccessLevel

### DIFF
--- a/Database/Updates/Authentication/2019-11-11-00-Add_NoAccess_To_Accesslevel_Table.sql
+++ b/Database/Updates/Authentication/2019-11-11-00-Add_NoAccess_To_Accesslevel_Table.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS `accesslevel`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+ SET character_set_client = utf8mb4 ;
+CREATE TABLE `accesslevel` (
+  `level` int(10) unsigned NOT NULL DEFAULT '0',
+  `name` varchar(45) NOT NULL,
+  `prefix` varchar(45) DEFAULT '',
+  PRIMARY KEY (`level`),
+  UNIQUE KEY `level` (`level`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (0,'NoAccess','');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (1,'Player','');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (2,'Advocate','');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (3,'Sentinel','Sentinel');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (4,'Envoy','Envoy');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (5,'Developer','');
+INSERT INTO `accesslevel` (`level`,`name`,`prefix`) VALUES (6,'Admin','Admin');
+
+UPDATE `account` SET `accesslevel` = 1 WHERE `accesslevel` = 0;
+UPDATE `account` SET `accesslevel` = 2 WHERE `accesslevel` = 1;
+UPDATE `account` SET `accesslevel` = 3 WHERE `accesslevel` = 2;
+UPDATE `account` SET `accesslevel` = 4 WHERE `accesslevel` = 3;
+UPDATE `account` SET `accesslevel` = 5 WHERE `accesslevel` = 4;
+UPDATE `account` SET `accesslevel` = 6 WHERE `accesslevel` = 5;

--- a/Source/ACE.Common/AccountDefaults.cs
+++ b/Source/ACE.Common/AccountDefaults.cs
@@ -16,7 +16,7 @@ namespace ACE.Common
         /// Default AccessLevel for new accounts. Used when accesslevel is not specified by user.  for backwards compatibility, this is 0 (Player)
         /// by default.
         /// </summary>
-        [System.ComponentModel.DefaultValue(0)]
+        [System.ComponentModel.DefaultValue(1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public uint DefaultAccessLevel { get; set; }
 

--- a/Source/ACE.Entity/Enum/AccessLevel.cs
+++ b/Source/ACE.Entity/Enum/AccessLevel.cs
@@ -2,11 +2,12 @@
 {
     public enum AccessLevel
     {
-        Player      = 0,
-        Advocate    = 1,
-        Sentinel    = 2,
-        Envoy       = 3,
-        Developer   = 4,
-        Admin       = 5
+        NoAccess    = 0,
+        Player      = 1,
+        Advocate    = 2,
+        Sentinel    = 3,
+        Envoy       = 4,
+        Developer   = 5,
+        Admin       = 6
     }
 }

--- a/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
+++ b/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
@@ -26,7 +26,8 @@ namespace ACE.Server.Network.Enum
         SendToSocketException,
         WorldClosed,
         AbnormalSequenceReceived,
-        AccountLoggedIn
+        AccountLoggedIn,
+        NotAuthorizedAccessLevel
     }
     public static class SessionTerminationReasonHelper
     {
@@ -50,7 +51,8 @@ namespace ACE.Server.Network.Enum
             "MainSocket.SendTo exception occured",
             "World is closed",
             "Client supplied an abnormal sequence",
-            "Account was logged in, booting currently connected account in favor of new connection"
+            "Account was logged in, booting currently connected account in favor of new connection",
+            "Not Authorized: Access level set to NoAccess for this account"
         };
         public static string GetDescription(this SessionTerminationReason reason)
         {

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -193,6 +193,11 @@ namespace ACE.Server.Network.Handlers
                 return;
             }
 
+            if (account.AccessLevel < 1)
+            {
+                session.Terminate(SessionTerminationReason.NotAuthorizedAccessLevel, new GameMessageBootAccount(session, "The access level for this account is too low."));
+            }
+
             // TODO: check for account bans
 
             account.UpdateLastLogin(session.EndPoint.Address);


### PR DESCRIPTION
Accounts set to AccessLevel 0 will now be rejected.

0 - NoAccess
1 - Player
2 - Advocate
3 - Sentinel
4 - Envoy
5 - Developer
6 - Admin

Useful for servers that require email validation before a player can login.