### PR TITLE
WorldObject_Weapon / imbue refactoring

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -212,7 +212,7 @@ namespace ACE.Server.Entity
 
             // critical hit?
             var attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
-            CriticalChance = WorldObject.GetWeaponCritChanceModifier(attacker, attackSkill, defender);
+            CriticalChance = WorldObject.GetWeaponCriticalChance(attacker, attackSkill, defender);
             if (CriticalChance > ThreadSafeRandom.Next(0.0f, 1.0f))
             {
                 if (playerDefender != null && playerDefender.AugmentationCriticalDefense > 0)

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -2242,6 +2242,8 @@ namespace ACE.Server.Factories
         };
 
         // for logging epic/legendary drops
+        public static HashSet<int> MinorCantrips;
+        public static HashSet<int> MajorCantrips;
         public static HashSet<int> EpicCantrips;
         public static HashSet<int> LegendaryCantrips;
 
@@ -2249,6 +2251,8 @@ namespace ACE.Server.Factories
 
         static LootTables()
         {
+            BuildCantripsTable(ref MinorCantrips, 0);
+            BuildCantripsTable(ref MajorCantrips, 1);
             BuildCantripsTable(ref EpicCantrips, 2);
             BuildCantripsTable(ref LegendaryCantrips, 3);
         }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -360,7 +360,7 @@ namespace ACE.Server.WorldObjects
                 attackSkill = sourceCreature.GetCreatureSkill(Spell.School);
 
             // critical hit
-            var critical = GetWeaponMagicCritFrequencyModifier(sourceCreature, attackSkill, target);
+            var critical = GetWeaponMagicCritFrequency(sourceCreature, attackSkill, target);
             if (ThreadSafeRandom.Next(0.0f, 1.0f) < critical)
             {
                 if (targetPlayer != null && targetPlayer.AugmentationCriticalDefense > 0)
@@ -406,6 +406,22 @@ namespace ACE.Server.WorldObjects
             {
                 if (criticalHit)
                 {
+                    // Original:
+                    // http://acpedia.org/wiki/Announcements_-_2002/08_-_Atonement#Letter_to_the_Players
+
+                    // Critical Strikes: In addition to the skill-based damage bonus, each projectile spell has a 2% chance of causing a critical hit on the target and doing increased damage.
+                    // A magical critical hit is similar in some respects to melee critical hits (although the damage calculation is handled differently).
+                    // While a melee critical hit automatically does twice the maximum damage of the weapon, a magical critical hit will do an additional half the minimum damage of the spell.
+                    // For instance, a magical critical hit from a level 7 spell, which does 110-180 points of damage, would add an additional 55 points of damage to the spell.
+
+                    // Later updated for PvE only:
+
+                    // http://acpedia.org/wiki/Announcements_-_2004/07_-_Treaties_in_Stone#Letter_to_the_Players
+
+                    // Currently when a War Magic spell scores a critical hit, it adds a multiple of the base damage of the spell to a normal damage roll.
+                    // Starting in July, War Magic critical hits will instead add a multiple of the maximum damage of the spell.
+                    // No more crits that do less damage than non-crits!
+
                     if (isPVP) // PvP: 50% of the MIN damage added to normal damage roll
                         damageBonus = Spell.MinDamage * 0.5f;
                     else   // PvE: 50% of the MAX damage added to normal damage roll

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -529,9 +529,24 @@ namespace ACE.Server.WorldObjects
 
             // ( +500% sounds like it would be 6.0 multiplier)
 
-            var interval = GetImbuedInterval(skill);
+            var baseSkill = GetBaseSkillImbued(skill);
 
-            var cripplingBlowMod = SetInterval(interval, 1.0f, MaxCripplingBlowMod);
+            var baseMod = 1.0f;
+
+            switch(GetImbuedSkillType(skill))
+            {
+                case ImbuedSkillType.Melee:
+                    baseMod = Math.Max(0, baseSkill - 40) / 60.0f;
+                    break;
+
+                case ImbuedSkillType.Missile:
+                case ImbuedSkillType.Magic:
+
+                    baseMod = baseSkill / 60.0f;
+                    break;
+            }
+
+            var cripplingBlowMod = Math.Max(1.0f, baseMod);
 
             //Console.WriteLine($"CripplingBlowMod: {cripplingBlowMod}");
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -9,18 +9,6 @@ namespace ACE.Server.WorldObjects
 {
     partial class WorldObject
     {
-        public AttackType W_AttackType
-        {
-            get => (AttackType)(GetProperty(PropertyInt.AttackType) ?? 0);
-            set { if (value == 0) RemoveProperty(PropertyInt.AttackType); else SetProperty(PropertyInt.AttackType, (int)value); }
-        }
-
-        public WeaponType W_WeaponType
-        {
-            get => (WeaponType)(GetProperty(PropertyInt.WeaponType) ?? 0);
-            set { if (value == 0) RemoveProperty(PropertyInt.WeaponType); else SetProperty(PropertyInt.WeaponType, (int)value); }
-        }
-
         public Skill WeaponSkill
         {
             get => (Skill)(GetProperty(PropertyInt.WeaponSkill) ?? 0);
@@ -33,32 +21,16 @@ namespace ACE.Server.WorldObjects
             set { if (value == 0) RemoveProperty(PropertyInt.DamageType); else SetProperty(PropertyInt.DamageType, (int)value); }
         }
 
-        /// <summary>
-        /// Spell ID for 'Cast on Strike'
-        /// </summary>
-        public uint? ProcSpell
+        public AttackType W_AttackType
         {
-            get => GetProperty(PropertyDataId.ProcSpell);
-            set { if (!value.HasValue) RemoveProperty(PropertyDataId.ProcSpell); else SetProperty(PropertyDataId.ProcSpell, value.Value); }
+            get => (AttackType)(GetProperty(PropertyInt.AttackType) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt.AttackType); else SetProperty(PropertyInt.AttackType, (int)value); }
         }
 
-        /// <summary>
-        /// The chance for activating 'Cast on strike' spell
-        /// </summary>
-        public double? ProcSpellRate
+        public WeaponType W_WeaponType
         {
-            get => GetProperty(PropertyFloat.ProcSpellRate);
-            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ProcSpellRate); else SetProperty(PropertyFloat.ProcSpellRate, value.Value); }
-        }
-
-        /// <summary>
-        /// If TRUE, 'Cast on strike' spell targets self
-        /// instead of the target
-        /// </summary>
-        public bool ProcSpellSelfTargeted
-        {
-            get => GetProperty(PropertyBool.ProcSpellSelfTargeted) ?? false;
-            set { if (!value) RemoveProperty(PropertyBool.ProcSpellSelfTargeted); else SetProperty(PropertyBool.ProcSpellSelfTargeted, value); }
+            get => (WeaponType)(GetProperty(PropertyInt.WeaponType) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt.WeaponType); else SetProperty(PropertyInt.WeaponType, (int)value); }
         }
 
         /// <summary>
@@ -81,12 +53,6 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        const float defaultPhysicalCritFrequency = 0.10f;
-        const float defaultMagicCritFrequency = 0.02f;
-        const float defaultCritMultiplier = 1.0f;
-        const float defaultBonusModifier = 1.0f;
-        const uint defaultSpeed = 40;   // TODO: find default speed
-
         /// <summary>
         /// Returns the primary weapon equipped by a player
         /// (melee, missile, or wand)
@@ -104,33 +70,7 @@ namespace ACE.Server.WorldObjects
             return weapon;
         }
 
