### PR TITLE
backporting support functions from 1991

### DIFF
--- a/Source/ACE.Server/Entity/CastSpellParams.cs
+++ b/Source/ACE.Server/Entity/CastSpellParams.cs
@@ -1,3 +1,4 @@
+using ACE.Entity.Enum;
 using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Entity
@@ -10,6 +11,8 @@ namespace ACE.Server.Entity
         public uint ManaUsed { get; set; }
         public WorldObject Target { get; set; }
         public Player.CastingPreCheckStatus Status { get; set; }
+
+        public bool HasWindupGestures => !Spell.Flags.HasFlag(SpellFlags.FastCast) && !IsWeaponSpell && Spell.Formula.HasWindupGestures;
 
         public CastSpellParams(Spell spell, bool isWeaponSpell, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
         {

--- a/Source/ACE.Server/Entity/SpellFormula.cs
+++ b/Source/ACE.Server/Entity/SpellFormula.cs
@@ -236,6 +236,8 @@ namespace ACE.Server.Entity
             }
         }
 
+        public bool HasWindupGestures => Scarabs.Any(i => i != Scarab.Lead);
+
         /// <summary>
         /// Returns the spell casting gesture, after the initial windup(s) are completed
         /// Based on the talisman (assumed to be the last spell component)

--- a/Source/ACE.Server/Entity/SpellProjectileInfo.cs
+++ b/Source/ACE.Server/Entity/SpellProjectileInfo.cs
@@ -1,0 +1,56 @@
+using System.Numerics;
+using ACE.Entity;
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    public class SpellProjectileInfo
+    {
+        public SpellProjectile SpellProjectile;
+
+        public Position CasterPos;
+        public Position TargetPos;
+
+        public Vector3? CachedVelocity;
+
+        public Physics.Common.Position StartPos;
+
+        public SpellProjectileInfo(SpellProjectile spellProjectile)
+        {
+            var caster = spellProjectile.ProjectileSource;
+            var target = spellProjectile.ProjectileTarget;
+
+            SpellProjectile = spellProjectile;
+
+            if (caster?.Location != null)
+                CasterPos = new Position(caster.Location);
+
+            if (target?.Location != null)
+                TargetPos = new Position(target.Location);
+
+            if (spellProjectile.PhysicsObj.Position != null)
+                StartPos = new Physics.Common.Position(spellProjectile.PhysicsObj.Position);
+
+            CachedVelocity = target?.PhysicsObj.CachedVelocity;
+        }
+
+        public override string ToString()
+        {
+            var caster = SpellProjectile.ProjectileSource;
+            var target = SpellProjectile.ProjectileTarget;
+
+            var info = $"Caster: {caster.Name} ({caster.Guid})\n";
+            info += $"CasterPos: {CasterPos.ToLOCString()}\n";
+            info += $"Spell: {SpellProjectile.Spell.Id} - {SpellProjectile.Spell.Name}\n";
+            info += $"Velocity: {SpellProjectile.Velocity}\n";
+            info += $"CachedVelocity: {CachedVelocity}\n";
+            info += $"StartPos: {SpellProjectile.SpawnPos.ToLOCString()}\n";
+            info += $"ActualStartPos: {StartPos}\n";
+            info += $"EndPos: {SpellProjectile.Location.ToLOCString()}\n";
+            info += $"Target: {target.WeenieClassId} - {target.Name} ({target.Guid})\n";
+            info += $"TargetPos: {TargetPos.ToLOCString()}";
+
+            return info;
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionAutonomousPosition.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionAutonomousPosition.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Network.GameAction.Actions
         [GameAction(GameActionType.AutonomousPosition)]
         public static void Handle(ClientMessage message, Session session)
         {
-            //Console.WriteLine("AutonomousPosition");
+            //Console.WriteLine($"{session.Player.Name}.AutoPos");
 
             var position = new Position(message.Payload);
 

--- a/Source/ACE.Server/Network/Motion/MotionItem.cs
+++ b/Source/ACE.Server/Network/Motion/MotionItem.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+
 using ACE.Entity.Enum;
 using ACE.Server.Network.Sequence;
 using ACE.Server.WorldObjects;
@@ -44,6 +46,17 @@ namespace ACE.Server.Network.Structure
             ServerActionSequence = (ushort)(PackedSequence & 0x7FFF);
             IsAutonomous = (PackedSequence >> 15) == 1;
             Speed = reader.ReadSingle();
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"MotionCommand: {MotionCommand}");
+            sb.AppendLine($"IsAutonomous: {IsAutonomous}");
+            sb.AppendLine($"Speed: {Speed}");
+
+            return sb.ToString();
         }
     }
 

--- a/Source/ACE.Server/Network/Motion/MovementData.cs
+++ b/Source/ACE.Server/Network/Motion/MovementData.cs
@@ -137,6 +137,10 @@ namespace ACE.Server.Network.Structure
                 interpState.TurnCommand = MotionCommand.TurnRight;
                 interpState.TurnSpeed = holdKey == HoldKey.Run ? 1.5f : 1.0f;
 
+                // mouselook
+                if (rawState.TurnSpeed != 0 && rawState.TurnSpeed <= 1.5f)
+                    interpState.TurnSpeed = rawState.TurnSpeed;
+
                 if (rawState.TurnCommand == MotionCommand.TurnLeft)
                     interpState.TurnSpeed *= -1;
             }

--- a/Source/ACE.Server/Network/Motion/RawMotionState.cs
+++ b/Source/ACE.Server/Network/Motion/RawMotionState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
@@ -13,13 +14,15 @@ namespace ACE.Server.Network.Structure
     /// </summary>
     public class RawMotionState
     {
+        public static RawMotionState None = new RawMotionState();
+
         public MoveToState MoveToState;
 
         public uint PackedFlags;
 
         public RawMotionFlags Flags;        // stored as the first 11 bits of PackedFlags
-        public ushort CommandListLength;    // starts at bit 12 of PackedFlags 
-                                            
+        public ushort CommandListLength;    // starts at bit 12 of PackedFlags
+
         // choose valid sections by masking against Flags
         public HoldKey CurrentHoldKey;          // 0x1 - walk/run
         public MotionStance CurrentStyle;       // 0x2 - current stance
@@ -32,11 +35,13 @@ namespace ACE.Server.Network.Structure
         public MotionCommand TurnCommand;       // 0x100 - turn command - this is always sent as 1 direction in RawMotion,
                                                 // with a negative speed for the opposite direction. A negative speed
                                                 // is then in turn translated to the opposite Motion in InterpretedMotionState.
-        public uint TurnHoldKey;                // 0x200 - whether turn key is being held, or mouselook in progress
+        public HoldKey TurnHoldKey;             // 0x200 - whether turn key is being held, or mouselook in progress
         public float TurnSpeed;                 // 0x400 - turn movement speed - somewhat static
 
         // commands: list of length commandListLength
         public List<MotionItem> Commands;
+
+        public RawMotionState() { }
 
         public RawMotionState(MoveToState moveToState, BinaryReader reader)
         {
@@ -68,7 +73,7 @@ namespace ACE.Server.Network.Structure
             if ((Flags & RawMotionFlags.TurnCommand) != 0)
                 TurnCommand = (MotionCommand)reader.ReadUInt32();
             if ((Flags & RawMotionFlags.TurnHoldKey) != 0)
-                TurnHoldKey = reader.ReadUInt32();
+                TurnHoldKey = (HoldKey)reader.ReadUInt32();
             if ((Flags & RawMotionFlags.TurnSpeed) != 0)
                 TurnSpeed = reader.ReadSingle();
 
@@ -78,6 +83,58 @@ namespace ACE.Server.Network.Structure
                 for (var i = 0; i < CommandListLength; i++)
                     Commands.Add(new MotionItem(moveToState.WorldObject, reader));
             }
+        }
+
+        public string ToString(bool showFlags)
+        {
+            var sb = new StringBuilder();
+
+            if (showFlags)
+                sb.AppendLine($"Flags: {Flags}");
+
+            if ((Flags & RawMotionFlags.CurrentHoldKey) != 0)
+                sb.AppendLine($"CurrentHoldKey: {CurrentHoldKey}");
+            if ((Flags & RawMotionFlags.CurrentStyle) != 0)
+                sb.AppendLine($"CurrentStyle: {CurrentStyle}");
+            if ((Flags & RawMotionFlags.ForwardCommand) != 0)
+                sb.AppendLine($"ForwardCommand: {ForwardCommand}");
+            if ((Flags & RawMotionFlags.ForwardHoldKey) != 0)
+                sb.AppendLine($"ForwardHoldKey: {ForwardHoldKey}");
+            if ((Flags & RawMotionFlags.ForwardSpeed) != 0)
+                sb.AppendLine($"ForwardSpeed: {ForwardSpeed}");
+            if ((Flags & RawMotionFlags.SideStepCommand) != 0)
+                sb.AppendLine($"SidestepCommand: {SidestepCommand}");
+            if ((Flags & RawMotionFlags.SideStepHoldKey) != 0)
+                sb.AppendLine($"SidestepHoldKey: {SidestepHoldKey}");
+            if ((Flags & RawMotionFlags.SideStepSpeed) != 0)
+                sb.AppendLine($"SidestepSpeed: {SidestepSpeed}");
+            if ((Flags & RawMotionFlags.TurnCommand) != 0)
+                sb.AppendLine($"TurnCommand: {TurnCommand}");
+            if ((Flags & RawMotionFlags.TurnHoldKey) != 0)
+                sb.AppendLine($"TurnHoldKey: {TurnHoldKey}");
+            if ((Flags & RawMotionFlags.TurnSpeed) != 0)
+                sb.AppendLine($"TurnSpeed: {TurnSpeed}");
+
+            if (CommandListLength > 0)
+            {
+                sb.AppendLine($"CommandListLength: {CommandListLength}");
+                foreach (var command in Commands)
+                    sb.Append(command);
+            }
+
+            sb.AppendLine("---");
+
+            return sb.ToString();
+        }
+
+        public override string ToString()
+        {
+            return ToString(true);
+        }
+
+        public bool HasMovement()
+        {
+            return (Flags & (RawMotionFlags.ForwardCommand | RawMotionFlags.TurnCommand | RawMotionFlags.SideStepCommand)) != 0;
         }
 
         public bool HasSoulEmote()

