### PR TITLE
improved RunRate handling for players

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2663,5 +2663,19 @@ namespace ACE.Server.Command.Handlers
             if (player != session.Player)
                 session.Network.EnqueueSend(new GameMessageSystemChat("Removed vitae for {player.Name}", ChatMessageType.Broadcast));
         }
+
+        [CommandHandler("fast", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        public static void HandleFast(Session session, params string[] parameters)
+        {
+            var spell = new Spell(SpellId.QuicknessSelf8);
+            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+        }
+
+        [CommandHandler("slow", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
+        public static void HandleSlow(Session session, params string[] parameters)
+        {
+            var spell = new Spell(SpellId.SlownessSelf8);
+            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+        }
     }
 }

--- a/Source/ACE.Server/Entity/Spell.cs
+++ b/Source/ACE.Server/Entity/Spell.cs
@@ -268,6 +268,33 @@ namespace ACE.Server.Entity
         }
 
         /// <summary>
+        /// Returns TRUE for any spells which could potentially affect the run rate,
+        /// such as spells which alter run / quickness / strength
+        /// </summary>
+        public bool UpdatesRunRate
+        {
+            get
+            {
+                if (_spell == null)
+                    return false;
+
+                // this is commented out as below in UpdatesMaxVitals
+                // i forget the exact reasoning, are all the proper hooks in places for each vitae %,
+                // and not just add/remove?
+                /*if (_spell.Id == 666)   // vitae
+                    return true;*/
+
+                if (StatModType.HasFlag(EnchantmentTypeFlags.Attribute) && (StatModKey == (uint)PropertyAttribute.Strength || StatModKey == (uint)PropertyAttribute.Quickness))
+                    return true;
+
+                if (StatModType.HasFlag(EnchantmentTypeFlags.Skill) && StatModKey == (uint)Skill.Run)
+                    return true;
+
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Returns a list of MaxVitals affected by this spell
         /// </summary>
         public List<PropertyAttribute2nd> UpdatesMaxVitals
@@ -278,6 +305,15 @@ namespace ACE.Server.Entity
 
                 if (_spell == null)
                     return maxVitals;
+
+                /*if (_spell.Id == 666)   // Vitae
+                {
+                    maxVitals.Add(PropertyAttribute2nd.MaxHealth);
+                    maxVitals.Add(PropertyAttribute2nd.MaxStamina);
+                    maxVitals.Add(PropertyAttribute2nd.MaxMana);
+
+                    return maxVitals;
+                }*/
 
                 if (StatModType.HasFlag(EnchantmentTypeFlags.SecondAtt) && StatModKey != 0)
                     maxVitals.Add((PropertyAttribute2nd)StatModKey);
@@ -296,14 +332,6 @@ namespace ACE.Server.Entity
                             break;
                     }
                 }
-
-                //if (_spell.Id == 666) // Vitae
-                //{
-                //    maxVitals.Add(PropertyAttribute2nd.MaxHealth);
-                //    maxVitals.Add(PropertyAttribute2nd.MaxStamina);
-                //    maxVitals.Add(PropertyAttribute2nd.MaxMana);
-                //}
-
                 return maxVitals;
             }
         }

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -504,6 +504,7 @@ namespace ACE.Server.Managers
                 ("pk_server_safe_training_academy", new Property<bool>(false, "set this to TRUE to disable pk fighting in training academy and time to exit starter town safely")),
                 ("pkl_server", new Property<bool>(false, "set this to TRUE for pink servers")),
                 ("quest_info_enabled", new Property<bool>(false, "toggles the /myquests player command")),
+                ("runrate_add_hooks", new Property<bool>(false, "if TRUE, adds some runrate hooks that were missing from retail (exhaustion done, raise skill/attribute")),
                 ("require_spell_comps", new Property<bool>(true, "if FALSE spell components are no longer required to be in inventory to cast spells. defaults to enabled, as in retail")),
                 ("salvage_handle_overages", new Property<bool>(false, "in retail, if 2 salvage bags were combined beyond 100 structure, the overages would be lost")),
                 ("show_dot_messages", new Property<bool>(false, "enabled, shows combat messages for DoT damage ticks. defaults to disabled, as in retail")),

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
@@ -11,6 +11,7 @@ namespace ACE.Server.Network.GameAction.Actions
         public static void Handle(ClientMessage message, Session session)
         {
             var moveToState = new MoveToState(session.Player, message.Payload);
+            session.Player.CurrentMoveToState = moveToState;
 
             session.Player.SetRequestedLocation(moveToState.Position);
 

--- a/Source/ACE.Server/Network/Motion/InterpretedMotionState.cs
+++ b/Source/ACE.Server/Network/Motion/InterpretedMotionState.cs
@@ -85,6 +85,11 @@ namespace ACE.Server.Network.Structure
 
             return flags;
         }
