### PR TITLE
fixing aug resist

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -113,6 +113,20 @@ namespace ACE.Server.WorldObjects
             if (protMod > naturalResistMod)
                 protMod = naturalResistMod;
 
+            // does this stack with natural resistance?
+            if (this is Player player)
+            {
+                var resistAug = player.GetAugmentationResistance(damageType);
+                if (resistAug > 0)
+                {
+                    // should the existing protMod be converted to additive space first?
+
+                    // +10% protection = 0.90909 mod
+                    // +20% protection = 0.83333 mod
+                    protMod *= 1.0f / (1.0f + resistAug * 0.1f);
+                }
+            }
+
             // vulnerability mod becomes either life vuln or weapon resistance mod,
             // whichever is more powerful
             if (vulnMod < weaponResistanceMod)

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -852,41 +852,6 @@ namespace ACE.Server.WorldObjects.Managers
             foreach (var enchantment in enchantments)
                 modifier *= enchantment.StatModValue;
 
-            if (WorldObject is Player player)
-            {
-                switch (resistance)
-                {
-                    case PropertyFloat.ResistSlash:
-                        if (player.AugmentationResistanceSlash > 0)
-                            modifier -= player.AugmentationResistanceSlash * 0.1f;
-                        break;
-                    case PropertyFloat.ResistPierce:
-                        if (player.AugmentationResistancePierce > 0)
-                            modifier -= player.AugmentationResistancePierce * 0.1f;
-                        break;
-                    case PropertyFloat.ResistBludgeon:
-                        if (player.AugmentationResistanceBlunt > 0)
-                            modifier -= player.AugmentationResistanceBlunt * 0.1f;
-                        break;
-                    case PropertyFloat.ResistFire:
-                        if (player.AugmentationResistanceFire > 0)
-                            modifier -= player.AugmentationResistanceFire * 0.1f;
-                        break;
-                    case PropertyFloat.ResistCold:
-                        if (player.AugmentationResistanceFrost > 0)
-                            modifier -= player.AugmentationResistanceFrost * 0.1f;
-                        break;
-                    case PropertyFloat.ResistAcid:
-                        if (player.AugmentationResistanceAcid > 0)
-                            modifier -= player.AugmentationResistanceAcid * 0.1f;
-                        break;
-                    case PropertyFloat.ResistElectric:
-                        if (player.AugmentationResistanceLightning > 0)
-                            modifier -= player.AugmentationResistanceLightning * 0.1f;
-                        break;
-                }
-            }
-
             return modifier;
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -1097,5 +1097,35 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.CurrentAppraisalTarget); else SetProperty(PropertyInstanceId.CurrentAppraisalTarget, value.Value); }
         }
 
+        /// <summary>
+        /// Returns player's augmentation resistance for damage type
+        /// </summary>
+        public float GetAugmentationResistance(DamageType damageType)
+        {
+            switch (damageType)
+            {
+                case DamageType.Slash:
+                    return AugmentationResistanceSlash;
+
+                case DamageType.Pierce:
+                    return AugmentationResistancePierce;
+
+                case DamageType.Bludgeon:
+                    return AugmentationResistanceBlunt;
+
+                case DamageType.Fire:
+                    return AugmentationResistanceFire;
+
+                case DamageType.Cold:
+                    return AugmentationResistanceFrost;
+
+                case DamageType.Acid:
+                    return AugmentationResistanceAcid;
+
+                case DamageType.Electric:
+                    return AugmentationResistanceLightning;
+            }
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
A few bugs here:

- AugmentationResistance was in EnchantmentManager before, which was an odd place to put it. There might be caching issues if the enchantment cache isn't cleared out when augs change.

- AugmentationResistance in its previous EnchantmentManager location was only in GetResistanceMod(), which gets the combined prot + vuln resistances. 

This particular method was split up into 2 sub-methods when natural resistances were introduced: GetProtectionResistanceMod and GetVulnerabilityResistanceMod. So combat was effectively no longer calling the original combined method, yet some other odd places like appraisal were. It just seemed like AugmentationResistance was crammed into EnchantmentManager, even though it wasn't really the right place for it.

- AugmentationResistance was adding a flat NumAugs * 0.1, which doesn't really work, as prots/vulns are additive multipliers, and they are already in multiplicative space.

This method has been updated to a more accurate formula - basically the same formula ratings use for converting additives into multipliers.

There is still an issue, however, that to do this completely properly, I'm thinking the protMod would have to be converted from its native multiplicative space, back into additive space, do the combination there, and then determine the final multiplier. Again, this would be the same theory as the ratings - combine in additive space to determine the final multiplier, as combining in multiplicative space will have undesired cumulative effects.

Another issue, is if aug resistance stacked with natural resistance, if the player was unbuffed