### PR TITLE
update house query

### DIFF
--- a/Source/ACE.Server/Managers/HouseManager.cs
+++ b/Source/ACE.Server/Managers/HouseManager.cs
@@ -723,7 +723,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// Registers a callback to run when the slumlord inventory has been loaded
         /// </summary>
-        private static void RegisterCallback(House house, Action<House> callback)
+        public static void RegisterCallback(House house, Action<House> callback)
         {
             if (!SlumlordCallbacks.TryGetValue(house.SlumLord.Guid.Full, out var callbacks))
             {

--- a/Source/ACE.Server/Managers/HouseManager.cs
+++ b/Source/ACE.Server/Managers/HouseManager.cs
@@ -687,7 +687,7 @@ namespace ACE.Server.Managers
         /// else return a copy of the House biota from the latest info in the db
         ///
         /// <param name="callback">called when the slumlord inventory is fully loaded</param>
-        private static void GetHouse(uint houseGuid, Action<House> callback)
+        public static void GetHouse(uint houseGuid, Action<House> callback)
         {
             var landblock = (ushort)((houseGuid >> 12) & 0xFFFF);
 

--- a/Source/ACE.Server/WorldObjects/House.cs
+++ b/Source/ACE.Server/WorldObjects/House.cs
@@ -76,7 +76,7 @@ namespace ACE.Server.WorldObjects
         /// Builds a HouseData structure for this house
         /// This is used to populate the info in the House panel
         /// </summary>
-        public HouseData GetHouseData(Player owner)
+        public HouseData GetHouseData(IPlayer owner)
         {
             var houseData = new HouseData();
             houseData.Position = Location;

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -456,6 +456,16 @@ namespace ACE.Server.WorldObjects
             if (HouseRentTimestamp == null)
                 HouseRentTimestamp = (int)House.GetRentDue(purchaseTime);
 
+            if (!House.SlumLord.InventoryLoaded)
+            {
+                HouseManager.RegisterCallback(House, (house) => HandleHouseOnLogin_Inner());
+            }
+            else
+                HandleHouseOnLogin_Inner();
+        }
+
+        public void HandleHouseOnLogin_Inner()
+        {
             var actionChain = new ActionChain();
             actionChain.AddDelaySeconds(5.0f);
             actionChain.AddAction(this, () =>

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -733,26 +733,33 @@ namespace ACE.Server.WorldObjects
             return totalValue;
         }
 
-        public uint? GetHouseInstance()
+        public IPlayer GetHouseOwner()
         {
             // if this character owns a house, always use that
             if (HouseInstance != null)
-                return HouseInstance;
+                return this;
 
             // if server is running house_per_char mode (non-default),
             // only use the HouseInstance for the current character
             if (PropertyManager.GetBool("house_per_char").Item)
-                return HouseInstance;
+                return this;
 
-            // else return the HouseInstance for the account
+            // else return the account house owner
             var accountHouseOwner = GetAccountHouseOwner();
 
-            return accountHouseOwner?.HouseInstance;
+            return accountHouseOwner;
+        }
+
+        public uint? GetHouseInstance()
+        {
+            return GetHouseOwner()?.HouseInstance;
         }
 
         public void HandleActionQueryHouse()
         {
-            var houseInstance = GetHouseInstance();
+            var houseOwner = GetHouseOwner();
+
+            var houseInstance = houseOwner?.HouseInstance;
 
             // no house owned - send 0x226 HouseStatus?
             if (houseInstance == null)
@@ -765,23 +772,11 @@ namespace ACE.Server.WorldObjects
             if (House == null)
                 LoadHouse(houseInstance);
 
-            var house = GetHouse(houseInstance);
-            if (house == null)
+            HouseManager.GetHouse(houseInstance.Value, (house) =>
             {
-                Session.Network.EnqueueSend(new GameEventHouseStatus(Session));
-                return;
-            }
-
-            // slumlord inventory callback...
-            var actionChain = new ActionChain();
-            actionChain.AddDelaySeconds(1.0f);
-            actionChain.AddAction(this, () =>
-            {
-                // ensure house.Slumlord.InventoryLoaded?
-                var houseData = house.GetHouseData(this);
+                var houseData = house.GetHouseData(houseOwner);
                 Session.Network.EnqueueSend(new GameEventHouseData(Session, houseData));
             });
-            actionChain.EnqueueChain();
         }
 
         public House LoadHouse(uint? houseInstance, bool forceLoad = false)


### PR DESCRIPTION
This fixes a couple of issues with HandleActionQueryHouse:

- If the house landblock / slumlord inventory takes a particularly long time to load on the server, the player would get a 'warning! you have not paid your maintenance costs' message, even if the slumlord inventory is potentially paid already.

This was the result of some older code that was commented as 'needing a slumlord inventory callback'. This callback system was already implemented for HouseManager, so HandleActionQueryHouse() has been updated to use a proper callback, instead of waiting an arbitrary amount of time for the slumlord inventory to load.

- For servers running in '1 house per account' mode (the default), if a player who wasn't the direct house owner logged in, the house panel was showing 'Bought: N/A', which was also causing a display error for the other timestamps shown to the player.

This was because the call to GetHouseData() was always using the current player, instead of the actual house owner.

Thanks to lee-cantonais and Ripley for helping to diagnose and debug these issues!