### PR TITLE
mana conversion mod tweaks

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -509,6 +509,7 @@ namespace ACE.Server.Managers
                 ("require_spell_comps", new Property<bool>(true, "if FALSE spell components are no longer required to be in inventory to cast spells. defaults to enabled, as in retail")),
                 ("salvage_handle_overages", new Property<bool>(false, "in retail, if 2 salvage bags were combined beyond 100 structure, the overages would be lost")),
                 ("show_dot_messages", new Property<bool>(false, "enabled, shows combat messages for DoT damage ticks. defaults to disabled, as in retail")),
+                ("show_mana_conv_bonus_0", new Property<bool>(true, "if disabled, only shows mana conversion bonus if not zero, during appraisal of casting items")),
                 ("smite_uses_takedamage", new Property<bool>(false, "if enabled, smite applies damage via TakeDamage")),
                 ("suicide_instant_death", new Property<bool>(false, "if enabled, @die command kills player instantly. defaults to disabled, as in retail")),
                 ("universal_masteries", new Property<bool>(true, "if TRUE, matches end of retail masteries - players wielding almost any weapon get +5 DR, except if the weapon \"seems tough to master\". " +

--- a/Source/ACE.Server/Network/Enum/ResistMask.cs
+++ b/Source/ACE.Server/Network/Enum/ResistMask.cs
@@ -31,28 +31,33 @@ namespace ACE.Server.Network.Enum
         {
             ResistMask highlightMask = 0;
 
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Slash) != 1.0f)
-                highlightMask |= ResistMask.ResistSlash;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Pierce) != 1.0f)
-                highlightMask |= ResistMask.ResistPierce;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Bludgeon) != 1.0f)
-                highlightMask |= ResistMask.ResistBludgeon;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Fire) != 1.0f)
-                highlightMask |= ResistMask.ResistFire;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Cold) != 1.0f)
-                highlightMask |= ResistMask.ResistCold;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Electric) != 1.0f)
-                highlightMask |= ResistMask.ResistElectric;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Health) != 1.0f)      // ??
-                highlightMask |= ResistMask.ResistHealthBoost;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) != 1.0f)
-                highlightMask |= ResistMask.ResistStaminaDrain;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) != 1.0f)
-                highlightMask |= ResistMask.ResistStaminaBoost;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) != 1.0f)
-                highlightMask |= ResistMask.ResistManaDrain;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) != 1.0f)
-                highlightMask |= ResistMask.ResistManaBoost;
+            if (wielder != null)
+            {
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Slash) != 1.0f)
+                    highlightMask |= ResistMask.ResistSlash;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Pierce) != 1.0f)
+                    highlightMask |= ResistMask.ResistPierce;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Bludgeon) != 1.0f)
+                    highlightMask |= ResistMask.ResistBludgeon;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Fire) != 1.0f)
+                    highlightMask |= ResistMask.ResistFire;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Cold) != 1.0f)
+                    highlightMask |= ResistMask.ResistCold;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Electric) != 1.0f)
+                    highlightMask |= ResistMask.ResistElectric;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Health) != 1.0f)      // ??
+                    highlightMask |= ResistMask.ResistHealthBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) != 1.0f)
+                    highlightMask |= ResistMask.ResistStaminaDrain;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) != 1.0f)
+                    highlightMask |= ResistMask.ResistStaminaBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) != 1.0f)
+                    highlightMask |= ResistMask.ResistManaDrain;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) != 1.0f)
+                    highlightMask |= ResistMask.ResistManaBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Nether) != 1.0f)
+                    highlightMask |= ResistMask.ResistNether;
+            }
 
             // ManaConversionMod and ElementalDamageMod are only needed for weapons
             var manaConversionMod = GetManaConversionMod(wielder, weapon);
@@ -65,8 +70,6 @@ namespace ACE.Server.Network.Enum
             if (elementalDamageMod != 0.0f)
                 highlightMask |= ResistMask.ElementalDamageMod;
 
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Nether) != 1.0f)
-                highlightMask |= ResistMask.ResistNether;
 
             return highlightMask;
         }
