### PR TITLE
Loot sim update

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.Command.Handlers
 {
     public static class DeveloperLootCommands
     {
-        [CommandHandler("testlootgen", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 1, "Generates Loot for testing LootFactories.  Do testlootgen -info for examples.", "<number of items> <loot tier> <melee, missile, caster, armor, pet (optional)>")]
+        [CommandHandler("testlootgen", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 1, "Generates Loot for testing LootFactories.  Do testlootgen -info for examples.", "<number of items> <loot tier> <melee, missile, caster, armor, pet, aetheria (optional)>")]
         public static void TestLootGenerator(Session session, params string[] parameters)
         {
             // This generates loot items and displays the drop rates of LootFactory
@@ -22,7 +22,7 @@ namespace ACE.Server.Command.Handlers
             {
                 case "-info":
                     Console.WriteLine($"Usage: \n" +
-                                    $"<number of items> <loot tier> <(optional)display table - melee, missile, caster, armor, pet> \n" +
+                                    $"<number of items> <loot tier> <(optional)display table - melee, missile, caster, armor, pet, aetheria> \n" +
                                     $" Example: The following command will generate 1000 items in Tier 7 that shows the melee table\n" +
                                     $"testlootgen 1000 7 melee \n" +
                                     $" Example: The following command will generate 1000 items in Tier 6 that just shows a summary \n" +
@@ -72,7 +72,7 @@ namespace ACE.Server.Command.Handlers
                 case "":
                     break;
                 default:
-                    Console.WriteLine("Invalid Table Option.  Available Tables to show are melee, missile, caster, armor, pet, or all.");
+                    Console.WriteLine("Invalid Table Option.  Available Tables to show are melee, missile, caster, armor, pet, aetheria or all.");
                     return;
             }
             if (parameters.LongLength > 3)
@@ -97,7 +97,7 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
         }
-        [CommandHandler("testlootgencorpse", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 1, "Generates Corpses for testing LootFactories", "<DID> <number corpses> <display table - melee, missile, caster, armor, pet>")]
+        [CommandHandler("testlootgencorpse", AccessLevel.Admin, CommandHandlerFlag.ConsoleInvoke, 1, "Generates Corpses for testing LootFactories", "<DID> <number corpses> <display table - melee, missile, caster, armor, pet, aetheria>")]
         public static void TestLootGeneratorCorpse(Session session, params string[] parameters)
         {
             // This generates loot items and displays the drop rates of LootFactory
@@ -113,7 +113,7 @@ namespace ACE.Server.Command.Handlers
             {
                 case "-info":
                     Console.WriteLine($"Usage: \n" +
-                                    $"<DID> <number corpses> <(optional)display table - melee, missile, caster, armor, pet> \n" +
+                                    $"<DID> <number corpses> <(optional)display table - melee, missile, caster, armor, pet, aetheria> \n" +
                                     $" Example: The following command will generate 50 corpses generated from DeathTreasure DID 998 that shows the caster table\n" +
                                     $"testlootgencorpse 998 50 caster \n" +
                                     $" Example: The following command will generate 75 corpses generated from DeathTreasure DID 452 that just shows a summary \n" +

--- a/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
@@ -69,6 +69,9 @@ namespace ACE.Server.Command.Handlers
                     break;
                 case "all":
                     break;
+                case "-log":
+                    logstats = true;                    
+                    break;
                 case "":
                     break;
                 default:
@@ -157,6 +160,9 @@ namespace ACE.Server.Command.Handlers
                 case "aetheria":
                     break;
                 case "all":
+                    break;
+                case "-log":
+                    logstats = true;
                     break;
                 case "":
                     break;

--- a/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
@@ -80,8 +80,8 @@ namespace ACE.Server.Command.Handlers
                 case "":
                     break;
                 case "-log":
-                    logstats = false;
-                    Console.WriteLine("Logging is not currently working, Displaying results to screen.");
+                    logstats = true;
+                    // Console.WriteLine("Logging is not currently working, Displaying results to screen.");
                     break;
                 default:
                     Console.WriteLine("Invalid Option.  To log a file, use option -log");
@@ -167,8 +167,8 @@ namespace ACE.Server.Command.Handlers
                 case "":
                     break;
                 case "-log":
-                    logstats = false;
-                    Console.WriteLine("Logging is not currently working, Displaying results to screen.");
+                    logstats = true;
+                    // Console.WriteLine("Logging is not currently working, Displaying results to screen.");
                     break;
                 default:
                     Console.WriteLine("Invalid Option.  To log a file, use option -log");

--- a/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperLootCommands.cs
@@ -65,6 +65,8 @@ namespace ACE.Server.Command.Handlers
                     break;
                 case "pet":
                     break;
+                case "aetheria":
+                    break;
                 case "all":
                     break;
                 case "":
@@ -152,12 +154,14 @@ namespace ACE.Server.Command.Handlers
                     break;
                 case "pet":
                     break;
+                case "aetheria":
+                    break;
                 case "all":
                     break;
                 case "":
                     break;
                 default:
-                    Console.WriteLine("Invalid Table Option.  Available Tables to show are melee, missile, caster, armor, pet, or all.");
+                    Console.WriteLine("Invalid Table Option.  Available Tables to show are melee, missile, caster, armor, pet, aetheria or all.");
                     return;
             }
             if (parameters.LongLength > 3)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -22,13 +22,13 @@ namespace ACE.Server.Factories
 
             Console.WriteLine($"Creating {numItems} items, that are in tier {tier}");
 
-             var ls = SetLootStatsDefaults(new LootStats());
+             var ls = SetLootStatsDefaults(new LootStats(),logstats);
 
             // Loop depending on how many items you are creating
             for (int i = 0; i < numItems; i++)
             {
                 var testItem = LootGenerationFactory.CreateRandomLootObjects(tier, true);
-                ls = LootStats(testItem, ls);
+                ls = LootStats(testItem, ls, logstats);
             }
             Console.WriteLine(displayHeader);
             Console.WriteLine(DisplayStats(ls, displaytable));
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories
             string displayHeader = $"\n LootFactory Simulator - Corpses\n ---------------------\n";
 
             var corpseContainer = new List<WorldObject>();
-            var ls = SetLootStatsDefaults(new LootStats());
+            var ls = SetLootStatsDefaults(new LootStats(),logstats);
 
             Console.WriteLine($"Creating {numberofcorpses} corpses.");
             
@@ -67,7 +67,7 @@ namespace ACE.Server.Factories
 
                     foreach (var lootItem in corpseContainer)
                     {
-                        ls = LootStats(lootItem, ls);
+                        ls = LootStats(lootItem, ls, logstats);
                     }
                 }
                 else
@@ -77,9 +77,15 @@ namespace ACE.Server.Factories
             Console.WriteLine(displayHeader);
             Console.WriteLine(DisplayStats(ls, displaytable));
             displayHeader += $" A total of {ls.TotalItems} unique items were generated.";
+            if (logstats == true)
+            {
+                string myfilename = string.Format("LootSim-{0:hh-mm-ss-tt_MM-dd-yyyy}.csv", DateTime.Now);
+                System.IO.File.WriteAllText(myfilename, DisplayStats(ls, displaytable));
+            }
+
             return displayHeader;
         }
-        public static LootStats LootStats(WorldObject wo, LootStats ls)
+        public static LootStats LootStats(WorldObject wo, LootStats ls, bool logstats)
         {          
             // Weapon Properties 
             double missileDefMod = 0.00f;
@@ -122,9 +128,16 @@ namespace ACE.Server.Factories
                         if (testItem.WieldDifficulty != null)
                             wield = testItem.WieldDifficulty.Value;
                         if (testItem.WeaponSkill == Skill.TwoHandedCombat)
-                            ls.MeleeWeapons = ls.MeleeWeapons + $" {testItem.WeaponSkill}\t {wield}\t {testItem.Damage.Value}\t\t {strikeType} \t\t {testItem.DamageVariance.Value}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {testItem.Name}\n";
+                        {
+                            if (logstats == true)
+                            {
+                                ls.MeleeWeapons += $"{testItem.WeaponSkill},{wield},{testItem.Damage.Value},{strikeType},{testItem.DamageVariance.Value},{testItem.WeaponDefense.Value},{magicDefMod},{missileDefMod},{value},{testItem.Name}\n";
+                            }
+                            else
+                                ls.MeleeWeapons += $" {testItem.WeaponSkill}\t {wield}\t {testItem.Damage.Value}\t\t {strikeType} \t\t {testItem.DamageVariance.Value}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {testItem.Name}\n";
+                        }
                         else
-                        {                         
+                        {
                             AttackType attackType = testItem.W_AttackType;
                             string at = attackType.ToString("F");
                             if (at.Contains("DoubleSlash") || at.Contains("DoubleThrust"))
@@ -135,12 +148,22 @@ namespace ACE.Server.Factories
                             {
                                 strikeType = "3x";
                             }
-                            ls.MeleeWeapons = ls.MeleeWeapons + $" {testItem.WeaponSkill}\t\t {wield}\t {testItem.Damage.Value}\t\t {strikeType}\t\t {testItem.DamageVariance.Value}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {testItem.Name}\n";
+                            if (logstats == true)
+                            {
+                                ls.MeleeWeapons += $"{testItem.WeaponSkill},{wield},{testItem.Damage.Value},{strikeType},{testItem.DamageVariance.Value},{testItem.WeaponDefense.Value},{magicDefMod},{missileDefMod},{value},{testItem.Name}\n";
+                            }
+                            else
+                                ls.MeleeWeapons += $" {testItem.WeaponSkill}\t\t {wield}\t {testItem.Damage.Value}\t\t {strikeType}\t\t {testItem.DamageVariance.Value}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {testItem.Name}\n";
                         }
                         break;
                     case ItemType.Armor:
                         ls.ArmorCount++;
-                        ls.Armor += $" {testItem.ArmorLevel}\t {testItem.Value.Value} \t {testItem.Name}\n";
+                        if (logstats == true)
+                        {
+                            ls.Armor += $"{testItem.ArmorLevel},{testItem.Value.Value},{testItem.Name}\n";
+                        }
+                        else
+                            ls.Armor += $" {testItem.ArmorLevel}\t {testItem.Value.Value} \t {testItem.Name}\n";
                         if (testItem.Name.Contains("Sheild"))
                             break;
                         if (testItem.ArmorLevel > ls.MaxAL)
@@ -244,7 +267,12 @@ namespace ACE.Server.Factories
                                 totalRatings += petDevice.GearCritResist.Value;
                                 critResist = petDevice.GearCritResist.Value;
                             }
-                            ls.Pets += $" {petLevel}\t {damage}\t {damageResist}\t {crit}\t {critDamage}\t {critDamageResist}\t {critResist}\t {totalRatings}\n";
+                            if (logstats == true)
+                            {
+                                ls.Pets += $"{petLevel},{damage},{damageResist},{crit},{critDamage},{critDamageResist},{critResist},{totalRatings}\n";
+                            }
+                            else
+                                ls.Pets += $" {petLevel}\t {damage}\t {damageResist}\t {crit}\t {critDamage}\t {critDamageResist}\t {critResist}\t {totalRatings}\n";
 
                             if (totalRatings > 99)
                                 ls.PetRatingsOverHundred++;
@@ -339,7 +367,15 @@ namespace ACE.Server.Factories
                             ls.DinnerWare++;
                         }
                         else
-                            ls.MissileWeapons = ls.MissileWeapons + $"{missileType}\t {wield}\t {Math.Round(damageMod, 2)}\t\t{eleBonus}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\n";
+                        {
+                            if (logstats == true)
+                            {
+                                ls.MissileWeapons += $"{missileType},{wield},{Math.Round(damageMod, 2)},{eleBonus},{testItem.WeaponDefense.Value},{magicDefMod},{missileDefMod},{value}\n";
+                            }
+                            else
+                                ls.MissileWeapons += $" {missileType}\t {wield}\t {Math.Round(damageMod, 2)}\t\t{eleBonus}\t\t {testItem.WeaponDefense.Value}\t\t {magicDefMod}\t\t {missileDefMod}\t\t {value}\n";
+                        }
+                        
                         break;
                     case ItemType.Container:
                         break;
@@ -378,7 +414,12 @@ namespace ACE.Server.Factories
                             eleMod = testItem.ElementalDamageMod.Value;
                         if (testItem.ItemMaxMana != null)
                             ls.ItemMaxMana = testItem.ItemMaxMana.Value;
-                        ls.CasterWeapons = ls.CasterWeapons + $" {wield}\t {eleMod}\t\t {testItem.WeaponDefense.Value}\t\t  {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {ls.ItemMaxMana}\n";
+                        if (logstats == true)
+                        {
+                            ls.CasterWeapons += $"{wield},{eleMod},{testItem.WeaponDefense.Value},{magicDefMod},{missileDefMod},{value},{ls.ItemMaxMana}\n";
+                        }
+                        else
+                            ls.CasterWeapons += $" {wield}\t {eleMod}\t\t {testItem.WeaponDefense.Value}\t\t  {magicDefMod}\t\t {missileDefMod}\t\t {value}\t {ls.ItemMaxMana}\n";
                         break;
                     case ItemType.Portal:
                         break;
@@ -470,7 +511,7 @@ namespace ACE.Server.Factories
                     if (testItem.ItemMaxMana < ls.MinMana)
                         ls.MinMana = testItem.ItemMaxMana.Value;
                     ls.HasManaCount++;
-                    ls.TotalMaxMana = ls.TotalMaxMana + testItem.ItemMaxMana.Value;
+                    ls.TotalMaxMana += testItem.ItemMaxMana.Value;
                 }
                 if (testItem == null)
                 {
@@ -600,7 +641,7 @@ namespace ACE.Server.Factories
             }
             return displayStats;
         }
-        public static LootStats SetLootStatsDefaults(LootStats ls)
+        public static LootStats SetLootStatsDefaults(LootStats ls, bool logstats)
         {
             // Counters
             ls.ArmorCount = 0;
@@ -649,11 +690,36 @@ namespace ACE.Server.Factories
             ls.MaxAL = 0;
 
             // Tables
-            ls.MeleeWeapons = $"-----Melee Weapons----\n Skill \t\t\t Wield \t Damage \t MStrike \t Variance \t DefenseMod \t MagicDBonus \t MissileDBonus\t Value\t Type \n";
-            ls.MissileWeapons = $"-----Missile Weapons----\n Type \t Wield \t Modifier \tElementBonus \t DefenseMod \t MagicDBonus \t MissileDBonus\t Value\n";
-            ls.CasterWeapons = $"-----Caster Weapons----\n Wield \t ElementBonus \t DefenseMod \t MagicDBonus \t MissileDBonus \t Value \t MaxMana\n";
-            ls.Armor = $"-----Armor----\n AL \t Value \t Type\n";
-            ls.Pets = $"-----Pet Devices----\n Level \t Dmg \t DmgR \t Crit \t CritD \t CDR \t CritR \t Total \n";
+            if (logstats == true)
+            {
+                ls.MeleeWeapons = $"-----Melee Weapons----\nSkill,Wield,Damage,MStrike,Variance,DefenseMod,MagicDBonus,MissileDBonus,Value,Type\n";
+            }
+            else
+                ls.MeleeWeapons = $"-----Melee Weapons----\n Skill \t\t\t Wield \t Damage \t MStrike \t Variance \t DefenseMod \t MagicDBonus \t MissileDBonus\t Value\t Type \n";
+            if (logstats == true)
+            {
+                ls.MissileWeapons = $"-----Missile Weapons----\nType,Wield,Modifier,ElementBonus,DefenseMod,MagicDBonus,MissileDBonus,Value\n";
+            }
+            else
+                ls.MissileWeapons = $"-----Missile Weapons----\n Type \t Wield \t Modifier \tElementBonus \t DefenseMod \t MagicDBonus \t MissileDBonus\t Value\n";
+            if (logstats == true)
+            {
+                ls.CasterWeapons = $"-----Caster Weapons----\nWield,ElementBonus,DefenseMod,MagicDBonus,MissileDBonus,Value,MaxMana\n";
+            }
+            else
+                ls.CasterWeapons = $"-----Caster Weapons----\n Wield \t ElementBonus \t DefenseMod \t MagicDBonus \t MissileDBonus \t Value \t MaxMana\n";
+            if (logstats == true)
+            {
+                ls.Armor = $"-----Armor----\nAL,Value,Type\n";
+            }
+            else
+                ls.Armor = $"-----Armor----\n AL \t Value \t Type\n";
+            if (logstats == true)
+            {
+                ls.Pets = $"-----Pet Devices----\nLevel,Dmg,DmgR,Crit,CritD,CDR,CritR,Total\n";
+            }
+            else
+                ls.Pets = $"-----Pet Devices----\n Level \t Dmg \t DmgR \t Crit \t CritD \t CDR \t CritR \t Total \n";
 
             return ls;
         }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -22,7 +22,7 @@ namespace ACE.Server.Factories
 
             Console.WriteLine($"Creating {numItems} items, that are in tier {tier}");
 
-             var ls = SetLootStatsDefaults(new LootStats(),logstats);
+             var ls = SetLootStatsDefaults(new LootStats(), logstats);
 
             // Loop depending on how many items you are creating
             for (int i = 0; i < numItems; i++)
@@ -33,6 +33,11 @@ namespace ACE.Server.Factories
             Console.WriteLine(displayHeader);
             Console.WriteLine(DisplayStats(ls, displaytable));
             displayHeader += $" A total of {ls.TotalItems} items were generated in Tier {tier}. \n";
+            if (logstats == true)
+            {
+                string myfilename = string.Format("LootSim-{0:hh-mm-ss-tt_MM-dd-yyyy}.csv", DateTime.Now);
+                System.IO.File.WriteAllText(myfilename, displayHeader + DisplayStats(ls, displaytable));
+            }
 
             return displayHeader;
         }
