### PR TITLE
Enforce quest timers for Portal.QuestRestriction

### DIFF
--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -474,14 +474,25 @@ namespace ACE.Server.Managers
 
             if (player == null) return;
 
-            if (wo is Portal)
+            var error = new GameEventInventoryServerSaveFailed(player.Session, wo.Guid.Full, WeenieError.ItemRequiresQuestToBePickedUp);
+            player.Session.Network.EnqueueSend(error);
+        }
+
+        public void HandlePortalQuestError(string questName)
+        {
+            var player = Creature as Player;
+
+            if (player == null) return;
+
+            if (!HasQuest(questName))
             {
                 player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YouMustCompleteQuestToUsePortal));
             }
-            else
+            else if (CanSolve(questName))
             {
-                var error = new GameEventInventoryServerSaveFailed(player.Session, wo.Guid.Full, WeenieError.ItemRequiresQuestToBePickedUp);
-                player.Session.Network.EnqueueSend(error);
+                var error = new GameEventWeenieError(player.Session, WeenieError.QuestSolvedTooLongAgo);
+                var text = new GameMessageSystemChat("You completed the quest this portal requires too long ago!", ChatMessageType.Magic); // This msg wasn't sent in retail PCAP, leading to a completely silent fail when using the portal with an expired flag.
+                player.Session.Network.EnqueueSend(text, error);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -138,15 +138,23 @@ namespace ACE.Server.WorldObjects
             }
 
             // handle quest initial flagging
-            if (Quest != null && !player.QuestManager.HasQuest(Quest))
+            if (Quest != null)
             {
                 player.QuestManager.Update(Quest);
             }
 
-            if (QuestRestriction != null && !player.QuestManager.HasQuest(QuestRestriction) && !player.IgnorePortalRestrictions)
+            if (QuestRestriction != null && !player.IgnorePortalRestrictions)
             {
-                player.QuestManager.HandleNoQuestError(this);
-                return new ActivationResult(false);
+                var hasQuest = player.QuestManager.HasQuest(QuestRestriction);
+                var canSolve = player.QuestManager.CanSolve(QuestRestriction);
+
+                var success = hasQuest && !canSolve;
+
+                if (!success)
+                {
+                    player.QuestManager.HandlePortalQuestError(QuestRestriction);
+                    return new ActivationResult(false);
+                }
             }
 
             return new ActivationResult(true);


### PR DESCRIPTION
Some portals have quests that require reflagging after the flag "expires" based on quest definitions for max solves and min delta

Haunted Mansion, Aug Gem/Bellas are examples