### PR TITLE
fix minor sync issue in TurnToHeading, rework TurnTo during magic casting to allow for player manual control

### DIFF
--- a/Source/ACE.Server/Entity/MagicState.cs
+++ b/Source/ACE.Server/Entity/MagicState.cs
@@ -73,6 +73,12 @@ namespace ACE.Server.Entity
         public DateTime StartTime { get; set; }
 
         /// <summary>
+        /// If a player interrupts a TurnTo during casting,
+        /// the TurnTo resumes when the player is no longer holding any Turn keys
+        /// </summary>
+        public bool PendingTurnRelease { get; set; }
+
+        /// <summary>
         /// Tracks the cast # for /recordcast
         /// </summary>
         public int CastNum { get; set; }
@@ -109,6 +115,7 @@ namespace ACE.Server.Entity
             CastMotionDone = false;
             TurnStarted = false;
             IsTurning = false;
+            PendingTurnRelease = false;
 
             StartTime = DateTime.UtcNow;
             CastGestureStartTime = DateTime.MinValue;
@@ -136,6 +143,7 @@ namespace ACE.Server.Entity
             CastMotionDone = false;
             TurnStarted = false;
             IsTurning = false;
+            PendingTurnRelease = false;
 
             CastGesture = MotionCommand.Invalid;
             CastGestureStartTime = DateTime.MinValue;

--- a/Source/ACE.Server/Entity/MagicState.cs
+++ b/Source/ACE.Server/Entity/MagicState.cs
@@ -144,6 +144,7 @@ namespace ACE.Server.Entity
             TurnStarted = false;
             IsTurning = false;
             PendingTurnRelease = false;
+            Player.TurnTarget = null;
 
             CastGesture = MotionCommand.Invalid;
             CastGestureStartTime = DateTime.MinValue;

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
@@ -15,6 +15,12 @@ namespace ACE.Server.Network.GameAction.Actions
             var moveToState = new MoveToState(session.Player, message.Payload);
             session.Player.CurrentMoveToState = moveToState;
 
+            if (session.Player.IsPlayerMovingTo)
+                session.Player.StopExistingMoveToChains();
+
+            if (session.Player.IsPlayerMovingTo2)
+                session.Player.StopExistingMoveToChains2();
+
             if (!session.Player.Teleporting)
             {
                 session.Player.OnMoveToState(moveToState);
@@ -26,12 +32,6 @@ namespace ACE.Server.Network.GameAction.Actions
 
             //if (!moveToState.StandingLongJump)
                 session.Player.BroadcastMovement(moveToState);
-
-            if (session.Player.IsPlayerMovingTo)
-                session.Player.StopExistingMoveToChains();
-
-            if (session.Player.IsPlayerMovingTo2)
-                session.Player.StopExistingMoveToChains2();
         }
     }
 }

--- a/Source/ACE.Server/Physics/Managers/MoveToManager.cs
+++ b/Source/ACE.Server/Physics/Managers/MoveToManager.cs
@@ -516,8 +516,7 @@ namespace ACE.Server.Physics.Animation
                 return;
             }
 
-            if (PendingActions.Count == 0)
-                return;
+            if (PhysicsObj.IsAnimating) return;
 
             var pendingAction = PendingActions[0];
             var headingDiff = heading_diff(pendingAction.Heading, PhysicsObj.get_heading(), (uint)MotionCommand.TurnRight);

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -4152,6 +4152,11 @@ namespace ACE.Server.Physics
                 Console.WriteLine($"{(MotionCommand)motion.Motion}");
         }
 
+        public bool motions_pending()
+        {
+            return IsAnimating;
+        }
+
         /// <summary>
         /// This is for legacy movement system
         /// </summary>

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -92,7 +92,7 @@ namespace ACE.Server.Physics
 
         // this is used by the 1991 branch to determine when physics updates need to be run
         public bool IsMovingOrAnimating => !PartArray.Sequence.is_first_cyclic() || CachedVelocity != Vector3.Zero || Velocity != Vector3.Zero ||
-            MovementManager.MotionInterpreter.InterpretedState.HasCommands();
+            MovementManager.MotionInterpreter.InterpretedState.HasCommands() || MovementManager.MoveToManager.Initialized;
 
         // server
         public Position RequestPos;

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -31,7 +31,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public DatLoader.FileTypes.CombatManeuverTable CombatTable { get; set; }
 
-        public CombatMode CombatMode { get; private set; }
+        public CombatMode CombatMode { get; protected set; }
 
         public AttackType AttackType { get; set; }
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -619,6 +619,8 @@ namespace ACE.Server.WorldObjects
             return PlayerKillerStatus.HasFlag(PlayerKillerStatus.PKLite) && new ObjectGuid(killerGuid ?? 0).IsPlayer() && killerGuid != Guid.Full;
         }
 
+        public CombatMode LastCombatMode;
+
         public static readonly float UseTimeEpsilon = 0.05f;
 
         /// <summary>
@@ -628,6 +630,8 @@ namespace ACE.Server.WorldObjects
         {
             //log.Info($"{Name}.HandleActionChangeCombatMode({newCombatMode})");
 
+            LastCombatMode = newCombatMode;
+            
             if (DateTime.UtcNow >= NextUseTime.AddSeconds(UseTimeEpsilon))
                 HandleActionChangeCombatMode_Inner(newCombatMode);
             else

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -672,9 +672,12 @@ namespace ACE.Server.WorldObjects
             DoCastSpell_Inner(spell, isWeaponSpell, manaUsed, target, castingPreCheckStatus);
         }
 
