### PR TITLE
additional check for verify-skill

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
@@ -228,7 +228,24 @@ namespace ACE.Server.Command.Handlers
 
                     var sac = (SkillAdvancementClass)skill.SAC;
                     if (sac < SkillAdvancementClass.Trained)
+                    {
+                        if (skill.PP > 0 || skill.LevelFromPP > 0)
+                        {
+                            Console.WriteLine($"{player.Name} has {sac} skill {(Skill)skill.Type} with {skill.PP:N0} xp (rank {skill.LevelFromPP})");
+                            foundIssues = true;
+
+                            if (fix)
+                            {
+                                // i have found no instances of this situation being run into,
+                                // but if it does happen, verify-xp will refund the player xp properly
+                                skill.PP = 0;
+                                skill.LevelFromPP = 0;
+
+                                updated = true;
+                            }
+                        }
                         continue;
+                    }
 
                     // verify skill rank
                     var correctRank = Player.CalcSkillRank(sac, skill.PP);


### PR DESCRIPTION
Adding this check just for completeness

I ran this additional check on the ce shard, and it found no instances of players having untrained skills where xp/ranks > 0