@@ -75,28 +78,33 @@ namespace ACE.Server.Network.Enum
         {
             ResistMask colorMask = 0;
 
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Slash) > 1.0f)
-                colorMask |= ResistMask.ResistSlash;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Pierce) > 1.0f)
-                colorMask |= ResistMask.ResistPierce;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Bludgeon) > 1.0f)
-                colorMask |= ResistMask.ResistBludgeon;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Fire) > 1.0f)
-                colorMask |= ResistMask.ResistFire;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Cold) > 1.0f)
-                colorMask |= ResistMask.ResistCold;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Electric) > 1.0f)
-                colorMask |= ResistMask.ResistElectric;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Health) > 1.0f)      // ??
-                colorMask |= ResistMask.ResistHealthBoost;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) > 1.0f)
-                colorMask |= ResistMask.ResistStaminaDrain;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) > 1.0f)
-                colorMask |= ResistMask.ResistStaminaBoost;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) > 1.0f)
-                colorMask |= ResistMask.ResistManaDrain;
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) > 1.0f)
-                colorMask |= ResistMask.ResistManaBoost;
+            if (wielder != null)
+            {
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Slash) > 1.0f)
+                    colorMask |= ResistMask.ResistSlash;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Pierce) > 1.0f)
+                    colorMask |= ResistMask.ResistPierce;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Bludgeon) > 1.0f)
+                    colorMask |= ResistMask.ResistBludgeon;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Fire) > 1.0f)
+                    colorMask |= ResistMask.ResistFire;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Cold) > 1.0f)
+                    colorMask |= ResistMask.ResistCold;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Electric) > 1.0f)
+                    colorMask |= ResistMask.ResistElectric;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Health) > 1.0f)      // ??
+                    colorMask |= ResistMask.ResistHealthBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) > 1.0f)
+                    colorMask |= ResistMask.ResistStaminaDrain;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Stamina) > 1.0f)
+                    colorMask |= ResistMask.ResistStaminaBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) > 1.0f)
+                    colorMask |= ResistMask.ResistManaDrain;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) > 1.0f)
+                    colorMask |= ResistMask.ResistManaBoost;
+                if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Nether) > 1.0f)
+                    colorMask |= ResistMask.ResistNether;
+            }
 
             // ManaConversionMod and ElementalDamageMod are only needed for weapons
             var manaConversionMod = GetManaConversionMod(wielder, weapon);
@@ -108,9 +116,6 @@ namespace ACE.Server.Network.Enum
 
             if (elementalDamageMod > 0.0f)
                 colorMask |= ResistMask.ElementalDamageMod;
-
-            if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Nether) > 1.0f)
-                colorMask |= ResistMask.ResistNether;
 
             return colorMask;
         }

--- a/Source/ACE.Server/Network/Enum/ResistMask.cs
+++ b/Source/ACE.Server/Network/Enum/ResistMask.cs
@@ -117,8 +117,8 @@ namespace ACE.Server.Network.Enum
 
         public static float GetManaConversionMod(WorldObject wielder, WorldObject weapon)
         {
-            var wielderManaConvMod = wielder?.EnchantmentManager.GetManaConvMod() ?? 1.0f;
-            var weaponManaConvMod = weapon?.EnchantmentManager.GetManaConvMod() ?? 1.0f;
+            var wielderManaConvMod = wielder != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetManaConvMod() : 1.0f;
+            var weaponManaConvMod = weapon != null ? weapon.EnchantmentManager.GetManaConvMod() : 1.0f;
 
             var manaConversionMod = wielderManaConvMod * weaponManaConvMod;
 
@@ -127,8 +127,8 @@ namespace ACE.Server.Network.Enum
 
         public static float GetElementalDamageBonus(WorldObject wielder, WorldObject weapon)
         {
-            var wielderElementalDamageMod = wielder?.EnchantmentManager.GetElementalDamageMod() ?? 0.0f;
-            var weaponElementalDamageMod = weapon?.EnchantmentManager.GetElementalDamageMod() ?? 0.0f;
+            var wielderElementalDamageMod = wielder != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetElementalDamageMod() : 0.0f;
+            var weaponElementalDamageMod = weapon != null ? weapon.EnchantmentManager.GetElementalDamageMod() : 0.0f;
 
             var elementalDamageMod = wielderElementalDamageMod + weaponElementalDamageMod;
 

--- a/Source/ACE.Server/Network/Enum/ResistMask.cs
+++ b/Source/ACE.Server/Network/Enum/ResistMask.cs
@@ -53,13 +53,14 @@ namespace ACE.Server.Network.Enum
                 highlightMask |= ResistMask.ResistManaDrain;
             if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) != 1.0f)
                 highlightMask |= ResistMask.ResistManaBoost;
