### PR TITLE
removing player.rotate during looting that wasnt in retail

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -920,7 +920,8 @@ namespace ACE.Server.WorldObjects
                     });
 
                     pickupChain.EnqueueChain();
-                });
+
+                }, null, false);    // if player is within UseRadius of moveToTarget, do not perform rotation
             }
             else // This is a self-contained movement
             {
@@ -1250,7 +1251,8 @@ namespace ACE.Server.WorldObjects
                     });
 
                     pickupChain.EnqueueChain();
-                });
+
+                }, null, false);    // if player is within UseRadius of moveToTarget, do not perform rotation
             }
             else
             {
@@ -1735,7 +1737,8 @@ namespace ACE.Server.WorldObjects
                     });
 
                     pickupChain.EnqueueChain();
-                });
+
+                }, null, false);    // if player is within UseRadius of moveToTarget, do not perform rotation
             }
             else // This is a self-contained movement
             {
@@ -2077,7 +2080,9 @@ namespace ACE.Server.WorldObjects
                     });
 
                     pickupChain.EnqueueChain();
-                });
+
+                }, null, false);    // if player is within UseRadius of moveToTarget, do not perform rotation
+
             }
             else // This is a self-contained movement
             {
@@ -2250,7 +2255,8 @@ namespace ACE.Server.WorldObjects
                     GiveObjectToPlayer(targetAsPlayer, item, itemFoundInContainer, itemRootOwner, itemWasEquipped, amount);
                 else
                     GiveObjectToNPC(target, item, itemFoundInContainer, itemRootOwner, itemWasEquipped, amount);
-            });
+
+            });    // if player is within UseRadius of moveToTarget, perform rotation?
         }
 
         private void GiveObjectToPlayer(Player target, WorldObject item, Container itemFoundInContainer, Container itemRootOwner, bool itemWasEquipped, int amount)

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -34,7 +34,7 @@ namespace ACE.Server.WorldObjects
             lastCompletedMove = moveToChainCounter;
         }
 
-        public void CreateMoveToChain(WorldObject target, Action<bool> callback, float? useRadius = null)
+        public void CreateMoveToChain(WorldObject target, Action<bool> callback, float? useRadius = null, bool rotate = true)
         {
             var thisMoveToChainNumber = GetNextMoveToChainNumber();
 
@@ -59,16 +59,24 @@ namespace ACE.Server.WorldObjects
             var withinUseRadius = CurrentLandblock.WithinUseRadius(this, target.Guid, out var targetValid, useRadius);
             if (withinUseRadius)
             {
-                // send TurnTo motion
-                var rotateTime = Rotate(target);
-                var actionChain = new ActionChain();
-                actionChain.AddDelaySeconds(rotateTime);
-                actionChain.AddAction(this, () =>
+                if (rotate)
+                {
+                    // send TurnTo motion
+                    var rotateTime = Rotate(target);
+                    var actionChain = new ActionChain();
+                    actionChain.AddDelaySeconds(rotateTime);
+                    actionChain.AddAction(this, () =>
+                    {
+                        lastCompletedMove = thisMoveToChainNumber;
+                        callback(true);
+                    });
+                    actionChain.EnqueueChain();
+                }
+                else
                 {
                     lastCompletedMove = thisMoveToChainNumber;
                     callback(true);
-                });
-                actionChain.EnqueueChain();
+                }
                 return;
             }
 


### PR DESCRIPTION
When a corpse or a chest is double clicked, the server always performs a MoveTo and waits for it to successfully complete, before showing the container inventory

If the player then rotates their character away from the container, but stays within UseRadius range, and then loots an item, they should NOT be doing a 2nd MoveTo / rotate in this case.

See retail video:

https://youtu.be/JApdqG-oJps?t=155

Thanks to Damage Master for reporting this issue!