### PR TITLE
xp divvy accuracy

### DIFF
--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -51,6 +51,8 @@ namespace ACE.Server.Entity
             }
         }
 
+        public float TotalHealth => TotalDamage.Values.Sum(i => i.TotalDamage);
+
         /// <summary>
         /// Returns the DamageHistoryInfo for the top damager
         /// for determining 'Killed by' corpse looting rights
@@ -79,7 +81,7 @@ namespace ACE.Server.Entity
         /// <param name="amount">The amount of damage hit for</param>
         public void Add(WorldObject attacker, DamageType damageType, uint amount)
         {
-            //Console.WriteLine($"DamageHistory.Add({Creature.Name}, {amount})");
+            //Console.WriteLine($"{Creature.Name}.DamageHistory.Add({attacker.Name}, {damageType}, {amount})");
 
             if (amount == 0) return;
 

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -149,6 +149,11 @@ namespace ACE.Server.WorldObjects
             if (this is Player && PlayerKillerStatus == PlayerKillerStatus.PKLite)
                 return;
 
+            var totalHealth = DamageHistory.TotalHealth;
+
+            if (totalHealth == 0)
+                return;
+
             foreach (var kvp in DamageHistory.TotalDamage)
             {
                 var damager = kvp.Value.TryGetAttacker();
@@ -163,7 +168,8 @@ namespace ACE.Server.WorldObjects
 
                 var totalDamage = kvp.Value.TotalDamage;
 
-                var damagePercent = totalDamage / Health.MaxValue;
+                var damagePercent = totalDamage / totalHealth;
+
                 var totalXP = (XpOverride ?? 0) * damagePercent;
 
                 // should this be passed upstream to fellowship / allegiance?

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1285,6 +1285,7 @@ namespace ACE.Server.WorldObjects.Managers
             var creature = WorldObject as Creature;
             if (creature == null) return;
 
+            bool isDead = false;
             var damagers = new Dictionary<WorldObject, float>();
 
             // get the total tick amount
@@ -1328,6 +1329,13 @@ namespace ACE.Server.WorldObjects.Managers
 
                 tickAmount *= damageRatingMod * damageResistRatingMod * dotResistRatingMod;
 
+                // make sure the target's current health is not exceeded
+                if (tickAmountTotal + tickAmount >= creature.Health.Current)
+                {
+                    tickAmount = creature.Health.Current - tickAmountTotal;
+                    isDead = true;
+                }
+
                 if (damagers.ContainsKey(damager))
                     damagers[damager] += tickAmount;
                 else
@@ -1336,6 +1344,8 @@ namespace ACE.Server.WorldObjects.Managers
                 creature.DamageHistory.Add(damager, damageType, (uint)Math.Round(tickAmount));
 
                 tickAmountTotal += tickAmount;
+
+                if (isDead) break;
             }
 
             creature.TakeDamageOverTime(tickAmountTotal, damageType);


### PR DESCRIPTION
This fixes some subtle errors that were possible when divvying up XP earned from killing a creature

Example mob in all of these scenarios has 100/100 health

Scenario A:

Player deals 90 direct damage to monster, and then lands a DF bleed attack. The DF bleed deals 30 damage to the monster, resulting in 120 in the damage history. The player was earning 120% of the xp for the monster in this case.

Scenario B:

Player deals 90 damage to monster. Monster is now at 10/100 health.

Monster than casts a spell which raises its MaxHealth by 20. Monster is now at 10/120 health.

Player then kills the monster. In this case, the player was only earning ~83% of the XP for the mob.

Scenario C:

Player deals 90 damage to monster. Monster is now at 10/100 health.

In this case, the monster had a MaxHealth-raising spell in effect, and it now expires. Monster is now at 10/80 health.

Player then kills the monster. In this case, Player was receiving 125% of the XP for the mob.

For Scenario A, the DoT pre-tick where it adds up all of the damage from the individual sources, and adds them each to the DamageHistory separately, could simply be amended to cap to the monster's currently remaining health, similar to regular damage.

However, for Scenarios B & C, these are subtler issues where the monster's MaxHealth can change over the course of a battle. The best way to handle all 3 of these scenarios is to simply divide by the total damage in the history (which should equal their MaxHealth in *most* instances, but not always)



