### PR TITLE
Magic and Missile Defense Modifier Bonus simplifcation/fix

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1390,12 +1390,12 @@ namespace ACE.Server.Factories
                         magicMissileDefenseMod = 0;
                         break;
                     case 3:
-                        int chance = ThreadSafeRandom.Next(0, 100);
+                        int chance = ThreadSafeRandom.Next(1, 100);
                         if (chance > 95)
                             magicMissileDefenseMod = .005;
                         break;
                     case 4:
-                        chance = ThreadSafeRandom.Next(0, 100);
+                        chance = ThreadSafeRandom.Next(1, 100);
                         if (chance > 95)
                             magicMissileDefenseMod = .01;
                         else if (chance > 80)
@@ -1404,7 +1404,7 @@ namespace ACE.Server.Factories
                             magicMissileDefenseMod = 0;
                         break;
                     case 5:
-                        chance = ThreadSafeRandom.Next(0, 1000);
+                        chance = ThreadSafeRandom.Next(1, 1000);
                         if (chance > 950)
                             magicMissileDefenseMod = .01;
                         else if (chance > 800)
@@ -1413,7 +1413,7 @@ namespace ACE.Server.Factories
                             magicMissileDefenseMod = 0;
                         break;
                     case 6:
-                        chance = ThreadSafeRandom.Next(0, 1000);
+                        chance = ThreadSafeRandom.Next(1, 1000);
                         if (chance > 975)
                             magicMissileDefenseMod = .020;
                         else if (chance > 900)
@@ -1426,7 +1426,7 @@ namespace ACE.Server.Factories
                             magicMissileDefenseMod = 0;
                         break;
                     case 7:
-                        chance = ThreadSafeRandom.Next(0, 1000);
+                        chance = ThreadSafeRandom.Next(1, 1000);
                         if (chance > 990)
                             magicMissileDefenseMod = .030;
                         else if (chance > 985)
@@ -1443,7 +1443,7 @@ namespace ACE.Server.Factories
                             magicMissileDefenseMod = 0;
                         break;
                     default: // tier 8
-                        chance = ThreadSafeRandom.Next(0, 1000);
+                        chance = ThreadSafeRandom.Next(1, 1000);
                         if (chance > 998)
                             magicMissileDefenseMod = .04;
                         else if (chance > 994)

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1373,11 +1373,13 @@ namespace ACE.Server.Factories
 
             return manaDMod;
         }
-
+        /// <summary>
+        /// Returns Values for Magic & Missile Defense Bonus. Updated HarliQ 11/17/19
+        /// </summary>
         private static double GetMagicMissileDMod(int tier)
         {
             double magicMissileDefenseMod = 0;
-
+            // For seeing if weapon even gets a chance at a modifier
             int modifierChance = ThreadSafeRandom.Next(1, 2);
             if (modifierChance > 1)
             {
@@ -2377,36 +2379,5 @@ namespace ACE.Server.Factories
             meleeMod = meleeMod + 1.0;
             return meleeMod;
         }
-        /// <summary>
-        /// Returns Values for Magic & Missile Defense Bonus. HarliQ 11/17/19
-        /// </summary>
-        private static double GetMagicMissileADefenseBonus()
-        {
-            double mBonus = 0;
-
-            int chance = ThreadSafeRandom.Next(1, 100);
-
-            if (chance > 98)
-                mBonus = 0.04;
-            else if (chance > 95)
-                mBonus = 0.035;
-            else if (chance > 90)
-                mBonus = 0.030;
-            else if (chance > 80)
-                mBonus = 0.025;
-            else if (chance > 65)
-                mBonus = 0.02;
-            else if (chance > 50)
-                mBonus = 0.015;
-            else if (chance > 25)
-                mBonus = 0.010;
-            else 
-                mBonus = 0.005;
-
-            return mBonus +1;
-
-            
-        }
-    } 
-        
+    }         
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1374,95 +1374,98 @@ namespace ACE.Server.Factories
             return manaDMod;
         }
 
