### PR TITLE
minimizing DamageHistory.WeakReference

### DIFF
--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -27,46 +27,41 @@ namespace ACE.Server.Entity
         /// A lookup table of WorldObjects that have damaged this WorldObject,
         /// and the total amount of damage they have inflicted
         /// </summary>
-        public readonly Dictionary<ObjectGuid, WorldObjectInfo<float>> TotalDamage = new Dictionary<ObjectGuid, WorldObjectInfo<float>>();
+        public readonly Dictionary<ObjectGuid, DamageHistoryInfo> TotalDamage = new Dictionary<ObjectGuid, DamageHistoryInfo>();
 
         /// <summary>
         /// Returns the list of players or creatures who inflicted damage
         /// </summary>
-        public List<WorldObjectInfo<float>> Damagers => TotalDamage.Values.ToList();
+        public List<DamageHistoryInfo> Damagers => TotalDamage.Values.ToList();
 
         /// <summary>
-        /// Returns the WorldObject that last damaged this WorldObject
+        /// Returns the DamageHistoryInfo for the last damager
         /// </summary>
-        public WorldObject LastDamager
+        public DamageHistoryInfo LastDamager
         {
             get
             {
                 var lastDamager = Log.LastOrDefault(l => l.Amount < 0);
-                WorldObject lastDamagerObj = null;
-                if (lastDamager != null)
-                {
-                    if (TotalDamage.TryGetValue(lastDamager.DamageSource, out var value))
-                        lastDamagerObj = value.TryGetWorldObject();
-                }
-                //var lastDamagerName = lastDamagerObj != null ? lastDamagerObj.Name : null;
-                //Console.WriteLine($"DamageHistory.LastDamager: {lastDamagerName}");
-                return lastDamagerObj;
+                if (lastDamager == null)
+                    return null;
+
+                TotalDamage.TryGetValue(lastDamager.Attacker, out var info);
+
+                return info;
             }
         }
 
         /// <summary>
-        /// Returns the WorldObject that did the most damage to this WorldObject
-        /// Used to determine corpse looting rights
+        /// Returns the DamageHistoryInfo for the top damager
+        /// for determining 'Killed by' corpse looting rights
         /// </summary>
-        public WorldObject TopDamager => GetTopDamager();
+        public DamageHistoryInfo TopDamager => GetTopDamager();
 
-        public WorldObject GetTopDamager(bool includeSelf = true)
+        public DamageHistoryInfo GetTopDamager(bool includeSelf = true)
         {
-            var sorted = TotalDamage.Values.Where(wo => includeSelf || wo.Guid != Creature.Guid).OrderByDescending(wo => wo.Value);
+            var sorted = TotalDamage.Values.Where(wo => includeSelf || wo.Guid != Creature.Guid).OrderByDescending(wo => wo.TotalDamage);
 
-            var topDamager = sorted.FirstOrDefault();
-
-            return topDamager?.TryGetWorldObject();
+            return sorted.FirstOrDefault();
         }
 
         /// <summary>
@@ -82,39 +77,35 @@ namespace ACE.Server.Entity
         /// </summary>
         /// <param name="source">The attacker or source of damage</param>
         /// <param name="amount">The amount of damage hit for</param>
-        public void Add(WorldObject damager, DamageType damageType, uint amount)
+        public void Add(WorldObject attacker, DamageType damageType, uint amount)
         {
             //Console.WriteLine($"DamageHistory.Add({Creature.Name}, {amount})");
 
             if (amount == 0) return;
 
-            var entry = new DamageHistoryEntry(Creature, damager.Guid, damageType, -(int)amount);
+            var entry = new DamageHistoryEntry(Creature, attacker.Guid, damageType, -(int)amount);
             Log.Add(entry);
 
-            AddInternal(damager, amount);
+            AddInternal(attacker, amount);
         }
 
         /// <summary>
         /// Internally increments the total damage table
         /// </summary>