@@ -41,7 +46,7 @@ namespace ACE.Server.Factories
             string displayHeader = $"\n LootFactory Simulator - Corpses\n ---------------------\n";
 
             var corpseContainer = new List<WorldObject>();
-            var ls = SetLootStatsDefaults(new LootStats(),logstats);
+            var ls = SetLootStatsDefaults(new LootStats(), logstats);
 
             Console.WriteLine($"Creating {numberofcorpses} corpses.");
             
@@ -76,11 +81,11 @@ namespace ACE.Server.Factories
             }
             Console.WriteLine(displayHeader);
             Console.WriteLine(DisplayStats(ls, displaytable));
-            displayHeader += $" A total of {ls.TotalItems} unique items were generated.";
+            displayHeader += $" A total of {ls.TotalItems} unique items were generated. \n";
             if (logstats == true)
             {
                 string myfilename = string.Format("LootSim-{0:hh-mm-ss-tt_MM-dd-yyyy}.csv", DateTime.Now);
-                System.IO.File.WriteAllText(myfilename, DisplayStats(ls, displaytable));
+                System.IO.File.WriteAllText(myfilename, displayHeader + DisplayStats(ls, displaytable));
             }
 
             return displayHeader;
@@ -386,9 +391,7 @@ namespace ACE.Server.Factories
                         Console.WriteLine($"ItemType.Useless Name={testItem.Name}");
                         break;
                     case ItemType.Gem:
