### PR TITLE
suppress TakeItems output when player has 0 items

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1185,7 +1185,7 @@ namespace ACE.Server.WorldObjects.Managers
                             break;
                         }
 
-                        if (player.TryConsumeFromInventoryWithNetworking(weenieItemToTake, amountToTake == -1 ? int.MaxValue : amountToTake))
+                        if (player.GetNumInventoryItemsOfWCID(weenieItemToTake) > 0 && player.TryConsumeFromInventoryWithNetworking(weenieItemToTake, amountToTake == -1 ? int.MaxValue : amountToTake))
                         {
                             var itemTaken = DatabaseManager.World.GetCachedWeenie(weenieItemToTake);
                             if (itemTaken != null)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -159,7 +159,7 @@ namespace ACE.Server.WorldObjects
                 if (leftReq <= 0)
                     break;
             }
-            return leftReq <= 0;
+            return true;
         }
 
         public enum RemoveFromInventoryAction

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -159,7 +159,7 @@ namespace ACE.Server.WorldObjects
                 if (leftReq <= 0)
                     break;
             }
-            return true;
+            return leftReq <= 0;
         }
 
         public enum RemoveFromInventoryAction


### PR DESCRIPTION
This will effectively make TakeItems not show output message if player has 0 items

@DridsGhost