### PR TITLE
ensure pktypes are calling the correct MoveTo function

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -36,6 +36,12 @@ namespace ACE.Server.WorldObjects
 
         public void CreateMoveToChain(WorldObject target, Action<bool> callback, float? useRadius = null, bool rotate = true)
         {
+            if (FastTick)
+            {
+                CreateMoveToChain2(target, callback, useRadius, rotate);
+                return;
+            }
+
             var thisMoveToChainNumber = GetNextMoveToChainNumber();
 
             if (target.Location == null)


### PR DESCRIPTION
This fixes the bug where a PK/PKL could 'use' an object on the other side of a trap, effectively running across the trap without triggering it

Thanks to @Jkurs and @CrimsonMage for reporting this issue