-                        //ls.GemCount++;
                         string aetheriaColor = "None";
-                        int aetheriaLevel = 0;
                         if (testItem.Name.Contains("Aetheria"))
                         {
                             ls.AetheriaCount++;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -386,7 +386,27 @@ namespace ACE.Server.Factories
                         Console.WriteLine($"ItemType.Useless Name={testItem.Name}");
                         break;
                     case ItemType.Gem:
-                        ls.GemCount++;
+                        //ls.GemCount++;
+                        string aetheriaColor = "None";
+                        int aetheriaLevel = 0;
+                        if (testItem.Name.Contains("Aetheria"))
+                        {
+                            ls.AetheriaCount++;
+                            if (testItem.WieldDifficulty == 75)
+                                aetheriaColor = "Blue  ";
+                            else if (testItem.WieldDifficulty == 150)
+                                aetheriaColor = "Yellow";
+                            else if (testItem.WieldDifficulty == 225)
+                                aetheriaColor = "Red   ";
+                            if (logstats == true)
+                            {
+                                ls.Aetheria += $"{aetheriaColor},{testItem.ItemMaxLevel}\n";
+                            }
+                            else
+                                ls.Aetheria += $" {aetheriaColor}\t {testItem.ItemMaxLevel}\n";
+                        }
+                        else
+                            ls.GemCount++;
                         break;
                     case ItemType.SpellComponents:
                         ls.SpellComponents++;
@@ -548,12 +568,16 @@ namespace ACE.Server.Factories
                 case "pet":
                     displayStats += ls.Pets + $"\n";
                     break;
+                case "aetheria":
+                    displayStats += ls.Aetheria + $"\n";
+                    break;
                 case "all":
                     displayStats += ls.MeleeWeapons + $"\n";
                     displayStats += ls.MissileWeapons + $"\n";
                     displayStats += ls.CasterWeapons + $"\n";
                     displayStats += ls.Armor + $"\n";
                     displayStats += ls.Pets + $"\n";
+                    displayStats += ls.Aetheria + $"\n";
                     break;
                 default:
                     displayStats += $"\n No Table(s) was selected to display, showing only general statistics";
@@ -568,6 +592,7 @@ namespace ACE.Server.Factories
                     $"MissileWeapon={ls.MissileWeaponCount} \n " +
                     $"Jewelry={ls.JewelryCount} \n " +
                     $"Gem={ls.GemCount} \n " +
+                    $"Aetheria={ls.AetheriaCount} \n " +
                     $"Clothing={ls.ClothingCount} \n " +
                     $"\n Generic Items \n " +
                     $"---- \n " +
@@ -595,6 +620,7 @@ namespace ACE.Server.Factories
                                 $"MissileWeapon= {ls.MissileWeaponCount / ls.TotalItems * 100}% \n " +
                                 $"Jewelry= {ls.JewelryCount / ls.TotalItems * 100}% \n " +
                                 $"Gem= {ls.GemCount / ls.TotalItems * 100}% \n " +
+                                $"Aetheria= {ls.AetheriaCount / ls.TotalItems * 100}% \n " +
                                 $"Clothing= {ls.ClothingCount / ls.TotalItems * 100}% \n " +
                                 $"Food= {ls.Food / ls.TotalItems * 100}% \n " +
                                 $"SpellComps= {ls.SpellComponents / ls.TotalItems * 100}% \n " +
@@ -653,6 +679,7 @@ namespace ACE.Server.Factories
             ls.MissileWeaponCount = 0;
             ls.JewelryCount = 0;
             ls.GemCount = 0;
+            ls.AetheriaCount = 0;
             ls.ClothingCount = 0;
             ls.OtherCount = 0;
             ls.NullCount = 0;
@@ -723,7 +750,12 @@ namespace ACE.Server.Factories
             }
             else
                 ls.Pets = $"-----Pet Devices----\n Level \t Dmg \t DmgR \t Crit \t CritD \t CDR \t CritR \t Total \n";
