### PR TITLE
Upped Melee D Bonus for no wield wands upto 10% from 5%. 

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -2266,6 +2266,27 @@ namespace ACE.Server.Factories
             switch (wield)
             {
                 case 0:
+                    if (chance < 20)
+                        meleeMod = 0.01;
+                    else if (chance < 30)
+                        meleeMod = 0.02;
+                    else if (chance < 40)
+                        meleeMod = 0.03;
+                    else if (chance < 50)
+                        meleeMod = 0.04;
+                    else if (chance < 60)
+                        meleeMod = 0.05;
+                    else if (chance < 70)
+                        meleeMod = 0.06;
+                    else if (chance < 80)
+                        meleeMod = 0.07;
+                    else if (chance < 90)
+                        meleeMod = 0.08;
+                    else if (chance < 95)
+                        meleeMod = 0.09;
+                    else
+                        meleeMod = 0.10;
+                    break;
                 case 250: // Missile
                     if (chance < 20)
                         meleeMod = 0.01;

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -2266,23 +2266,23 @@ namespace ACE.Server.Factories
             switch (wield)
             {
                 case 0:
-                    if (chance < 20)
+                    if (chance < 16)
                         meleeMod = 0.01;
-                    else if (chance < 30)
+                    else if (chance < 31)
                         meleeMod = 0.02;
-                    else if (chance < 40)
+                    else if (chance < 41)
                         meleeMod = 0.03;
-                    else if (chance < 50)
+                    else if (chance < 51)
                         meleeMod = 0.04;
-                    else if (chance < 60)
+                    else if (chance < 61)
                         meleeMod = 0.05;
-                    else if (chance < 70)
+                    else if (chance < 71)
                         meleeMod = 0.06;
-                    else if (chance < 80)
+                    else if (chance < 81)
                         meleeMod = 0.07;
-                    else if (chance < 90)
+                    else if (chance < 91)
                         meleeMod = 0.08;
-                    else if (chance < 95)
+                    else if (chance < 98)
                         meleeMod = 0.09;
                     else
                         meleeMod = 0.10;


### PR DESCRIPTION
Upped Melee D Bonus for no wield wands up to 10% from 5%.  That is what data supports from Optim.