### PR TITLE
send updates to Monarch ID over network, and adding some missing calls to allegiance house boot

### DIFF
--- a/Source/ACE.Server/Entity/IPlayer.cs
+++ b/Source/ACE.Server/Entity/IPlayer.cs
@@ -94,5 +94,7 @@ namespace ACE.Server.Entity
         /// lock-step with other players
         /// </summary>
         void SaveBiotaToDatabase(bool enqueueSave = true);
+
+        void UpdateProperty(PropertyInstanceId prop, uint? value, bool broadcast = false);
     }
 }

--- a/Source/ACE.Server/Entity/OfflinePlayer.cs
+++ b/Source/ACE.Server/Entity/OfflinePlayer.cs
@@ -378,5 +378,13 @@ namespace ACE.Server.Entity
         public Allegiance Allegiance { get; set; }
 
         public AllegianceNode AllegianceNode { get; set; }
+
+        public void UpdateProperty(PropertyInstanceId prop, uint? value, bool broadcast = false)
+        {
+            if (value != null)
+                SetProperty(prop, value.Value);
+            else
+                RemoveProperty(prop);
+        }
     }
 }

--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -353,10 +353,7 @@ namespace ACE.Server.Managers
 
             if (player.MonarchId != null)
             {
-                player.MonarchId = null;
-
-                if (onlinePlayer != null)
-                    onlinePlayer.Session.Network.EnqueueSend(new GameMessagePrivateUpdateInstanceID(onlinePlayer, PropertyInstanceId.Monarch, 0));
+                player.UpdateProperty(PropertyInstanceId.Monarch, null, true);
 
                 updated = true;
             }
@@ -409,7 +406,7 @@ namespace ACE.Server.Managers
             }
 
             player.PatronId = null;
-            player.MonarchId = null;
+            player.UpdateProperty(PropertyInstanceId.Monarch, null, true);
 
             // vassals now become monarchs...
             foreach (var vassalNode in allegianceNode.Vassals.Values)
@@ -419,12 +416,12 @@ namespace ACE.Server.Managers
                 if (vassal == null) continue;
 
                 vassal.PatronId = null;
-                vassal.MonarchId = null;
+                vassal.UpdateProperty(PropertyInstanceId.Monarch, null, true);
 
                 // walk the allegiance tree from this node, update monarch ids
                 vassalNode.Walk((node) =>
                 {
-                    node.Player.MonarchId = vassalNode.PlayerGuid.Full;
+                    node.Player.UpdateProperty(PropertyInstanceId.Monarch, vassalNode.PlayerGuid.Full, true);
 
                     node.Player.SaveBiotaToDatabase();
 
@@ -448,6 +445,9 @@ namespace ACE.Server.Managers
             // save immediately?
             foreach (var p in players)
                 p.SaveBiotaToDatabase();
+
+            foreach (var p in players)
+                Player.CheckAllegianceHouse(p.Guid);
         }
     }
 }

--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -447,7 +447,13 @@ namespace ACE.Server.Managers
                 p.SaveBiotaToDatabase();
 
             foreach (var p in players)
