### PR TITLE
Support FirstEnterWorldDone on Players

### DIFF
--- a/Database/Updates/Shard/2019-12-13-00-Remove-All-FirstEnterWorldDone.sql
+++ b/Database/Updates/Shard/2019-12-13-00-Remove-All-FirstEnterWorldDone.sql
@@ -1,0 +1,4 @@
+USE `ace_shard`;
+
+DELETE FROM biota_properties_bool
+WHERE id > 0 AND `type` = 106;

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -139,6 +139,7 @@ namespace ACE.Entity.Enum.Properties
         [SendOnLogin]
         ActdReceivedItems                = 104,
         Unknown105                       = 105,
+        [Ephemeral]
         FirstEnterWorldDone              = 106,
         RecallsDisabled                  = 107,
         RareUsesTimer                    = 108,

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -1,9 +1,10 @@
-using System;
 using System.Collections.Generic;
 
 using ACE.Common.Extensions;
 using ACE.Entity.Enum;
 using ACE.Server.Network.Enum;
+
+using log4net;
 
 namespace ACE.Server.Network.GameAction.Actions
 {
@@ -16,9 +17,17 @@ namespace ACE.Server.Network.GameAction.Actions
 
     public static class GameActionSetCharacterOptions
     {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         [GameAction(GameActionType.SetCharacterOptions)]
         public static void Handle(ClientMessage message, Session session)
         {
+            if (!session.Player.FirstEnterWorldDone)
+            {
+                log.Warn($"{session.Player.Name} sent GameAction 0x1A1 - SetCharacterOptions before FirstEnterWorldDone, ignoring...");
+                return;
+            }
+
             int characterOptions1Flag;
             int characterOptions2Flag = 0;
             uint spellbookFilters = 0;

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionSetCharacterOptions.cs
@@ -24,6 +24,12 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             if (!session.Player.FirstEnterWorldDone)
             {
+                // if a player is stuck in pink bubble state during login,
+                // and they press the 'logout' button before first entering world,
+                // their client will have not registered their character options from the server yet,
+                // and their client will send the default character options upon clicking the logout button,
+                // overwriting their custom options on the server with the defaults. this code avoids that situation
+
                 log.Warn($"{session.Player.Name} sent GameAction 0x1A1 - SetCharacterOptions before FirstEnterWorldDone, ignoring...");
                 return;
             }

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -108,6 +108,8 @@ namespace ACE.Server.WorldObjects
             // This should be handled automatically...
             //PositionFlags |= PositionFlags.OrientationHasNoX | PositionFlags.OrientationHasNoY | PositionFlags.IsGrounded | PositionFlags.HasPlacementID;
 
+            FirstEnterWorldDone = false;
+
             SetStance(MotionStance.NonCombat, false);
 
             // radius for object updates

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2460,7 +2460,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// <para>Used to mark when EnterWorld has completed for first time for this objects instance.</para>
+        /// <para>Used to mark when EnterWorld has completed for first time for this object's instance.</para>
         /// Currently used by Generators and Players
         /// </summary>
         public bool FirstEnterWorldDone

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2460,6 +2460,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// <para>Used to mark when EnterWorld has completed for first time for this objects instance.</para>
         /// Currently used by Generators and Players
         /// </summary>
         public bool FirstEnterWorldDone


### PR DESCRIPTION
* Switch `FirstEnterWorldDone` to ephemeral property
* Add SQL script to remove all `FirstEnterWorldDone` properties from shard DB
* Set FirstEnterWorldDone to false in Player ctor if previous script is not run
* Existing code already sets to true appropriately, when client reports a successfully completed login.
* Add a check in GameActionSetCharacterOptions for FirstEnterWorldDone being completed before processing and persisting.