### PR TITLE
improved /targetloc

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2666,12 +2666,40 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("targetloc", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the location of the last appraised object")]
         public static void HandleTargetLoc(Session session, params string[] parameters)
         {
-            var wo = CommandHandlerHelper.GetLastAppraisedObject(session);
-            if (wo == null)
-                return;
+            WorldObject wo = null;
+            if (parameters.Length == 0)
+            {
+                wo = CommandHandlerHelper.GetLastAppraisedObject(session);
 
+                if (wo == null) return;
+            }
+            else
+            {
+                if (parameters[0].StartsWith("0x"))
+                    parameters[0] = parameters[0].Substring(2);
+
+                if (!uint.TryParse(parameters[0], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint guid))
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"{parameters[0]} is not a valid guid", ChatMessageType.Broadcast));
+                    return;
+                }
+
+                wo = session.Player.CurrentLandblock?.GetObject(guid);
+
+                if (wo == null)
+                    wo = ServerObjectManager.GetObjectA(guid)?.WeenieObj?.WorldObject;
+
+                if (wo == null)
+                {
+                    session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find {parameters[0]}", ChatMessageType.Broadcast));
+                    return;
+                }
+            }
+
+            session.Network.EnqueueSend(new GameMessageSystemChat($"CurrentLandblock: 0x{wo.CurrentLandblock?.Id.Landblock:X4}", ChatMessageType.Broadcast));
             session.Network.EnqueueSend(new GameMessageSystemChat($"Location: {wo.Location?.ToLOCString()}", ChatMessageType.Broadcast));
             session.Network.EnqueueSend(new GameMessageSystemChat($"Physics : {wo.PhysicsObj?.Position}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"CurCell: 0x{wo.PhysicsObj?.CurCell?.ID:X8}", ChatMessageType.Broadcast));
         }
 
         [CommandHandler("damagehistory", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]


### PR DESCRIPTION
/targetloc developer command now supports specifying an exact guid, in addition to the default mode of last appraised object

This guid can be a landblock object that is anywhere on the server, and it will find it

PhysicsObj.CurCell has also been added to the output, and these 2 features will help debug some of the generator issues that CE has been seeing