-        /// <summary>
-        /// Returns the weapon speed, with enchantments factored in
-        /// </summary>
-        public static uint GetWeaponSpeed(Creature wielder)
-        {
-            WorldObject weapon = GetWeapon(wielder as Player);
-
-            var baseSpeed = weapon != null ? weapon.GetProperty(PropertyInt.WeaponTime) ?? (int)defaultSpeed : (int)defaultSpeed;
-
-            var speedMod = weapon != null ? weapon.EnchantmentManager.GetWeaponSpeedMod() : 0;
-            var auraSpeedMod = wielder != null ? wielder.EnchantmentManager.GetWeaponSpeedMod() : 0;
-
-            return (uint)Math.Max(0, baseSpeed + speedMod + auraSpeedMod);
-        }
-
-        /// <summary>
-        /// Returns the Mana Conversion skill modifier for the current weapon
-        /// </summary>
-        public static float GetWeaponManaConversionModifier(Creature wielder)
-        {
-            WorldObject weapon = GetWeapon(wielder as Player);
-
-            if (weapon == null)
-                return defaultBonusModifier;
-
-            return defaultBonusModifier + (float)(weapon.GetProperty(PropertyFloat.ManaConversionMod) ?? 0.0f) * wielder.EnchantmentManager.GetManaConvMod();
-        }
+        private const float defaultModifier = 1.0f;
 
         /// <summary>
         /// Returns the Melee Defense skill modifier for the current weapon
@@ -140,11 +80,11 @@ namespace ACE.Server.WorldObjects
             WorldObject weapon = GetWeapon(wielder as Player);
 
             if (weapon == null)
-                return defaultBonusModifier;
+                return defaultModifier;
 
             if (wielder.CombatMode != CombatMode.NonCombat)
             {
-                var defenseMod = (float)(weapon.GetProperty(PropertyFloat.WeaponDefense) + weapon.EnchantmentManager.GetDefenseMod() ?? defaultBonusModifier);
+                var defenseMod = (float)(weapon.WeaponDefense ?? defaultModifier) + weapon.EnchantmentManager.GetDefenseMod();
 
                 if (weapon.IsEnchantable)
                     defenseMod += wielder.EnchantmentManager.GetDefenseMod();
@@ -152,7 +92,7 @@ namespace ACE.Server.WorldObjects
                 return defenseMod;
             }
 