-        private void AddInternal(WorldObject damager, uint amount)
+        private void AddInternal(WorldObject attacker, uint amount)
         {
-            if (TotalDamage.TryGetValue(damager.Guid, out var value))
-                value.Value += amount;
+            if (TotalDamage.TryGetValue(attacker.Guid, out var value))
+                value.TotalDamage += amount;
             else
-            {
-                var woi = new WorldObjectInfo<float>(damager, amount);
-
-                TotalDamage.Add(damager.Guid, woi);
-            }
+                TotalDamage.Add(attacker.Guid, new DamageHistoryInfo(attacker, amount));
         }
 
         /// <summary>
         /// Internally increments the total damage table
         /// </summary>
-        private void AddInternal(ObjectGuid damager, uint amount)
+        private void AddInternal(ObjectGuid attacker, uint amount)
         {
-            TotalDamage[damager].Value += amount;
+            TotalDamage[attacker].TotalDamage += amount;
         }
 
         /// <summary>
@@ -144,10 +135,10 @@ namespace ACE.Server.Entity
             if (healAmount == 0 || missingHealth == 0) return;
             var scalar = 1.0f - (float)healAmount / missingHealth;
 
-            var damagers = TotalDamage.Keys.ToList();
+            var attackers = TotalDamage.Keys.ToList();
 
-            foreach (var damager in damagers)
-                TotalDamage[damager].Value *= scalar;
+            foreach (var attacker in attackers)
+                TotalDamage[attacker].TotalDamage *= scalar;
         }
 
         /// <summary>
@@ -163,9 +154,9 @@ namespace ACE.Server.Entity
         /// <summary>
         /// The last time the log was pruned
         /// </summary>
-        public static DateTime LastPruneTime = DateTime.UtcNow;
+        public DateTime LastPruneTime { get; set; } = DateTime.UtcNow;
 
-        private static readonly TimeSpan minimumPruneInverval = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan minimumPruneInterval = TimeSpan.FromSeconds(30);
 
         private static readonly TimeSpan maximumTimeToRetain = TimeSpan.FromMinutes(3);
 
@@ -174,7 +165,7 @@ namespace ACE.Server.Entity
         /// </summary>
         public void TryPrune()
         {
-            if (LastPruneTime + minimumPruneInverval < DateTime.UtcNow)
+            if (LastPruneTime + minimumPruneInterval < DateTime.UtcNow)
                 Prune();
         }
 
@@ -214,13 +205,13 @@ namespace ACE.Server.Entity
 
             var guids = new HashSet<ObjectGuid>();
             foreach (var entry in Log)
-                guids.Add(entry.DamageSource);
+                guids.Add(entry.Attacker);
 
             var keys = TotalDamage.Keys.ToList();
             foreach (var key in keys)
             {
                 if (guids.Contains(key))
-                    TotalDamage[key].Value = 0;
+                    TotalDamage[key].TotalDamage = 0;
                 else
                     TotalDamage.Remove(key);
             }
@@ -230,7 +221,7 @@ namespace ACE.Server.Entity
             foreach (var entry in Log)
             {
                 if (entry.Amount < 0)
-                    AddInternal(entry.DamageSource, (uint)-entry.Amount);
+                    AddInternal(entry.Attacker, (uint)-entry.Amount);
                 else
                     OnHealInternal((uint)entry.Amount, entry.CurrentHealth, entry.MaxHealth);
             }
@@ -240,13 +231,9 @@ namespace ACE.Server.Entity
         {
             var table = "";
 
-            foreach (var damager in TotalDamage.Values)
-            {
-                var wo = damager.TryGetWorldObject();
-                var guid = wo?.Guid;
+            foreach (var attacker in TotalDamage.Values)
+                table += $"{attacker.Name} ({attacker.Guid}) - {attacker.TotalDamage}\n";
 
-                table += $"{damager.Name} ({guid}) - {damager.Value}\n";
-            }
             return table;
         }
     }

--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -154,7 +154,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// The last time the log was pruned
         /// </summary>
-        public DateTime LastPruneTime { get; set; } = DateTime.UtcNow;
+        public DateTime LastPruneTime = DateTime.UtcNow;
 
         private static readonly TimeSpan minimumPruneInterval = TimeSpan.FromSeconds(30);
 