+
+        public bool HasMovement()
+        {
+            return (ForwardCommand != MotionCommand.Invalid && ForwardCommand != MotionCommand.Ready) || TurnCommand != MotionCommand.Invalid || SidestepCommand != MotionCommand.Invalid;
+        }
     }
 
     public static class InterpretedMotionStateExtensions

--- a/Source/ACE.Server/Network/Motion/MoveToState.cs
+++ b/Source/ACE.Server/Network/Motion/MoveToState.cs
@@ -26,6 +26,8 @@ namespace ACE.Server.Network.Structure
         public bool Contact;                // verify: contact (indicates if player is on ground), or sticky bit?
         public bool StandingLongJump;
 
+        public MoveToState() { }
+
         public MoveToState(WorldObject wo, BinaryReader reader)
         {
             WorldObject = wo;

--- a/Source/ACE.Server/Network/Motion/MovementData.cs
+++ b/Source/ACE.Server/Network/Motion/MovementData.cs
@@ -29,6 +29,8 @@ namespace ACE.Server.Network.Structure
         public TurnToObject TurnToObject;
         public TurnToHeading TurnToHeading;
 
+        public MovementData() { }
+
         public MovementData(WorldObject wo)
         {
             WorldObject = wo;
@@ -37,7 +39,7 @@ namespace ACE.Server.Network.Structure
         public MovementData(WorldObject wo, Motion motion)
         {
             WorldObject = wo;
-            var sequence = wo.Sequences;
+            //var sequence = wo.Sequences;
 
             // do this here, or in network writer?
             IsAutonomous = motion.IsAutonomous;

--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -17,9 +17,10 @@ namespace ACE.Server.Physics.Animation
         public Dictionary<uint, Dictionary<uint, MotionData>> Links;
         public uint DefaultStyle;
 
-        public static Dictionary<uint, float> WalkSpeed;
-        public static Dictionary<uint, float> RunSpeed;
-        public static Dictionary<uint, float> TurnSpeed;
+        // TODO: use proper ConcurrentDictionary
+        public static Dictionary<uint, float> WalkSpeed { get; set; }
+        public static Dictionary<uint, float> RunSpeed { get; set; }
+        public static Dictionary<uint, float> TurnSpeed { get; set; }
 
         static MotionTable()
         {
@@ -499,7 +500,7 @@ namespace ACE.Server.Physics.Animation
                 return 0.0f;
 
             var speed = GetAnimDist(motionData);
-            RunSpeed.Add(motionTableID, speed);
+            RunSpeed[motionTableID] = speed;
             return speed;
         }
 
@@ -517,7 +518,7 @@ namespace ACE.Server.Physics.Animation
                 return 0.0f;
 
             var speed = Math.Abs(motionData.Omega.Z);
-            TurnSpeed.Add(motionTableID, speed);
+            TurnSpeed[motionTableID] = speed;
             return speed;
         }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -197,11 +197,13 @@ namespace ACE.Server.WorldObjects
             // does not apply for mana?
             if (vital.Vital == PropertyAttribute2nd.MaxMana) return 1.0f;
 
+            var forwardCommand = CurrentMovementData.MovementType == MovementType.Invalid ? CurrentMovementData.Invalid.State.ForwardCommand : MotionCommand.Invalid;
+
             // combat mode / running
-            if (CombatMode != CombatMode.NonCombat || CurrentMotionCommand == MotionCommand.RunForward)
+            if (CombatMode != CombatMode.NonCombat || forwardCommand == MotionCommand.RunForward)
                 return 0.5f;
 
-            switch (CurrentMotionCommand)
+            switch (forwardCommand)
             {
                 // TODO: verify multipliers
                 default:

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -319,12 +319,6 @@ namespace ACE.Server.WorldObjects.Managers
 
                 if (sound && entry.SpellCategory != SpellCategory_Cooldown)
                     Player.Session.Network.EnqueueSend(new GameMessageSound(Player.Guid, Sound.SpellExpire, 1.0f));
-
-                if (entry.SpellCategory != SpellCategory_Cooldown)
-                {
-                    var spell = new Spell(spellID);
-                    Player.HandleMaxVitalUpdate(spell);
-                }
             }
             else
             {
@@ -472,12 +466,7 @@ namespace ACE.Server.WorldObjects.Managers
                 WorldObject.ChangesDetected = true;
 
             if (Player != null)
-            {
                 Player.Session.Network.EnqueueSend(new GameEventMagicDispelEnchantment(Player.Session, (ushort)entry.SpellId, entry.LayerId));
-
-                var spell = new Spell(spellID);
-                Player.HandleMaxVitalUpdate(spell);
-            }
         }
 
         /// <summary>
@@ -492,12 +481,6 @@ namespace ACE.Server.WorldObjects.Managers
             {
                 if (WorldObject.Biota.TryRemoveEnchantment(entry, out _, WorldObject.BiotaDatabaseLock))
                     WorldObject.ChangesDetected = true;
-
-                if (Player != null)
-                {
-                    var spell = new Spell(entry.SpellId);
-                    Player.HandleMaxVitalUpdate(spell);
-                }
             }
             if (Player != null)
                 Player.Session.Network.EnqueueSend(new GameEventMagicDispelMultipleEnchantments(Player.Session, entries));

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -52,6 +52,12 @@ namespace ACE.Server.WorldObjects.Managers
             base.Remove(entry, sound);
 
             ClearCache();
+
+            if (entry.SpellCategory != SpellCategory_Cooldown)
+            {
+                var spell = new Spell(entry.SpellId);
+                Player.HandleSpellHooks(spell);
+            }
         }
 
         /// <summary>
@@ -99,6 +105,12 @@ namespace ACE.Server.WorldObjects.Managers
             base.Dispel(entry);
 
             ClearCache();
+
+            if (Player != null)
+            {
+                var spell = new Spell(entry.SpellId);
+                Player.HandleSpellHooks(spell);
+            }
         }
 
         /// <summary>