-            return defaultBonusModifier;
+            return defaultModifier;
         }
 
         /// <summary>
@@ -163,11 +103,11 @@ namespace ACE.Server.WorldObjects
             WorldObject weapon = GetWeapon(wielder as Player);
 
             if (weapon == null)
-                return defaultBonusModifier;
+                return defaultModifier;
 
             if (wielder.CombatMode != CombatMode.NonCombat)
             {
-                var offenseMod = (float)(weapon.GetProperty(PropertyFloat.WeaponOffense) + weapon.EnchantmentManager.GetAttackMod() ?? defaultBonusModifier);
+                var offenseMod = (float)(weapon.WeaponOffense ?? defaultModifier) + weapon.EnchantmentManager.GetAttackMod();
 
                 if (weapon.IsEnchantable)
                     offenseMod += wielder.EnchantmentManager.GetAttackMod();
@@ -175,89 +115,116 @@ namespace ACE.Server.WorldObjects
                 return offenseMod;
             }
 
-            return defaultBonusModifier;
+            return defaultModifier;
         }
 
         /// <summary>
-        /// Returns the critical chance modifier for the current weapon
+        /// Returns the Mana Conversion skill modifier for the current weapon
         /// </summary>
-        public static float GetWeaponCritChanceModifier(Creature wielder, CreatureSkill skill, Creature target)
+        public static float GetWeaponManaConversionModifier(Creature wielder)
+        {
+            WorldObject weapon = GetWeapon(wielder as Player);
+
+            if (weapon == null)
+                return defaultModifier;
+
+            return defaultModifier + (float)(weapon.ManaConversionMod ?? 0.0f) * wielder.EnchantmentManager.GetManaConvMod();
+        }
+
+        private const uint defaultSpeed = 40;   // TODO: find default speed
+
+        /// <summary>
+        /// Returns the weapon speed, with enchantments factored in
+        /// </summary>
+        public static uint GetWeaponSpeed(Creature wielder)
+        {
+            WorldObject weapon = GetWeapon(wielder as Player);
+
+            var baseSpeed = weapon?.WeaponTime ?? (int)defaultSpeed;
+
+            var speedMod = weapon != null ? weapon.EnchantmentManager.GetWeaponSpeedMod() : 0;
+            var auraSpeedMod = wielder != null ? wielder.EnchantmentManager.GetWeaponSpeedMod() : 0;
+
+            return (uint)Math.Max(0, baseSpeed + speedMod + auraSpeedMod);
+        }
+
+        /// <summary>
+        /// Biting Strike
+        /// </summary>
+        public double? CriticalFrequency
+        {
+            get => GetProperty(PropertyFloat.CriticalFrequency);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.CriticalFrequency); else SetProperty(PropertyFloat.CriticalFrequency, value.Value); }
+        }
+
+        private const float defaultPhysicalCritFrequency = 0.1f;    // 10% base chance
+
+        /// <summary>
+        /// Returns the critical chance for the current weapon
+        /// </summary>
+        public static float GetWeaponCriticalChance(Creature wielder, CreatureSkill skill, Creature target)
         {
             WorldObject weapon = GetWeapon(wielder as Player);
 
             if (weapon == null)
                 return defaultPhysicalCritFrequency;
 
-            var critRateMod = (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultPhysicalCritFrequency);
+            var critRate = (float)(weapon.CriticalFrequency ?? defaultPhysicalCritFrequency);
 
-            // multipliers before additives?
-            var chanceRatingMod = Creature.GetPositiveRatingMod(wielder.GetCritRating());
-            critRateMod *= chanceRatingMod;
-
-            // TODO: handle AlwaysCritical upstream
             if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
             {
-                var criticalStrikeMod = GetCriticalStrikeMod(skill);
-                critRateMod += criticalStrikeMod;
+                var criticalStrikeBonus = GetCriticalStrikeMod(skill);
+
+                critRate = Math.Max(critRate, criticalStrikeBonus);
             }
+
+            critRate += wielder.GetCritRating() * 0.01f;
 
             // mitigation
             var critResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritResistRating());
-            critRateMod *= critResistRatingMod;
+            critRate *= critResistRatingMod;
 
-            // 50% cap here, or only in criticalStrikeMod?
-            critRateMod = Math.Min(critRateMod, 0.5f);
-
-            return critRateMod;
+            return critRate;
         }
 