-        private static double GetMissileDMod(int tier)
+        private static double GetMagicMissileDMod(int tier)
         {
-            double missileMod = 0;
+            double magicMissileDefenseMod = 0;
 
-            switch (tier)
+            int modifierChance = ThreadSafeRandom.Next(1, 2);
+            if (modifierChance > 1)
             {
-                case 1:
-                case 2:
-                    missileMod = 0;
-                    break;
-                case 3:
-                    int chance = ThreadSafeRandom.Next(0, 100);
-                    if (chance > 95)
-                        missileMod = .005;
-                    break;
-                case 4:
-                    chance = ThreadSafeRandom.Next(0, 100);
-                    if (chance > 95)
-                        missileMod = .01;
-                    else if (chance > 80)
-                        missileMod = .005;
-                    else
-                        missileMod = 0;
-                    break;
-                case 5:
-                    chance = ThreadSafeRandom.Next(0, 1000);
-                    if (chance > 950)
-                        missileMod = .01;
-                    else if (chance > 800)
-                        missileMod = .005;
-                    else
-                        missileMod = 0;
-                    break;
-                case 6:
-                    chance = ThreadSafeRandom.Next(0, 1000);
-                    if (chance > 975)
-                        missileMod = .020;
-                    else if (chance > 900)
-                        missileMod = .015;
-                    else if (chance > 800)
-                        missileMod = .010;
-                    else if (chance > 700)
-                        missileMod = .005;
-                    else
-                        missileMod = 0;
-                    break;
-                case 7:
-                    chance = ThreadSafeRandom.Next(0, 1000);
-                    if (chance > 990)
-                        missileMod = .030;
-                    else if (chance > 985)
-                        missileMod = .025;
-                    else if (chance > 950)
-                        missileMod = .020;
-                    else if (chance > 900)
-                        missileMod = .015;
-                    else if (chance > 850)
-                        missileMod = .01;
-                    else if (chance > 800)
-                        missileMod = .005;
-                    else
-                        missileMod = 0;
-                    break;
-                default: // tier 8
-                    chance = ThreadSafeRandom.Next(0, 1000);
-                    if (chance > 998)
-                        missileMod = .04;
-                    else if (chance > 994)
-                        missileMod = .035;
-                    else if (chance > 990)
-                        missileMod = .03;
-                    else if (chance > 985)
-                        missileMod = .025;
-                    else if (chance > 950)
-                        missileMod = .02;
-                    else if (chance > 900)
-                        missileMod = .015;
-                    else if (chance > 850)
-                        missileMod = .01;
-                    else if (chance > 800)
-                        missileMod = .005;
-                    else
-                        missileMod = 0;
-                    break;
+                switch (tier)
+                {
+                    case 1:
+                    case 2:
+                        magicMissileDefenseMod = 0;
+                        break;
+                    case 3:
+                        int chance = ThreadSafeRandom.Next(0, 100);
+                        if (chance > 95)
+                            magicMissileDefenseMod = .005;
+                        break;
+                    case 4:
+                        chance = ThreadSafeRandom.Next(0, 100);
+                        if (chance > 95)
+                            magicMissileDefenseMod = .01;
+                        else if (chance > 80)
+                            magicMissileDefenseMod = .005;
+                        else
+                            magicMissileDefenseMod = 0;
+                        break;
+                    case 5:
+                        chance = ThreadSafeRandom.Next(0, 1000);
+                        if (chance > 950)
+                            magicMissileDefenseMod = .01;
+                        else if (chance > 800)
+                            magicMissileDefenseMod = .005;
+                        else
+                            magicMissileDefenseMod = 0;
+                        break;
+                    case 6:
+                        chance = ThreadSafeRandom.Next(0, 1000);
+                        if (chance > 975)
+                            magicMissileDefenseMod = .020;
+                        else if (chance > 900)
+                            magicMissileDefenseMod = .015;
+                        else if (chance > 800)
+                            magicMissileDefenseMod = .010;
+                        else if (chance > 700)
+                            magicMissileDefenseMod = .005;
+                        else
+                            magicMissileDefenseMod = 0;
+                        break;
+                    case 7:
+                        chance = ThreadSafeRandom.Next(0, 1000);
+                        if (chance > 990)
+                            magicMissileDefenseMod = .030;
+                        else if (chance > 985)
+                            magicMissileDefenseMod = .025;
+                        else if (chance > 950)
+                            magicMissileDefenseMod = .020;
+                        else if (chance > 900)
+                            magicMissileDefenseMod = .015;
+                        else if (chance > 850)
+                            magicMissileDefenseMod = .01;
+                        else if (chance > 800)
+                            magicMissileDefenseMod = .005;
+                        else
+                            magicMissileDefenseMod = 0;
+                        break;
+                    default: // tier 8
+                        chance = ThreadSafeRandom.Next(0, 1000);
+                        if (chance > 998)
+                            magicMissileDefenseMod = .04;
+                        else if (chance > 994)
+                            magicMissileDefenseMod = .035;
+                        else if (chance > 990)
+                            magicMissileDefenseMod = .03;
+                        else if (chance > 985)
+                            magicMissileDefenseMod = .025;
+                        else if (chance > 950)
+                            magicMissileDefenseMod = .02;
+                        else if (chance > 900)
+                            magicMissileDefenseMod = .015;
+                        else if (chance > 850)
+                            magicMissileDefenseMod = .01;
+                        else if (chance > 800)
+                            magicMissileDefenseMod = .005;
+                        else
+                            magicMissileDefenseMod = 0;
+                        break;
+                }
             }
+            double modifier = 1.0 + magicMissileDefenseMod;
 
-            double m2 = 1.0 + missileMod;
-
-            return m2;
+            return modifier;
         }
 
         private static int GetValue(int tier, int work, double gemMod, double matMod)
