### PR TITLE
adding null pointer prevention to GetAllPlayerBiotasInParallel()

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -871,7 +871,10 @@ namespace ACE.Database
                 {
                     var biota = GetBiota(result.Id);
 
-                    biotas.Add(biota);
+                    if (biota != null)
+                        biotas.Add(biota);
+                    else
+                        log.Error($"ShardDatabase.GetAllPlayerBiotasInParallel() - couldn't find biota for character 0x{result.Id:X8}");
                 });
             }
 


### PR DESCRIPTION
This shouldn't happen under normal circumstances, but is possible if a player biota has been deleted from the db, or something has seriously gone awry..