-        public ImbuedEffectType GetImbuedEffects()
-        {
-            return (ImbuedEffectType)(
-                (GetProperty(PropertyInt.ImbuedEffect) ?? 0) |
-                (GetProperty(PropertyInt.ImbuedEffect2) ?? 0) |
-                (GetProperty(PropertyInt.ImbuedEffect3) ?? 0) |
-                (GetProperty(PropertyInt.ImbuedEffect4) ?? 0) |
-                (GetProperty(PropertyInt.ImbuedEffect5) ?? 0) );
-        }
+        // http://acpedia.org/wiki/Announcements_-_2002/08_-_Atonement#Letter_to_the_Players
 
-        public bool HasImbuedEffect(ImbuedEffectType type)
-        {
-            return (GetImbuedEffects() & type) != 0;
-        }
+        private const float defaultMagicCritFrequency = 0.02f;      // 2% base chance
 
         /// <summary>
-        /// Returns the magic critical chance modifier for the current weapon
+        /// Returns the critical chance for the current magic weapon
         /// </summary>
-        public static float GetWeaponMagicCritFrequencyModifier(Creature wielder, CreatureSkill skill, Creature target)
+        public static float GetWeaponMagicCritFrequency(Creature wielder, CreatureSkill skill, Creature target)
         {
+            // TODO : merge with above function
+            // FIXME: do not use GetWeapon for spell projectiles
+
             WorldObject weapon = GetWeapon(wielder as Player);
 
-            if (wielder == null || weapon == null)
+            if (weapon == null)
                 return defaultMagicCritFrequency;
 
-            var critRateMod = (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultMagicCritFrequency);
+            var critRate = (float)(weapon.GetProperty(PropertyFloat.CriticalFrequency) ?? defaultMagicCritFrequency);
 
-            // multipliers before additives?
-            var chanceRatingMod = Creature.GetPositiveRatingMod(wielder.GetCritRating());
-            critRateMod *= chanceRatingMod;
-
-            // TODO: handle AlwaysCritical upstream
-            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike) && skill != null)
+            if (weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
             {
-                var criticalStrikeMod = GetCriticalStrikeMod(skill);
-                critRateMod += criticalStrikeMod;
+                var isPvP = wielder is Player && target is Player;
+
+                var criticalStrikeMod = GetCriticalStrikeMod(skill, isPvP);
+
+                critRate = Math.Max(critRate, criticalStrikeMod);
             }
+
+            critRate += wielder.GetCritRating() * 0.01f;
 
             // mitigation
             var critResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritResistRating());
-            critRateMod *= critResistRatingMod;
+            critRate *= critResistRatingMod;
 
-            // 10% cap here, or only in criticalStrikeMod?
-            critRateMod = Math.Min(critRateMod, 0.1f);
-
-            return critRateMod;
+            return critRate;
         }
+
+        private const float defaultCritDamageMultiplier = 1.0f;
 
         /// <summary>
         /// Returns the critical damage multiplier for the current weapon
@@ -266,49 +233,25 @@ namespace ACE.Server.WorldObjects
         {
             WorldObject weapon = GetWeapon(wielder as Player);
 
-            if (wielder == null || weapon == null)
-                return defaultCritMultiplier;
+            if (weapon == null)
+                return defaultCritDamageMultiplier;     // 1.0 would be normal crit damage here
 
-            var critDamageMod = (float)(weapon.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritMultiplier);
-
-            // multipliers before additive?
-            var critDamageRatingMod = Creature.GetPositiveRatingMod(wielder.GetCritDamageRating());
-            critDamageMod *= critDamageRatingMod;
+            var critDamageMod = (float)(weapon.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritDamageMultiplier);
 
             if (weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
             {
                 var cripplingBlowMod = GetCripplingBlowMod(skill);
-                critDamageMod += cripplingBlowMod;      // additive float?
+
+                critDamageMod = Math.Max(critDamageMod, cripplingBlowMod); 
             }
+
+            critDamageMod += wielder.GetCritDamageRating() * 0.01f;
 
             // mitigation
             var critDamageResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritDamageResistRating());
             critDamageMod *= critDamageResistRatingMod;
 
-            // caps at 6x upstream?
-            critDamageMod = Math.Min(critDamageMod, 5.0f);
-
             return critDamageMod;
-        }
-
-        /// <summary>
-        /// Returns the slayer 2x+ damage bonus for the current weapon
-        /// against a particular creature type
-        /// </summary>
-        public static float GetWeaponCreatureSlayerModifier(Creature wielder, Creature target)
-        {
-            float modifier = defaultBonusModifier;
-
-            WorldObject weapon = GetWeapon(wielder as Player);
-
-            if (wielder == null || weapon == null)
-                return modifier;
-
-            if (weapon.GetProperty(PropertyInt.SlayerCreatureType) != null && target != null)
-                if ((CreatureType)weapon.GetProperty(PropertyInt.SlayerCreatureType) == target.CreatureType)
-                    modifier = (float)(weapon.GetProperty(PropertyFloat.SlayerDamageBonus) ?? modifier);
-
-            return modifier;
         }
 
         /// <summary>