@@ -109,6 +121,15 @@ namespace ACE.Server.WorldObjects.Managers
             base.Dispel(entries);
 
             ClearCache();
+
+            if (Player != null)
+            {
+                foreach (var entry in entries)
+                {
+                    var spell = new Spell(entry.SpellId);
+                    Player.HandleSpellHooks(spell);
+                }
+            }
         }
 
 

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -349,8 +349,24 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public float GetRunRate()
         {
+            var burden = 0.0f;
+
+            // assuming burden only applies to players...
+            if (this is Player player)
+            {
+                var strength = Strength.Current;
+
+                var capacity = EncumbranceSystem.EncumbranceCapacity((int)strength, player.AugmentationIncreasedCarryingCapacity);
+                burden = EncumbranceSystem.GetBurden(capacity, EncumbranceVal ?? 0);
+
+                // TODO: find this exact formula in client
+                // technically this would be based on when the player releases / presses the movement key after stamina > 0
+                if (player.IsExhausted)
+                    burden = 3.0f;
+            }
+
             var runSkill = GetCreatureSkill(Skill.Run).Current;
-            var runRate = MovementSystem.GetRunRate(0.0f, (int)runSkill, 1.0f);
+            var runRate = MovementSystem.GetRunRate(burden, (int)runSkill, 1.0f);
 
             return (float)runRate;
         }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -765,7 +765,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool HandleRunRateUpdate()
         {
-            Console.WriteLine($"{Name}.HandleRunRateUpdates()");
+            //Console.WriteLine($"{Name}.HandleRunRateUpdates()");
 
             if (CurrentMovementData.MovementType != MovementType.Invalid)
                 return false;
@@ -782,12 +782,12 @@ namespace ACE.Server.WorldObjects
             if (!changed)
                 return false;
 
-            Console.WriteLine($"Old: {prevState.ForwardSpeed}, New: {currentState.ForwardSpeed}");
+            //Console.WriteLine($"Old: {prevState.ForwardSpeed}, New: {currentState.ForwardSpeed}");
 
             if (!CurrentMovementData.Invalid.State.HasMovement() || IsJumping)
                 return false;
 
-            Console.WriteLine($"{Name}.OnRunRateChanged()");
+            //Console.WriteLine($"{Name}.OnRunRateChanged()");
 
             CurrentMovementData = new MovementData(this, CurrentMoveToState);
 

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -753,20 +753,52 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void OnExhausted()
         {
-            // adjust player speed if running
-            if (CurrentMotionCommand == MotionCommand.RunForward && !IsJumping)
-            {
-                // verify - forced commands from server should be non-autonomous, but could have been sent as autonomous in retail?
-                // if set to autonomous here, the desired effect doesn't happen
-                // motion.IsAutonomous = true;
-                var motion = new Motion(this, MotionCommand.RunForward);
+            // adjust player speed if they are currently pressing movement keys
+            HandleRunRateUpdate();
 
-                CurrentMotionState = motion;
-
-                if (CurrentLandblock != null)
-                    EnqueueBroadcastMotion(motion);
-            }
             Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "You're Exhausted!"));
