### PR TITLE
filling some gaps for instant vital updates for targeted creature

### DIFF
--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -89,6 +89,8 @@ namespace ACE.Server.Entity
             Log.Add(entry);
 
             AddInternal(attacker, amount);
+
+            Creature.OnHealthUpdate();
         }
 
         /// <summary>
@@ -125,6 +127,8 @@ namespace ACE.Server.Entity
 
             // calculate previous missingHealth
             OnHealInternal(healAmount, Creature.Health.Current, Creature.Health.MaxValue);
+
+            Creature.OnHealthUpdate();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
+
 using log4net;
 
 using ACE.Common;
-using ACE.DatLoader.FileTypes;
 using ACE.DatLoader;
+using ACE.DatLoader.FileTypes;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -40,6 +42,11 @@ namespace ACE.Server.WorldObjects
                 return _questManager;
             }
         }
+
+        /// <summary>
+        /// A table of players who currently have their targeting reticule on this creature
+        /// </summary>
+        private Dictionary<uint, WorldObjectInfo> selectedTargets;
 
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
@@ -108,6 +115,8 @@ namespace ACE.Server.WorldObjects
             SetMonsterState();
 
             CurrentMotionState = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+
+            selectedTargets = new Dictionary<uint, WorldObjectInfo>();
         }
 
         public void GenerateNewFace()
@@ -310,6 +319,38 @@ namespace ACE.Server.WorldObjects
                 door.OnCollideObject(this);
             else if (target is Hotspot hotspot)
                 hotspot.OnCollideObject(this);
+        }
+
+        /// <summary>
+        /// Called when a player selects a target
+        /// </summary>
+        public bool OnTargetSelected(Player player)
+        {
+            return selectedTargets.TryAdd(player.Guid.Full, new WorldObjectInfo(player));
+        }
+
+        /// <summary>
+        /// Called when a player deselects a target
+        /// </summary>
+        public bool OnTargetDeselected(Player player)
+        {
+            return selectedTargets.Remove(player.Guid.Full);
+        }
+
+        /// <summary>
+        /// Called when a creature's health changes
+        /// </summary>
+        public void OnHealthUpdate()
+        {
+            foreach (var kvp in selectedTargets)
+            {
+                var player = kvp.Value.TryGetWorldObject() as Player;
+
+                if (player?.Session != null)
+                    QueryHealth(player.Session);
+                else
+                    selectedTargets.Remove(kvp.Key);
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -309,8 +309,6 @@ namespace ACE.Server.WorldObjects
 
                 source.SendMessage(msg, type);
             }
-
-            source.Session.Network.EnqueueSend(new GameEventUpdateHealth(source.Session, Guid.Full, (float)Health.Current / Health.MaxValue));
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -188,9 +188,6 @@ namespace ACE.Server.WorldObjects
                     target.EmoteManager.OnReceiveCritical(this);
             }
 
-            if (damageEvent.Damage > 0.0f)
-                Session.Network.EnqueueSend(new GameEventUpdateHealth(Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
-
             if (targetPlayer == null)
                 OnAttackMonster(target);
 

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -257,6 +257,8 @@ namespace ACE.Server.WorldObjects
 
                     // reset damage history for this player
                     DamageHistory.Reset();
+
+                    OnHealthUpdate();
                 });
 
                 teleportChain.EnqueueChain();

--- a/Source/ACE.Server/WorldObjects/Player_Tracking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tracking.cs
@@ -16,7 +16,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// ObjectId of the currently selected Target (only players and creatures)
         /// </summary>
-        private ObjectGuid selectedTarget = ObjectGuid.Invalid;
+        private WorldObjectInfo selectedTarget { get; set; }
 
         /// <summary>
         /// This dictionary is used to keep track of the last use of any item that implemented shared cooldown.

--- a/Source/ACE.Server/WorldObjects/Player_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Vitals.cs
@@ -163,19 +163,14 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleTargetVitals()
         {
-            if (selectedTarget == ObjectGuid.Invalid)
-                return;
+            var target = selectedTarget?.TryGetWorldObject() as Creature;
 
-            var target = CurrentLandblock?.GetObject(selectedTarget) as Creature;
-            if (target == null)
-                return;
-
-            if (target.Health.Current <= 0)
+            if (target == null || target.Health.Current <= 0)
                 return;
 
             var healthPercent = (float)target.Health.Current / target.Health.MaxValue;
 
-            Session.Network.EnqueueSend(new GameEventUpdateHealth(Session, selectedTarget.Full, healthPercent));
+            Session.Network.EnqueueSend(new GameEventUpdateHealth(Session, target.Guid.Full, healthPercent));
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -676,8 +676,6 @@ namespace ACE.Server.WorldObjects
 
                     if (!player.SquelchManager.Squelches.Contains(target, ChatMessageType.Magic))
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(attackerMsg, ChatMessageType.Magic));
-
-                    player.Session.Network.EnqueueSend(new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)target.Health.Current / target.Health.MaxValue));
                 }
 
                 if (targetPlayer != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -643,7 +643,7 @@ namespace ACE.Server.WorldObjects
             float healthPercentage = 1f;
 
             if (this is Creature creature)
-                healthPercentage = (float)creature.Health.Current / (float)creature.Health.MaxValue;
+                healthPercentage = (float)creature.Health.Current / creature.Health.MaxValue;
 
             var updateHealth = new GameEventUpdateHealth(examiner, Guid.Full, healthPercentage);
             examiner.Network.EnqueueSend(updateHealth);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -441,9 +441,6 @@ namespace ACE.Server.WorldObjects
                         }
                     }
 
-                    if (player != null && srcVital != null && srcVital.Equals("health"))
-                        player.Session.Network.EnqueueSend(new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)spellTarget.Health.Current / spellTarget.Health.MaxValue));
-
                     // handle cloaks
                     if (spellTarget != this && spellTarget.IsAlive && srcVital != null && srcVital.Equals("health") && boost < 0 && spellTarget.HasCloakEquipped)
                     {
@@ -598,9 +595,6 @@ namespace ACE.Server.WorldObjects
                                 targetMsg = new GameMessageSystemChat($"You gain {destVitalChange} points of {destVital} due to {caster.Name} casting {spell.Name} on you", ChatMessageType.Magic);
                         }
                     }
-
-                    if (player != null && srcVital != null && srcVital.Equals("health"))
-                        player.Session.Network.EnqueueSend(new GameEventUpdateHealth(player.Session, target.Guid.Full, (float)spellTarget.Health.Current / spellTarget.Health.MaxValue));
 
                     // handle cloaks
                     if (spellTarget != this && spellTarget.IsAlive && srcVital != null && srcVital.Equals("health"))


### PR DESCRIPTION
This PR replaces a bunch of hooks scattered around the codebase for UpdateHealth for the attacker

The 'selectedTarget' system has been upgraded to use WorldObjectInfo, and to have ties directly into DamageHistory

Some gaps that this covers:

- Player A and Player B are both attacking the same creature. While Player A is doing damage to the creature, Player B previously did not receive the instant health updates.

- A bunch of missing hooks all throughout the system, for healing, vital ticks, etc.