### PR TITLE
fixing monster resleep -> wakeup cycle for combat mode

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -52,6 +52,8 @@ namespace ACE.Server.WorldObjects
 
             SetCombatMode(CombatMode.NonCombat);
 
+            CurrentAttack = null;
+            firstUpdate = true;
             AttackTarget = null;
             IsAwake = false;
             IsMoving = false;


### PR DESCRIPTION
This fixes a bug where a monster that wakes up from spotting a player, then the player goes out of range and the monster returns to home / falls back asleep, then another player wakes the monster up again, the monster was not returning to the correct combat state again.

Repro steps:
/teleloc 0x654A011E [54.633018 -31.307457 0.005000] 0.672991 0.000000 0.000000 -0.739651
Note any rock-throwing lugians and archer tumeroks are behaving correctly
Run back to the entrance portal of the dungeon, and exit the dungeon
Re-enter the dungeon portal
Run back to those same monsters

Expected: same as before
Actual: monster will be in non-combat mode, but launching projectiles without doing any animations. The tumeroks are especially bugged, where they are launching arrows faster than normal

This patch fixes that bug, and has the monsters re-enter the correct combat stance after re-awakening