-            if (wielder.EnchantmentManager.GetManaConvMod() != 1.0f)     // only for items?
+
+            // ManaConversionMod and ElementalDamageMod are only needed for weapons
+            var manaConversionMod = GetManaConversionMod(wielder, weapon);
+
+            if (manaConversionMod != 1.0f)
                 highlightMask |= ResistMask.ManaConversionMod;
 
-            var wielderElementalDamageMod = wielder.EnchantmentManager.GetElementalDamageMod();
-            var weaponElementalDamageMod = weapon != null ? weapon.EnchantmentManager.GetElementalDamageMod() : 0.0f;
-
-            var elementalDamageMod = wielderElementalDamageMod + weaponElementalDamageMod;
+            var elementalDamageMod = GetElementalDamageBonus(wielder, weapon);
 
             if (elementalDamageMod != 0.0f)
                 highlightMask |= ResistMask.ElementalDamageMod;
@@ -96,13 +97,14 @@ namespace ACE.Server.Network.Enum
                 colorMask |= ResistMask.ResistManaDrain;
             if (wielder.EnchantmentManager.GetResistanceMod(DamageType.Mana) > 1.0f)
                 colorMask |= ResistMask.ResistManaBoost;
-            if (wielder.EnchantmentManager.GetManaConvMod() > 1.0f)      // only for items?
+
+            // ManaConversionMod and ElementalDamageMod are only needed for weapons
+            var manaConversionMod = GetManaConversionMod(wielder, weapon);
+
+            if (manaConversionMod > 1.0f)
                 colorMask |= ResistMask.ManaConversionMod;
 
-            var wielderElementalDamageMod = wielder.EnchantmentManager.GetElementalDamageMod();
-            var weaponElementalDamageMod = weapon != null ? weapon.EnchantmentManager.GetElementalDamageMod() : 0.0f;
-
-            var elementalDamageMod = wielderElementalDamageMod + weaponElementalDamageMod;
+            var elementalDamageMod = GetElementalDamageBonus(wielder, weapon);
 
             if (elementalDamageMod > 0.0f)
                 colorMask |= ResistMask.ElementalDamageMod;
@@ -111,6 +113,26 @@ namespace ACE.Server.Network.Enum
                 colorMask |= ResistMask.ResistNether;
 
             return colorMask;
+        }
+
+        public static float GetManaConversionMod(WorldObject wielder, WorldObject weapon)
+        {
+            var wielderManaConvMod = wielder?.EnchantmentManager.GetManaConvMod() ?? 1.0f;
+            var weaponManaConvMod = weapon?.EnchantmentManager.GetManaConvMod() ?? 1.0f;
+
+            var manaConversionMod = wielderManaConvMod * weaponManaConvMod;
+
+            return manaConversionMod;
+        }
+
+        public static float GetElementalDamageBonus(WorldObject wielder, WorldObject weapon)
+        {
+            var wielderElementalDamageMod = wielder?.EnchantmentManager.GetElementalDamageMod() ?? 0.0f;
+            var weaponElementalDamageMod = weapon?.EnchantmentManager.GetElementalDamageMod() ?? 0.0f;
+
+            var elementalDamageMod = wielderElementalDamageMod + weaponElementalDamageMod;
+
+            return elementalDamageMod;
         }
     }
 }