+        }
+
+        /// <summary>
+        /// Detects changes in the player's RunRate --
+        /// If there are changes, re-broadcasts player movement packet
+        /// </summary>
+        public bool HandleRunRateUpdate()
+        {
+            Console.WriteLine($"{Name}.HandleRunRateUpdates()");
+
+            if (CurrentMovementData.MovementType != MovementType.Invalid)
+                return false;
+
+            var prevState = CurrentMovementData.Invalid.State;
+
+            var movementData = new MovementData(this, CurrentMoveToState);
+            var currentState = movementData.Invalid.State;
+
+            var changed = currentState.ForwardSpeed != prevState.ForwardSpeed ||
+                          currentState.TurnSpeed != prevState.TurnSpeed ||
+                          currentState.SidestepSpeed != prevState.SidestepSpeed;
+
+            if (!changed)
+                return false;
+
+            Console.WriteLine($"Old: {prevState.ForwardSpeed}, New: {currentState.ForwardSpeed}");
+
+            if (!CurrentMovementData.Invalid.State.HasMovement() || IsJumping)
+                return false;
+
+            Console.WriteLine($"{Name}.OnRunRateChanged()");
+
+            CurrentMovementData = new MovementData(this, CurrentMoveToState);
+
+            // verify - forced commands from server should be non-autonomous, but could have been sent as autonomous in retail?
+            // if set to autonomous here, the desired effect doesn't happen
+            CurrentMovementData.IsAutonomous = false;
+
+            var movementEvent = new GameMessageUpdateMotion(this, CurrentMovementData);
+            EnqueueBroadcast(movementEvent);    // broadcast to all players, including self
+
+            return true;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -775,8 +775,8 @@ namespace ACE.Server.WorldObjects
             var movementData = new MovementData(this, CurrentMoveToState);
             var currentState = movementData.Invalid.State;
 
-            var changed = currentState.ForwardSpeed != prevState.ForwardSpeed ||
-                          currentState.TurnSpeed != prevState.TurnSpeed ||
+            var changed = currentState.ForwardSpeed  != prevState.ForwardSpeed ||
+                          currentState.TurnSpeed     != prevState.TurnSpeed ||
                           currentState.SidestepSpeed != prevState.SidestepSpeed;
 
             if (!changed)

--- a/Source/ACE.Server/WorldObjects/Player_Attributes.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Attributes.cs
@@ -55,6 +55,9 @@ namespace ACE.Server.WorldObjects
                 {
                     Session.Network.EnqueueSend(abilityUpdate, soundEvent, message);
                 }
+
+                if (attribute == PropertyAttribute.Strength || attribute == PropertyAttribute.Quickness)
+                    HandleRunRateUpdate();
             }
             else
             {

--- a/Source/ACE.Server/WorldObjects/Player_Attributes.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Attributes.cs
@@ -3,6 +3,7 @@ using System;
 using ACE.DatLoader;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.GameMessages.Messages;
@@ -56,7 +57,8 @@ namespace ACE.Server.WorldObjects
                     Session.Network.EnqueueSend(abilityUpdate, soundEvent, message);
                 }
 
-                if (attribute == PropertyAttribute.Strength || attribute == PropertyAttribute.Quickness)
+                // retail was missing the 'raise attribute' runrate hook here
+                if ((attribute == PropertyAttribute.Strength || attribute == PropertyAttribute.Quickness) && PropertyManager.GetBool("runrate_add_hooks").Item)
                     HandleRunRateUpdate();
             }
             else

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1422,6 +1422,12 @@ namespace ACE.Server.WorldObjects
             // send error message?
         }
 
+        public void HandleSpellHooks(Spell spell)
+        {
+            HandleMaxVitalUpdate(spell);
+            HandleRunRateUpdate(spell);
+        }
+
         /// <summary>
         /// Called when an enchantment is added or removed,
         /// checks if the spell affects the max vitals,
@@ -1446,6 +1452,14 @@ namespace ACE.Server.WorldObjects
                 }
             });
             actionChain.EnqueueChain();
