### PR TITLE
updating GetLastAppraisedObject()

### DIFF
--- a/Source/ACE.Server/Command/Handlers/CommandHandlerHelper.cs
+++ b/Source/ACE.Server/Command/Handlers/CommandHandlerHelper.cs
@@ -49,7 +49,7 @@ namespace ACE.Server.Command.Handlers
         /// </summary>
         public static WorldObject GetLastAppraisedObject(Session session)
         {
-            var targetID = session.Player.CurrentAppraisalTarget;
+            var targetID = session.Player.RequestedAppraisalTarget;
             if (targetID == null)
             {
                 WriteOutputInfo(session, "GetLastAppraisedObject() - no appraisal target");


### PR DESCRIPTION
With the latest appraisal changes, server commands which use the last appraised object were failing if the last appraised object was a monster that returned ???'s

Thanks to @harliq for discovering / reporting this bug