### PR TITLE
cleaning up spell resistance code

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -938,17 +938,8 @@ namespace ACE.Server.WorldObjects
                     if (targetPlayer == null)
                         OnAttackMonster(targetCreature);
 
-                    if (spell.IsHarmful)
-                    {
-                        var resisted = ResistSpell(target, spell, caster);
-                        if (resisted == true)
-                            break;
-                        if (resisted == null)
-                        {
-                            log.Error("Something went wrong with the Magic resistance check");
-                            break;
-                        }
-                    }
+                    if (TryResistSpell(target, spell, caster))
+                        break;
 
                     if (targetCreature != null && targetCreature.NonProjectileMagicImmune)
                     {
@@ -983,20 +974,11 @@ namespace ACE.Server.WorldObjects
                     if (targetPlayer == null)
                         OnAttackMonster(targetCreature);
 
+                    if (TryResistSpell(target, spell, caster))
+                        break;
+
                     if (spell.MetaSpellType != SpellType.LifeProjectile)
                     {
-                        if (spell.IsHarmful)
-                        {
-                            var resisted = ResistSpell(target, spell, caster);
-                            if (resisted == true)
-                                break;
-                            if (resisted == null)
-                            {
-                                log.Error("Something went wrong with the Magic resistance check");
-                                break;
-                            }
-                        }
-
                         if (targetCreature != null && targetCreature.NonProjectileMagicImmune)
                         {
                             Session.Network.EnqueueSend(new GameMessageSystemChat($"You fail to affect {targetCreature.Name} with {spell.Name}", ChatMessageType.Magic));
@@ -1049,17 +1031,8 @@ namespace ACE.Server.WorldObjects
                         if (targetResist == null && target?.WielderId != null)
                             targetResist = CurrentLandblock?.GetObject(target.WielderId.Value) as Creature;
 
-                        if (targetResist != null)
-                        {
-                            var resisted = ResistSpell(targetResist, spell, caster);
-                            if (resisted == true)
-                                break;
-                            if (resisted == null)
-                            {
-                                log.Error("Something went wrong with the Magic resistance check");
-                                break;
-                            }
-                        }
+                        if (targetResist != null && TryResistSpell(targetResist, spell, caster))
+                            break;
                     }
 
                     if (spell.IsImpenBaneType)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -358,8 +358,8 @@ namespace ACE.Server.WorldObjects
             if (sourceCreature?.Overpower != null)
                 overpower = Creature.GetOverpower(sourceCreature, target);
 
-            var resisted = source.ResistSpell(target, Spell, caster);
-            if (resisted == true && !overpower)
+            var resisted = source.TryResistSpell(target, Spell, caster, true);
+            if (resisted && !overpower)
                 return null;
 
             CreatureSkill attackSkill = null;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -51,7 +51,7 @@ namespace ACE.Server.WorldObjects
                 return;*/
 
             // perform resistance check, if applicable
-            var resisted = tryResist ? TryResistSpell(spell, target, caster) : false;
+            var resisted = tryResist ? TryResistSpell(target, spell, caster) : false;
             if (resisted)
                 return;
 
@@ -95,55 +95,6 @@ namespace ACE.Server.WorldObjects
 
             if (caster != null && spell.CasterEffect != 0)
                 caster.EnqueueBroadcast(new GameMessageScript(caster.Guid, spell.CasterEffect, spell.Formula.Scale));
-        }
-
-        /// <summary>
-        /// If this spell has a chance to be resisted, rolls for a chance
-        /// Returns TRUE if spell is resistable and was resisted for this attempt
-        /// </summary>
-        public bool TryResistSpell(Spell spell, WorldObject target, WorldObject caster = null)
-        {
-            if (spell.IsBeneficial || !spell.IsResistable)
-                return false;
-
-            // todo: verify this flag exists for all resistable spells
-            //if (!spell.Flags.HasFlag(SpellFlags.Resistable))
-                //return false;
-
-            var targetSelf = spell.Flags.HasFlag(SpellFlags.SelfTargeted);
-            if (targetSelf) return false;
-
-            switch (spell.School)
-            {
-                case MagicSchool.WarMagic:
-                    // war magic projectiles do the resistance check on projectile collision
-                    break;
-                case MagicSchool.LifeMagic:
-                case MagicSchool.CreatureEnchantment:
-                    if (spell.NumProjectiles == 0)  // life magic projectiles
-                    {
-                        bool? resisted = ResistSpell(target, spell, caster);
-                        if (resisted != null && resisted == true)
-                            return true;
-                    }
-                    break;
-                case MagicSchool.ItemEnchantment:
-                    {
-                        bool? resisted = ResistSpell(target, spell, caster);
-                        if (resisted != null && resisted == true)
-                            return true;
-                    }
-                    break;
-                case MagicSchool.VoidMagic:
-                    if (spell.NumProjectiles == 0)  // void magic projectiles
-                    {
-                        bool? resisted = ResistSpell(target, spell, caster);
-                        if (resisted != null && resisted == true)
-                            return true;
-                    }
-                    break;
-            }
-            return false;
         }
 
         /// <summary>
@@ -289,10 +240,17 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Performs the magic defense checks for spell attacks
+        /// If this spell has a chance to be resisted, rolls for a chance
+        /// Returns TRUE if spell is resistable and was resisted for this attempt
         /// </summary>
-        public bool? ResistSpell(WorldObject target, Spell spell, WorldObject caster = null)
+        public bool TryResistSpell(WorldObject target, Spell spell, WorldObject caster = null, bool projectileHit = false)
         {
+            if (!spell.IsResistable && spell.School != MagicSchool.ItemEnchantment || spell.IsSelfTargeted)
+                return false;
+
+            if (spell.NumProjectiles > 0 && !projectileHit)
+                return false;
+
             uint magicSkill = 0;
 
             if (caster == null)
@@ -319,7 +277,7 @@ namespace ACE.Server.WorldObjects
 
             // only creatures can resist spells?
             if (!(target is Creature targetCreature))
-                return null;
+                return false;
 
             // Retrieve target's Magic Defense Skill
             var difficulty = targetCreature.GetEffectiveMagicDefense();
@@ -1503,17 +1461,8 @@ namespace ACE.Server.WorldObjects
             if (player != null && targetCreature != null && targetPlayer == null)
                 player.OnAttackMonster(targetCreature);
 
-            if (spell.IsHarmful)
-            {
-                var resisted = ResistSpell(target, spell, caster);
-                if (resisted == true)
-                    return false;
-                if (resisted == null)
-                {
-                    log.Error("Something went wrong with the Magic resistance check");
-                    return false;
-                }
-            }
+            if (TryResistSpell(target, spell, caster))
+                return false;
 
             EnqueueBroadcast(new GameMessageScript(target.Guid, (PlayScript)spell.TargetEffect, spell.Formula.Scale));
             var enchantmentStatus = CreatureMagic(target, spell);


### PR DESCRIPTION
This fixes a bug with 32359 Glenden Wood Recall Orb

Repro steps:
/ci 32359
equip orb
go into magic combat stance
select self
try to cast built-in gw recall spell

Expected:
spell is cast successfully

Actual:
player has a chance of resisting spell, which they usually did in previous version