@@ -2377,7 +2380,7 @@ namespace ACE.Server.Factories
         /// <summary>
         /// Returns Values for Magic & Missile Defense Bonus. HarliQ 11/17/19
         /// </summary>
-        private static double GetMagicMissileDefenseBonus()
+        private static double GetMagicMissileADefenseBonus()
         {
             double mBonus = 0;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -186,21 +186,9 @@ namespace ACE.Server.Factories
 
             // Setting Weapon defensive mods 
             wo.WeaponDefense = GetWieldReqMeleeDMod(wield);
-            // A 5% chance to get any MagicD/Missile Bonus
-            if (wield > 355)
-            {
-                int chance = ThreadSafeRandom.Next(1, 40);
-                if (chance > 39)
-                {
-                    wo.WeaponMagicDefense = GetMagicMissileDefenseBonus();
-                }
+            wo.WeaponMagicDefense = GetMagicMissileDMod(tier);
+            wo.WeaponMissileDefense = GetMagicMissileDMod(tier);
 
-                chance = ThreadSafeRandom.Next(1, 40);
-                if (chance > 39)
-                {
-                    wo.WeaponMissileDefense = GetMagicMissileDefenseBonus();
-                }
-            }
             // Setting weapon Offensive Mods
             if (elementalDamageMod > 1.0f)
                 wo.ElementalDamageMod = elementalDamageMod;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -1,4 +1,3 @@
-
 using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -19,9 +18,9 @@ namespace ACE.Server.Factories
             double weaponOffense = 0;
             int longDescDecoration = 5;
 
-            ///Properties for weapons
-            double magicD = GetMissileDMod(tier);
-            double missileD = GetMissileDMod(tier);
+            // Properties for weapons
+            double magicD = GetMagicMissileDMod(tier);
+            double missileD = GetMagicMissileDMod(tier);
             int gemCount = ThreadSafeRandom.Next(1, 5);
             int gemType = ThreadSafeRandom.Next(10, 50);
             int workmanship = GetWorkmanship(tier);
@@ -384,7 +383,7 @@ namespace ACE.Server.Factories
             Spears,
         }
 
