### PR TITLE
fixing some gaps for ranged missile mobs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -130,7 +130,9 @@ namespace ACE.Server.WorldObjects
             // hide previously held ammo
             EnqueueBroadcast(new GameMessagePickupEvent(ammo));
 
-            if (ammo.StackSize == null || ammo.StackSize <= 1)
+            // monsters have infinite ammo?
+
+            /*if (ammo.StackSize == null || ammo.StackSize <= 1)
             {
                 TryUnwieldObjectWithBroadcasting(ammo.Guid, out _, out _);
                 ammo.Destroy();
@@ -139,7 +141,7 @@ namespace ACE.Server.WorldObjects
             {
                 ammo.SetStackSize(ammo.StackSize - 1);
                 EnqueueBroadcast(new GameMessageSetStackSize(ammo));
-            }
+            }*/
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -80,17 +80,13 @@ namespace ACE.Server.WorldObjects
 
             // select a new weapon if missile launcher is out of ammo
             var weapon = GetEquippedWeapon();
-            if (weapon != null && weapon.IsAmmoLauncher)
+            /*if (weapon != null && weapon.IsAmmoLauncher)
             {
                 var ammo = GetEquippedAmmo();
                 if (ammo == null)
-                {
-                    TryUnwieldObjectWithBroadcasting(weapon.Guid, out _, out _);
-                    EquipInventoryItems(true);
-                    DoAttackStance();
-                    CurrentAttack = null;
-                }
-            }
+                    SwitchToMeleeAttack();
+            }*/
+
             if (weapon == null && CurrentAttack != null && CurrentAttack == CombatType.Missile)
             {
                 EquipInventoryItems(true);
@@ -149,6 +145,15 @@ namespace ACE.Server.WorldObjects
                     // perform attack
                     if (AttackReady())
                         Attack();
+                }
+                else
+                {
+                    // monster switches to melee combat immediately,
+                    // if target is beyond max range?
+
+                    // should ranged mobs only get CurrentTargets within MaxRange?
+                    //Console.WriteLine($"{Name}.MissileAttack({AttackTarget.Name}): targetDist={targetDist}, MaxRange={MaxRange}, switching to melee");
+                    SwitchToMeleeAttack();
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/Projectile.cs
+++ b/Source/ACE.Server/WorldObjects/Projectile.cs
@@ -110,9 +110,14 @@ namespace ACE.Server.WorldObjects
             WorldObject.CurrentLandblock?.RemoveWorldObject(WorldObject.Guid, showError: !PhysicsObj.entering_world);
             PhysicsObj.set_active(false);
 
-            var player = ProjectileSource as Player;
-            if (player != null)
+            if (ProjectileSource is Player player)
+            {
                 player.Session.Network.EnqueueSend(new GameMessageSystemChat("Your missile attack hit the environment.", ChatMessageType.Broadcast));
+            }
+            else if (ProjectileSource is Creature creature)
+            {
+                creature.MonsterProjectile_OnCollideEnvironment();
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -83,13 +83,6 @@ namespace ACE.Server.WorldObjects
 
             if (item.StackSize > 0)
             {
-                // fix lugians only having 1 rock?
-                if (wo.Name.Equals("Rock") && item.StackSize == 1 && item.StackSizeVariance == 0)
-                {
-                    item.StackSize = 10;
-                    item.StackSizeVariance = 0.1f;
-                }
-
                 var stackSize = item.StackSize;
 
                 var hasVariance = item.StackSizeVariance > 0;
@@ -101,7 +94,6 @@ namespace ACE.Server.WorldObjects
                 }
                 wo.SetStackSize(stackSize);
             }
-
             return wo;
         }
 


### PR DESCRIPTION
This patch updates the monsters in CombatMode.Missile (bow/crossbow/thrown weapons) to fix some gaps in their logic, and to bring them closer to retail.

Currently in ACE, monsters are depleting ammo for their ranged weapons, and stand their ground until they run out of ammo.

In retail, monsters appeared to have infinite ammo for their ranged weapons, and they decided to switch to melee mode based on other criteria:

- A monster will switch from ranged to melee if their target is beyond their MaxRange. They will then run in to close the gap.

- A monster will switch from ranged to melee if it has too many attacks that miss the target completely, and hit the environment.