### PR TITLE
reversing exemption checks, adding missing WeenieObject.IsTypes

### DIFF
--- a/Source/ACE.Server/Physics/Common/WeenieObject.cs
+++ b/Source/ACE.Server/Physics/Common/WeenieObject.cs
@@ -58,39 +58,37 @@ namespace ACE.Server.Physics.Common
 
         public bool IsCorpse()
         {
-            return false;
+            return WorldObject is Corpse;
         }
 
-        public bool IsImpenetable()
+        public bool IsImpenetrable()
         {
-            return false;
+            return false;   // ?
         }
 
         public bool IsPK()
         {
-            return false;
+            return WorldObject is Player player && player.IsPK;
         }
 
         public bool IsPKLite()
         {
-            return false;
+            return WorldObject is Player player && player.IsPKL;
         }
 
         public bool IsPlayer()
         {
-            return true;
+            return WorldObject is Player;
         }
 
         public bool IsCreature()
         {
             return WorldObject is Creature;
-
-            //return true;
         }
 
         public bool IsStorage()
         {
-            return false;
+            return WorldObject is Storage;
         }
 
         public float JumpStaminaCost(float extent, int staminaCost)

--- a/Source/ACE.Server/Physics/Common/WeenieObject.cs
+++ b/Source/ACE.Server/Physics/Common/WeenieObject.cs
@@ -63,7 +63,7 @@ namespace ACE.Server.Physics.Common
 
         public bool IsImpenetrable()
         {
-            return false;   // ?
+            return WorldObject is Player player && player.PlayerKillerStatus == PlayerKillerStatus.Free;
         }
 
         public bool IsPK()

--- a/Source/ACE.Server/Physics/ObjectInfo.cs
+++ b/Source/ACE.Server/Physics/ObjectInfo.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Physics.Animation
             var wobj = Object.WeenieObj;
             if (wobj != null)
             {
-                if (wobj.IsImpenetable())
+                if (wobj.IsImpenetrable())
                     State |= ObjectInfoState.IsImpenetrable;
                 if (wobj.IsPlayer())
                     State |= ObjectInfoState.IsPlayer;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -385,11 +385,13 @@ namespace ACE.Server.Physics
             transition.SpherePath.ObstructionEthereal = ethereal;
 
             var state = transition.ObjectInfo.State;
-            var exemption = (WeenieObj == null || !WeenieObj.IsPlayer() || !state.HasFlag(ObjectInfoState.IsPlayer) ||
-                state.HasFlag(ObjectInfoState.IsImpenetrable) || WeenieObj.IsImpenetable() ||
+
+            var exemption = !(WeenieObj == null || !WeenieObj.IsPlayer() || !state.HasFlag(ObjectInfoState.IsPlayer) ||
+                state.HasFlag(ObjectInfoState.IsImpenetrable) || WeenieObj.IsImpenetrable() ||
                 state.HasFlag(ObjectInfoState.IsPK) && WeenieObj.IsPK() || state.HasFlag(ObjectInfoState.IsPKLite) && WeenieObj.IsPKLite());
 
             var missileIgnore = transition.ObjectInfo.MissileIgnore(this);
+
             var isCreature = State.HasFlag(PhysicsState.Missile) || WeenieObj != null && WeenieObj.IsCreature();
             //isCreature = false; // hack?
 
@@ -518,7 +520,7 @@ namespace ACE.Server.Physics
         {
             if (newCell == null) return SetPositionError.NoCell;
             set_frame(pos.Frame);
-            if (!CurCell.Equals(newCell))
+            if (CurCell != newCell)
             {
                 change_cell(newCell);
                 calc_cross_cells();


### PR DESCRIPTION
This fixes the bug with TA char positions getting bumped around