-
+            if (logstats == true)
+            {
+                ls.Aetheria = $"-----Aetheria----\nColor,Level";
+            }
+            else
+                ls.Aetheria = $"-----Aetheria----\n Color \t Level\n";
             return ls;
         }
         public static string LogStats()

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -158,12 +158,15 @@ namespace ACE.Server.Factories
                         break;
                     case ItemType.Armor:
                         ls.ArmorCount++;
+                        string equipmentSet = "None";
+                        if (testItem.EquipmentSetId != null)
+                            equipmentSet = Enum.GetName(typeof(EquipmentSet), testItem.EquipmentSetId);
                         if (logstats == true)
                         {
-                            ls.Armor += $"{testItem.ArmorLevel},{testItem.Value.Value},{testItem.Name}\n";
+                            ls.Armor += $"{testItem.ArmorLevel},{equipmentSet},{testItem.Value.Value},{testItem.Name}\n";
                         }
                         else
-                            ls.Armor += $" {testItem.ArmorLevel}\t {testItem.Value.Value} \t {testItem.Name}\n";
+                            ls.Armor += $" {testItem.ArmorLevel}\t {equipmentSet}\t\t {testItem.Value.Value} \t {testItem.Name}\n";
                         if (testItem.Name.Contains("Sheild"))
                             break;
                         if (testItem.ArmorLevel > ls.MaxAL)
