### PR TITLE
ThreadSafeRandom Cleanup

### DIFF
--- a/Source/ACE.Common/ThreadSafeRandom.cs
+++ b/Source/ACE.Common/ThreadSafeRandom.cs
@@ -1,21 +1,23 @@
-namespace ACE
+using System;
+
+namespace ACE.Common
 {
     // important class, ensure unit tests pass for this
+    // todo: implement exactly the way AC handles it.. which we'll never know unless we get original source code
     public static class ThreadSafeRandom
     {
         private static readonly object randomMutex = new object();
-        private static readonly System.Random random = new System.Random();
+        private static readonly Random random = new Random();
+
         /// <summary>
-        /// Returns a random number between min and max
+        /// Returns a random floating-point number between min and max, inclusive
         /// </summary>
+        /// <param name="min">The minimum possible value to return</param>
+        /// <param name="max">The maximum possible value to return</param>
         public static float Next(float min, float max)
         {
-            // todo: implement exactly the way AC handles it
-            // inclusive/exclusive?
             lock (randomMutex)
-            {
                 return (float)(random.NextDouble() * (max - min) + min);
-            }
         }
 
         /// <summary>
@@ -26,17 +28,7 @@ namespace ACE
         public static int Next(int min, int max)
         {
             lock (randomMutex)
-            {
                 return random.Next(min, max + 1);
-            }
-        }
-
-        public static uint Next(uint min, uint max)
-        {
-            lock (randomMutex)
-            {
-                return (uint)random.Next((int)min, (int)(max + 1));
-            }
         }
     }
 }

--- a/Source/ACE.Entity/Enum/DamageType.cs
+++ b/Source/ACE.Entity/Enum/DamageType.cs
@@ -1,5 +1,6 @@
 using System;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Server/Entity/Aetheria.cs
+++ b/Source/ACE.Server/Entity/Aetheria.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
-using ACE.Database.Models.Shard;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;

--- a/Source/ACE.Server/Entity/BodyPart.cs
+++ b/Source/ACE.Server/Entity/BodyPart.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Entity/Chess/ChessLogic.cs
+++ b/Source/ACE.Server/Entity/Chess/ChessLogic.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader.Entity;
 using ACE.Entity.Enum;

--- a/Source/ACE.Server/Entity/DeathItem.cs
+++ b/Source/ACE.Server/Entity/DeathItem.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.WorldObjects;
 

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Managers;

--- a/Source/ACE.Server/Entity/Spell.cs
+++ b/Source/ACE.Server/Entity/Spell.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+
+using log4net;
+
+using ACE.Common;
 using ACE.DatLoader;
 using ACE.DatLoader.Entity;
 using ACE.DatLoader.FileTypes;
