### PR TITLE
EquipmentSetID

### DIFF
--- a/Source/ACE.Entity/Enum/EquipmentSet.cs
+++ b/Source/ACE.Entity/Enum/EquipmentSet.cs
@@ -1,4 +1,6 @@
-﻿namespace ACE.Entity.Enum
+using System.ComponentModel;
+
+namespace ACE.Entity.Enum
 {
     // List of equipment sets for armor/weapons. Compiled from aclogview, and the client.
     public enum EquipmentSet
@@ -16,23 +18,40 @@
         ArmMindHeart                     = 10,
         ArmorPerfectLight                = 11,
         ArmorPerfectLight2               = 12,
+        [Description("Soldier's")]
         Soldiers                         = 13,
-        Adepts                           = 14,
-        Archers                          = 15,
-        Defenders                        = 16,
-        Tinkers                          = 17,
-        Crafters                         = 18,
-        Hearty                           = 19,
-        Dexterous                        = 20,
-        Wise                             = 21,
-        Swift                            = 22,
-        Hardened                         = 23,
-        Reinforced                       = 24,
-        Interlocking                     = 25,
-        Flameproof                       = 26,
-        Acidproof                        = 27,
-        Coldproof                        = 28,
-        Lightningproof                   = 29,
+        [Description("Adept's")]
+        Adepts = 14,
+        [Description("Archer's")]
+        Archers = 15,
+        [Description("Defender's")]
+        Defenders = 16,
+        [Description("Tinker's")]
+        Tinkers = 17,
+        [Description("Crafter's")]
+        Crafters = 18,
+        [Description("Hearty")]
+        Hearty = 19,
+        [Description("Dexterous")]
+        Dexterous = 20,
+        [Description("Wise")]
+        Wise = 21,
+        [Description("Swift")]
+        Swift = 22,
+        [Description("Hardened")]
+        Hardened = 23,
+        [Description("Reinforced")]
+        Reinforced = 24,
+        [Description("Interlocking")]
+        Interlocking = 25,
+        [Description("Flameproof")]
+        Flameproof = 26,
+        [Description("Acidproof")]
+        Acidproof = 27,
+        [Description("Coldproof")]
+        Coldproof = 28,
+        [Description("Lightningproof")]
+        Lightningproof = 29,
         SocietyArmor                     = 30,
         ColosseumClothing                = 31,
         GraveyardClothing                = 32,
@@ -148,5 +167,14 @@
         UNKNOWN_139                      = 139,
         // Possibly Paragon Melee Weapons
         UNKNOWN_140                      = 140,
+    }
+
+    public static class EquipmentSetStringExtensions
+    {
+        public static string GetDescription(this EquipmentSet prop)
+        {
+            var description = prop.GetAttributeOfType<DescriptionAttribute>();
+            return description?.Description ?? prop.ToString();
+        }
     }
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -286,7 +286,7 @@ namespace ACE.Server.Factories
                 int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
                 if (chance < 11)
                 {
-                    equipSetId = ThreadSafeRandom.Next(13, 30);
+                    equipSetId = ThreadSafeRandom.Next((int)EquipmentSet.Soldiers, (int)EquipmentSet.Lightningproof);
 
                     wo.SetProperty(PropertyInt.EquipmentSetId, equipSetId);
                 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -282,6 +282,7 @@ namespace ACE.Server.Factories
                 double dropRate = PropertyManager.GetDouble("equipmentsetid_drop_rate").Item;
                 double dropRateMod = 1.0 / dropRate;
 
+                // Initial base 10% chance to add a random EquipmentSetID, which can be adjusted via property mod
                 int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
                 if (chance < 11)
                 {

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -290,7 +290,8 @@ namespace ACE.Server.Factories
 
                     wo.SetProperty(PropertyInt.EquipmentSetId, (int)equipSetId);
 
-                    wo.Name = string.Join(" ", equipSetId.GetDescription(), wo.Name);
+                    if (PropertyManager.GetBool("equipmentsetid_name_decoration").Item)
+                        wo.Name = string.Join(" ", equipSetId.GetDescription(), wo.Name);
                 }
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -277,7 +277,8 @@ namespace ACE.Server.Factories
         {
             EquipmentSet equipSetId = EquipmentSet.Invalid;
 
-            if (PropertyManager.GetBool("equipmentsetid_enabled").Item && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear && tier > 6)
+            if (PropertyManager.GetBool("equipmentsetid_enabled").Item
+                && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear && !wo.IsShield && tier > 6)
             {
                 if (wo.WieldRequirements == WieldRequirement.Level || wo.WieldRequirements == WieldRequirement.RawSkill)
                 {

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -2,6 +2,7 @@
 using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Factories
@@ -152,16 +153,6 @@ namespace ACE.Server.Factories
             return wo;
         }
 
-        private static WorldObject AssignEquipmentSetId(WorldObject wo, int tier)
-        {
-            int equipSetId = 0;
-
-            if (tier > 6)
-                wo.SetProperty(PropertyInt.EquipmentSetId, equipSetId);
-
-            return wo;
-        }
-
         private static int GetCovenantWieldReq(int tier, Skill skill)
         {
             int index, wield;
@@ -280,6 +271,27 @@ namespace ACE.Server.Factories
             }
 
             return wield;
+        }
+
+        private static WorldObject AssignEquipmentSetId(WorldObject wo, int tier)
+        {
+            int equipSetId = 0;
+
+            if (PropertyManager.GetBool("equipmentsetid_enabled").Item && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear && tier > 6)
+            {
+                double dropRate = PropertyManager.GetDouble("equipmentsetid_drop_rate").Item;
+                double dropRateMod = 1.0 / dropRate;
+
+                int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
+                if (chance < 11)
+                {
+                    equipSetId = ThreadSafeRandom.Next(13, 30);
+
+                    wo.SetProperty(PropertyInt.EquipmentSetId, equipSetId);
+                }
+            }
+
+            return wo;
         }
 
         private static WorldObject AssignArmorLevel(WorldObject wo, int tier, LootTables.ArmorType armorType)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -279,19 +279,22 @@ namespace ACE.Server.Factories
 
             if (PropertyManager.GetBool("equipmentsetid_enabled").Item && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear && tier > 6)
             {
-                double dropRate = PropertyManager.GetDouble("equipmentsetid_drop_rate").Item;
-                double dropRateMod = 1.0 / dropRate;
-
-                // Initial base 10% chance to add a random EquipmentSetID, which can be adjusted via property mod
-                int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
-                if (chance < 11)
+                if (wo.WieldRequirements == WieldRequirement.Level || wo.WieldRequirements == WieldRequirement.RawSkill)
                 {
-                    equipSetId = (EquipmentSet)ThreadSafeRandom.Next((int)EquipmentSet.Soldiers, (int)EquipmentSet.Lightningproof);
+                    double dropRate = PropertyManager.GetDouble("equipmentsetid_drop_rate").Item;
+                    double dropRateMod = 1.0 / dropRate;
 
-                    wo.SetProperty(PropertyInt.EquipmentSetId, (int)equipSetId);
+                    // Initial base 10% chance to add a random EquipmentSetID, which can be adjusted via property mod
+                    int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
+                    if (chance < 11)
+                    {
+                        equipSetId = (EquipmentSet)ThreadSafeRandom.Next((int)EquipmentSet.Soldiers, (int)EquipmentSet.Lightningproof);
 
-                    if (PropertyManager.GetBool("equipmentsetid_name_decoration").Item)
-                        wo.Name = string.Join(" ", equipSetId.GetDescription(), wo.Name);
+                        wo.EquipmentSetId = equipSetId;
+
+                        if (PropertyManager.GetBool("equipmentsetid_name_decoration").Item)
+                            wo.Name = string.Join(" ", equipSetId.GetDescription(), wo.Name);
+                    }
                 }
             }
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -275,7 +275,7 @@ namespace ACE.Server.Factories
 
         private static WorldObject AssignEquipmentSetId(WorldObject wo, int tier)
         {
-            int equipSetId = 0;
+            EquipmentSet equipSetId = EquipmentSet.Invalid;
 
             if (PropertyManager.GetBool("equipmentsetid_enabled").Item && wo.ClothingPriority != (CoverageMask)CoverageMaskHelper.Underwear && tier > 6)
             {
@@ -286,9 +286,11 @@ namespace ACE.Server.Factories
                 int chance = ThreadSafeRandom.Next(1, (int)(100 * dropRateMod));
                 if (chance < 11)
                 {
-                    equipSetId = ThreadSafeRandom.Next((int)EquipmentSet.Soldiers, (int)EquipmentSet.Lightningproof);
+                    equipSetId = (EquipmentSet)ThreadSafeRandom.Next((int)EquipmentSet.Soldiers, (int)EquipmentSet.Lightningproof);
 
-                    wo.SetProperty(PropertyInt.EquipmentSetId, equipSetId);
+                    wo.SetProperty(PropertyInt.EquipmentSetId, (int)equipSetId);
+
+                    wo.Name = string.Join(" ", equipSetId.GetDescription(), wo.Name);
                 }
             }
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -514,6 +514,7 @@ namespace ACE.Server.Managers
                                                                  "if FALSE, players start with mastery of 1 melee and 1 ranged weapon type based on heritage, and can later re-select these 2 masteries")),
                 ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
                 ("equipmentsetid_enabled", new Property<bool>(false, "enable this to allow adding EquipmentSetIDs to loot armor")),
+                ("equipmentsetid_name_decoration", new Property<bool>(false, "enable this to add the EquipmentSet name to loot armor name")),
                 ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
                 );
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -513,6 +513,7 @@ namespace ACE.Server.Managers
                 ("universal_masteries", new Property<bool>(true, "if TRUE, matches end of retail masteries - players wielding almost any weapon get +5 DR, except if the weapon \"seems tough to master\". " +
                                                                  "if FALSE, players start with mastery of 1 melee and 1 ranged weapon type based on heritage, and can later re-select these 2 masteries")),
                 ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