+        }
+
+        public bool HandleRunRateUpdate(Spell spell)
+        {
+            if (!spell.UpdatesRunRate)
+                return false;
+
+            return HandleRunRateUpdate();
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -228,7 +228,8 @@ namespace ACE.Server.WorldObjects
             EnqueueBroadcast(false, movementEvent);    // shouldn't need to go to originating player?
 
             // TODO: use real motion / animation system from physics
-            CurrentMotionCommand = movementData.Invalid.State.ForwardCommand;
+            //CurrentMotionCommand = movementData.Invalid.State.ForwardCommand;
+            CurrentMovementData = movementData;
         }
 
         private EnvironChangeType? currentFogColor;

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -250,7 +250,8 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.RaiseTrait, 1f));
                 Session.Network.EnqueueSend(new GameMessageSystemChat(messageText, ChatMessageType.Advancement));
 
-                if (skill == Skill.Run)
+                // retail was missing the 'raise skill' runrate hook here
+                if (skill == Skill.Run && PropertyManager.GetBool("runrate_add_hooks").Item)
                     HandleRunRateUpdate();
             }
             else if (prevXP != creatureSkill.ExperienceSpent)

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -249,6 +249,9 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameMessagePrivateUpdateSkill(this, creatureSkill));
                 Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.RaiseTrait, 1f));
                 Session.Network.EnqueueSend(new GameMessageSystemChat(messageText, ChatMessageType.Advancement));
+
+                if (skill == Skill.Run)
+                    HandleRunRateUpdate();
             }
             else if (prevXP != creatureSkill.ExperienceSpent)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Vitals.cs
@@ -5,6 +5,7 @@ using ACE.DatLoader;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages;
@@ -195,10 +196,9 @@ namespace ACE.Server.WorldObjects
                 {
                     OnExhausted();
                 }
-                else if (prevVal == 0)
+                // retail was missing the 'exhausted done' automatic hook here
+                else if (prevVal == 0 && PropertyManager.GetBool("runrate_add_hooks").Item)
                 {
-                    // did retail automatically run faster as soon as stamina ticked back up above 0,
-                    // or did it require the player to release and re-press the forward movement key?
                     HandleRunRateUpdate();
                 }
             }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1344,7 +1344,7 @@ namespace ACE.Server.WorldObjects
             {
                 playerTarget.Session.Network.EnqueueSend(new GameEventMagicUpdateEnchantment(playerTarget.Session, new Enchantment(playerTarget, addResult.Enchantment)));
 
-                playerTarget.HandleMaxVitalUpdate(spell);
+                playerTarget.HandleSpellHooks(spell);
             }
 
             if (playerTarget == null && target.Wielder is Player wielder)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -12,6 +12,7 @@ using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Managers;
+using ACE.Server.Network.Structure;
 
 namespace ACE.Server.WorldObjects
 {
@@ -558,13 +559,15 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-
         // ========================================
         // ======== Physics Desc Properties =======
         // ========================================
         // used in CalculatedPhysicsDescriptionFlag()
         public Motion CurrentMotionState { get; set; }
-        public MotionCommand CurrentMotionCommand { get; set; }
+
+        public MoveToState CurrentMoveToState { get; set; } = new MoveToState();
+        public MovementData CurrentMovementData { get; set; } = new MovementData();
+
 
         public Placement? Placement // Sometimes known as AnimationFrame
         {


### PR DESCRIPTION
this PR builds on top of https://github.com/ACEmulator/ACE/pull/2415

key scenario: if i cast Slowness on another player who is running, that player's RunRate should be affected immediately on both the server and client

currently in master, the player will continue to run at the same speed, until they release/re-press a movement key on their client

some temporary developer debug commands have been added to help test this, /fast and /slow, which invisibly cast QuicknessSelf8 and SlownessSelf8, respectively. The /dispel command is also useful.

Other scenarios handled: any spells which affect quickness/run/strength, and the player raising their quickness/run/strength while running/sidestepping

The previous Exhaustion detection system has been updated with this, and hooks have been added for both the player going into and out of stamina==0. The exact behavior for stamina in retail when exhausted/burdened needs to be confirmed.

Update: it appears retail had the runrate update hooks for spells which affected quickness/run/strength, and for 'exhaustion start', but it was missing the automatic hooks for 'exhaustion done' and player clicking button to raise quickness/run/strength attributes/skills while running.

The server now defaults to retail runrate hooks by default (spells and exhaustion start), and a custom server option 'runrate_add_hooks' can be enabled if the server operators wants to add the missing events.