--- a/Source/ACE.Server/Physics/Animation/InterpretedMotionState.cs
+++ b/Source/ACE.Server/Physics/Animation/InterpretedMotionState.cs
@@ -124,5 +124,11 @@ namespace ACE.Server.Physics.Animation
                     break;
             }
         }
+
+        public bool HasCommands()
+        {
+            //return ForwardCommand != 0 && ForwardCommand != (uint)MotionCommand.Ready || SideStepCommand != 0 || TurnCommand != 0;
+            return SideStepCommand != 0 || TurnCommand != 0;
+        }
     }
 }

--- a/Source/ACE.Server/Physics/Animation/MotionInterp.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionInterp.cs
@@ -645,7 +645,7 @@ namespace ACE.Server.Physics.Animation
                 return 10.0f;
 
             float vz = extent;
-            if (WeenieObj.InqJumpVelocity(extent, ref vz))
+            if (WeenieObj.InqJumpVelocity(extent, out vz))
                 return vz;
 
             return 0.0f;
@@ -656,8 +656,8 @@ namespace ACE.Server.Physics.Animation
             var velocity = get_state_velocity();
             velocity.Z = get_jump_v_z();
 
-            if (!velocity.Equals(Vector3.Zero))
-                velocity = PhysicsObj.Position.GlobalToLocalVec(velocity);
+            if (Vec.IsZero(velocity))
+                velocity = PhysicsObj.Position.GlobalToLocalVec(PhysicsObj.Velocity);
 
             return velocity;
         }

