### PR TITLE
spell projectile dormant fix redux

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -465,11 +465,14 @@ namespace ACE.Server.Entity
                 {
                     if (lastActiveTime + dormantInterval < thisHeartBeat)
                     {
-                        var spellProjectiles = worldObjects.Values.Where(i => i is SpellProjectile).ToList();
-                        foreach (var spellProjectile in spellProjectiles)
+                        if (!IsDormant)
                         {
-                            spellProjectile.PhysicsObj.set_active(false);
-                            spellProjectile.Destroy();
+                            var spellProjectiles = worldObjects.Values.Where(i => i is SpellProjectile).ToList();
+                            foreach (var spellProjectile in spellProjectiles)
+                            {
+                                spellProjectile.PhysicsObj.set_active(false);
+                                spellProjectile.Destroy();
+                            }
                         }
 
                         IsDormant = true;

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -464,7 +464,16 @@ namespace ACE.Server.Entity
                 if (!Permaload)
                 {
                     if (lastActiveTime + dormantInterval < thisHeartBeat)
+                    {
+                        var spellProjectiles = worldObjects.Values.Where(i => i is SpellProjectile).ToList();
+                        foreach (var spellProjectile in spellProjectiles)
+                        {
+                            spellProjectile.PhysicsObj.set_active(false);
+                            spellProjectile.Destroy();
+                        }
+
                         IsDormant = true;
+                    }
                     if (lastActiveTime + UnloadInterval < thisHeartBeat)
                         LandblockManager.AddToDestructionQueue(this);
                 }
@@ -807,11 +816,6 @@ namespace ACE.Server.Entity
             if (wo is Player player)
                 player.SetFogColor(FogColor);
 
-            if (wo is SpellProjectile)
-            {
-                wo.CurrentLandblock.lastActiveTime = DateTime.UtcNow;
-                wo.CurrentLandblock.IsDormant = false;
-            }
             return true;
         }
 

--- a/Source/ACE.Server/Managers/LandblockManager.cs
+++ b/Source/ACE.Server/Managers/LandblockManager.cs
@@ -346,6 +346,14 @@ namespace ACE.Server.Managers
         {
             var oldBlock = worldObject.CurrentLandblock;
             var newBlock = GetLandblock(worldObject.Location.LandblockId, true);
+
+            if (newBlock.IsDormant && worldObject is SpellProjectile)
+            {
+                worldObject.PhysicsObj.set_active(false);
+                worldObject.Destroy();
+                return;
+            }
+
             // Remove from the old landblock -- force
             if (oldBlock != null)
                 oldBlock.RemoveWorldObjectForPhysics(worldObject.Guid, adjacencyMove);


### PR DESCRIPTION
scenario: some NPCs that continually cast spells at regular intervals / on heartbeat emotes, are now keeping landblocks alive forever

the 'rolling ball of death' rooms in gaerlan's citadel and oswald's dagger quests would be a good example of this

confirmed that updated version still fixes the original bug using previous setup and repro steps