@@ -347,24 +290,58 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static int GetMissileElementalDamageBonus(Creature wielder, DamageType damageType)
         {
-            // An additive bonus, so the default is zero
-            int modifier = 0;
+            WorldObject weapon = GetWeapon(wielder as Player);
 
-            var wielderAsPlayer = wielder as Player;
-
-            WorldObject weapon = GetWeapon(wielderAsPlayer);
-
-            if (weapon is MissileLauncher)
+            if (weapon is MissileLauncher && weapon.ElementalDamageBonus != null)
             {
-                var elementalDamageModType = weapon.GetProperty(PropertyInt.DamageType) ?? (int)DamageType.Undef;
-                if (elementalDamageModType != (int)DamageType.Undef && elementalDamageModType == (int)damageType)
-                {
-                    var launcherElementalDmgMod = weapon.GetProperty(PropertyInt.ElementalDamageBonus) ?? modifier;
-                    modifier = launcherElementalDmgMod;
-                }
-            }
+                var elementalDamageType = weapon.W_DamageType;
 
-            return modifier;
+                if (elementalDamageType != DamageType.Undef && elementalDamageType == damageType)
+                    return weapon.ElementalDamageBonus.Value;
+            }
+            return 0;
+        }
+
+        public CreatureType? SlayerCreatureType
+        {
+            get => (CreatureType?)GetProperty(PropertyInt.SlayerCreatureType);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.SlayerCreatureType); else SetProperty(PropertyInt.SlayerCreatureType, (int)value.Value); }
+        }
+
+        public double? SlayerDamageBonus
+        {
+            get => GetProperty(PropertyFloat.SlayerDamageBonus);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.SlayerDamageBonus); else SetProperty(PropertyFloat.SlayerDamageBonus, value.Value); }
+        }
+
+        /// <summary>
+        /// Returns the slayer damage multiplier for the current weapon
+        /// against a particular creature type
+        /// </summary>
+        public static float GetWeaponCreatureSlayerModifier(Creature wielder, Creature target)
+        {
+            WorldObject weapon = GetWeapon(wielder as Player);
+
+            if (weapon != null && weapon.SlayerCreatureType != null && weapon.SlayerDamageBonus != null &&
+                target != null && weapon.SlayerCreatureType == target.CreatureType)
+            {
+                // TODO: scale with base weapon skill?
+                return (float)weapon.SlayerDamageBonus;
+            }
+            else
+                return defaultModifier;
+        }
+
+        public DamageType? ResistanceModifierType
+        {
+            get => (DamageType?)GetProperty(PropertyInt.ResistanceModifierType);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.ResistanceModifierType); else SetProperty(PropertyInt.ResistanceModifierType, (int)value.Value); }
+        }
+
+        public double? ResistanceModifier
+        {
+            get => GetProperty(PropertyFloat.ResistanceModifier);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ResistanceModifier); else SetProperty(PropertyFloat.ResistanceModifier, value.Value); }
         }
 
         /// <summary>
@@ -372,17 +349,17 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public static float GetWeaponResistanceModifier(Creature wielder, CreatureSkill skill, DamageType damageType)
         {
-            float resistMod = defaultBonusModifier;
+            float resistMod = defaultModifier;
 
             WorldObject weapon = GetWeapon(wielder as Player);
 
             if (wielder == null || weapon == null)
-                return defaultBonusModifier;
+                return defaultModifier;
 
-            var weaponResistanceModifierType = weapon.GetProperty(PropertyInt.ResistanceModifierType) ?? (int)DamageType.Undef;
-            if (weaponResistanceModifierType != (int)DamageType.Undef)
-                if (weaponResistanceModifierType == (int)damageType)
-                    resistMod = (float)(weapon.GetProperty(PropertyFloat.ResistanceModifier) ?? defaultBonusModifier) + 1.0f;
+            var weaponResistanceModifierType = weapon.ResistanceModifierType ?? (int)DamageType.Undef;
+
+            if (weaponResistanceModifierType != (int)DamageType.Undef && weaponResistanceModifierType == damageType)
+                resistMod = 1.0f + (float)(weapon.ResistanceModifier ?? defaultModifier);       // verify
 
             // handle rends
 
@@ -392,7 +369,7 @@ namespace ACE.Server.WorldObjects
 
             var rendDamageType = GetRendDamageType(damageType);
             if (rendDamageType == ImbuedEffectType.Undef)
-                Console.WriteLine($"{wielder.Name}.GetRendDamageType({damageType}) unexpected damage type for {weapon.Name} ({weapon.Guid})");
+                log.Debug($"{wielder.Name}.GetRendDamageType({damageType}) unexpected damage type for {weapon.Name} ({weapon.Guid})");
 
             if (rendDamageType != ImbuedEffectType.Undef && weapon.HasImbuedEffect(rendDamageType) && skill != null)
             {
@@ -400,10 +377,22 @@ namespace ACE.Server.WorldObjects
                 resistMod *= rendingMod;
             }
 
-            // caps at 250% here?
-            resistMod = Math.Min(resistMod, 2.5f);
-
             return resistMod;
+        }
+
+        public ImbuedEffectType GetImbuedEffects()
+        {
+            return (ImbuedEffectType)(
+                (GetProperty(PropertyInt.ImbuedEffect) ?? 0) |
+                (GetProperty(PropertyInt.ImbuedEffect2) ?? 0) |
+                (GetProperty(PropertyInt.ImbuedEffect3) ?? 0) |
+                (GetProperty(PropertyInt.ImbuedEffect4) ?? 0) |
+                (GetProperty(PropertyInt.ImbuedEffect5) ?? 0));
+        }
+
+        public bool HasImbuedEffect(ImbuedEffectType type)
+        {
+            return (GetImbuedEffects() & type) != 0;
         }
 
         public static ImbuedEffectType GetRendDamageType(DamageType damageType)
