### PR TITLE
Fixed caster damage modifier to use appropriate PvP modifier instead of PvM

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -332,7 +332,7 @@ namespace ACE.Server.WorldObjects
             if (modifier > 1.0f && wielder is Player && target is Player)
                 modifier = 1.0f + (modifier - 1.0f) * ElementalDamageBonusPvPReduction;
 
-            return modifier * (float)(elementalDamageMod + enchantments);
+            return modifier;
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -332,7 +332,7 @@ namespace ACE.Server.WorldObjects
             if (modifier > 1.0f && wielder is Player && target is Player)
                 modifier = 1.0f + (modifier - 1.0f) * ElementalDamageBonusPvPReduction;
 
-            return (float)(elementalDamageMod + enchantments);
+            return modifier * (float)(elementalDamageMod + enchantments);
         }
 
         /// <summary>


### PR DESCRIPTION
It appears that the casting damage modifier being used for PvP mode is in fact unaffected by the PvP modifier for weapon damage, so it is using the PvM caster modifier instead. This patch includes the `modifier` which is the piece that includes reduction of the caster modifier for PK purposes.