--- a/Source/ACE.Server/Network/Enum/ResistMask.cs
+++ b/Source/ACE.Server/Network/Enum/ResistMask.cs
@@ -122,7 +122,7 @@ namespace ACE.Server.Network.Enum
 
         public static float GetManaConversionMod(WorldObject wielder, WorldObject weapon)
         {
-            var wielderManaConvMod = wielder != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetManaConvMod() : 1.0f;
+            var wielderManaConvMod = wielder != null && weapon != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetManaConvMod() : 1.0f;
             var weaponManaConvMod = weapon != null ? weapon.EnchantmentManager.GetManaConvMod() : 1.0f;
 
             var manaConversionMod = wielderManaConvMod * weaponManaConvMod;
@@ -132,7 +132,7 @@ namespace ACE.Server.Network.Enum
 
         public static float GetElementalDamageBonus(WorldObject wielder, WorldObject weapon)
         {
-            var wielderElementalDamageMod = wielder != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetElementalDamageMod() : 0.0f;
+            var wielderElementalDamageMod = wielder != null && weapon != null && weapon.IsEnchantable ? wielder.EnchantmentManager.GetElementalDamageMod() : 0.0f;
             var weaponElementalDamageMod = weapon != null ? weapon.EnchantmentManager.GetElementalDamageMod() : 0.0f;
 
             var elementalDamageMod = wielderElementalDamageMod + weaponElementalDamageMod;

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -355,12 +355,10 @@ namespace ACE.Server.Network.Structure
             if (wo.ItemSkillLimit != null)
                 PropertiesInt[PropertyInt.AppraisalItemSkill] = (int)wo.ItemSkillLimit;
 
-            if (wielder == null || !wo.IsEnchantable) return;
-
             if (PropertiesFloat.ContainsKey(PropertyFloat.WeaponDefense) && !(wo is Missile) && !(wo is Ammunition))
             {
                 var defenseMod = wo.EnchantmentManager.GetDefenseMod();
-                var auraDefenseMod = wo.IsEnchantable ? wielder.EnchantmentManager.GetDefenseMod() : 0.0f;
+                var auraDefenseMod = wielder != null && wo.IsEnchantable ? wielder.EnchantmentManager.GetDefenseMod() : 0.0f;
 
                 PropertiesFloat[PropertyFloat.WeaponDefense] += defenseMod + auraDefenseMod;
             }
@@ -380,8 +378,10 @@ namespace ACE.Server.Network.Structure
                         ResistColor = ResistMaskHelper.GetColorMask(wielder, wo);
                     }
                 }
-                else
+                else if (!PropertyManager.GetBool("show_mana_conv_bonus_0").Item)
+                {
                     PropertiesFloat.Remove(PropertyFloat.ManaConversionMod);
+                }
             }
 
             if (PropertiesFloat.ContainsKey(PropertyFloat.ElementalDamageMod))

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -365,28 +365,32 @@ namespace ACE.Server.Network.Structure
                 PropertiesFloat[PropertyFloat.WeaponDefense] += defenseMod + auraDefenseMod;
             }
 