@@ -427,7 +416,7 @@ namespace ACE.Server.WorldObjects
                 case DamageType.Nether:
                     return ImbuedEffectType.NetherRending;
                 default:
-                    //Console.WriteLine($"GetRendDamageType({damageType}) unexpected damage type");
+                    //log.Debug($"GetRendDamageType({damageType}) unexpected damage type");
                     return ImbuedEffectType.Undef;
             }
         }
@@ -504,134 +493,62 @@ namespace ACE.Server.WorldObjects
         // - Melee/missile: this is a direct multiplier of your maximum non-crit damage.
         // - Magic: my best guess here is that the CB modifier modifies the additional crit damage (see note-2), but i'm not 100% on this
 
+
+        // elemental vuln damage modifier, capped at 2.5
+        public static float MaxRendingMod = 2.5f;
+
+        public static float GetRendingMod(CreatureSkill skill)
+        {
+            // was MaxRendingMod 2.25 for magic/missile?
+            var rendingMod = GetImbuedInterval(skill, false) * MaxRendingMod;
+
+            return rendingMod;
+        }
+
+        public static float MaxArmorRendingMod = 0.6f;
+
         public static float GetArmorRendingMod(CreatureSkill skill)
         {
             // % of armor ignored, min 0%, max 60%
 
-            var baseSkill = GetBaseSkillImbued(skill);
+            var armorRendingMod = GetImbuedInterval(skill, false) * MaxArmorRendingMod;
 
-            switch (GetImbuedSkillType(skill))
-            {
-                case ImbuedSkillType.Melee:
-                    return 1.0f - Math.Max(0, baseSkill - 160) / 400.0f;
-
-                case ImbuedSkillType.Missile:
-                    return 1.0f - Math.Max(0, baseSkill - 144) / 360.0f;
-
-                default:
-                    return 1.0f;
-            }
+            return 1.0f - armorRendingMod;
         }
 
-        public static float GetCriticalStrikeMod(CreatureSkill skill)
+        // http://acpedia.org/wiki/Announcements_-_2004/07_-_Treaties_in_Stone#Letter_to_the_Players
+
+        // for PvP, this gets halved
+        public static float MaxCriticalStrikeMod = 0.5f;
+
+        public static float GetCriticalStrikeMod(CreatureSkill skill, bool isPvP = false)
         {
-            // increases crit chance (additive?)
-            // maximum 5x bonus
-            // melee/missile: 10% -> 50%
-            // magic: 2% -> 10%
+            var criticalStrikeMod = GetImbuedInterval(skill) * MaxCriticalStrikeMod;
 
-            var baseSkill = GetBaseSkillImbued(skill);
+            if (isPvP)
+                criticalStrikeMod *= 0.5f;
 
-            var baseMod = 0.0f;
-            var skillType = GetImbuedSkillType(skill);
-            switch (skillType)
-            {
-                case ImbuedSkillType.Melee:
-                    baseMod = Math.Max(0, baseSkill - 100) / 600.0f;
-                    break;
-
-                case ImbuedSkillType.Missile:
-                    baseMod = Math.Max(0, baseSkill - 60) / 600.0f;
-                    break;
-
-                case ImbuedSkillType.Magic:
-                    baseMod = Math.Max(0, baseSkill - 60) / 3000.0f;
-                    break;
-
-                default:
-                    return 0.0f;
-            }
-
-            switch (skillType)
-            {
-                // minimum 2% for magic
-                case ImbuedSkillType.Magic:
-                    return Math.Max(0.02f, baseMod);
-
-                // minimum 10% for melee / missile
-                case ImbuedSkillType.Melee:
-                case ImbuedSkillType.Missile:
-                    return Math.Max(0.10f, baseMod);
-            }
-            return 0.0f;
+            return criticalStrikeMod;
         }