+                ("equipmentsetid_enabled", new Property<bool>(false, "enable this to allow adding EquipmentSetIDs to loot armor")),
                 ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
                 );
 
@@ -533,6 +534,7 @@ namespace ACE.Server.Managers
                 ("epic_cantrip_drop_rate", new Property<double>(1.0, "Modifier for epic cantrip drop rate, 1 being normal")),
                 ("legendary_cantrip_drop_rate", new Property<double>(1.0, "Modifier for legendary cantrip drop rate, 1 being normal")),
                 ("aetheria_drop_rate", new Property<double>(1.0, "Modifier for Aetheria drop rate, 1 being normal")),
+                ("equipmentsetid_drop_rate", new Property<double>(1.0, "Modifier for EquipmentSetID drop rate, 1 being normal")),
                 ("chess_ai_start_time", new Property<double>(-1.0, "the number of seconds for the chess ai to start. defaults to -1 (disabled)")),
                 ("encounter_delay", new Property<double>(1800, "the number of seconds a generator profile for regions is delayed from returning to free slots")),
                 ("encounter_regen_interval", new Property<double>(600, "the number of seconds a generator for regions at which spawns its next set of objects")),


### PR DESCRIPTION
- Add method to apply a random EquipmentSetID to tier 7 & 8 armor, with a modifiable base line of 10% chance
- Initial introduction controlled via server property, which is set to false by default, allowing server ops to decide for themselves to enable it
- Added option to add Set name to item name
