### PR TITLE
fixing 1 gap for pk casting

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -172,6 +172,7 @@ namespace ACE.Server.WorldObjects
             if (target == null)
             {
                 SendUseDoneEvent(WeenieError.TargetNotAcquired);
+                MagicState.OnCastDone();
                 return;
             }
 


### PR DESCRIPTION
For PKTypes, if the target is removed from the landblock while the player is doing the initial TurnTo, there was a gap here where OnCastDone wasn't being called