-        //The percentages for variances need to be fixed
+        // The percentages for variances need to be fixed
         private static double GetVariance(Skill category, LootWeaponType type)
         {
             double variance = 0;
@@ -510,7 +509,7 @@ namespace ACE.Server.Factories
                     switch (type)
                     {
                         case LootWeaponType.Axe:
-                            //Axe
+                            // Axe
                             if (chance < 10)
                                 variance = .80;
                             else if (chance < 30)
@@ -523,7 +522,7 @@ namespace ACE.Server.Factories
                                 variance = .95;
                             break;
                         case LootWeaponType.Dagger:
-                            //Dagger
+                            // Dagger
                             if (chance < 10)
                                 variance = .42;
                             else if (chance < 30)
@@ -536,7 +535,7 @@ namespace ACE.Server.Factories
                                 variance = .60;
                             break;
                         case LootWeaponType.DaggerMulti:
-                            //Dagger MultiStrike
+                            // Dagger MultiStrike
                             if (chance < 10)
                                 variance = .24;
                             else if (chance < 30)
@@ -549,7 +548,7 @@ namespace ACE.Server.Factories
                                 variance = .45;
                             break;
                         case LootWeaponType.Mace:
-                            //Mace
+                            // Mace
                             if (chance < 10)
                                 variance = .23;
                             else if (chance < 30)
@@ -562,7 +561,7 @@ namespace ACE.Server.Factories
                                 variance = .43;
                             break;
                         case LootWeaponType.Jitte:
-                            //Jitte
+                            // Jitte
                             if (chance < 10)
                                 variance = .325;
                             else if (chance < 30)
@@ -575,7 +574,7 @@ namespace ACE.Server.Factories
                                 variance = .50;
                             break;
                         case LootWeaponType.Spear:
-                            //Spear
+                            // Spear
                             if (chance < 10)
                                 variance = .65;
                             else if (chance < 30)
@@ -588,7 +587,7 @@ namespace ACE.Server.Factories
                                 variance = .80;
                             break;
                         case LootWeaponType.Staff:
-                            //Staff
+                            // Staff
                             if (chance < 10)
                                 variance = .325;
                             else if (chance < 30)
@@ -601,7 +600,7 @@ namespace ACE.Server.Factories
                                 variance = .50;
                             break;
                         case LootWeaponType.Sword:
-                            //Sword
+                            // Sword
                             if (chance < 10)
                                 variance = .42;
                             else if (chance < 30)
@@ -614,7 +613,7 @@ namespace ACE.Server.Factories
                                 variance = .60;
                             break;
                         case LootWeaponType.SwordMulti:
-                            //Sword Multistrike
+                            // Sword Multistrike
                             if (chance < 10)
                                 variance = .24;
                             else if (chance < 30)
@@ -627,7 +626,7 @@ namespace ACE.Server.Factories
                                 variance = .45;
                             break;
                         case LootWeaponType.UA:
-                            //UA
+                            // UA
                             if (chance < 10)
                                 variance = .44;
                             else if (chance < 30)
@@ -642,7 +641,7 @@ namespace ACE.Server.Factories
                     }
                     break;
                 case Skill.TwoHandedCombat:
-                    /// Two Handed only have one set of variances
+                    // Two Handed only have one set of variances
                     if (chance < 5)
                         variance = .30;
                     else if (chance < 20)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -1,4 +1,3 @@
-
 using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -43,11 +42,9 @@ namespace ACE.Server.Factories
             if (meleeDMod > 0.0f)
                 wo.SetProperty(PropertyFloat.WeaponDefense, meleeDMod);
 
-            double missileDMod = GetMissileDMod(tier);
-            if (missileDMod > 0.0f)
-                wo.SetProperty(PropertyFloat.WeaponMissileDefense, missileDMod);
-
-            // wo.SetProperty(PropertyFloat.WeaponMagicDefense, magicDefense);
+            // MagicD/Missile Bonus
+            wo.WeaponMagicDefense = GetMagicMissileDMod(tier); 
+            wo.WeaponMissileDefense = GetMagicMissileDMod(tier);
 
             wo.SetProperty(PropertyFloat.DamageMod, GetMissileDamageMod(wieldDifficulty, wo.GetProperty(PropertyInt.WeaponType)));
 


### PR DESCRIPTION
Made getting MagicD and MissileD modifier the same across all weapon types.  Also fixes Missile Weapons not receiving a chance of getting a MagicD modifier bonus.

Also neatened up Melee Factory to comply with StyleCop

Tested with loot sim to make sure drops are correct.