-            if (PropertiesFloat.ContainsKey(PropertyFloat.ManaConversionMod))
+            if (PropertiesFloat.TryGetValue(PropertyFloat.ManaConversionMod, out var manaConvMod))
             {
-                var manaConvMod = wielder.EnchantmentManager.GetManaConvMod();
-                if (manaConvMod != 1.0f)
+                if (manaConvMod != 0)
                 {
-                    PropertiesFloat[PropertyFloat.ManaConversionMod] *= manaConvMod;
+                    // hermetic link/void
+                    var enchantmentMod = ResistMaskHelper.GetManaConversionMod(wielder, wo);
 
-                    ResistHighlight = ResistMaskHelper.GetHighlightMask(wielder);
-                    ResistColor = ResistMaskHelper.GetColorMask(wielder);
+                    if (enchantmentMod != 1.0f)
+                    {
+                        PropertiesFloat[PropertyFloat.ManaConversionMod] *= enchantmentMod;
+
+                        ResistHighlight = ResistMaskHelper.GetHighlightMask(wielder, wo);
+                        ResistColor = ResistMaskHelper.GetColorMask(wielder, wo);
+                    }
                 }
+                else
+                    PropertiesFloat.Remove(PropertyFloat.ManaConversionMod);
             }
 
             if (PropertiesFloat.ContainsKey(PropertyFloat.ElementalDamageMod))
             {
-                var weaponEnchantments = wo.EnchantmentManager.GetElementalDamageMod();
-                var wielderEnchantments = wielder.EnchantmentManager.GetElementalDamageMod();
+                var enchantmentBonus = ResistMaskHelper.GetElementalDamageBonus(wielder, wo);
 
-                var enchantments = weaponEnchantments + wielderEnchantments;
-
-                if (enchantments != 0)
+                if (enchantmentBonus != 0)
                 {
-                    PropertiesFloat[PropertyFloat.ElementalDamageMod] += enchantments;
+                    PropertiesFloat[PropertyFloat.ElementalDamageMod] += enchantmentBonus;
 
                     ResistHighlight = ResistMaskHelper.GetHighlightMask(wielder, wo);
                     ResistColor = ResistMaskHelper.GetColorMask(wielder, wo);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -158,7 +158,27 @@ namespace ACE.Server.WorldObjects
             if (weapon == null)
                 return defaultModifier;
 
-            return defaultModifier + (float)(weapon.ManaConversionMod ?? 0.0f) * wielder.EnchantmentManager.GetManaConvMod();
+            if (wielder.CombatMode != CombatMode.NonCombat)
+            {
+                // hermetic link / void
+
+                // base mod starts at 0
+                var baseMod = (float)(weapon.ManaConversionMod ?? 0.0f);
+
+                // enchantments are multiplicative, so they are only effective if there is a base mod
+                var manaConvMod = weapon.EnchantmentManager.GetManaConvMod();
+
+                var auraManaConvMod = 1.0f;
+
+                if (weapon.IsEnchantable)
+                    auraManaConvMod = wielder?.EnchantmentManager.GetManaConvMod() ?? 1.0f;
+
+                var enchantmentMod = manaConvMod * auraManaConvMod;
+
+                return 1.0f + baseMod * enchantmentMod;
+            }
+
+            return defaultModifier;
         }
 
         private const uint defaultSpeed = 40;   // TODO: find default speed


### PR DESCRIPTION
The main purpose of this patch was to fix a bug where appraisal was showing Mana Conversion Bonus: +0% for a many casting items

At first I thought this was a bug in the loot generator, but after discussing it with @harliq, it turns out there are actually many casting items with base weenies that have PropertyFloat.ManaConversionMod=0 in the data

So to account for this, Appraisal is now checking if ManaConversionMod exists, but is 0, it removes it.

I also noticed some possible bugs with Hermetic Void, which sounds like it is cast on the wand, similar to the other item debuffs. The logic for ManaConversionMod enchantments should be taking both auras and spells cast directly on the item into account for this.

Update: it has been discovered from retail pcaps that retail also had this bug.

Retail also didn't normalize ManaConversionMod on the items -- some of the base weenies have 0, some of them have null. The retail pcaps had ManaConversionMod=0 in many instances (even while unbuffed), but there were also a few rare instances of ManaConversionMod not being sent.

The 'show_mana_conv_bonus_0' server option has been added, which defaults to true to match retail behavior.