+        public WorldObject TurnTarget;
+
         public void TurnTo_Magic(WorldObject target)
         {
             //Console.WriteLine($"{Name}.TurnTo_Magic()");
+            TurnTarget = target;
 
             MagicState.TurnStarted = true;
             MagicState.IsTurning = true;
@@ -725,7 +728,7 @@ namespace ACE.Server.WorldObjects
             bool movedTooFar = false;
 
             // only PKs affected by these caps?
-            if (dist > Windup_MaxMove && PlayerKillerStatus != PlayerKillerStatus.NPK && false)
+            if (dist > Windup_MaxMove && PlayerKillerStatus != PlayerKillerStatus.NPK)
             {
                 castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
                 movedTooFar = true;
@@ -1437,6 +1440,17 @@ namespace ACE.Server.WorldObjects
                 DoWindup(MagicState.WindupParams);
             else
                 DoCastSpell(MagicState, true);
+        }
+
+        public void CheckTurn()
+        {
+            if (TurnTarget != null && IsWithinAngle(TurnTarget))
+            {
+                if (MagicState.PendingTurnRelease)
+                    OnTurnRelease();
+                else
+                    PhysicsObj.StopCompletely(false);
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -81,8 +81,15 @@ namespace ACE.Server.WorldObjects
 
             if (CombatMode != CombatMode.Magic)
             {
-                SendUseDoneEvent();
-                return;
+                log.Error($"{Name}.HandleActionCastTargetedSpell({targetGuid:X8}, {spellId}, {builtInSpell}) - CombatMode mismatch {CombatMode}, LastCombatMode: {LastCombatMode}");
+
+                if (LastCombatMode == CombatMode.Magic)
+                    CombatMode = CombatMode.Magic;
+                else
+                {
+                    SendUseDoneEvent();
+                    return;
+                }
             }
 
             if (FastTick && !PhysicsObj.TransientState.HasFlag(TransientStateFlags.OnWalkable))
@@ -248,8 +255,15 @@ namespace ACE.Server.WorldObjects
 
             if (CombatMode != CombatMode.Magic)
             {
-                SendUseDoneEvent();
-                return;
+                log.Error($"{Name}.HandleActionMagicCastUnTargetedSpell({spellId}) - CombatMode mismatch {CombatMode}, LastCombatMode {LastCombatMode}");
+
+                if (LastCombatMode == CombatMode.Magic)
+                    CombatMode = CombatMode.Magic;
+                else
+                {
+                    SendUseDoneEvent();
+                    return;
+                }
             }
 
             if (FastTick && !PhysicsObj.TransientState.HasFlag(TransientStateFlags.OnWalkable))

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -51,7 +51,14 @@ namespace ACE.Server.WorldObjects
             //log.Info($"-");
 
             if (CombatMode != CombatMode.Melee)
-                return;
+            {
+                log.Error($"{Name}.HandleActionTargetedMeleeAttack({targetGuid:X8}, {attackHeight}, {powerLevel}) - CombatMode mismatch {CombatMode}, LastCombatMode {LastCombatMode}");
+
+                if (LastCombatMode == CombatMode.Melee)
+                    CombatMode = CombatMode.Melee;
+                else
+                    return;
+            }
 
             if (IsBusy)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -43,7 +43,14 @@ namespace ACE.Server.WorldObjects
             //log.Info($"-");
 
             if (CombatMode != CombatMode.Missile)
-                return;
+            {
+                log.Error($"{Name}.HandleActionTargetedMissileAttack({targetGuid:X8}, {attackHeight}, {accuracyLevel}) - CombatMode mismatch {CombatMode}, LastCombatMode: {LastCombatMode}");
+
+                if (LastCombatMode == CombatMode.Missile)
+                    CombatMode = CombatMode.Missile;
+                else
+                    return;
+            }
 
             if (IsBusy)
             {

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -140,6 +140,9 @@ namespace ACE.Server.WorldObjects
                 OnMoveToState_ServerMethod(moveToState);
             else
                 OnMoveToState_ClientMethod(moveToState);
+
+            if (MagicState.IsCasting && MagicState.PendingTurnRelease && moveToState.RawMotionState.TurnCommand == 0)
+                OnTurnRelease();
         }
 
         public void OnMoveToState_ClientMethod(MoveToState moveToState)

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -304,6 +304,9 @@ namespace ACE.Server.WorldObjects
                 }
                 LastMoveToState = null;
             }
+
+            if (MagicState.IsCasting && (MagicState.IsTurning || MagicState.PendingTurnRelease))
+                CheckTurn();
         }
 
         /// <summary>


### PR DESCRIPTION
Repro steps:

- Be in magic combat stance
- Be turned slightly away from target, ie. at a 45 degree angle
- Start running forward
- While running forward, press key to cast a targeted spell

Expected:
- Character stops, does a turn to, and begins casting spell

Actual:
- Character stops, would start turning to, but then would begin casting spell almost immediately, without fully turning towards target on client.

The server TurnToHeading method was not matched up with acclient, and was not waiting for the previously in-progress run animation to complete first, before performing the TurnTo

Updated - now includes much more significant improvements for taking manual control of TurnToTarget during magic casting