### PR TITLE
fixing AuditItemSpells for spell sets

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -496,18 +496,22 @@ namespace ACE.Server.WorldObjects
             // cleans up bugged chars with dangling item set spells
             // from previous bugs
 
+            // this is a legacy method, but is still a decent failsafe to catch any existing issues
+
             // get active item enchantments
             var enchantments = Biota.GetEnchantments(BiotaDatabaseLock).Where(i => i.Duration == -1 && i.SpellId != (int)SpellId.Vitae).ToList();
 
             foreach (var enchantment in enchantments)
             {
                 // if this item is not equipped, remove enchantment
+
                 if (!EquippedObjects.TryGetValue(new ObjectGuid(enchantment.CasterObjectId), out var item))
                 {
-                    var spell = new Spell(enchantment.SpellId, false);
+                    // this can fail for item sets, so disabling this section
+                    /*var spell = new Spell(enchantment.SpellId, false);
                     log.Error($"{Name}.AuditItemSpells(): removing spell {spell.Name} from non-equipped item");
 
-                    EnchantmentManager.Dispel(enchantment);
+                    EnchantmentManager.Dispel(enchantment);*/
                     continue;
                 }
 


### PR DESCRIPTION
Repro steps:

- equip 2 items from the same spell set
- dequip 1 of the items
- relog

Expected:

- no AuditItemSpells error, spells from 1st item remain

Actual:

- AuditItemSpells error, spells from 1st item do not remain

The reason for this is the way dequpping items from spell sets works for re-casting the previous level of spells. Instead of getting a new (random?) item that is still equipped from the set, it sets the caster guid to the item that was dequipped.

In the future, it could be investigated if we should set the caster guid to another (random?) item that is still equipped from the set