+
+        public static float MaxCripplingBlowMod = 6.0f;
 
         public static float GetCripplingBlowMod(CreatureSkill skill)
         {
-            // increases crit damage (additive?)
-            // caps at 6x here, possibly 7x cap upstream?
+            // increases the critical damage multiplier, additive
 
-            var baseSkill = GetBaseSkillImbued(skill);
+            // http://acpedia.org/wiki/Announcements_-_2004/07_-_Treaties_in_Stone#Letter_to_the_Players
 
-            var baseMod = 0.0f;
-            var skillType = GetImbuedSkillType(skill);
-            switch (skillType)
-            {
-                case ImbuedSkillType.Melee:
-                    baseMod = Math.Max(0, baseSkill - 40) / 60.0f;
-                    break;
+            // PvP only:
 
-                case ImbuedSkillType.Missile:
-                case ImbuedSkillType.Magic:
-                    baseMod = baseSkill / 60.0f;
-                    break;
+            // Crippling Blow for War Magic currently scales from adding 50% of the spells damage on critical hits to adding 100% at maximum effectiveness.
+            // In July, the maximum effectiveness will be increased to adding up to 500% of the spell's damage.
 
-                default:
-                    return 0.0f;
-            }
+            // ( +500% sounds like it would be 6.0 multiplier)
 
-            switch (skillType)
-            {
-                // minimum bonus for physical only?
-                case ImbuedSkillType.Melee:
-                case ImbuedSkillType.Missile:
-                    return Math.Max(1.0f, baseMod);
-            }
-            return baseMod;
-        }
+            var cripplingBlowBonus = GetImbuedInterval(skill) * MaxCripplingBlowMod;
 
-        public static float GetRendingMod(CreatureSkill skill)
-        {
-            // elemental vuln damage modifier, capped at 2.5
-
-            var baseSkill = GetBaseSkillImbued(skill);
-
-            switch (GetImbuedSkillType(skill))
-            {
-                case ImbuedSkillType.Melee:
-                    return baseSkill / 160.0f;
-
-                case ImbuedSkillType.Missile:
-                case ImbuedSkillType.Magic:
-                    return baseSkill / 144.0f;
-
-                default:
-                    return 1.0f;
-            }
-        }
-
-        public static uint GetBaseSkillImbued(CreatureSkill skill)
-        {
-            switch (GetImbuedSkillType(skill))
-            {
-                case ImbuedSkillType.Melee:
-                    return Math.Min(skill.Base, 400);
-
-                case ImbuedSkillType.Missile:
-                case ImbuedSkillType.Magic:
-                default:
-                    return Math.Min(skill.Base, 360);
-            }
+            return cripplingBlowBonus;
         }
 
         public enum ImbuedSkillType
@@ -644,7 +561,7 @@ namespace ACE.Server.WorldObjects
 
         public static ImbuedSkillType GetImbuedSkillType(CreatureSkill skill)
         {
-            switch (skill.Skill)
+            switch (skill?.Skill)
             {
                 case Skill.LightWeapons:
                 case Skill.HeavyWeapons:
@@ -680,9 +597,37 @@ namespace ACE.Server.WorldObjects
                     return ImbuedSkillType.Magic;
 
                 default:
-                    Console.WriteLine($"WorldObject_Weapon.GetImbuedSkillType({skill.Skill}): unexpected skill");
+                    log.Debug($"WorldObject_Weapon.GetImbuedSkillType({skill?.Skill}): unexpected skill");
                     return ImbuedSkillType.Undef;
             }
+        }
+
+        /// <summary>
+        /// Spell ID for 'Cast on Strike'
+        /// </summary>
+        public uint? ProcSpell
+        {
+            get => GetProperty(PropertyDataId.ProcSpell);
+            set { if (!value.HasValue) RemoveProperty(PropertyDataId.ProcSpell); else SetProperty(PropertyDataId.ProcSpell, value.Value); }
+        }
+
+        /// <summary>
+        /// The chance for activating 'Cast on strike' spell
+        /// </summary>
+        public double? ProcSpellRate
+        {
+            get => GetProperty(PropertyFloat.ProcSpellRate);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ProcSpellRate); else SetProperty(PropertyFloat.ProcSpellRate, value.Value); }
+        }
+
+        /// <summary>
+        /// If TRUE, 'Cast on strike' spell targets self
+        /// instead of the target
+        /// </summary>
+        public bool ProcSpellSelfTargeted
+        {
+            get => GetProperty(PropertyBool.ProcSpellSelfTargeted) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.ProcSpellSelfTargeted); else SetProperty(PropertyBool.ProcSpellSelfTargeted, value); }
         }
 
         /// <summary>