+            {
                 Player.CheckAllegianceHouse(p.Guid);
+
+                var newAllegiance = GetAllegiance(p);
+                if (newAllegiance != null)
+                    newAllegiance.Monarch.Walk((node) => Player.CheckAllegianceHouse(node.PlayerGuid), false);
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Allegiance.cs
@@ -296,10 +296,7 @@ namespace ACE.Server.WorldObjects
                 // if changed, update monarch id
                 if ((player.MonarchId ?? 0) != member.Value.Allegiance.MonarchId)
                 {
-                    player.MonarchId = member.Value.Allegiance.MonarchId;
-
-                    if (onlinePlayer != null)
-                        onlinePlayer.Session.Network.EnqueueSend(new GameMessagePrivateUpdateInstanceID(onlinePlayer, PropertyInstanceId.Monarch, player.MonarchId.Value));
+                    player.UpdateProperty(PropertyInstanceId.Monarch, member.Value.Allegiance.MonarchId, true);
 
                     updated = true;
                 }

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -1061,10 +1061,11 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called when player is exiting portal space
         /// </summary>
-        public void CheckHouse()
+        /// <returns>TRUE if player was booted from house property they don't have access to, upon exiting portal space</returns>
+        public bool CheckHouse()
         {
-            if (CurrentLandblock == null)
-                return;
+            if (CurrentLandblock == null || IgnoreHouseBarriers)
+                return false;
 
             foreach (var house in CurrentLandblock.Houses)
             {
@@ -1073,24 +1074,22 @@ namespace ACE.Server.WorldObjects
                 if (!rootHouse.OnProperty(this))
                     continue;
 
-                if (IgnoreHouseBarriers)
-                    continue;
-
                 if (rootHouse.HouseOwner != null && !rootHouse.HasPermission(this, false))
                 {
                     if (!rootHouse.IsOpen || (rootHouse.HouseType != HouseType.Apartment && CurrentLandblock.IsDungeon))
                     {
                         Teleport(rootHouse.BootSpot.Location);
-                        break;
+                        return true;
                     }
                 }
 
                 if (rootHouse.HouseOwner == null && rootHouse.HouseType != HouseType.Apartment && CurrentLandblock.IsDungeon)
                 {
                     Teleport(rootHouse.BootSpot.Location);
-                    break;
+                    return true;
                 }
             }
+            return false;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -2,6 +2,7 @@ using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
@@ -903,10 +904,7 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdatePropertyInt(obj, prop, value ?? 0);
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyBool prop, bool? value, bool broadcast = false)
@@ -918,10 +916,7 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdatePropertyBool(obj, prop, value ?? false);
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyFloat prop, double? value, bool broadcast = false)
@@ -933,10 +928,7 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdatePropertyFloat(obj, prop, value ?? 0.0);
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyDataId prop, uint? value, bool broadcast = false)
@@ -948,10 +940,16 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdatePropertyDataID(obj, prop, value ?? 0);
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
+        }
+
+        /// <summary>
+        /// Updates a property on the server, and broadcasts to appropriate players
+        /// </summary>
+        /// <param name="broadcast">If true, also broadcasts to all players who know about this player</param>
+        public void UpdateProperty(PropertyInstanceId prop, uint? value, bool broadcast = false)
+        {
+            UpdateProperty(this, prop, value, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyInstanceId prop, uint? value, bool broadcast = false)
@@ -963,10 +961,7 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdateInstanceID(obj, prop, new ObjectGuid(value ?? 0));
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyString prop, string value, bool broadcast = false)
@@ -980,10 +975,7 @@ namespace ACE.Server.WorldObjects
             // and the object will not update until relogging or CO
             var msg = new GameMessagePublicUpdatePropertyString(obj, prop, value);
 
-            if (broadcast)
-                EnqueueBroadcast(msg);
-            else
-                Session.Network.EnqueueSend(msg);
+            SendNetwork(msg, broadcast);
         }
 
         public void UpdateProperty(WorldObject obj, PropertyInt64 prop, long? value, bool broadcast = false)
@@ -995,6 +987,11 @@ namespace ACE.Server.WorldObjects
 
             var msg = new GameMessagePublicUpdatePropertyInt64(obj, prop, value ?? 0);
 
+            SendNetwork(msg, broadcast);
+        }
+
+        public void SendNetwork(GameMessage msg, bool broadcast)
+        {
             if (broadcast)
                 EnqueueBroadcast(msg);
             else


### PR DESCRIPTION
This builds on https://github.com/ACEmulator/ACE/pull/2421 from @LtRipley36706 

The core scenario for this: join an allegiance, and then recall to allegiance housing with /hom. You will end up with a black screen.

You can also join an allegiance, and if you try to run into the allegiance house, you will run into a barrier still (not sure how this was missed..)

A similar situation, if you break allegiance to your patron while standing outside of the Allegiance house, you will still be able to run into it afterwards. Similarly, if you were standing inside the Allegiance house at the time of the break, you will not be booted.

The core issue for this was the client needs to be sent the MonarchID, and it uses this to determine / update the barrier protections.

This PR also fixes a bunch of possible scenarios that can arise from players swearing allegiance / breaking allegiance / booting players / deleting players, where all the vassals involved need to also have their Monarch ID updates broadcast, and the server needs to check if any of these online vassals are on any house property that they no longer have access to.