### PR TITLE
additional logic for repeated appraisals

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -157,6 +157,7 @@ namespace ACE.Entity.Enum.Properties
         AllegianceInfoSpamTimestamp    = 139,
         AllegianceInfoSpamRate         = 140,
         NextSpellcastTimestamp         = 141,
+        [Ephemeral]
         AppraisalRequestedTimestamp    = 142,
         AppraisalHeartbeatDueTimestamp = 143,
         ManaConversionMod              = 144,

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -1048,5 +1048,27 @@ namespace ACE.Server.WorldObjects
             get => (SquelchMask)(GetProperty(PropertyInt.SquelchGlobal) ?? 0);
             set { if (value == 0) RemoveProperty(PropertyInt.SquelchGlobal); else SetProperty(PropertyInt.SquelchGlobal, (int)value); }
         }
+
+        public uint? RequestedAppraisalTarget
+        {
+            get => GetProperty(PropertyInstanceId.RequestedAppraisalTarget);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.RequestedAppraisalTarget); else SetProperty(PropertyInstanceId.RequestedAppraisalTarget, value.Value); }
+        }
+
+        public double? AppraisalRequestedTimestamp
+        {
+            get => GetProperty(PropertyFloat.AppraisalRequestedTimestamp);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.AppraisalRequestedTimestamp); else SetProperty(PropertyFloat.AppraisalRequestedTimestamp, value.Value); }
+        }
+
+        /// <summary>
+        /// ACE is currently using this for the last successful appraised object guid
+        /// </summary>
+        public uint? CurrentAppraisalTarget
+        {
+            get => GetProperty(PropertyInstanceId.CurrentAppraisalTarget);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.CurrentAppraisalTarget); else SetProperty(PropertyInstanceId.CurrentAppraisalTarget, value.Value); }
+        }
+
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2369,12 +2369,6 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.CurrentFollowTarget); else SetProperty(PropertyInstanceId.CurrentFollowTarget, value.Value); }
         }
 
-        public uint? CurrentAppraisalTarget
-        {
-            get => GetProperty(PropertyInstanceId.CurrentAppraisalTarget);
-            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.CurrentAppraisalTarget); else SetProperty(PropertyInstanceId.CurrentAppraisalTarget, value.Value); }
-        }
-
         public uint? CurrentFellowshipAppraisalTarget
         {
             get => GetProperty(PropertyInstanceId.CurrentFellowshipAppraisalTarget);
@@ -2397,12 +2391,6 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyInstanceId.ManaQueryTarget);
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.ManaQueryTarget); else SetProperty(PropertyInstanceId.ManaQueryTarget, value.Value); }
-        }
-
-        public uint? RequestedAppraisalTarget
-        {
-            get => GetProperty(PropertyInstanceId.RequestedAppraisalTarget);
-            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.RequestedAppraisalTarget); else SetProperty(PropertyInstanceId.RequestedAppraisalTarget, value.Value); }
         }
 
         public PKLevel PkLevel


### PR DESCRIPTION
This fixes a bug where a successful appraisal could then blip off to an unsuccessful attempt again (possibly automatically, for appraised combat targets)

With this change, some rate limiting for unsuccessful attempts also needs to be introduced. If a player were to be allowed to spam the server with unsuccessful appraisal attempts in a non-throttled manner, they would be able to get that '1 successful attempt' near instantly, negating most of the appraisal skill check