@@ -892,6 +837,34 @@ namespace ACE.Server.WorldObjects
                 }
             }
             return attackType;
+        }
+
+        /// <summary>
+        /// Returns the base skill multiplier to the maximum bonus
+        /// </summary>
+        public static float GetImbuedInterval(CreatureSkill skill, bool useMin = true)
+        {
+            var skillType = GetImbuedSkillType(skill);
+
+            var min = 0;
+            if (useMin)
+                min = skillType == ImbuedSkillType.Melee ? 150 : 125;
+            var max = skillType == ImbuedSkillType.Melee ? 400 : 360;
+
+            return GetInterval((int)skill.Base, min, max);
+        }
+
+        /// <summary>
+        /// Returns an interval between 0-1
+        /// </summary>
+        public static float GetInterval(int num, int min, int max)
+        {
+            if (num <= min) return 0.0f;
+            if (num >= max) return 1.0f;
+
+            var range = max - min;
+
+            return (float)(num - min) / range;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -543,10 +543,23 @@ namespace ACE.Server.WorldObjects
 
         public static float GetRendingMod(CreatureSkill skill)
         {
-            // no min skill?
-            var interval = GetImbuedInterval(skill, false);
+            var baseSkill = GetBaseSkillImbued(skill);
 
-            var rendingMod = SetInterval(interval, 1.0f, MaxRendingMod);
+            var rendingMod = 1.0f;
+
+            switch (GetImbuedSkillType(skill))
+            {
+                case ImbuedSkillType.Melee:
+                    rendingMod = baseSkill / 160.0f;
+                    break;
+
+                case ImbuedSkillType.Missile:
+                case ImbuedSkillType.Magic:
+                    rendingMod = baseSkill / 144.0f;
+                    break;
+            }
+
+            rendingMod = Math.Clamp(rendingMod, 1.0f, MaxRendingMod);
 
             //Console.WriteLine($"RendingMod: {rendingMod}");
 
@@ -564,6 +577,20 @@ namespace ACE.Server.WorldObjects
             //Console.WriteLine($"ArmorRendingMod: {armorRendingMod}");
 
             return armorRendingMod;
+        }
+
+        public static uint GetBaseSkillImbued(CreatureSkill skill)
+        {
+            switch (GetImbuedSkillType(skill))
+            {
+                case ImbuedSkillType.Melee:
+                    return Math.Min(skill.Base, 400);
+
+                case ImbuedSkillType.Missile:
+                case ImbuedSkillType.Magic:
+                default:
+                    return Math.Min(skill.Base, 360);
+            }
         }
 
         public enum ImbuedSkillType

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -572,24 +572,37 @@ namespace ACE.Server.WorldObjects
         {
             // % of armor ignored, min 0%, max 60%
 
-            var armorRendingMod = 1.0f - GetImbuedInterval(skill, false) * MaxArmorRendingMod;
+            var baseSkill = GetBaseSkillImbued(skill);
+
+            var armorRendingMod = 1.0f;
+
+            switch (GetImbuedSkillType(skill))
+            {
+                case ImbuedSkillType.Melee:
+                    armorRendingMod -= Math.Max(0, baseSkill - 160) / 400.0f;
+                    break;
+
+                case ImbuedSkillType.Missile:
+                    armorRendingMod -= Math.Max(0, baseSkill - 144) / 360.0f;
+                    break;
+            }
 
             //Console.WriteLine($"ArmorRendingMod: {armorRendingMod}");
 
             return armorRendingMod;
         }
 
-        public static uint GetBaseSkillImbued(CreatureSkill skill)
+        public static int GetBaseSkillImbued(CreatureSkill skill)
         {
             switch (GetImbuedSkillType(skill))
             {
                 case ImbuedSkillType.Melee:
-                    return Math.Min(skill.Base, 400);
+                    return (int)Math.Min(skill.Base, 400);
 
                 case ImbuedSkillType.Missile:
                 case ImbuedSkillType.Magic:
                 default:
-                    return Math.Min(skill.Base, 360);
+                    return (int)Math.Min(skill.Base, 360);
             }
         }
 


### PR DESCRIPTION
So this started with digging into an off-by-1 error for Crippling Blow, and then went down the rabbit hole of fixing some issues with Critical Strike, and figuring out more of the details with that, which eventually lead to finding some scaling issues that mostly affect people who aren't at the caps for imbues yet.

Along the way, I ended up cleaning up a lot of WorldObject_Weapon, and moving around some of the functions in that file for better organization / readability. The moving around of some function positions in the file unfortunately makes the git diff a bit confusing to read through, but all of the functionality is the same there, just moved around and refactored a bit.

Tested the 4 key imbues: Critical Strike, Crippling Blow, Elemental Rend, and Armor Rend, and verified that all of the new functions are working as expected.

More details to follow..