### PR TITLE
fix for ignored C2S NAK

### DIFF
--- a/Source/ACE.Server/Network/ClientPacket.cs
+++ b/Source/ACE.Server/Network/ClientPacket.cs
@@ -183,25 +183,14 @@ namespace ACE.Server.Network
             }
             else
             {
-                if (Header.HasFlag(PacketHeaderFlags.RequestRetransmit))
+                if (VerifyChecksum(0))
                 {
-                    // discard retransmission request with cleartext CRC
-                    // client sends one encrypted version and one non encrypted version of each retransmission request
-                    // honoring these causes client to drop because it's only expecting one of the two retransmission requests to be honored
-                    // and it's more secure to only accept the trusted version
-                    return false;
+                    packetLog.Debug($"{this}");
+                    return true;
                 }
                 else
                 {
-                    if (VerifyChecksum(0))
-                    {
-                        packetLog.Debug($"{this}");
-                        return true;
-                    }
-                    else
-                    {
-                        packetLog.Debug($"{this}, Checksum Failed");
-                    }
+                    packetLog.Debug($"{this}, Checksum Failed");
                 }
             }
             NetworkStatistics.C2S_CRCErrors_Aggregate_Increment();


### PR DESCRIPTION
Fixed bug that occurs when client sends only a cleartext CRC NAK and ACE ignoring them, switch from honoring only ciphertext CRC NAK to honoring only cleartext CRC NAK