### PR TITLE
fixing a possible lockup during physical combat when auto repeat attacks is disabled

### DIFF
--- a/Source/ACE.Server/Entity/Probability.cs
+++ b/Source/ACE.Server/Entity/Probability.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace ACE.Server.Entity
+{
+    public class Probability
+    {
+        /// <summary>
+        /// Returns the probability of none of the events occurring
+        /// from a list of chances
+        /// </summary>
+        public static float GetProbabilityNone(List<float> chances)
+        {
+            var probability = 1.0f;
+
+            foreach (var chance in chances)
+                probability *= 1.0f - chance;
+
+            return probability;
+        }
+
+        /// <summary>
+        /// Returns the probability of any of the events occurring
+        /// from a list of chances
+        /// </summary>
+        public static float GetProbabilityAny(List<float> chances)
+        {
+            return 1.0f - GetProbabilityNone(chances);
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -54,9 +54,25 @@ namespace ACE.Server.WorldObjects
             return skill.InitLevel + skill.Ranks;
         }
 
+        public float GetProbabilityAny()
+        {
+            var probabilities = new List<float>();
+
+            foreach (var spell in Biota.BiotaPropertiesSpellBook)
+            {
+                var probability = spell.Probability > 2.0f ? spell.Probability - 2.0f : spell.Probability / 100.0f;
+
+                probabilities.Add(probability);
+            }
+
+            return Probability.GetProbabilityAny(probabilities);
+        }
+
         public Spell TryRollSpell()
         {
             CurrentSpell = null;
+
+            //Console.WriteLine($"{Name}.TryRollSpell(), probability={GetProbabilityAny()}");
 
             // monster spellbooks have probabilities with base 2.0
             // ie. a 5% chance would be 2.05 instead of 0.05

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The target this player is currently performing a melee attack on
         /// </summary>
-        public WorldObject MeleeTarget;
+        public Creature MeleeTarget;
 
         private float _powerLevel;
 
@@ -46,6 +46,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionTargetedMeleeAttack(uint targetGuid, uint attackHeight, float powerLevel)
         {
+            //log.Info($"-");
+
             if (CombatMode != CombatMode.Melee)
                 return;
 
@@ -62,7 +64,7 @@ namespace ACE.Server.WorldObjects
             PowerLevel = powerLevel;
 
             // already in melee loop?
-            if (Attacking || MeleeTarget != null)
+            if (Attacking || MeleeTarget != null && MeleeTarget.IsAlive)
                 return;
 
             // get world object for target creature
@@ -91,7 +93,9 @@ namespace ACE.Server.WorldObjects
             if (target.Teleporting)
                 return;     // werror?
 
-            MeleeTarget = target;
+            //log.Info($"{Name}.HandleActionTargetedMeleeAttack({targetGuid:X8}, {attackHeight}, {powerLevel})");
+
+            MeleeTarget = creatureTarget;
             AttackTarget = MeleeTarget;
 
             var attackSequence = ++AttackSequence;
@@ -115,14 +119,19 @@ namespace ACE.Server.WorldObjects
                 // turn / move to required
                 if (GetCharacterOption(CharacterOption.UseChargeAttack))
                 {
+                    //log.Info($"{Name}.MoveTo({target.Name})");
+
                     // charge attack
                     MoveTo(target);
                 }
                 else
                 {
-                    
+                    //log.Info($"{Name}.CreateMoveToChain({target.Name})");
+
                     CreateMoveToChain(target, (success) =>
                     {
+                        log.Info($"{Name}.CreateMoveToChain({target.Name}) complete - {success}");
+
                         if (success)
                             Attack(target, attackSequence);
                     });
@@ -135,7 +144,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionCancelAttack()
         {
-            //Console.WriteLine("HandleActionCancelAttack");
+            //Console.WriteLine($"{Name}.HandleActionCancelAttack()");
 
             MeleeTarget = null;
             MissileTarget = null;
@@ -148,6 +157,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Attack(WorldObject target, int attackSequence)
         {
+            //log.Info($"{Name}.Attack({target.Name}, {attackSequence})");
+
             if (CombatMode != CombatMode.Melee || MeleeTarget == null || !IsAlive || AttackSequence != attackSequence)
                 return;
 

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.WorldObjects
             set => _accuracyLevel = value;
         }
 
-        public WorldObject MissileTarget;
+        public Creature MissileTarget;
 
         public PowerAccuracy GetAccuracyRange()
         {
@@ -59,14 +59,14 @@ namespace ACE.Server.WorldObjects
             AccuracyLevel = accuracyLevel;
 
             // get world object of target guid
-            var target = CurrentLandblock?.GetObject(targetGuid);
+            var target = CurrentLandblock?.GetObject(targetGuid) as Creature;
             if (target == null || target.Teleporting)
             {
-                log.Warn("Unknown target guid " + targetGuid.ToString("X8"));
+                log.Warn($"{Name}.HandleActionTargetedMissileAttack({targetGuid:X8}, {AttackHeight}, {accuracyLevel}) - couldn't find creature target guid");
                 return;
             }
 
-            if (Attacking || MissileTarget != null)
+            if (Attacking || MissileTarget != null && MissileTarget.IsAlive)
                 return;
 
             AttackTarget = target;


### PR DESCRIPTION
This bug can happen when the target creature dies from something else in the world, at just the right time in the melee chain. Only happens when repeat attacks is disabled (usually players running with vtank)

Repro steps:

I was able to repro this bug with Dirty Fighting middle melee attacks (bleed dot when it lands). Set repeat attacks to disabled, and run with vtank

(also throwing in some random spellcasting helper functions that have been sitting around for awhile, currently just used for debugging / uncalled otherwise)