--- a/Source/ACE.Server/Physics/Animation/MovementSystem.cs
+++ b/Source/ACE.Server/Physics/Animation/MovementSystem.cs
@@ -7,8 +7,7 @@ namespace ACE.Server.Physics.Animation
     {
         public static float GetJumpHeight(float burden, uint jumpSkill, float power, float scaling)
         {
-            if (power < 0.0f) power = 0.0f;
-            if (power > 1.0f) power = 1.0f;
+            power = Math.Clamp(power, 0.0f, 1.0f);
 
             var result = EncumbranceSystem.GetBurdenMod(burden) * (jumpSkill / (jumpSkill + 1300.0f) * 22.2f + 0.05f) * power / scaling;
 

--- a/Source/ACE.Server/Physics/Animation/RawMotionState.cs
+++ b/Source/ACE.Server/Physics/Animation/RawMotionState.cs
@@ -114,6 +114,31 @@ namespace ACE.Server.Physics.Animation
             TurnSpeed = 1.0f;
         }
 
+        public void SetState(Network.Structure.RawMotionState state)
+        {
+            CurrentHoldKey = state.CurrentHoldKey;
+            CurrentStyle = (uint)state.CurrentStyle;
+            if (CurrentStyle == 0)
+                CurrentStyle = (uint)MotionCommand.NonCombat;
+            ForwardCommand = (uint)state.ForwardCommand;
+            if (ForwardCommand == 0)
+                ForwardCommand = (uint)MotionCommand.Ready;
+            ForwardHoldKey = state.ForwardHoldKey;
+            ForwardSpeed = state.ForwardSpeed;      // todo: verifications
+            if (ForwardSpeed == 0)
+                ForwardSpeed = 1.0f;
+            SideStepCommand = (uint)state.SidestepCommand;
+            SideStepHoldKey = state.SidestepHoldKey;
+            SideStepSpeed = state.SidestepSpeed;
+            if (SideStepSpeed == 0)
+                SideStepSpeed = 1.0f;
+            TurnCommand = (uint)state.TurnCommand;
+            TurnHoldKey = state.TurnHoldKey;
+            TurnSpeed = state.TurnSpeed;
+            if (TurnSpeed == 0)
+                TurnSpeed = 1.0f;
+        }
+
         public uint RemoveAction()
         {
             if (Actions.Count == 0)

--- a/Source/ACE.Server/Physics/Animation/Sequence.cs
+++ b/Source/ACE.Server/Physics/Animation/Sequence.cs
@@ -22,6 +22,35 @@ namespace ACE.Server.Physics.Animation
         public int PlacementFrameID;
         public bool IsTrivial;
 
+        public static HashSet<uint> PlayerIdleAnims;
+
+        static Sequence()
+        {
+            PlayerIdleAnims = new HashSet<uint>();
+            PlayerIdleAnims.Add(0x03000001);    // NonCombat
+            PlayerIdleAnims.Add(0x0300049E);    // AtlatlCombat
+            PlayerIdleAnims.Add(0x0300045A);    // BowCombat
+            PlayerIdleAnims.Add(0x03000474);    // CrossbowCombat
+            PlayerIdleAnims.Add(0x03000CA8);    // DualWieldCombat
+            PlayerIdleAnims.Add(0x03000448);    // HandCombat
+            PlayerIdleAnims.Add(0x0300076C);    // Magic
+            PlayerIdleAnims.Add(0x0300043D);    // SwordCombat
+            PlayerIdleAnims.Add(0x03000426);    // SwordShieldCombat
+            PlayerIdleAnims.Add(0x030008DF);    // ThrownShieldCombat
+            PlayerIdleAnims.Add(0x0300049E);    // ThrownWeaponCombat
+            PlayerIdleAnims.Add(0x03000B05);    // TwoHandedSwordCombat
+        }
+
+        public bool is_idle_anim()
+        {
+            return CurrAnim == null || PlayerIdleAnims.Contains(CurrAnim.Value.Anim.ID);
+        }
+
+        public bool is_first_cyclic()
+        {
+            return CurrAnim == null || CurrAnim.Equals(FirstCyclic);
+        }
+
         public Sequence()
         {
             Init();

--- a/Source/ACE.Server/Physics/Command/ACCmdInterp.cs
+++ b/Source/ACE.Server/Physics/Command/ACCmdInterp.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Physics.Command
+{
+    public class ACCmdInterp : CommandInterpreter
+    {
+        public void CommenceJump()
+        {
+            /*var combatSystem = ClientCombatSystem.GetCombatSystem();
+            if (combatSystem != null)
+                combatSystem.CommenceJump();*/
+        }
+
+        public void DoJump()
+        {
+            /*var combatSystem = ClientCombatSystem.DoJump();
+            if (combatSystem != null)
+                combatSystem.DoJump();*/
+        }
+
+        public override void HandleNewForwardMovement()
+        {
+            /*var combatSystem = ClientCombatSystem.GetCombatSystem();
+            if (combatSystem != null)
+                combatSystem.AbortAutomaticAttack();*/
+
+            base.HandleNewForwardMovement();
+        }
+
+        public override void TakeControlFromServer()
+        {
+            /*var combatSystem = ClientCombatSystem.GetCombatSystem();
+            if (combatSystem != null)
+                combatSystem.AbortAutomaticAttack();*/
+
+            base.TakeControlFromServer();
+        }
+
+        public bool OnAction(InputEvent evt)
+        {
+            // vfptr[12] - IsActive
+            if (!IsActive())
+                return true;
+
+            switch (evt.InputAction)
+            {
+                case 0x32:
+                    // vfptr[2].OnLoseFocus
+                    return true;
+
+                case 0x30:
+                    SetMotion(MotionCommand.AutoRun, true);
+                    return true;
+
+                case 0x29:
+                    SetMotion(MotionCommand.WalkForward, evt.Start);
+                    return true;
+
+                case 0x2A:
+                    SetMotion(MotionCommand.WalkBackwards, evt.Start);
+                    return true;
+
+                case 0x2B:
+                    SetMotion(MotionCommand.Ready, true);
+                    return true;
+
+                case 0x2E:
+                    SetMotion(MotionCommand.TurnRight, evt.Start);
+                    return true;
+
+                case 0x2F:
+                    SetMotion(MotionCommand.TurnLeft, evt.Start);
+                    return true;
+
+                case 0x2C:
+                    SetMotion(MotionCommand.SideStepRight, evt.Start);
+                    return true;
+
+                case 0x2D:
+                    SetMotion(MotionCommand.SideStepLeft, evt.Start);
+                    return true;
+
+                case 0x31:
+                    if (evt.Start)
+                        CommenceJump();     // vfptr[5].OnAction - CommenceJump
+                    else
+                        DoJump();           // vfptr[5].OnLoseFocus - DoJump
+
+                    return true;
+
+                default:
+                    //var result = HashEmoteInputActionsToCommands.TryGetValue(evt.InputAction, out var emoteCommand);
+                    var result = false;
+                    //if (result)
+                    //SetMotion(emoteCommand, true);
+                    return result;
+            }
+        }
+
+        public void SetMotion(MotionCommand motion, bool start)
+        {
+            if (Player == null)
+                return;
+
+            var cmdStruct = new CmdStruct();
+            cmdStruct.Args[0] = 0;
+            cmdStruct.Args[1] = (uint)motion;
+            cmdStruct.Args[2] = Convert.ToUInt32(start);
+            cmdStruct.Args[3] = 4;
+
+            // vfptr[12].OnLoseFocus - HandleKeyboardCommand
+            HandleKeyboardCommand(cmdStruct, motion);
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/Command/CommandInterpreter.cs
+++ b/Source/ACE.Server/Physics/Command/CommandInterpreter.cs
@@ -1,0 +1,885 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using ACE.Entity.Enum;
+using ACE.Server.Physics.Animation;
+using ACE.Server.Physics.Common;
+
+namespace ACE.Server.Physics.Command
+{
+    public class CommandInterpreter
+    {
+        public PhysicsObj Player;
+        public SmartBox SmartBox;
+        public List<CommandListElement> SubstateList;
+        public List<CommandListElement> TurnList;
+        public List<CommandListElement> SidestepList;
+        public uint AutonomyLevel;
+        public bool ControlledByServer;
+        public bool HoldRun;
+        public bool HoldSidestep;
+        public bool TransientState { get; set; }
+        public bool Enabled;
+        public bool AutoRun;
+        public bool MouseLookActive;
+        public bool MouseLeftDown;
+        public float AutoRunSpeed;
+        public uint ActionStamp;
+        public DateTime LastSentPositionTime;
+        public Position LastSentPosition;
+        public Plane LastSentContactPlane;
+        public const double TimeBetweenPositionEvents = 1.875f;
+
+        public CommandInterpreter()
+        {
+            SubstateList = new List<CommandListElement>();
+            TurnList = new List<CommandListElement>();
+            SidestepList = new List<CommandListElement>();
+
+            AutonomyLevel = 2;
+            AutoRunSpeed = 1.0f;
+            ControlledByServer = true;
+            Enabled = true;
+            ActionStamp = 1;
+
+            LastSentPositionTime = DateTime.UtcNow;
+            LastSentPosition = new Position();
+            LastSentContactPlane = new Plane();
+        }
+
+        public void AddCommand(MotionCommand command, float speed, bool mouse, bool newHoldRun)
+        {
+            // vfptr[1](command) - whichlist
+            var list = WhichList(command);
+            if (list != null)
+            {
+                // CommandList.AddCommand
+                list.Add(new CommandListElement(command, speed, newHoldRun));
+                if (((uint)command & (uint)CommandMask.SubState) != 0)
+                {
+                    if (list == SubstateList)
+                    {
+                        // vfptr[6] - ACCmdInterp::HandleNewForwardMovement
+                        HandleNewForwardMovement();
+                    }
+
+                    TransientState = false;
+                }
+            }
+            else if (((uint)command & (uint)CommandMask.SubState) != 0)
+            {
+                if (((uint)command & (uint)CommandMask.Toggle) == 0)
+                {
+                    // vfptr[6] - ACCmdInterp::HandleNewForwardMovement
+                    HandleNewForwardMovement();
+                    if (command != MotionCommand.Ready)
+                        TransientState = true;
+                }
+            }
+        }
+
+        public void ApplyCurrentMovement(int a2)
+        {
+            if (Player == null)
+                return;
+
+            if (AutoRun)
+            {
+                // vfptr[13].OnAction - MovePlayer
+                MovePlayer(MotionCommand.WalkForward, true, AutoRunSpeed, true, true);
+                // goto LABEL_9
+            }
+            else
+            {
+                if (SubstateList.Count != 0)
+                {
+                    // vfptr[3].OnLoseFocus - ApplyListHeadMovement
+                    ApplyListHeadMovement(SubstateList);
+                }
+                else if (!TransientState)
+                {
+                    MovePlayer(MotionCommand.Ready, true, AutoRunSpeed, false, true);
+                }
+            }
+
+            // LABEL_9
+            if (TurnList.Count != 0)
+            {
+                // vfptr[3].OnLoseFocus - ApplyListHeadMovement w/ extra param?
+                //ApplyListHeadMovement(TurnList, a2);
+                ApplyListHeadMovement(TurnList);
+            }
+            else
+            {
+                //MovePlayer(MotionCommand.SideStepRight, false, 1.0f /* ? */, false, 0, a2);
+                MovePlayer(MotionCommand.SideStepRight, false, 1.0f /* ? */, false, false);
+                MovePlayer(MotionCommand.TurnRight, false, 1.0f /* /? */, false, false);
+            }
+
+            if (SidestepList.Count != 0)
+            {
+                ApplyListHeadMovement(SidestepList);
+            }
+            else
+            {
+                MovePlayer(MotionCommand.SideStepRight, false, 1.0f, false, false);
+            }
+        }
+
+        public void ApplyHoldKeysToCommand(ref MotionCommand command, float speed)
+        {
+            if (!HoldSidestep)
+                return;
+
+            if (command == MotionCommand.TurnRight)
+            {
+                command = MotionCommand.SideStepRight;
+            }
+            else if (command == MotionCommand.TurnLeft)
+            {
+                command = MotionCommand.SideStepLeft;
+            }
+        }
+
+        public void ApplyListHeadMovement(List<CommandListElement> list)
+        {
+            var head = list.LastOrDefault();
+            if (head == null)
+                return;
+
+            // if head is mouse
+            //MovePlayer(head.Command, true, head.Speed, true, head.HoldRun);
+
+            // else
+            MovePlayer(head.Command, true, head.Speed, false, false);   // always false?
+        }
+
+        public bool BookkeepCommandAndModifyIfNecessary(MotionCommand command, bool start, float speed, bool mouse, bool newHoldRun)
+        {
+            if (command == MotionCommand.Jump)
+                return true;
+
+            if (start)
+            {
+                // vfptr[1].OnAction - AddCommand
+                AddCommand(command, speed, mouse, newHoldRun);
+                return true;
+            }
+            else
+            {
+                // vfptr[1].OnLoseFocus - MovePlayer?
+                MovePlayer(command, start, speed, mouse, newHoldRun);
+            }
+            return false;
+        }
+
+        public void ClearAllCommands()
+        {
+            SubstateList.Clear();
+            TurnList.Clear();
+            SidestepList.Clear();
+        }
+
+        public void Disable()
+        {
+            // vfptr[3].OnAction()
+            // vfptr[2].OnLoseFocus(0);
+            var autonomy = AutonomyLevel != 0;
+            HoldSidestep = false;
+            if (AutonomyLevel != 0 && ControlledByServer)
+            {
+                // vfptr[2].OnAction(this)
+                // vfptr[6].OnAction(this)
+            }
+        }
+
+        public void Enable()
+        {
+            Enabled = true;
+            // vfptr[2].OnLoseFocus(HoldRun);
+        }
+
+        public bool GetMouseLeftDown()
+        {
+            return MouseLeftDown;
+        }
+
+        public bool GetMouseLookActive()
+        {
+            return MouseLookActive;
+        }
+
+        public void HandleExhaustion()
+        {
+            if (Player != null)
+                Player.report_exhaustion();
+        }
+
+        public void HandleKeyboardCommand(CmdStruct cmdStruct, MotionCommand command)
+        {
+            // vfptr[12] - IsActive
+            if (!IsActive()) return;
+
+            bool start;
+
+            if (cmdStruct.Command == MotionCommand.AutoRun)
+            {
+                start = Convert.ToBoolean(cmdStruct.Args[cmdStruct.Curr]);
+                cmdStruct.Curr++;
+                if (cmdStruct.Curr >= cmdStruct.Size)
+                {
+                    AutoRunSpeed = 1.0f;
+                }
+                else
+                {
+                    AutoRunSpeed = BitConverter.ToSingle(BitConverter.GetBytes(cmdStruct.Args[cmdStruct.Curr]));
+                    cmdStruct.Curr++;
+                }
+                // vfptr[16].OnLoseFocus - ToggleAutoRun
+                ToggleAutoRun();
+                // vfptr[6].OnAction - SendMovementEvent
+                SendMovementEvent();
+                return;
+            }
+
+            if (((uint)cmdStruct.Command & (uint)CommandMask.UI) != 0)
+                return;
+
+            start = Convert.ToBoolean(cmdStruct.Args[cmdStruct.Curr]);
+            cmdStruct.Curr++;
+
+            var speed = 1.0f;
+            if (cmdStruct.Curr < cmdStruct.Size)
+            {
+                speed = BitConverter.ToSingle(BitConverter.GetBytes(cmdStruct.Args[cmdStruct.Curr]));
+                cmdStruct.Curr++;
+            }
+
+            if (ControlledByServer && !start)
+            {
+                // vfptr[1].OnLoseFocus - MovePlayer?
+                MovePlayer((MotionCommand)cmdStruct.Command, start, speed, false, false);
+                return;
+            }
+
+            // vfptr[8].OnLoseFocus(a2) - ACCmdInterp::TakeControlFromServer?
+            TakeControlFromServer();
+
+            if (cmdStruct.Command == MotionCommand.HoldRun‬)
+            {
+                // vfptr[2].OnLoseFocus
+
+                if (!IsStandingStill())
+                    SendMovementEvent();
+
+                return;
+            }
+
+            if (cmdStruct.Command == MotionCommand.HoldSidestep)
+            {
+                // vfptr[3]
+
+                if (!IsStandingStill())
+                    SendMovementEvent();
+
+                return;
+            }
+
+            // vfptr[2] - Bookkeep
+            if (!BookkeepCommandAndModifyIfNecessary(cmdStruct.Command, start, speed, false, false))
+            {
+                SendMovementEvent();
+                return;
+            }
+
+            // vfptr[4].OnAction - ApplyHoldKeysToCommand
+            ApplyHoldKeysToCommand(ref cmdStruct.Command, speed);
+
+            // vfptr[13].OnAction - MovePlayer
+            MovePlayer(cmdStruct.Command, start, speed, false, false);
+
+            // vfptr[6].OnAction - SendMovementEvent
+            if (cmdStruct.Command != MotionCommand.Jump)
+                SendMovementEvent();
+        }
+
+        public void HandleLogOff()
+        {
+            // vfptr[11]
+            Disable();
+        }
+
+        public void HandleMouseMovementCommand(CmdStruct cmdStruct)
+        {
+
+        }
+
+        public virtual void HandleNewForwardMovement()
+        {
+            // vfptr[17](0, 1) - SetAutoRun
+            SetAutoRun(false, true);
+        }
+
+        public bool HandleSelectLeft(bool start)
+        {
+            MouseLeftDown = true;
+
+            // CInputManager : ICIDM
+            return false;
+        }
+
+        public bool IsActive()
+        {
+            return Enabled && Player != null;
+        }
+
+        public bool IsEnabled()
+        {
+            return Enabled;
+        }
+
+        public bool IsStandingStill()
+        {
+            if (Player == null)
+                return true;
+
+            var minterp = Player.get_minterp();
+
+            return minterp.is_standing_still();
+        }
+
+        public void LoseControlToServer()
+        {
+            if (AutonomyLevel == 0)
+                return;
+
+            ControlledByServer = true;
+            // vfptr[17](0, 0)
+            SetAutoRun(false, false);
+            // vfptr[6].OnLoseFocus(this)
+        }
+
+        public void LoseKeyboardFocus()
+        {
+            ClearAllCommands();
+            // vfptr[2].OnLoseFocus(this, 0) - SetHoldRun
+            SetHoldRun(false);
+
+            HoldSidestep = false;
+            // vfptr[6].OnLoseFocus(this) - ACCmdInterp::FinishJump
+
+            if (AutonomyLevel != 0)
+            {
+                if (!ControlledByServer)
+                {
+                    // vfptr[2].OnAction
+                    // vfptr[6].OnAction
+                }
+            }
+        }
+
+        public bool MaybeStopCompletely()
+        {
+            if (ControlledByServer)
+                return true;
+
+            // vfptr[15].OnLoseFocus
+            return false;
+        }
+
+        public void MovePlayer(MotionCommand command, bool start, float speed, bool mouse, bool newHoldRun)
+        {
+            if (Player == null || Player.InqInterpretedMotionState() == null)
+                return;
+
+            // if vfptr[10] - PlayerIsDead
+            if (PlayerIsDead())
+            {
+                // vfptr[9].OnAction - LoseKeyboardFocus
+                LoseKeyboardFocus();
+                // vfptr[17](0, 0) - SetAutoRun
+                SetAutoRun(false, false);
+                return;
+            }
+
+            // if !ICIDM::s_cidm->m_UseMouseTurning
+            // - goto LABEL_55
+
+            var mvp = new MovementParameters();
+
+            if (mouse)
+            {
+                // someFlags &= 0xFFFFF7FF;
+                // unset bit 11
+                mvp.SetHoldKey = false;
+                var holdRun = Convert.ToInt32(newHoldRun) + 1;
+            }
+
+            var turn = (MotionCommand)MotionStance.Invalid;
+            var sidestep = (MotionCommand)MotionStance.Invalid;
+
+            if (TurnList.Count != 0)
+                turn = TurnList.FirstOrDefault().Command;
+
+            if (SidestepList.Count != 0)
+                sidestep = SidestepList.FirstOrDefault().Command;
+
+            // vfptr[17].OnLoseFocus - GetMouseLookActive
+            var mouselook = GetMouseLookActive();
+
+            bool start_turn_left = false;
+            bool start_turn_right = false;
+            bool start_sidestep_left = false;
+            bool start_sidestep_right = false;
+
+            bool cancel_turn_left = false;
+            bool cancel_turn_right = false;
+            bool cancel_sidestep_left = false;
+            bool cancel_sidestep_right = false;
+
+            MotionCommand cmd1;
+
+            if (!mouse)
+            {
+                if (!mouselook)
+                {
+                    cmd1 = command;
+                    // goto LABEL_59
+                }
+                if (command != MotionCommand.TurnRight)
+                {
+                    if (command != MotionCommand.TurnLeft)
+                    {
+                        if (start)
+                        {
+                            cancel_turn_left = true;
+                            start_sidestep_left = true;
+                        }
+                        else
+                        {
+                            cancel_sidestep_left = true;
+                        }
+                    }
+                    else
+                    {
+                        cancel_turn_right = true;
+                        cancel_turn_left = true;
+                    }
+                    // goto LABEL_38
+                }
+                if (!start)
+                {
+                    cancel_sidestep_right = true;
+                    // goto LABEL_38
+                }
+                // LABEL_31:
+                cancel_turn_right = true;
+                start_sidestep_right = true;
+                // goto LABEL_38
+            }
+
+            if (!mouselook)
+            {
+                if (turn == MotionCommand.TurnRight)
+                {
+                    cancel_sidestep_right = true;
+                    start_turn_right = true;
+                }
+                else if (turn == MotionCommand.TurnLeft)
+                {
+                    cancel_sidestep_left = true;
+                    start_turn_left = true;
+                }
+                // goto LABEL_38
+            }
+
+            if (command != MotionCommand.MouseLook)
+            {
+                // goto LABEL_38
+            }
+
+            if (turn == MotionCommand.TurnRight)
+            {
+                cancel_turn_right = true;
+
+                if (sidestep == MotionCommand.SideStepLeft)
+                    start_sidestep_left = true;
+                else
+                    start_sidestep_right = true;
+
+                // goto LABEL_38
+            }
+
+            if (turn == MotionCommand.TurnLeft)
+            {
+                if (sidestep != MotionCommand.SideStepRight)
+                {
+                    cancel_turn_left = true;
+                    start_sidestep_left = true;
+
+                    // goto LABEL_38
+                }
+                // goto LABEL_31
+            }
+
+            if (MouseLeftDown)
+            {
+                start = true;
+                command = MotionCommand.WalkForward;
+            }
+
+            // ============
+            // LABEL 38:
+
+            // vfptr[8].OnLoseFocus - TakeControlFromServer
+            TakeControlFromServer();
+
+            if (cancel_sidestep_right)
+                Player.StopMotion((uint)MotionCommand.SideStepRight, mvp, true);
+
+            if (cancel_sidestep_left)
+                Player.StopMotion((uint)MotionCommand.SideStepLeft, mvp, true);
+
+            if (cancel_turn_right)
+                Player.StopMotion((uint)MotionCommand.TurnRight, mvp, true);
+
+            if (cancel_turn_left)
+                Player.StopMotion((uint)MotionCommand.TurnLeft, mvp, true);
+
+            if (start_turn_right)
+            {
+                start = true;
+                cmd1 = MotionCommand.TurnRight;
+            }
+            else
+                cmd1 = command;
+
+            if (start_turn_left)
+            {
+                start = true;
+                cmd1 = MotionCommand.TurnLeft;
+            }
+
+            if (start_sidestep_right)
+            {
+                start = true;
+                cmd1 = MotionCommand.SideStepRight;
+                speed = 1.0f;
+            }
+
+            if (start_sidestep_left)
+            {
+                start = true;
+                command = MotionCommand.SideStepLeft;
+                speed = 1.0f;
+
+                // LABEL_55:
+                cmd1 = command;
+            }
+
+            var holdRunRel1 = 0;
+            if (mouse)
+            {
+                holdRunRel1 = Convert.ToInt32(newHoldRun) + 1;
+                // goto LABEL_60
+            }
+
+            // LABEL_59:
+            holdRunRel1 = 0;
+
+            // LABEL_60:
+            if (AutonomyLevel != 0)
+            {
+                if (start)
+                {
+                    if (cmd1 != MotionCommand.Jump)
+                    {
+                        mvp = new MovementParameters();
+                        // set 12th flag
+                        mvp.Autonomous = true;
+                        if (mouse)
+                            mvp.SetHoldKey = false;     // unset 11th flag
+                        if (((uint)cmd1 & (uint)CommandMask.Action) != 0)
+                        {
+                            // vfptr[15].OnLoseFocus(this)
+                        }
+                        var werror = Player.DoMotion((uint)cmd1, mvp);
+                        switch (werror)
+                        {
+                            case WeenieError.None:
+                                if (((uint)cmd1 & (uint)CommandMask.Action) != 0)
+                                    ActionStamp++;
+                                return;
+
+                            case WeenieError.CantCrouchInCombat:
+                                break;  // 72
+
+                            case WeenieError.CantSitInCombat:
+                                break;  // 73
+
+                            case WeenieError.CantLieDownInCombat:
+                                break;  // 73
+
+                            case WeenieError.YouAreTooTiredToDoThat:
+                                break;  // 73
+
+                            case WeenieError.CantChatEmoteInCombat:
+                                break;  // 73
+
+                            case WeenieError.CantChatEmoteNotStanding:
+                                break;
+
+                            default:
+                                return;
+                        }
+                    }
+                }
+                else if (cmd1 != MotionCommand.Jump)
+                {
+                    mvp = new MovementParameters();
+                    var holdRunRel = 0;
+                    if (mouse)
+                    {
+                        mvp.SetHoldKey = false;
+                        holdRunRel = Convert.ToInt32(newHoldRun) + 1;
+                    }
+                    Player.StopMotion((uint)cmd1, mvp, true);
+                }
+            }
+            else
+            {
+                // vfptr[4].OnLoseFocus - NonAutonomous?
+                MovePlayer_NonAutonomous(cmd1, start, speed, (HoldKey)holdRunRel1);
+            }
+        }
+
+        public void MovePlayer_NonAutonomous(MotionCommand command, bool start, float speed, HoldKey holdKey)
+        {
+            if (start)
+            {
+                if (command == MotionCommand.Jump)
+                {
+                    // vfptr[5].OnAction
+                }
+                else
+                {
+                    // vfptr[19].OnAction
+                }
+            }
+            else if (command == MotionCommand.Jump)
+            {
+                // vfptr[5].OnLoseFocus
+            }
+            else
+            {
+                // vfptr[19].OnLoseFocus
+            }
+        }
+
+        public void NewPlayer(PhysicsObj player, bool autonomous_movement)
+        {
+            Player = player;
+            if (autonomous_movement)
+            {
+                // vfptr[2].OnAction
+            }
+            else
+            {
+                // vfptr[8].OnAction
+            }
+        }
+
+        public bool NukeCommand(MotionCommand command, bool start, float speed, bool mouse, bool newHoldRun)
+        {
+            return false;
+        }
+
+        public bool PlayerIsDead()
+        {
+            if (Player != null)
+            {
+                var motionState = Player.InqInterpretedMotionState();
+                if (motionState != null)
+                    return motionState.ForwardCommand == (uint)MotionCommand.Dead;
+            }
+            return false;
+        }
+
+        public void PlayerTeleported()
+        {
+            // vfptr[17](0, 1) - SetAutoRun?
+            SetAutoRun(false, true);
+
+            // vfptr[6].OnAction - SendMovementEvent?
+            SendMovementEvent();
+        }
+
+        public void SendMovementEvent()
+        {
+
+        }
+
+        public void SendPositionEvent()
+        {
+
+        }
+
+        public void SetAutoRun(bool val, bool apply_movement)
+        {
+            if (AutoRun != val)
+            {
+                AutoRun = val;
+                TransientState = false;
+                if (val)
+                {
+                    //vfptr[8].OnLoseFocus(this)
+                    // display string: AutoRun ON
+                }
+                else
+                {
+                    // display string: AutoRun OFF
+                }
+            }
+            if (apply_movement)
+            {
+                // vfptr[2].OnAction(this) - ApplyCurrentMovement
+                //ApplyCurrentMovement();
+            }
+        }
+
+        public bool SetAutonomyLevel(uint newLevel)
+        {
+            if (newLevel <= 2)
+            {
+                AutonomyLevel = newLevel;
+                // vfptr[19](newLevel)
+                return true;
+            }
+            return false;
+        }
+
+        public void SetHoldRun(bool newVal)
+        {
+            // vfptr[5] - ACCmdInterp::UITogglesRun()
+        }
+
+        public void SetHoldSidestep(bool newVal)
+        {
+            // vfptr[4](TurnList)
+            HoldSidestep = newVal;
+            // vfptr[2].OnAction
+        }
+
+        public void SetMouseLeftDown(bool active)
+        {
+            MouseLeftDown = active;
+        }
+
+        public void SetMouseLookActive(bool active)
+        {
+            MouseLookActive = active;
+        }
+
+        public void SetSmartBox(SmartBox smartBox)
+        {
+            SmartBox = smartBox;
+            if (smartBox != null)
+                Player = smartBox.Player;
+            else
+                Player = null;
+        }
+
+        public bool ShouldSendPositionEvent()
+        {
+            return true;
+        }
+
+        public bool StopCompletely()
+        {
+            return false;
+        }
+
+        public void StopDrift()
+        {
+
+        }
+
+        public void StopListHeadMovement(List<CommandListElement> list)
+        {
+
+        }
+
+        public virtual void TakeControlFromServer()
+        {
+            // vrptr[10]
+            if (ControlledByServer && AutonomyLevel != 0 && true)
+            {
+                ControlledByServer = false;
+
+                if (Player != null)
+                {
+                    Player.LastMoveWasAutonomous = true;
+                    Player.StopCompletely(true);
+                    Player.StopInterpolating();
+                }
+
+                // vfptr[2].OnLoseFocus(HoldRun)
+                // vfptr[2].OnAction
+            }
+        }
+
+        public void ToggleAutoRun()
+        {
+            var toggle = !AutoRun;
+            // vfptr[17] - SetAutoRun
+            SetAutoRun(toggle, true);
+        }
+
+        public bool TurnToHeading(float newHeading, bool run)
+        {
+            return false;
+        }
+
+        public void UpdateToggleRun()
+        {
+            // vfptr[2].OnLoseFocus(HoldRun)
+            // vfptr[6].OnAction
+        }
+
+        public bool UsePositionFromServer()
+        {
+            return AutonomyLevel != 2;
+        }
+
+        public void UseTime()
+        {
+
+        }
+
+        public List<CommandListElement> WhichList(MotionCommand command)
+        {
+            switch (command)
+            {
+                case MotionCommand.TurnLeft:
+                case MotionCommand.TurnRight:
+                    return TurnList;
+
+                case MotionCommand.SideStepLeft:
+                case MotionCommand.SideStepRight:
+                    return SidestepList;
+
+                default:
+                    if (((int)command & 0x40000000) != 0)
+                    {
+                        if (((int)command & 0x4000000) != 0)
+                        {
+                            return SubstateList;
+                        }
+                    }
+                    break;
+            }
+            return null;
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/Command/CommandList.cs
+++ b/Source/ACE.Server/Physics/Command/CommandList.cs
@@ -1,0 +1,127 @@
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Physics.Command
+{
+    public class CommandList
+    {
+        public CommandListElement Head;
+        public CommandListElement MouseCommand;
+        public CommandListElement Current;
+
+        public void AddCommand(MotionCommand command, float speed, bool mouse, bool holdRun)
+        {
+            var element = new CommandListElement(command, speed, holdRun);
+
+            CommandListElement mouse_cmd = null;
+
+            if (mouse)
+            {
+                mouse_cmd = MouseCommand;
+
+                if (mouse_cmd == null)
+                {
+                    SetMouseCommand(element);
+                    return;
+                }
+
+                var prevNext = mouse_cmd.Prev.Next;
+                if (prevNext != null)
+                {
+                    prevNext = mouse_cmd.Next;
+                }
+                else
+                {
+                    var next = mouse_cmd.Next;
+                    var nextNull = next == null;
+                    Head = mouse_cmd.Next;
+                    if (nextNull)
+                    {
+                        // label_12
+                        mouse_cmd.Next = null;
+                        mouse_cmd.Prev = null;
+
+                        SetMouseCommand(element);
+                        return;
+                    }
+                    next.Prev = null;
+                }
+                if (mouse_cmd.Next != null)
+                    mouse_cmd.Next.Prev = mouse_cmd.Prev;
+                // goto label_12
+            }
+        }
+
+        public void ClearAllCommands()
+        {
+            if (Head != null)
+            {
+                CommandListElement headPrevNext = null;
+
+                while (true)
+                {
+                    var head = Head;
+                    headPrevNext = Head.Prev.Next;
+                    if (headPrevNext != null)
+                        break;
+
+                    var headNext = head.Next;
+                    var headNextNull = head.Next == null;
+                    Head = head.Next;
+
+                    if (!headNextNull)
+                    {
+                        headNext.Prev = null;
+
+                        // label_6
+                        if (head.Next != null)
+                            head.Next.Prev = head.Prev;
+                    }
+
+                    head.Next = null;
+                    head.Prev = null;
+
+                    if (Head == null)
+                    {
+                        MouseCommand = null;
+                        return;
+                    }
+                }
+                headPrevNext = Head.Next;
+                // goto label_6
+            }
+            MouseCommand = null;
+        }
+
+        public void ClearKeyboardCommands()
+        {
+
+        }
+
+        public CommandListElement GetHead()
+        {
+            return Head;
+        }
+
+        public bool HeadIsMouse()
+        {
+            if (Head == null)
+                return false;
+
+            return Head == MouseCommand;
+        }
+
+        public bool RemoveCommand(MotionCommand command, float speed, bool mouse)
+        {
+            return false;
+        }
+
+        public void SetMouseCommand(CommandListElement element)
+        {
+            MouseCommand = element;
+            element.Next = Head;
+            if (Head != null)
+                Head.Prev = element;
+            Head = element;
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/Command/CommandListElement.cs
+++ b/Source/ACE.Server/Physics/Command/CommandListElement.cs
@@ -1,0 +1,26 @@
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Physics.Command
+{
+    public class CommandListElement
+    {
+        public CommandListElement Next;
+        public CommandListElement Prev;
+
+        public MotionCommand Command;
+        public float Speed;
+        public bool HoldRun;
+
+        public CommandListElement()
+        {
+            Speed = 1.0f;
+        }
+
+        public CommandListElement(MotionCommand command, float speed, bool holdRun)
+        {
+            Command = command;
+            Speed = speed;
+            HoldRun = holdRun;
+        }
+    }
+}

--- a/Source/ACE.Server/Physics/Command/CommandStruct.cs
+++ b/Source/ACE.Server/Physics/Command/CommandStruct.cs
@@ -1,0 +1,12 @@
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Physics.Command
+{
+    public class CmdStruct
+    {
+        public uint[] Args = new uint[64];
+        public uint Size;
+        public uint Curr;
+        public MotionCommand Command;
+    }
+}

--- a/Source/ACE.Server/Physics/Command/InputEvent.cs
+++ b/Source/ACE.Server/Physics/Command/InputEvent.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ACE.Server.Physics.Command
+{
+    public class InputEvent
+    {
+        public uint InputAction;
+        public bool Start;
+    }
+}

--- a/Source/ACE.Server/Physics/Common/Vector.cs
+++ b/Source/ACE.Server/Physics/Common/Vector.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+using System;
+using System.Numerics;
 
 namespace ACE.Server.Physics.Common
 {
@@ -12,6 +13,13 @@ namespace ACE.Server.Physics.Common
 
             v *= 1.0f / dist;
             return false;
+        }
+
+        public static bool IsZero(Vector3 v)
+        {
+            return Math.Abs(v.X) < PhysicsGlobals.EPSILON &&
+                   Math.Abs(v.Y) < PhysicsGlobals.EPSILON &&
+                   Math.Abs(v.Z) < PhysicsGlobals.EPSILON;
         }
     }
 }

--- a/Source/ACE.Server/Physics/Managers/MoveToManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MoveToManager.cs
@@ -32,7 +32,6 @@ namespace ACE.Server.Physics.Animation
         public List<MovementNode> PendingActions;
         public PhysicsObj PhysicsObj;
         public WeenieObject WeenieObj;
-        public List<Action<WeenieError>> Callbacks;
 
         public MoveToManager()
         {
@@ -59,7 +58,6 @@ namespace ACE.Server.Physics.Animation
             MovementParams = new MovementParameters();
 
             PendingActions = new List<MovementNode>();
-            Callbacks = new List<Action<WeenieError>>();
         }
 
         public void InitializeLocalVars()
@@ -587,6 +585,7 @@ namespace ACE.Server.Physics.Animation
 
             var pendingAction = PendingActions[0];
             var heading = PhysicsObj.get_heading();
+
             if (heading_greater(heading, pendingAction.Heading, CurrentCommand))
             {
                 FailProgressCount = 0;
@@ -690,6 +689,8 @@ namespace ACE.Server.Physics.Animation
 
         public void CancelMoveTo(WeenieError retval)
         {
+            //Console.WriteLine($"CancelMoveTo({retval})");
+
             if (MovementType == MovementType.Invalid)
                 return;
 
@@ -723,8 +724,8 @@ namespace ACE.Server.Physics.Animation
             if (PhysicsObj != null)
                 PhysicsObj.StopCompletely(false);
 
-            foreach (var callback in Callbacks.ToList())
-                callback(status);
+            // server custom
+            WeenieObj.OnMoveComplete(status);
         }
 
         public float GetCurrentDistance()
@@ -868,16 +869,6 @@ namespace ACE.Server.Physics.Animation
                 _StopMotion(AuxCommand, movementParams);
                 AuxCommand = 0;
             }
-        }
-
-        public void add_listener(Action<WeenieError> listener)
-        {
-            Callbacks.Add(listener);
-        }
-
-        public void remove_listener(Action<WeenieError> listener)
-        {
-            Callbacks.Remove(listener);
         }
     }
 }

--- a/Source/ACE.Server/Physics/Managers/MovementManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MovementManager.cs
@@ -124,6 +124,7 @@ namespace ACE.Server.Physics.Animation
         public WeenieError PerformMovement(MovementStruct mvs)
         {
             PhysicsObj.set_active(true);
+
             switch (mvs.Type)
             {
                 case MovementType.RawCommand:

--- a/Source/ACE.Server/WorldObjects/CombatPet.cs
+++ b/Source/ACE.Server/WorldObjects/CombatPet.cs
@@ -68,8 +68,8 @@ namespace ACE.Server.WorldObjects
             Name = player.Name + "'s " + Name;
             P_PetOwner = player;
             PetOwner = player.Guid.Full;
-            SetCombatMode(CombatMode.Melee);
             EnterWorld();
+            SetCombatMode(CombatMode.Melee);
             DamageType = damageType;
             Attackable = true;
             MonsterState = State.Awake;

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -242,12 +242,16 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Sends the network commands to move a player towards an object
         /// </summary>
-        public void MoveToObject(WorldObject target, float? useRadius)
+        public void MoveToObject(WorldObject target, float? useRadius = null)
         {
             var distanceToObject = useRadius ?? target.UseRadius ?? 0.6f;
 
             var moveToObject = new Motion(this, target, MovementType.MoveToObject);
             moveToObject.MoveToParameters.DistanceToObject = distanceToObject;
+
+            // move directly to portal origin
+            //if (target is Portal)
+                //moveToObject.MoveToParameters.MovementParameters &= ~MovementParams.UseSpheres;
 
             SetWalkRunThreshold(moveToObject, target.Location);
 

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -43,10 +43,6 @@ namespace ACE.Server.WorldObjects
 
             var baseArmorMod = (float)(Biota.BaseArmor + enchantmentMod);
 
-            // handle armor rending mod here?
-            //if (baseArmorMod > 0)
-                //baseArmorMod *= armorRendingMod;
-
             // for creatures, can this be modified via enchantments?
             var armorVsType = Creature.GetArmorVsType(damageType);
 
@@ -60,7 +56,7 @@ namespace ACE.Server.WorldObjects
             foreach (var armorLayer in armorLayers)
                 effectiveAL += GetArmorMod(armorLayer, damageType, ignoreMagicArmor);
 
-            // Armor Rending reduces physical armor too?
+            // armor rending reduces base armor + all physical armor too?
             if (effectiveAL > 0)
                 effectiveAL *= armorRendingMod;
 

--- a/Source/ACE.Server/WorldObjects/GamePiece.cs
+++ b/Source/ACE.Server/WorldObjects/GamePiece.cs
@@ -162,15 +162,6 @@ namespace ACE.Server.WorldObjects
 
             SetWalkRunThreshold(moveToPosition, to);
 
-            if (!InitSticky)
-            {
-                PhysicsObj.add_moveto_listener(OnMoveComplete);
-
-                PhysicsObj.add_sticky_listener(OnSticky);
-                PhysicsObj.add_unsticky_listener(OnUnsticky);
-                InitSticky = true;
-            }
-
             var mvp = GetMovementParameters();
             mvp.CanWalk = true;
             mvp.StopCompletely = true;

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -182,6 +182,7 @@ namespace ACE.Server.WorldObjects
                 return false;
 
             PhysicsObj.update_object();
+            UpdatePosition_SyncLocation();
 
             return !PhysicsObj.IsAnimating;
         }
@@ -196,6 +197,7 @@ namespace ACE.Server.WorldObjects
                 return false;
 
             PhysicsObj.update_object();
+            UpdatePosition_SyncLocation();
 
             return !PhysicsObj.IsAnimating;
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -61,7 +61,6 @@ namespace ACE.Server.WorldObjects
 
         public bool DebugMove;
 
-        public bool InitSticky;
         public bool Sticky;
 
         public double NextMoveTime;
@@ -103,18 +102,9 @@ namespace ACE.Server.WorldObjects
 
             var mvp = GetMovementParameters();
             if (turnTo)
-                PhysicsObj.TurnToObject(AttackTarget.PhysicsObj.ID, mvp);
+                PhysicsObj.TurnToObject(AttackTarget.PhysicsObj, mvp);
             else
                 PhysicsObj.MoveToObject(AttackTarget.PhysicsObj, mvp);
-
-            if (!InitSticky)
-            {
-                PhysicsObj.add_moveto_listener(OnMoveComplete);
-
-                PhysicsObj.add_sticky_listener(OnSticky);
-                PhysicsObj.add_unsticky_listener(OnUnsticky);
-                InitSticky = true;
-            }
         }
 
         /// <summary>
@@ -143,7 +133,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Called when the MoveTo process has completed
         /// </summary>
-        public virtual void OnMoveComplete(WeenieError status)
+        public override void OnMoveComplete(WeenieError status)
         {
             if (DebugMove)
                 Console.WriteLine($"{Name} ({Guid}) - OnMoveComplete({status})");
@@ -423,13 +413,13 @@ namespace ACE.Server.WorldObjects
             return mvp;
         }
 
-        public void OnSticky()
+        public override void OnSticky()
         {
             //Console.WriteLine($"{Name} ({Guid}) - OnSticky");
             Sticky = true;
         }
 
-        public void OnUnsticky()
+        public override void OnUnsticky()
         {
             //Console.WriteLine($"{Name} ({Guid}) - OnUnsticky");
             Sticky = false;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -44,6 +44,8 @@ namespace ACE.Server.WorldObjects
         public bool LastContact = true;
         public bool IsJumping = false;
 
+        public DateTime LastJumpTime;
+
         public ConfirmationManager ConfirmationManager;
 
         public SquelchManager SquelchManager;
@@ -698,6 +700,7 @@ namespace ACE.Server.WorldObjects
         public void HandleActionJump(JumpPack jump)
         {
             StartJump = new ACE.Entity.Position(Location);
+            //Console.WriteLine($"JumpPack: Velocity: {jump.Velocity}, Extent: {jump.Extent}");
 
             var strength = Strength.Current;
             var capacity = EncumbranceSystem.EncumbranceCapacity((int)strength, AugmentationIncreasedCarryingCapacity);
@@ -725,6 +728,7 @@ namespace ACE.Server.WorldObjects
             }*/
 
             IsJumping = true;
+            LastJumpTime = DateTime.UtcNow;
 
             UpdateVitalDelta(Stamina, -staminaCost);
 

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -147,8 +147,6 @@ namespace ACE.Server.WorldObjects
 
         public Position StartJump;
 
-        public bool InitMoveListener;
-
         public override void MoveTo(WorldObject target, float runRate = 0.0f)
         {
             if (runRate == 0.0f)
@@ -171,12 +169,6 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.MoveToObject(target.PhysicsObj, mvp);
 
             IsMoving = true;
-
-            if (!InitMoveListener)
-            {
-                PhysicsObj.add_moveto_listener(OnMoveComplete);
-                InitMoveListener = true;
-            }
 
             MoveTo_Tick();
         }
@@ -203,8 +195,14 @@ namespace ACE.Server.WorldObjects
 
         public override void OnMoveComplete(WeenieError status)
         {
-            //Console.WriteLine($"{Name}.OnMoveComplete()");
+            //Console.WriteLine($"{Name}.OnMoveComplete({status})");
             IsMoving = false;
+
+            if (IsPlayerMovingTo)
+            {
+                //OnMoveComplete_MoveTo(status);
+                return;
+            }
 
             switch (status)
             {
@@ -236,7 +234,7 @@ namespace ACE.Server.WorldObjects
         {
             // starting with phat logic
             var jumpVelocity = 0.0f;
-            PhysicsObj.WeenieObj.InqJumpVelocity(1.0f, ref jumpVelocity);
+            PhysicsObj.WeenieObj.InqJumpVelocity(1.0f, out jumpVelocity);
 
             var cachedVelocity = PhysicsObj.CachedVelocity;
 

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -216,6 +216,20 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public void OnMoveComplete_MoveTo(WeenieError status)
+        {
+            //Console.WriteLine($"{Name}.OnMoveComplete_MoveTo({status})");
+
+            /*IsPlayerMovingTo = false;
+
+            var success = status == WeenieError.None;
+
+            if (MoveToCallback != null)
+                MoveToCallback(success);
+
+            MoveToCallback = null;*/
+        }
+
         public MovementParameters GetChargeParameters()
         {
             var mvp = new MovementParameters();

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -181,9 +181,10 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Records where the client thinks we are, for use by physics engine later
         /// </summary>
-        public void SetRequestedLocation(Position pos)
+        public void SetRequestedLocation(Position pos, bool broadcast = true)
         {
             RequestedLocation = pos;
+            RequestedLocationBroadcast = broadcast;
         }
 
         //public DateTime LastSoulEmote;

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -311,5 +311,10 @@ namespace ACE.Server.WorldObjects
                 }
             }
         }
+
+        public override void HandleMotionDone(uint motionID, bool success)
+        {
+            //Console.WriteLine($"{Name}.HandleMotionDone({(MotionCommand)motionID}, {success})");
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -418,6 +418,7 @@ namespace ACE.Server.WorldObjects
         public void GrantLevelProportionalXp(double percent, ulong max, bool shareable = false)
         {
             var nextLevelXP = GetXPBetweenLevels(Level.Value, Level.Value + 1);
+
             var scaledXP = (long)Math.Min(nextLevelXP * percent, max);
 
             var shareType = shareable ? ShareType.All : ShareType.None;

--- a/Source/ACE.Server/WorldObjects/SkillFormula.cs
+++ b/Source/ACE.Server/WorldObjects/SkillFormula.cs
@@ -29,7 +29,6 @@ namespace ACE.Server.WorldObjects
         public static float CalcArmorMod(float armorLevel)
         {
             if (armorLevel > 0)
-                //return armorLevel / (armorLevel + ArmorMod);
                 return ArmorMod / (armorLevel + ArmorMod);
             else if (armorLevel < 0)
                 return 1.0f - armorLevel / ArmorMod;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Numerics;
 
+using log4net;
+
 using ACE.Common;
 using ACE.Database.Models.Shard;
 using ACE.Database.Models.World;
@@ -20,9 +22,11 @@ namespace ACE.Server.WorldObjects
         public Server.Entity.Spell Spell;
         public ProjectileSpellType SpellType { get; set; }
 
-        public Position SpawnPos;
+        public Position SpawnPos { get; set; }
         public float DistanceToTarget { get; set; }
         public uint LifeProjectileDamage { get; set; }
+
+        public SpellProjectileInfo Info { get; set; }
 
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
@@ -233,6 +237,12 @@ namespace ACE.Server.WorldObjects
         public override void OnCollideEnvironment()
         {
             //Console.WriteLine($"{Name}.OnCollideEnvironment()");
+            if (Info != null && ProjectileSource is Player player && player.DebugSpell)
+            {
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name}.OnCollideEnvironment()", ChatMessageType.Broadcast));
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat(Info.ToString(), ChatMessageType.Broadcast));
+            }
+
             ProjectileImpact();
         }
 
@@ -241,6 +251,12 @@ namespace ACE.Server.WorldObjects
             //Console.WriteLine($"{Name}.OnCollideObject({_target.Name})");
 
             var player = ProjectileSource as Player;
+
+            if (Info != null && player != null && player.DebugSpell)
+            {
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{Name}.OnCollideObject({_target?.Name} ({_target?.Guid}))", ChatMessageType.Broadcast));
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat(Info.ToString(), ChatMessageType.Broadcast));
+            }
 
             if (player != null)
                 player.LastHitSpellProjectile = Spell;

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -21,6 +21,7 @@ using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Sequence;
+using ACE.Server.Network.Structure;
 using ACE.Server.Physics;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
@@ -424,7 +425,16 @@ namespace ACE.Server.WorldObjects
         // ******************************************************************* OLD CODE BELOW ********************************
         // ******************************************************************* OLD CODE BELOW ********************************
 
+        public MoveToState LastMoveToState { get; set; }
+
         public Position RequestedLocation { get; set; }
+
+        /// <summary>
+        /// Flag indicates if RequestedLocation should be broadcast to other players
+        /// - For AutoPos packets, this is set to TRUE
+        /// - For MoveToState packets, this is set to FALSE
+        /// </summary>
+        public bool RequestedLocationBroadcast { get; set; }
 
         ////// Logical Game Data
         public ContainerType ContainerType
@@ -904,7 +914,7 @@ namespace ACE.Server.WorldObjects
             {
                 var motionInterp = PhysicsObj.get_minterp();
 
-                var rawState = new RawMotionState();
+                var rawState = new Physics.Animation.RawMotionState();
                 rawState.ForwardCommand = 0;    // always 0? must be this for monster sleep animations (skeletons, golems)
                                                 // else the monster will immediately wake back up..
                 rawState.CurrentHoldKey = HoldKey.Run;
@@ -972,6 +982,26 @@ namespace ACE.Server.WorldObjects
                 if (CurrentMotionState.MotionState != null)
                     currentMotion = CurrentMotionState.MotionState.ForwardCommand;
             }
+        }
+
+        public virtual void HandleMotionDone(uint motionID, bool success)
+        {
+            // empty base
+        }
+
+        public virtual void OnMoveComplete(WeenieError status)
+        {
+            // empty base
+        }
+
+        public virtual void OnSticky()
+        {
+            // empty base
+        }
+
+        public virtual void OnUnsticky()
+        {
+            // empty base
         }
 
         public virtual bool IsAttunedOrContainsAttuned => (Attuned ?? 0) >= 1;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -395,12 +395,18 @@ namespace ACE.Server.WorldObjects
             writer.Align();
         }
 
+        public DateTime LastUpdatePosition;
+
         /// <summary>
         /// Broadcast position updates to players within range
         /// </summary>
-        protected void SendUpdatePosition()
+        public void SendUpdatePosition()
         {
+            //Console.WriteLine($"{Name}.SendUpdatePosition({Location.ToLOCString()})");
+
             EnqueueBroadcast(new GameMessageUpdatePosition(this));
+
+            LastUpdatePosition = DateTime.UtcNow;
         }
 
         public virtual void SendPartialUpdates(Session targetSession, List<GenericPropertyId> properties)


### PR DESCRIPTION
This PR is to help bridge the gap between master branch and https://github.com/ACEmulator/ACE/pull/1991

All of the support functions and non-critical functions that can be ported from 1991 -> master branch are included here. These updates should provide 0 noticeable difference to current master branch, but helps pave the way for integrating these 2 branches

This will bring the line count in 1991 down to about ~900, which is much more manageable, and contains only the core functions needed for advanced player movement / spellcasting