### PR TITLE
fix chest reset interval

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -69,6 +69,7 @@ namespace ACE.Entity.Enum.Properties
         ReleasedTimestamp              = 56,
         MinHomeRadius                  = 57,
         Facing                         = 58,
+        [Ephemeral]
         ResetTimestamp                 = 59,
         LogoffTimestamp                = 60,
         EconRecoveryInterval           = 61,

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -160,9 +161,11 @@ namespace ACE.Server.WorldObjects
 
             if (!ResetMessagePending && !double.IsPositiveInfinity(ChestResetInterval))
             {
+                var resetTimestamp = ResetTimestamp;
+
                 var actionChain = new ActionChain();
                 actionChain.AddDelaySeconds(ChestResetInterval);
-                actionChain.AddAction(this, Reset);
+                actionChain.AddAction(this, () => Reset(resetTimestamp));
                 actionChain.EnqueueChain();
 
                 ResetMessagePending = true;
@@ -182,11 +185,14 @@ namespace ACE.Server.WorldObjects
             base.Close(player);
 
             if (ChestRegenOnClose && tryReset)
-                Reset();
+                Reset(ResetTimestamp);
         }
 
-        public override void Reset()
+        public void Reset(double? resetTimestamp)
         {
+            if (resetTimestamp != ResetTimestamp)
+                return;     // already cleared by previous reset
+
             // TODO: if 'ResetInterval' style, do we want to ensure a minimum amount of time for the last viewer?
 
             var player = CurrentLandblock.GetObject(Viewer) as Player;
@@ -207,6 +213,7 @@ namespace ACE.Server.WorldObjects
                     Generator_Regeneration();
             }
 
+            ResetTimestamp = Time.GetUnixTime();
             ResetMessagePending = false;
         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -20,7 +20,7 @@ namespace ACE.Server.WorldObjects
         protected double? ResetTimestamp
         {
             get => GetProperty(PropertyFloat.ResetTimestamp);
-            set { if (value.HasValue) RemoveProperty(PropertyFloat.ResetTimestamp); else SetProperty(PropertyFloat.ResetTimestamp, value.Value); }
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.ResetTimestamp); else SetProperty(PropertyFloat.ResetTimestamp, value.Value); }
         }
 
         protected double? ResetInterval


### PR DESCRIPTION
Repro steps:
- /create 38446
- appraise chest
- /setproperty PropertyFloat.ResetInterval 15
- /crack
- open chest
- take a step back, to close chest immediately
- appraise chest, /crack
- wait until slightly before 15 seconds after last opening
- open chest

Expected:
- chest stays open for 15 seconds

Actual:
- chest was closing almost immediately
