### PR TITLE
fix cast tick gap

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1396,7 +1396,12 @@ namespace ACE.Server.WorldObjects
 
                 var actionChain = new ActionChain();
                 actionChain.AddDelayForOneTick();
-                actionChain.AddAction(this, () => DoCastSpell(MagicState));
+                actionChain.AddAction(this, () =>
+                {
+                    if (!MagicState.IsCasting) return;
+
+                    DoCastSpell(MagicState);
+                });
                 actionChain.EnqueueChain();
             }
         }
@@ -1421,6 +1426,8 @@ namespace ACE.Server.WorldObjects
             actionChain.AddDelayForOneTick();
             actionChain.AddAction(this, () =>
             {
+                if (!MagicState.IsCasting) return;
+
                 if (!MagicState.CastMotionDone)
                     DoWindup(MagicState.WindupParams);
                 else


### PR DESCRIPTION
Repro steps:
- Go into magic combat stance
- Turn away from target
- Start casting targeted spell
- Very quickly, right before the the TurnTo has completed, right before the Windup, tap ` to go out of combat mode

Expected:
Server doesn't crash

Actual:
Server crashes