@@ -710,10 +713,10 @@ namespace ACE.Server.Factories
                 ls.CasterWeapons = $"-----Caster Weapons----\n Wield \t ElementBonus \t DefenseMod \t MagicDBonus \t MissileDBonus \t Value \t MaxMana\n";
             if (logstats == true)
             {
-                ls.Armor = $"-----Armor----\nAL,Value,Type\n";
+                ls.Armor = $"-----Armor----\nAL,EquipmentSet,Value,Type\n";
             }
             else
-                ls.Armor = $"-----Armor----\n AL \t Value \t Type\n";
+                ls.Armor = $"-----Armor----\n AL \t Equipment Set \t\t Value \t Type\n";
             if (logstats == true)
             {
                 ls.Pets = $"-----Pet Devices----\nLevel,Dmg,DmgR,Crit,CritD,CDR,CritR,Total\n";

--- a/Source/ACE.Server/Factories/LootStats.cs
+++ b/Source/ACE.Server/Factories/LootStats.cs
@@ -13,6 +13,7 @@ namespace ACE.Server.Factories
         public float MissileWeaponCount { get; set; }
         public float JewelryCount { get; set; }
         public float GemCount { get; set; }
+        public float AetheriaCount { get; set; }        
         public float ClothingCount { get; set; }
         public float OtherCount { get; set; }
         public float NullCount { get; set; }
@@ -38,6 +39,7 @@ namespace ACE.Server.Factories
         public string CasterWeapons { get; set; }
         public string Armor { get; set; }
         public string Pets { get; set; }
+        public string Aetheria { get; set; }
 
         // Item Stats
         public int ItemMaxMana { get; set; }
@@ -49,6 +51,7 @@ namespace ACE.Server.Factories
         public int MaxAL { get; set; }
         public string MinALItem { get; set; }
         public string MaxALItem { get; set; }
+        
 
         // Pet Stats
         public int PetsTotalRatings { get; set; }


### PR DESCRIPTION
Added support for Armor Equipment Sets in armor table
Added Aetheria counters and table.
Added Logging LootSim stats. Example Command
```testlootgencorpse 998 100 armor -log```
File is written in startup folder (same as ACE_Log).  Its named "Loot-Sim" + Time and date.  Example ```LootSim-08-36-06-PM_02-04-2020.csv```
File is in csv format for using in spread sheet

