### PR TITLE
Remove .net standard 2.1 from Adatper and Database

### DIFF
--- a/Source/ACE.Adapter/ACE.Adapter.csproj
+++ b/Source/ACE.Adapter/ACE.Adapter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <Platforms>AnyCPU</Platforms>
         <Version>1.0.0</Version>
         <Authors>ACEmulator Contributors</Authors>

--- a/Source/ACE.Database/ACE.Database.csproj
+++ b/Source/ACE.Database/ACE.Database.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <Authors>ACEmulator Contributors</Authors>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Not sure why they were 2.1.

2.0 is the latest that's supported by desktop apps. Moving these two libraries back to 2.0 makes them easier to consume.