### PR TITLE
Fix issue with VerifyUse

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2546,7 +2546,7 @@ namespace ACE.Server.Command.Handlers
                     {
                         var profile = wo.GeneratorProfiles[activeProfile];
 
-                        msg += $"Active GeneratorProfile id: {activeProfile}\n";
+                        msg += $"Active GeneratorProfile id: {activeProfile} | LinkId: {profile.LinkId}\n";
 
                         msg += $"Probability: {profile.Biota.Probability} | WCID: {profile.Biota.WeenieClassId} | Delay: {profile.Biota.Delay} | Init: {profile.Biota.InitCreate} | Max: {profile.Biota.MaxCreate}\n";
                         msg += $"WhenCreate: {((RegenerationType)profile.Biota.WhenCreate).ToString()} | WhereCreate: {((RegenLocationType)profile.Biota.WhereCreate).ToString()}\n";

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -458,6 +458,10 @@ namespace ACE.Server.Entity
         {
             //log.Debug($"{_generator.Name}.NotifyGenerator({target:X8}, {eventType})");
 
+            Spawned.TryGetValue(target.Full, out var woi);
+
+            if (woi == null) return;
+
             var adjEventType = eventType; // some generators use pickup when they mean to use destruction, some use destruction when they mean to use pickup. this data comes from 16py mostly and these issues are corrected below.
             var whenCreate = (RegenerationType)Biota.WhenCreate;
             var adjWhenCreate = (RegenerationType)Biota.WhenCreate;
@@ -477,17 +481,13 @@ namespace ACE.Server.Entity
                 adjWhenCreate = RegenerationType.PickUp;
 
             if (eventType != adjEventType)
-                log.Warn($"GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjEventType.ToString()} as RegenerationType instead");
+                log.Warn($"{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjEventType.ToString()} as RegenerationType instead");
 
             if (whenCreate != adjWhenCreate)
-                log.Warn($"GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjWhenCreate.ToString()} as WhenCreate instead");
+                log.Warn($"{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjWhenCreate.ToString()} as WhenCreate instead");
 
             if (adjWhenCreate != adjEventType)
-                return;
-
-            Spawned.TryGetValue(target.Full, out var woi);
-
-            if (woi == null) return;
+                return;            
 
             RemoveQueue.Enqueue((DateTime.UtcNow.AddSeconds(Delay), woi.Guid.Full));
         }

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -22,6 +22,13 @@ namespace ACE.Server.Entity
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
         /// <summary>
+        /// The id for the profile. This id will be either a GUID from Landblock_Instances or an incremental id based on profile order from biota entry. 
+        /// </summary>
+        public uint Id;
+
+        public string LinkId => Id > 0x70000000 ? $"0x{Id:X8}" : $"{Id}";
+
+        /// <summary>
         /// The biota with all the generator profile info
         /// </summary>
         public BiotaPropertiesGenerator Biota;
@@ -120,10 +127,11 @@ namespace ACE.Server.Entity
         /// Constructs a new active generator profile
         /// from a biota generator
         /// </summary>
-        public GeneratorProfile(WorldObject generator, BiotaPropertiesGenerator biota)
+        public GeneratorProfile(WorldObject generator, BiotaPropertiesGenerator biota, uint profileId)
         {
             Generator = generator;
             Biota = biota;
+            Id = profileId;
         }
 
         /// <summary>
@@ -481,10 +489,10 @@ namespace ACE.Server.Entity
                 adjWhenCreate = RegenerationType.PickUp;
 
             if (eventType != adjEventType)
-                log.Warn($"{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjEventType.ToString()} as RegenerationType instead");
+                log.Warn($"0x{Generator.Guid}:{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile[{LinkId}].NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjEventType.ToString()} as RegenerationType instead");
 
             if (whenCreate != adjWhenCreate)
-                log.Warn($"{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjWhenCreate.ToString()} as WhenCreate instead");
+                log.Warn($"0x{Generator.Guid}:{Generator.Name}({Generator.WeenieClassId}).GeneratorProfile[{LinkId}].NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjWhenCreate.ToString()} as WhenCreate instead");
 
             if (adjWhenCreate != adjEventType)
                 return;            

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -470,6 +470,9 @@ namespace ACE.Server.Entity
             if (eventType == RegenerationType.Destruction && (RegenerationType)Biota.WhenCreate == RegenerationType.Undef)
                 Biota.WhenCreate = (uint)RegenerationType.Destruction;
 
+            if (eventType == RegenerationType.PickUp && (RegenerationType)Biota.WhenCreate == RegenerationType.Undef)
+                Biota.WhenCreate = (uint)RegenerationType.PickUp;
+
             if (Biota.WhenCreate != (uint)adjEventType)
                 return;
 

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -459,21 +459,30 @@ namespace ACE.Server.Entity
             //log.Debug($"{_generator.Name}.NotifyGenerator({target:X8}, {eventType})");
 
             var adjEventType = eventType; // some generators use pickup when they mean to use destruction, some use destruction when they mean to use pickup. this data comes from 16py mostly and these issues are corrected below.
+            var whenCreate = (RegenerationType)Biota.WhenCreate;
+            var adjWhenCreate = (RegenerationType)Biota.WhenCreate;
 
-            if (eventType == RegenerationType.PickUp && (RegenerationType)Biota.WhenCreate == RegenerationType.Destruction)
+            if (eventType == RegenerationType.PickUp && whenCreate == RegenerationType.Destruction)
                 adjEventType = RegenerationType.Destruction;
 
-            if (eventType == RegenerationType.Destruction && (RegenerationType)Biota.WhenCreate == RegenerationType.PickUp)
+            if (eventType == RegenerationType.Destruction && whenCreate == RegenerationType.PickUp)
                 adjEventType = RegenerationType.PickUp;
 
             // If WhenCreate is Undef, assume it means Destruction (bad data)
-            if (eventType == RegenerationType.Destruction && (RegenerationType)Biota.WhenCreate == RegenerationType.Undef)
-                Biota.WhenCreate = (uint)RegenerationType.Destruction;
+            if (eventType == RegenerationType.Destruction && whenCreate == RegenerationType.Undef)
+                adjWhenCreate = RegenerationType.Destruction;
 
-            if (eventType == RegenerationType.PickUp && (RegenerationType)Biota.WhenCreate == RegenerationType.Undef)
-                Biota.WhenCreate = (uint)RegenerationType.PickUp;
+            // If WhenCreate is Undef, assume it means Pickup (bad data)
+            if (eventType == RegenerationType.PickUp && whenCreate == RegenerationType.Undef)
+                adjWhenCreate = RegenerationType.PickUp;
 
-            if (Biota.WhenCreate != (uint)adjEventType)
+            if (eventType != adjEventType)
+                log.Warn($"GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjEventType.ToString()} as RegenerationType instead");
+
+            if (whenCreate != adjWhenCreate)
+                log.Warn($"GeneratorProfile.NotifyGenerator: RegenerationType = {eventType.ToString()}, WhenCreate = {whenCreate.ToString()}, Using {adjWhenCreate.ToString()} as WhenCreate instead");
+
+            if (adjWhenCreate != adjEventType)
                 return;
 
             Spawned.TryGetValue(target.Full, out var woi);

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -458,14 +458,19 @@ namespace ACE.Server.Entity
         {
             //log.Debug($"{_generator.Name}.NotifyGenerator({target:X8}, {eventType})");
 
+            var adjEventType = eventType; // some generators use pickup when they mean to use destruction, some use destruction when they mean to use pickup. this data comes from 16py mostly and these issues are corrected below.
+
             if (eventType == RegenerationType.PickUp && (RegenerationType)Biota.WhenCreate == RegenerationType.Destruction)
-                eventType = RegenerationType.Destruction;
+                adjEventType = RegenerationType.Destruction;
+
+            if (eventType == RegenerationType.Destruction && (RegenerationType)Biota.WhenCreate == RegenerationType.PickUp)
+                adjEventType = RegenerationType.PickUp;
 
             // If WhenCreate is Undef, assume it means Destruction (bad data)
             if (eventType == RegenerationType.Destruction && (RegenerationType)Biota.WhenCreate == RegenerationType.Undef)
                 Biota.WhenCreate = (uint)RegenerationType.Destruction;
 
-            if (Biota.WhenCreate != (uint)eventType)
+            if (Biota.WhenCreate != (uint)adjEventType)
                 return;
 
             Spawned.TryGetValue(target.Full, out var woi);

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -726,7 +726,7 @@ namespace ACE.Server.Managers
             if (usable.HasFlag(Usable.Wielded))
                 searchLocations |= Player.SearchLocations.MyEquippedItems;
             if (usable.HasFlag(Usable.Remote))
-                searchLocations |= Player.SearchLocations.Landblock;    // TODO: moveto for this type
+                searchLocations |= Player.SearchLocations.LocationsICanMove;    // TODO: moveto for this type
 
             return player.FindObject(obj.Guid.Full, searchLocations) != null;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -42,9 +42,10 @@ namespace ACE.Server.WorldObjects
         public void AddGeneratorProfiles()
         {
             GeneratorProfiles = new List<GeneratorProfile>();
+            uint i = 0;
 
             foreach (var generator in Biota.BiotaPropertiesGenerator)
-                GeneratorProfiles.Add(new GeneratorProfile(this, generator));
+                GeneratorProfiles.Add(new GeneratorProfile(this, generator, i++));
         }
 
         /// <summary>
@@ -744,7 +745,7 @@ namespace ACE.Server.WorldObjects
                 profile.WhenCreate = profileTemplate.Biota.WhenCreate;
                 profile.WhereCreate = profileTemplate.Biota.WhereCreate;
 
-                GeneratorProfiles.Add(new GeneratorProfile(this, profile));
+                GeneratorProfiles.Add(new GeneratorProfile(this, profile, link.Guid));
                 if (profile.Probability == -1)
                 {
                     InitCreate += profile.InitCreate;


### PR DESCRIPTION
http://acpedia.org/wiki/The_Moars

Use the Emerald Clasp on the Adjanite Gem to create Decorated Adjanite Gem.

Both objects are contained but Clasp has ItemUseable.SourceContainedTargetRemote flag, was also this way EoR

https://github.com/ACEmulator/ACE-World-16PY/blob/master/Database/3-Core/4%20CraftTable/SQL/04774%20Decorated%20Adjanite%20Gem.sql