@@ -7,7 +11,6 @@ using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;
-using log4net;
 
 namespace ACE.Server.Entity
 {

--- a/Source/ACE.Server/Entity/Strings.cs
+++ b/Source/ACE.Server/Entity/Strings.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.WorldObjects;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.Database.Models.Shard;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Aetheria.cs
@@ -1,5 +1,6 @@
+
+using ACE.Common;
 using ACE.Server.Entity;
-using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Factories

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -1,3 +1,5 @@
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -1,3 +1,5 @@
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -1,3 +1,4 @@
+using ACE.Common;
 using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -1,3 +1,5 @@
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -1,3 +1,5 @@
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Mundane.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Mundane.cs
@@ -1,3 +1,5 @@
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.WorldObjects;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
@@ -1,6 +1,7 @@
 using System.Linq;
-
 using System.Collections.Generic;
+
+using ACE.Common;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Factories

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using log4net;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database;
 using ACE.Database.Models.Shard;

--- a/Source/ACE.Server/Network/NetworkSyntheticTesting.cs
+++ b/Source/ACE.Server/Network/NetworkSyntheticTesting.cs
@@ -1,5 +1,7 @@
 using System;
 
+using ACE.Common;
+
 namespace ACE.Server.Network
 {
 

--- a/Source/ACE.Server/Physics/Particles/Particle.cs
+++ b/Source/ACE.Server/Physics/Particles/Particle.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Numerics;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
@@ -64,8 +66,8 @@ namespace ACE.Server.Physics
                     A = a;
                     B = b;
 
-                    var ra = ACE.ThreadSafeRandom.Next(-(float)Math.PI, (float)Math.PI);
-                    var po = ACE.ThreadSafeRandom.Next(-(float)Math.PI, (float)Math.PI);
+                    var ra = ThreadSafeRandom.Next(-(float)Math.PI, (float)Math.PI);
+                    var po = ThreadSafeRandom.Next(-(float)Math.PI, (float)Math.PI);
                     var rb = Math.Cos(po);
 
                     C.X = (float)(Math.Cos(ra) * c.X * rb);

--- a/Source/ACE.Server/Physics/Particles/ParticleEmitterInfo.cs
+++ b/Source/ACE.Server/Physics/Particles/ParticleEmitterInfo.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Numerics;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.Physics.Common;
 using ACE.Server.Physics.Extensions;
@@ -96,7 +98,7 @@ namespace ACE.Server.Physics
 
         public double GetRandomStartScale()
         {
-            var result = ACE.ThreadSafeRandom.Next(-1.0f, 1.0f) * ScaleRand + StartScale;
+            var result = ThreadSafeRandom.Next(-1.0f, 1.0f) * ScaleRand + StartScale;
             result = result.Clamp(0.1f, 10.0f);
 
             return result;
@@ -104,7 +106,7 @@ namespace ACE.Server.Physics
 
         public double GetRandomFinalScale()
         {
-            var result = ACE.ThreadSafeRandom.Next(-1.0f, 1.0f) * ScaleRand * FinalScale;
+            var result = ThreadSafeRandom.Next(-1.0f, 1.0f) * ScaleRand * FinalScale;
             result = result.Clamp(0.1f, 10.0f);
 
             return result;
@@ -112,7 +114,7 @@ namespace ACE.Server.Physics
 
         public double GetRandomStartTrans()
         {
-            var result = ACE.ThreadSafeRandom.Next(-1.0f, 1.0f) * TransRand * StartTrans;
+            var result = ThreadSafeRandom.Next(-1.0f, 1.0f) * TransRand * StartTrans;
             result = result.Clamp(0.0f, 1.0f);
 
             return result;
@@ -120,7 +122,7 @@ namespace ACE.Server.Physics
 
         public double GetRandomFinalTrans()
         {
-            var result = ACE.ThreadSafeRandom.Next(-1.0f, 1.0f) * TransRand * FinalTrans;
+            var result = ThreadSafeRandom.Next(-1.0f, 1.0f) * TransRand * FinalTrans;
             result = result.Clamp(0.0f, 1.0f);
 
             return result;
@@ -128,7 +130,7 @@ namespace ACE.Server.Physics
 
         public double GetRandomLifespan()
         {
-            var result = ACE.ThreadSafeRandom.Next(-1.0f, 1.0f) * LifeSpanRand + LifeSpan;
+            var result = ThreadSafeRandom.Next(-1.0f, 1.0f) * LifeSpanRand + LifeSpan;
             result = Math.Max(0.0f, result);
 
             return result;
@@ -171,22 +173,22 @@ namespace ACE.Server.Physics
         public Vector3 GetRandomOffset()
         {
             var rng = new Vector3(
-                ACE.ThreadSafeRandom.Next(-1.0f, 1.0f),
-                ACE.ThreadSafeRandom.Next(-1.0f, 1.0f),
-                ACE.ThreadSafeRandom.Next(-1.0f, 1.0f));
+                ThreadSafeRandom.Next(-1.0f, 1.0f),
+                ThreadSafeRandom.Next(-1.0f, 1.0f),
+                ThreadSafeRandom.Next(-1.0f, 1.0f));
 
             var randomAngle = rng - OffsetDir * Vector3.Dot(OffsetDir, rng);
 
             if (Vec.NormalizeCheckSmall(ref randomAngle))
                 return Vector3.Zero;
 
-            var scaled = randomAngle * ((MaxOffset - MinOffset) + MinOffset) * ACE.ThreadSafeRandom.Next(0.0f, 1.0f);
+            var scaled = randomAngle * ((MaxOffset - MinOffset) + MinOffset) * ThreadSafeRandom.Next(0.0f, 1.0f);
             return scaled;
         }
 
         public Vector3 GetRandomA()
         {
-            var rng = ACE.ThreadSafeRandom.Next(0.0f, 1.0f);
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
             var magnitude = (MaxA - MinA) * rng + MinA;
 
             return A * magnitude;
@@ -194,7 +196,7 @@ namespace ACE.Server.Physics
 
         public Vector3 GetRandomB()
         {
-            var rng = ACE.ThreadSafeRandom.Next(0.0f, 1.0f);
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
             var magnitude = (MaxB - MinB) * rng + MinB;
 
             return B * magnitude;
@@ -202,7 +204,7 @@ namespace ACE.Server.Physics
 
         public Vector3 GetRandomC()
         {
-            var rng = ACE.ThreadSafeRandom.Next(0.0f, 1.0f);
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
             var magnitude = (MaxC - MinC) * rng + MinC;
 
             return C * magnitude;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Physics.Animation;
@@ -270,7 +271,7 @@ namespace ACE.Server.Physics
                 return;
             }
             var upperBound = (float)delta;
-            var randp = ACE.ThreadSafeRandom.Next(0.0f, upperBound);
+            var randp = ThreadSafeRandom.Next(0.0f, upperBound);
             var hook = new FPHook(PhysicsHookType.Velocity | PhysicsHookType.MotionTable | PhysicsHookType.Setup, PhysicsTimer_CurrentTime, randp, 0.0f, 1.0f, pes);
             Hooks.AddLast(hook);
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;

--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -1,5 +1,6 @@
 using System;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/Lock.cs
+++ b/Source/ACE.Server/WorldObjects/Lock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;

--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database;
 using ACE.Database.Models.Shard;

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;

--- a/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database;
 using ACE.Database.Models.World;

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Common.Extensions;
 using ACE.Database.Models.Shard;
 using ACE.DatLoader;

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using log4net;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 
+using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
 using ACE.Server.Entity;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 
+using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.Shard;
 using ACE.Entity;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -1,4 +1,6 @@
 using System;
+
+using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;


### PR DESCRIPTION
This fixes the namespace for ThreadSafeRandom, from ACE -> ACE.Common.

It also adds better Summary descriptions.

The rest of the file changes are simply adding ACE.Common references.

This is mainly commenting and namespace preparation for adding a non-thread safe random class, in effort to reduce lock contention.