### PR TITLE
fix CharacterOption to match acclient PlayerOption ordering

### DIFF
--- a/Source/ACE.Entity/Enum/CharacterOption.cs
+++ b/Source/ACE.Entity/Enum/CharacterOption.cs
@@ -13,163 +13,164 @@ namespace ACE.Entity.Enum
     public enum CharacterOption
     {
         [CharacterOptions1(CharacterOptions1.AutoRepeatAttacks)]
-        AutoRepeatAttacks                       = 0,
+        AutoRepeatAttacks                       = 0x00, // AutoRepeatAttack_PlayerOption
 
         [CharacterOptions1(CharacterOptions1.IgnoreAllegianceRequests)]
-        IgnoreAllegianceRequests                = 1,
+        IgnoreAllegianceRequests                = 0x01, // IgnoreAllegianceRequests_PlayerOption
 
         [CharacterOptions1(CharacterOptions1.IgnoreFellowshipRequests)]
-        IgnoreFellowshipRequests                = 2,
-
-        [CharacterOptions1(CharacterOptions1.ShareFellowshipExpAndLuminance)]
-        ShareFellowshipExpAndLuminance          = 15,
-
-        [CharacterOptions1(CharacterOptions1.AcceptCorpseLootingPermissions)]
-        AcceptCorpseLootingPermissions          = 16,
-
-        [CharacterOptions1(CharacterOptions1.ShareFellowshipLoot)]
-        ShareFellowshipLoot                     = 17,
-
-        [CharacterOptions1(CharacterOptions1.AutomaticallyAcceptFellowshipRequests)]
-        AutomaticallyAcceptFellowshipRequests   = 18,
-
-        [CharacterOptions1(CharacterOptions1.UseChargeAttack)]
-        UseChargeAttack                         = 25,
-
-        [CharacterOptions1(CharacterOptions1.ListenToAllegianceChat)]
-        ListenToAllegianceChat                  = 27,        
-
-        [CharacterOptions2(CharacterOptions2.ListenToGeneralChat)]
-        ListenToGeneralChat                     = 35,
-
-        [CharacterOptions2(CharacterOptions2.ListenToTradeChat)]
-        ListenToTradeChat                       = 36,
-
-        [CharacterOptions2(CharacterOptions2.ListenToLFGChat)]
-        ListenToLFGChat                         = 37,
-
-        [CharacterOptions2(CharacterOptions2.ListentoRoleplayChat)]
-        ListentoRoleplayChat                    = 38,
-
-        [CharacterOptions2(CharacterOptions2.AppearOffline)]
-        AppearOffline                           = 39,
-
-        [CharacterOptions2(CharacterOptions2.LeadMissileTargets)]
-        LeadMissileTargets                      = 42,
-
-        [CharacterOptions2(CharacterOptions2.UseFastMissiles)]
-        UseFastMissiles                         = 43,
-
-        [CharacterOptions2(CharacterOptions2.ListenToSocietyChat)]
-        ListenToSocietyChat                     = 46,
-
-        [CharacterOptions2(CharacterOptions2.ShowYourHelmOrHeadGear)]
-        ShowYourHelmOrHeadGear                  = 47,
-
-        [CharacterOptions2(CharacterOptions2.ShowYourCloak)]
-        ShowYourCloak                           = 50,
-
-        [CharacterOptions2(CharacterOptions2.LockUI)]
-        LockUI = 51,
-
-        [CharacterOptions2(CharacterOptions2.ListenToPKDeathMessages)]
-        ListenToPKDeathMessages                 = 52,
-
-        [CharacterOptions1(CharacterOptions1.KeepCombatTargetsInView)]
-        KeepCombatTargetsInView,
-
-        [CharacterOptions1(CharacterOptions1.LetOtherPlayersGiveYouItems)]
-        LetOtherPlayersGiveYouItems,
-
-        [CharacterOptions1(CharacterOptions1.Display3dTooltips)]
-        Display3dTooltips,
-
-        [CharacterOptions1(CharacterOptions1.AttemptToDeceiveOtherPlayers)]
-        AttemptToDeceiveOtherPlayers,
-
-        [CharacterOptions1(CharacterOptions1.RunAsDefaultMovement)]
-        RunAsDefaultMovement,
-
-        [CharacterOptions1(CharacterOptions1.StayInChatModeAfterSendingMessage)]
-        StayInChatModeAfterSendingMessage,
-
-        [CharacterOptions1(CharacterOptions1.AdvancedCombatInterface)]
-        AdvancedCombatInterface,
-
-        [CharacterOptions1(CharacterOptions1.AutoTarget)]
-        AutoTarget,
-
-        [CharacterOptions1(CharacterOptions1.VividTargetingIndicator)]
-        VividTargetingIndicator,
-
-        [CharacterOptions1(CharacterOptions1.DisableMostWeatherEffects)]
-        DisableMostWeatherEffects,
+        IgnoreFellowshipRequests                = 0x02, // IgnoreFellowshipRequests_PlayerOption
 
         [CharacterOptions1(CharacterOptions1.IgnoreAllTradeRequests)]
-        IgnoreAllTradeRequests,
+        IgnoreAllTradeRequests                  = 0x03, // IgnoreTradeRequests_PlayerOption
 
-        [CharacterOptions1(CharacterOptions1.SideBySideVitals)]
-        SideBySideVitals,
-
-        [CharacterOptions1(CharacterOptions1.ShowCoordinatesByTheRadar)]
-        ShowCoordinatesByTheRadar,
-
-        [CharacterOptions1(CharacterOptions1.DisplaySpellDurations)]
-        DisplaySpellDurations,
-
-        [CharacterOptions1(CharacterOptions1.DisableHouseRestrictionEffects)]
-        DisableHouseRestrictionEffects,
-
-        [CharacterOptions1(CharacterOptions1.DragItemToPlayerOpensTrade)]
-        DragItemToPlayerOpensTrade,
-
-        [CharacterOptions1(CharacterOptions1.ShowAllegianceLogons)]
-        ShowAllegianceLogons,
-
-        [CharacterOptions1(CharacterOptions1.UseCraftingChanceOfSuccessDialog)]
-        UseCraftingChanceOfSuccessDialog,
+        [CharacterOptions1(CharacterOptions1.DisableMostWeatherEffects)]
+        DisableMostWeatherEffects               = 0x04, // DisableMostWeatherEffects_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.AlwaysDaylightOutdoors)]
-        AlwaysDaylightOutdoors,
+        AlwaysDaylightOutdoors                  = 0x05, // PersistentAtDay_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.LetOtherPlayersGiveYouItems)]
+        LetOtherPlayersGiveYouItems             = 0x06, // AllowGive_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.KeepCombatTargetsInView)]
+        KeepCombatTargetsInView                 = 0x07, // ViewCombatTarget_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.Display3dTooltips)]
+        Display3dTooltips                       = 0x08, // ShowTooltips_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.AttemptToDeceiveOtherPlayers)]
+        AttemptToDeceiveOtherPlayers            = 0x09, // UseDeception_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.RunAsDefaultMovement)]
+        RunAsDefaultMovement                    = 0x0A, // ToggleRun_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.StayInChatModeAfterSendingMessage)]
+        StayInChatModeAfterSendingMessage       = 0x0B, // StayInChatMode_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.AdvancedCombatInterface)]
+        AdvancedCombatInterface                 = 0x0C, // AdvancedCombatUI_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.AutoTarget)]
+        AutoTarget                              = 0x0D, // AutoTarget_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.VividTargetingIndicator)]
+        VividTargetingIndicator                 = 0x0E, // VividTargetingIndicator_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.ShareFellowshipExpAndLuminance)]
+        ShareFellowshipExpAndLuminance          = 0x0F, // FellowshipShareXP_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.AcceptCorpseLootingPermissions)]
+        AcceptCorpseLootingPermissions          = 0x10, // AcceptLootPermits_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.ShareFellowshipLoot)]
+        ShareFellowshipLoot                     = 0x11, // FellowshipShareLoot_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.AutomaticallyAcceptFellowshipRequests)]
+        AutomaticallyAcceptFellowshipRequests   = 0x12, // FellowshipAutoAcceptRequests_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.SideBySideVitals)]
+        SideBySideVitals                        = 0x13, // SideBySideVitals_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.ShowCoordinatesByTheRadar)]
+        ShowCoordinatesByTheRadar               = 0x14, // CoordinatesOnRadar_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.DisplaySpellDurations)]
+        DisplaySpellDurations                   = 0x15, // SpellDuration_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.DisableHouseRestrictionEffects)]
+        DisableHouseRestrictionEffects          = 0x16, // DisableHouseRestrictionEffects_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.DragItemToPlayerOpensTrade)]
+        DragItemToPlayerOpensTrade              = 0x17, // DragItemOnPlayerOpensSecureTrade_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.ShowAllegianceLogons)]
+        ShowAllegianceLogons                    = 0x18, // DisplayAllegianceLogonNotifications_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.UseChargeAttack)]
+        UseChargeAttack                         = 0x19, // UseChargeAttack_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.UseCraftingChanceOfSuccessDialog)]
+        UseCraftingChanceOfSuccessDialog        = 0x1A, // UseCraftSuccessDialog_PlayerOption
+
+        [CharacterOptions1(CharacterOptions1.ListenToAllegianceChat)]
+        ListenToAllegianceChat                  = 0x1B, // HearAllegianceChat_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourDateOfBirth)]
-        AllowOthersToSeeYourDateOfBirth,
-
-        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourChessRank)]
-        AllowOthersToSeeYourChessRank,
-
-        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourFishingSkill)]
-        AllowOthersToSeeYourFishingSkill,
-
-        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourNumberOfDeaths)]
-        AllowOthersToSeeYourNumberOfDeaths,
+        AllowOthersToSeeYourDateOfBirth         = 0x1C, // DisplayDateOfBirth_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourAge)]
-        AllowOthersToSeeYourAge,
+        AllowOthersToSeeYourAge                 = 0x1D, // DisplayAge_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourChessRank)]
+        AllowOthersToSeeYourChessRank           = 0x1E, // DisplayChessRank_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourFishingSkill)]
+        AllowOthersToSeeYourFishingSkill        = 0x1F, // DisplayFishingSkill_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourNumberOfDeaths)]
+        AllowOthersToSeeYourNumberOfDeaths      = 0x20, // DisplayNumberDeaths_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.DisplayTimestamps)]
-        DisplayTimestamps,
+        DisplayTimestamps                       = 0x21, // DisplayTimeStamps_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.SalvageMultipleMaterialsAtOnce)]
-        SalvageMultipleMaterialsAtOnce,
+        SalvageMultipleMaterialsAtOnce          = 0x22, // SalvageMultiple_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListenToGeneralChat)]
+        ListenToGeneralChat                     = 0x23, // HearGeneralChat_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListenToTradeChat)]
+        ListenToTradeChat                       = 0x24, // HearTradeChat_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListenToLFGChat)]
+        ListenToLFGChat                         = 0x25, // HearLFGChat_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListentoRoleplayChat)]
+        ListentoRoleplayChat                    = 0x26, // HearRoleplayChat_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.AppearOffline)]
+        AppearOffline                           = 0x27, // AppearOffline_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.AllowOthersToSeeYourNumberOfTitles)]
-        AllowOthersToSeeYourNumberOfTitles,
+        AllowOthersToSeeYourNumberOfTitles      = 0x28, // DisplayNumberCharacterTitles_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.UseMainPackAsDefaultForPickingUpItems)]
-        UseMainPackAsDefaultForPickingUpItems,
+        UseMainPackAsDefaultForPickingUpItems   = 0x29, // MainPackPreferred_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.LeadMissileTargets)]
+        LeadMissileTargets                      = 0x2A, // LeadMissileTargets_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.UseFastMissiles)]
+        UseFastMissiles                         = 0x2B, // UseFastMissiles_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.FilterLanguage)]
-        FilterLanguage,
+        FilterLanguage                          = 0x2C, // FilterLanguage_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.ConfirmUseOfRareGems)]
-        ConfirmUseOfRareGems,
+        ConfirmUseOfRareGems                    = 0x2D, // ConfirmVolatileRareUse_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListenToSocietyChat)]
+        ListenToSocietyChat                     = 0x2E, // HearSocietyChat_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ShowYourHelmOrHeadGear)]
+        ShowYourHelmOrHeadGear                  = 0x2F, // ShowHelm_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.DisableDistanceFog)]
-        DisableDistanceFog,
+        DisableDistanceFog                      = 0x30, // DisableDistanceFog_PlayerOption
 
         [CharacterOptions2(CharacterOptions2.UseMouseTurning)]
-        UseMouseTurning
+        UseMouseTurning                         = 0x31, // UseMouseTurning_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ShowYourCloak)]
+        ShowYourCloak                           = 0x32, // ShowCloak_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.LockUI)]
+        LockUI                                  = 0x33, // LockUI_PlayerOption
+
+        [CharacterOptions2(CharacterOptions2.ListenToPKDeathMessages)]
+        ListenToPKDeathMessages                 = 0x34, // HearPKDeath_PlayerOption
+
     }
 
     public static class CharacterOptionExtensions


### PR DESCRIPTION
This is an update from Yonneh, to fix an issue with decal plugins calling GameAction 5 - SetSingleCharacterOption for various options

Whoever originally wrote CharacterOption did not match up the names and ordering of this enum with PlayerOption in acclient. It looks like they started to, but then jumped around to use the ordering in the UI options display, and did not properly set all of the # values.

I have verified that this fix does not break any of the existing character options / db ordering in ace