--- a/Source/ACE.Server/Entity/DamageHistoryEntry.cs
+++ b/Source/ACE.Server/Entity/DamageHistoryEntry.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Entity
 {
     public class DamageHistoryEntry
     {
-        public ObjectGuid DamageSource;
+        public ObjectGuid Attacker;
 
         public DamageType DamageType;
         public int Amount;
@@ -21,11 +21,11 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Constructs a new entry for the DamageHistory
         /// </summary>
-        /// <param name="damageSource">The attacker or source of the damage</param>
+        /// <param name="attacker">The creature source of the damage. In the case of a projectile, this would be the Creature that launched the projectile.</param>
         /// <param name="amount">A negative amount for damage taken, positive for healing</param>
-        public DamageHistoryEntry(Creature creature, ObjectGuid damageSource, DamageType damageType, int amount)
+        public DamageHistoryEntry(Creature creature, ObjectGuid attacker, DamageType damageType, int amount)
         {
-            DamageSource = damageSource;
+            Attacker = attacker;
 
             DamageType = damageType;
             Amount = amount;

--- a/Source/ACE.Server/Entity/DamageHistoryInfo.cs
+++ b/Source/ACE.Server/Entity/DamageHistoryInfo.cs
@@ -1,0 +1,48 @@
+using System;
+
+using ACE.Entity;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    public class DamageHistoryInfo
+    {
+        public readonly WeakReference<WorldObject> Attacker;
+
+        public readonly ObjectGuid Guid;
+        public readonly string Name;
+
+        public float TotalDamage;
+
+        public readonly WeakReference<Player> PetOwner;
+
+        public bool IsPlayer => Guid.IsPlayer();
+
+        public DamageHistoryInfo(WorldObject attacker, float totalDamage = 0.0f)
+        {
+            Attacker = new WeakReference<WorldObject>(attacker);
+
+            Guid = attacker.Guid;
+            Name = attacker.Name;
+
+            TotalDamage = totalDamage;
+
+            if (attacker is CombatPet combatPet && combatPet.P_PetOwner != null)
+                PetOwner = new WeakReference<Player>(combatPet.P_PetOwner);
+        }
+
+        public WorldObject TryGetAttacker()
+        {
+            Attacker.TryGetTarget(out var attacker);
+
+            return attacker;
+        }
+
+        public Player TryGetPetOwner()
+        {
+            PetOwner.TryGetTarget(out var petOwner);
+
+            return petOwner;
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -211,7 +211,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called to generate rare and add to corpse inventory
         /// </summary>
-        public void GenerateRare(WorldObject killer)
+        public void GenerateRare(DamageHistoryInfo killer)
         {
             //todo: calculate chances for killer's luck (rare timers)
 

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -26,12 +26,12 @@ namespace ACE.Server.WorldObjects
         /// <param name="lastDamager">The last damager that landed the death blow</param>
         /// <param name="damageType">The damage type for the death message</param>
         /// <param name="criticalHit">True if the death blow was a critical hit, generates a critical death message</param>
-        public virtual DeathMessage OnDeath(WorldObject lastDamager, DamageType damageType, bool criticalHit = false)
+        public virtual DeathMessage OnDeath(DamageHistoryInfo lastDamager, DamageType damageType, bool criticalHit = false)
         {
             IsTurning = false;
             IsMoving = false;
 
-            EmoteManager.OnDeath(DamageHistory);
+            EmoteManager.OnDeath(lastDamager?.TryGetAttacker());
 
             OnDeath_GrantXP();
 
@@ -42,16 +42,15 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        public DeathMessage GetDeathMessage(WorldObject lastDamager, DamageType damageType, bool criticalHit = false)
+        public DeathMessage GetDeathMessage(DamageHistoryInfo lastDamager, DamageType damageType, bool criticalHit = false)
         {
             var deathMessage = Strings.GetDeathMessage(damageType, criticalHit);
 
-            if (lastDamager == null || lastDamager == this)
-                deathMessage = Strings.General[1];
+            if (lastDamager == null || lastDamager.Guid == Guid)
+                return Strings.General[1];
 
             // if killed by a player, send them a message
-            var playerKiller = lastDamager as Player;
-            if (playerKiller != null && playerKiller != this)
+            if (lastDamager.IsPlayer)
             {
                 if (criticalHit && this is Player)
                     deathMessage = Strings.PKCritical[0];
@@ -59,7 +58,10 @@ namespace ACE.Server.WorldObjects
                 var killerMsg = string.Format(deathMessage.Killer, Name);
 
                 // todo: verify message type
-                playerKiller.Session.Network.EnqueueSend(new GameMessageSystemChat(killerMsg, ChatMessageType.Broadcast));
+                var playerKiller = lastDamager.TryGetAttacker() as Player;
+
+                if (playerKiller != null)
+                    playerKiller.Session.Network.EnqueueSend(new GameMessageSystemChat(killerMsg, ChatMessageType.Broadcast));
             }
             return deathMessage;
         }
@@ -75,15 +77,21 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Performs the full death sequence for non-Player creatures
         /// </summary>
-        protected virtual void Die(WorldObject lastDamager, WorldObject topDamager)
+        protected virtual void Die(DamageHistoryInfo lastDamager, DamageHistoryInfo topDamager)
         {
             UpdateVital(Health, 0);
 
             if (topDamager != null)
+            {
                 KillerId = topDamager.Guid.Full;
 
-            if (topDamager is Player)
-                topDamager.CreatureKills++;
+                if (topDamager.IsPlayer)
+                {
+                    var topDamagerPlayer = topDamager.TryGetAttacker();
+                    if (topDamagerPlayer != null)
+                        topDamagerPlayer.CreatureKills = (topDamagerPlayer.CreatureKills ?? 0) + 1;
+                }
+            }
 
             CurrentMotionState = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
             //IsMonster = false;
@@ -123,7 +131,8 @@ namespace ACE.Server.WorldObjects
             else
             {
                 OnDeath();
-                Die(smiter, smiter);
+                var smiterInfo = new DamageHistoryInfo(smiter);
+                Die(smiterInfo, smiterInfo);
             }
         }
 
@@ -142,20 +151,17 @@ namespace ACE.Server.WorldObjects
 
             foreach (var kvp in DamageHistory.TotalDamage)
             {
-                var damager = kvp.Value.TryGetWorldObject();
-                var totalDamage = kvp.Value.Value;
+                var damager = kvp.Value.TryGetAttacker();
 
                 var playerDamager = damager as Player;
-                if (playerDamager == null)
-                {
-                    var petDamager = damager as CombatPet;
-                    if (petDamager == null)
-                        continue;
 
-                    playerDamager = petDamager.P_PetOwner;
-                    if (playerDamager == null)
-                        continue;
-                }
+                if (playerDamager == null && kvp.Value.PetOwner != null)
+                    playerDamager = kvp.Value.TryGetPetOwner();
+
+                if (playerDamager == null)
+                    continue;
+
+                var totalDamage = kvp.Value.TotalDamage;
 
                 var damagePercent = totalDamage / Health.MaxValue;
                 var totalXP = (XpOverride ?? 0) * damagePercent;
@@ -178,7 +184,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Create a corpse for both creatures and players currently
         /// </summary>
-        protected void CreateCorpse(WorldObject killer)
+        protected void CreateCorpse(DamageHistoryInfo killer)
         {
             if (NoCorpse)
             {
@@ -256,10 +262,14 @@ namespace ACE.Server.WorldObjects
                     if (!string.IsNullOrWhiteSpace(killer.Name))
                         killerName = killer.Name.TrimStart('+');  // vtank requires + to be stripped for regex matching.
 
-                    if (killer is CombatPet)
-                        corpse.KillerId = killer.PetOwner.Value;
-                    else
-                        corpse.KillerId = killer.Guid.Full;
+                    corpse.KillerId = killer.Guid.Full;
+
+                    if (killer.PetOwner != null)
+                    {
+                        var petOwner = killer.TryGetPetOwner();
+                        if (petOwner != null)
+                            corpse.KillerId = petOwner.Guid.Full;
+                    }
                 }
             }
 
@@ -289,9 +299,19 @@ namespace ACE.Server.WorldObjects
             {
                 corpse.IsMonster = true;
                 GenerateTreasure(killer, corpse);
-                if (killer is Player && (Level >= 100 || Level >= killer.Level + 5))
+
+                if (killer != null && killer.IsPlayer)
                 {
-                    CanGenerateRare = true;
+                    if (Level >= 100)
+                    {
+                        CanGenerateRare = true;
+                    }
+                    else
+                    {
+                        var killerPlayer = killer.TryGetAttacker();
+                        if (killerPlayer != null && Level >= killerPlayer.Level + 5)
+                            CanGenerateRare = true;
+                    }
                 }
             }
 
@@ -323,7 +343,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Transfers generated treasure from creature to corpse
         /// </summary>
-        private List<WorldObject> GenerateTreasure(WorldObject killer, Corpse corpse)
+        private List<WorldObject> GenerateTreasure(DamageHistoryInfo killer, Corpse corpse)
         {
             var droppedItems = new List<WorldObject>();
 
@@ -386,7 +406,7 @@ namespace ACE.Server.WorldObjects
             return droppedItems;
         }
 
-        public void DoCantripLogging(WorldObject killer, WorldObject wo)
+        public void DoCantripLogging(DamageHistoryInfo killer, WorldObject wo)
         {
             var epicCantrips = wo.EpicCantrips;
             var legendaryCantrips = wo.LegendaryCantrips;

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1467,14 +1467,11 @@ namespace ACE.Server.WorldObjects.Managers
             ExecuteEmoteSet(EmoteCategory.ReceiveCritical, null, attacker);
         }
 
-        public void OnDeath(DamageHistory damageHistory)
+        public void OnDeath(WorldObject lastDamager)
         {
             IsBusy = false;
 
-            if (damageHistory.Damagers.Count == 0)
-                ExecuteEmoteSet(EmoteCategory.Death, null, null);
-            else 
-                ExecuteEmoteSet(EmoteCategory.Death, null, damageHistory.LastDamager);
+            ExecuteEmoteSet(EmoteCategory.Death, null, lastDamager);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -180,14 +180,14 @@ namespace ACE.Server.WorldObjects
 
                     case TargetingTactic.LastDamager:
 
-                        var lastDamager = DamageHistory.LastDamager as Creature;
+                        var lastDamager = DamageHistory.LastDamager?.TryGetAttacker();
                         if (lastDamager != null)
                             AttackTarget = lastDamager;
                         break;
 
                     case TargetingTactic.TopDamager:
 
-                        var topDamager = DamageHistory.TopDamager as Creature;
+                        var topDamager = DamageHistory.TopDamager?.TryGetAttacker();
                         if (topDamager != null)
                             AttackTarget = topDamager;
                         break;

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -180,14 +180,14 @@ namespace ACE.Server.WorldObjects
 
                     case TargetingTactic.LastDamager:
 
-                        var lastDamager = DamageHistory.LastDamager?.TryGetAttacker();
+                        var lastDamager = DamageHistory.LastDamager?.TryGetAttacker() as Creature;
                         if (lastDamager != null)
                             AttackTarget = lastDamager;
                         break;
 
                     case TargetingTactic.TopDamager:
 
-                        var topDamager = DamageHistory.TopDamager?.TryGetAttacker();
+                        var topDamager = DamageHistory.TopDamager?.TryGetAttacker() as Creature;
                         if (topDamager != null)
                             AttackTarget = topDamager;
                         break;

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -215,7 +215,7 @@ namespace ACE.Server.WorldObjects
                     var targetDeath = LifeMagic(spell, out uint damage, out bool critical, out var msg, target);
                     if (targetDeath && target is Creature targetCreature)
                     {
-                        targetCreature.OnDeath(this, DamageType.Health, false);
+                        targetCreature.OnDeath(new DamageHistoryInfo(this), DamageType.Health, false);
                         targetCreature.Die();
                     }
                     if (target != null)

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -446,7 +446,7 @@ namespace ACE.Server.WorldObjects
 
             if (Health.Current <= 0)
             {
-                OnDeath(source, damageType, crit);
+                OnDeath(new DamageHistoryInfo(source), damageType, crit);
                 Die();
                 return (int)damageTaken;
             }
@@ -603,7 +603,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns TRUE if this player is PK and died to another player
         /// </summary>
-        public bool IsPKDeath(WorldObject topDamager)
+        public bool IsPKDeath(DamageHistoryInfo topDamager)
         {
             return IsPKDeath(topDamager?.Guid.Full);
         }
@@ -616,7 +616,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns TRUE if this player is PKLite and died to another player
         /// </summary>
-        public bool IsPKLiteDeath(WorldObject topDamager)
+        public bool IsPKLiteDeath(DamageHistoryInfo topDamager)
         {
             return IsPKLiteDeath(topDamager?.Guid.Full);
         }

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -31,34 +31,18 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         /// <param name="lastDamager">The last damager that landed the death blow</param>
         /// <param name="damageType">The damage type for the death message</param>
-        public override DeathMessage OnDeath(WorldObject lastDamager, DamageType damageType, bool criticalHit = false)
+        public override DeathMessage OnDeath(DamageHistoryInfo lastDamager, DamageType damageType, bool criticalHit = false)
         {
             var topDamager = DamageHistory.GetTopDamager(false);
 
-            if (topDamager is Player pkPlayer)
-            {
-                if (IsPKDeath(pkPlayer))
-                {
-                    pkPlayer.PkTimestamp = Time.GetUnixTime();
-                    pkPlayer.PlayerKillsPk++;
-
-                    var globalPKDe = $"{lastDamager.Name} has defeated {Name}!";
-
-                    if ((Location.Cell & 0xFFFF) < 0x100)
-                        globalPKDe += $" The kill occured at {Location.GetMapCoordStr()}";
-
-                    globalPKDe += "\n[PKDe]";
-
-                    PlayerManager.BroadcastToAll(new GameMessageSystemChat(globalPKDe, ChatMessageType.Broadcast));
-                }
-                else if (IsPKLiteDeath(pkPlayer))
-                    pkPlayer.PlayerKillsPkl++;
-            }
+            HandlePKDeathBroadcast(lastDamager, topDamager);
 
             var deathMessage = base.OnDeath(lastDamager, damageType, criticalHit);
 
-            if (lastDamager != null)
-                lastDamager.EmoteManager.OnKill(this);
+            var lastDamagerObj = lastDamager?.TryGetAttacker();
+
+            if (lastDamagerObj != null)
+                lastDamagerObj.EmoteManager.OnKill(this);
 
             var playerMsg = "";
             if (lastDamager != null)
@@ -81,7 +65,7 @@ namespace ACE.Server.WorldObjects
             log.Debug("[CORPSE] " + nearbyMsg);
 
             var excludePlayers = new List<Player>();
-            if (lastDamager is Player lastDamagerPlayer)
+            if (lastDamagerObj is Player lastDamagerPlayer)
                 excludePlayers.Add(lastDamagerPlayer);
 
             var nearbyPlayers = EnqueueBroadcast(excludePlayers, false, broadcastMsg);
@@ -107,6 +91,33 @@ namespace ACE.Server.WorldObjects
             }
 
             return deathMessage;
+        }
+
+        public void HandlePKDeathBroadcast(DamageHistoryInfo lastDamager, DamageHistoryInfo topDamager)
+        {
+            if (topDamager == null || !topDamager.IsPlayer)
+                return;
+
+            var pkPlayer = topDamager.TryGetAttacker() as Player;
+            if (pkPlayer == null)
+                return;
+
+            if (IsPKDeath(topDamager))
+            {
+                pkPlayer.PkTimestamp = Time.GetUnixTime();
+                pkPlayer.PlayerKillsPk++;
+
+                var globalPKDe = $"{lastDamager.Name} has defeated {Name}!";
+
+                if ((Location.Cell & 0xFFFF) < 0x100)
+                    globalPKDe += $" The kill occured at {Location.GetMapCoordStr()}";
+
+                globalPKDe += "\n[PKDe]";
+
+                PlayerManager.BroadcastToAll(new GameMessageSystemChat(globalPKDe, ChatMessageType.Broadcast));
+            }
+            else if (IsPKLiteDeath(topDamager))
+                pkPlayer.PlayerKillsPkl++;
         }
 
         /// <summary>
@@ -135,13 +146,13 @@ namespace ACE.Server.WorldObjects
         /// Broadcasts the player death animation, updates vitae, and sends network messages for player death
         /// Queues the action to call TeleportOnDeath and enter portal space soon
         /// </summary>
-        protected override void Die(WorldObject lastDamager, WorldObject topDamager)
+        protected override void Die(DamageHistoryInfo lastDamager, DamageHistoryInfo topDamager)
         {
-            if (topDamager == this && IsPKType)
+            if (topDamager?.Guid == Guid && IsPKType)
             {
                 var topDamagerOther = DamageHistory.GetTopDamager(false);
 
-                if (topDamagerOther is Player)
+                if (topDamagerOther != null && topDamagerOther.IsPlayer)
                     topDamager = topDamagerOther;
             }
 
@@ -268,7 +279,7 @@ namespace ACE.Server.WorldObjects
             suicideInProgress = true;
 
             if (PropertyManager.GetBool("suicide_instant_death").Item)
-                Die(this, DamageHistory.TopDamager);
+                Die(new DamageHistoryInfo(this), DamageHistory.TopDamager);
             else
                 HandleSuicide(NumDeaths);
         }
@@ -297,7 +308,7 @@ namespace ACE.Server.WorldObjects
                 suicideChain.EnqueueChain();
             }
             else
-                Die(this, DamageHistory.TopDamager);
+                Die(new DamageHistoryInfo(this), DamageHistory.TopDamager);
         }
 
         public List<WorldObject> CalculateDeathItems(Corpse corpse)

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -821,7 +821,7 @@ namespace ACE.Server.WorldObjects
 
                     if (targetDeath == true)
                     {
-                        targetCreature.OnDeath(this, DamageType.Health, false);
+                        targetCreature.OnDeath(new DamageHistoryInfo(this), DamageType.Health, false);
                         targetCreature.Die();
                     }
                     else

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -278,7 +278,7 @@ namespace ACE.Server.WorldObjects
 
             if (Health.Current <= 0)
             {
-                OnDeath(this, DamageType.Bludgeon, false);
+                OnDeath(new DamageHistoryInfo(this), DamageType.Bludgeon, false);
                 Die();
             }
             else

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -670,7 +670,8 @@ namespace ACE.Server.WorldObjects
             }
             else
             {
-                target.OnDeath(ProjectileSource, Spell.DamageType, critical);
+                var lastDamager = ProjectileSource != null ? new DamageHistoryInfo(ProjectileSource) : null;
+                target.OnDeath(lastDamager, Spell.DamageType, critical);
                 target.Die();
             }
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -63,7 +63,7 @@ namespace ACE.Server.WorldObjects
                     var targetDeath = LifeMagic(spell, out uint damage, out bool critical, out status, target, caster);
                     if (targetDeath && target is Creature targetCreature)
                     {
-                        targetCreature.OnDeath(this, DamageType.Health, false);
+                        targetCreature.OnDeath(new DamageHistoryInfo(this), DamageType.Health, false);
                         targetCreature.Die();
                     }
                     break;
@@ -644,7 +644,9 @@ namespace ACE.Server.WorldObjects
                     if (caster.Health.Current <= 0)
                     {
                         // should this be possible?
-                        caster.OnDeath(caster, damageType, false);
+                        var lastDamager = caster != null ? new DamageHistoryInfo(caster) : null;
+
+                        caster.OnDeath(lastDamager, damageType, false);
                         caster.Die();
                     }
                     break;


### PR DESCRIPTION
This patch minimizes the reliance on DamageHistory WeakReferences

The main purpose of this patch is to fix the effects of a long-standing bug where DamageHistory WeakReferences to valid Players and WorldObjects are somehow going null.

In current master, this results in PKDeaths not being detected as PKDeaths, and causes a bug where players drop their items and accumulate vitae in PKLite mode

This patch also fixes some other bugs with over-reliance on WeakReferences, such as:

- A monster damages a player for 75% of their health, and then the player kills the monster. Another monster then kills the player. In this scenario, the TopDamager for the 'Killed by' message on the player's corpse was reading 'Killed by misadventure.', since it was relying on a full reference to the TopDamager WeakReference (which had correctly expired)

- A summoning player spawns a CombatPet, and that pet deals 75% damage to a nearby monster. The CombatPet then despawns, and the player kills the monster. In this scenario, awarding XP was relying on a WeakReference to all the attackers to divy up the XP, and the WeakReference to the CombatPet had (correctly) expired. In this scenario, this was resulting in the player only getting 25% of the monster's XP, instead of the full amount.

Note that the root cause of DamageHistory WeakReferences to valid objects going null has still not been identified, but this patch minimizes the effect of that bug.