### PR TITLE
Update default dats path on windows

### DIFF
--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -31,7 +31,7 @@
     // The folder that contains AC DAT files (client_cell_1.dat, client_portal.dat, client_highres.dat, client_local_English.dat)
     // Note that for servers running on Linux, the ~ home folder must be fully expanded, ie. /home/user/ace/, instead of ~/ace/
     // Note that for servers running on Windows, a path like c:\ace\ MUST be entered as c:\\ace\\, replacing the single backslashes (\) with double backslashes (\\)
-    "DatFilesDirectory": "c:\\ACE\\",
+    "DatFilesDirectory": "c:\\ACE\\Dats\\",
 
     "ShutdownInterval": "60",
 


### PR DESCRIPTION
This lines up with the ACE install on windows wiki. I've seen others using the same directory structure as well before this documentation update:

https://github.com/ACEmulator/ACE/wiki/ACE-Hosting-Windows