### PR TITLE
EmoteMananger: Where before OrderBy

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1394,7 +1394,7 @@ namespace ACE.Server.WorldObjects.Managers
             if (useRNG)
             {
                 var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
-                emoteSet = emoteSet.OrderBy(e => e.Probability).Where(e => e.Probability >= rng);
+                emoteSet = emoteSet.Where(e => e.Probability >= rng).OrderBy(e => e.Probability);
                 //emoteSet = emoteSet.Where(e => e.Probability >= rng);
             }
 


### PR DESCRIPTION
Good description here: https://stackoverflow.com/questions/7499384/does-the-order-of-linq-functions-matter/7499454#7499454

This is something easy to get into master while we think about using the dictionary cache that Ripley has made.