### PR TITLE
Move ThreadSafeTeleport to WorldManager

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1074,7 +1074,7 @@ namespace ACE.Server.WorldObjects.Managers
                             var destination = new Position(emote.ObjCellId.Value, emote.OriginX.Value, emote.OriginY.Value, emote.OriginZ.Value, emote.AnglesX.Value, emote.AnglesY.Value, emote.AnglesZ.Value, emote.AnglesW.Value);
 
                             WorldObject.AdjustDungeon(destination);
-                            player.ThreadSafeTeleport(destination);
+                            WorldManager.ThreadSafeTeleport(player, destination);
                         }
                     }
                     break;

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -231,7 +231,7 @@ namespace ACE.Server.WorldObjects
             // teleport to sanctuary or best location
             var newPosition = Sanctuary ?? Instantiation ?? Location;
 
-            ThreadSafeTeleport(newPosition, new ActionEventDelegate(() =>
+            WorldManager.ThreadSafeTeleport(this, newPosition, new ActionEventDelegate(() =>
             { 
                 // Stand back up
                 SetCombatMode(CombatMode.NonCombat);

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -586,7 +586,7 @@ namespace ACE.Server.WorldObjects
                 var delayTelport = new ActionChain();
                 delayTelport.AddAction(this, () => ClearFogColor());
                 delayTelport.AddDelaySeconds(1);
-                delayTelport.AddAction(this, () => Teleport(_newPosition));
+                delayTelport.AddAction(this, () => WorldManager.ThreadSafeTeleport(this, _newPosition));
 
                 delayTelport.EnqueueChain();
 

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -563,26 +563,11 @@ namespace ACE.Server.WorldObjects
             actionChain.EnqueueChain();
         }
 
-        /// <summary>
-        /// ACE allows for multi-threading with thread boundaries based on the "LandblockGroup" concept
-        /// The risk of moving the player immediately is that the player may move onto another LandblockGroup, and thus, cross thread boundaries
-        /// This will enqueue the work onto WorldManager making the teleport thread safe.
-        /// Note that this work will be done on the next tick, not immediately, so be careful about your order of operations.
-        /// If you must ensure order, pass your follow up work in with the argument actionToFollowUpWith. That work will be enqueued onto the Player.
-        /// </summary>
-        public void ThreadSafeTeleport(Position _newPosition, IAction actionToFollowUpWith = null)
-        {
-            WorldManager.EnqueueAction(new ActionEventDelegate(() =>
-            {
-                Teleport(_newPosition);
-
-                if (actionToFollowUpWith != null)
-                    EnqueueAction(actionToFollowUpWith);
-            }));
-        }
-
         public DateTime LastTeleportTime;
 
+        /// <summary>
+        /// This is not thread-safe. Consider using WorldManager.ThreadSafeTeleport() instead if you're calling this from a multi-threaded subsection.
+        /// </summary>
         public void Teleport(Position _newPosition)
         {
             var newPosition = new Position(_newPosition);

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -1,4 +1,5 @@
 using System;
+
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
 using ACE.Entity;
@@ -6,6 +7,7 @@ using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -134,7 +136,7 @@ namespace ACE.Server.WorldObjects
             var portalDest = new Position(Destination);
             WorldObject.AdjustDungeon(portalDest);
 
-            player.ThreadSafeTeleport(portalDest, new ActionEventDelegate(() =>
+            WorldManager.ThreadSafeTeleport(player, portalDest, new ActionEventDelegate(() =>
             {
                 // If the portal just used is able to be recalled to,
                 // save the destination coordinates to the LastPortal character position save table


### PR DESCRIPTION
Moving objets across thread boundaries is a funciton of the WorldManager, not a Player