### PR TITLE
further cleanup for spell_projectile_ethereal

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -524,7 +524,7 @@ namespace ACE.Server.Managers
                 ("show_mana_conv_bonus_0", new Property<bool>(true, "if disabled, only shows mana conversion bonus if not zero, during appraisal of casting items")),
                 ("smite_uses_takedamage", new Property<bool>(false, "if enabled, smite applies damage via TakeDamage")),
                 ("spellcast_recoil_queue", new Property<bool>(false, "if true, players can queue the next spell to cast during recoil animation")),
-                ("spell_projectile_ethereal", new Property<bool>(false, "braodcasts all spell projectiles as ethereal to clients only, and manually send stop velocity on collision. can fix various issues with client missing target id.")),
+                ("spell_projectile_ethereal", new Property<bool>(false, "broadcasts all spell projectiles as ethereal to clients only, and manually send stop velocity on collision. can fix various issues with client missing target id.")),
                 ("suicide_instant_death", new Property<bool>(false, "if enabled, @die command kills player instantly. defaults to disabled, as in retail")),
                 ("taboo_table", new Property<bool>(true, "if enabled, taboo table restricts player names during character creation")),
                 ("tailoring_intermediate_uieffects", new Property<bool>(false, "If true, tailoring intermediate icons retain the magical/elemental highlight of the original item")),

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Collision;
 using ACE.Server.Physics.Combat;
@@ -1294,12 +1295,21 @@ namespace ACE.Server.Physics
 
             if (transition.SpherePath.CurCell == null) return SetPositionError.NoCell;
 
-            // custom
-            if (ProjectileTarget != null)
-                handle_all_collisions(transition.CollisionInfo, false, false);
+            // custom:
+            // test for non-ethereal spell projectile collision on world entry
+            var spellCollide = WeenieObj.WorldObject is SpellProjectile && transition.CollisionInfo.CollideObject.Count > 0 && !PropertyManager.GetBool("spell_projectile_ethereal").Item;
+
+            if (spellCollide)
+            {
+                // send initial CO as ethereal
+                WeenieObj.WorldObject.Ethereal = true;
+            }
 
             if (!SetPositionInternal(transition))
                 return SetPositionError.GeneralFailure;
+
+            if (spellCollide)
+                handle_all_collisions(transition.CollisionInfo, false, false);
 
             return SetPositionError.OK;
         }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -214,25 +214,23 @@ namespace ACE.Server.WorldObjects
 
             PhysicsObj.set_active(false);
 
-            var broadcaster = PhysicsObj.entering_world ? ProjectileSource : this;
-
-            broadcaster.EnqueueBroadcast(new GameMessageSetState(this, PhysicsObj.State));
-            broadcaster.EnqueueBroadcast(new GameMessageScript(Guid, PlayScript.Explode, GetProjectileScriptIntensity(SpellType)));
-
             if (PhysicsObj.entering_world)
             {
-                // for this path, since the projectile is being set to ethereal before the CO is sent,
-                // setting small velocity to still show the particle effects, but prevent the projectile from continuing
-                // to sail through the target
-
-                Velocity *= 0.05f;
+                // this path should only happen if spell_projectile_ethereal = false
+                EnqueueBroadcast(new GameMessageScript(Guid, PlayScript.Launch, GetProjectileScriptIntensity(SpellType)));
                 WorldEntryCollision = true;
             }
-            else if (PropertyManager.GetBool("spell_projectile_ethereal").Item)
-            {
-                PhysicsObj.Velocity = Vector3.Zero;
-                broadcaster.EnqueueBroadcast(new GameMessageVectorUpdate(this));
-            }
+
+            EnqueueBroadcast(new GameMessageSetState(this, PhysicsObj.State));
+            EnqueueBroadcast(new GameMessageScript(Guid, PlayScript.Explode, GetProjectileScriptIntensity(SpellType)));
+
+            // this should only be needed for spell_projectile_ethereal = true,
+            // however it can also fix a display issue on client in default mode,
+            // where GameMessageSetState updates projectile to ethereal before it has actually collided on client,
+            // causing a 'ghost' projectile to continue to sail through the target
+
+            PhysicsObj.Velocity = Vector3.Zero;
+            EnqueueBroadcast(new GameMessageVectorUpdate(this));
 
             ActionChain selfDestructChain = new ActionChain();
             selfDestructChain.AddDelaySeconds(5.0);


### PR DESCRIPTION
This PR has further improvements for spell projectiles, regardless if spell_projectile_ethereal is enabled or disabled

- Point-blank collisions now play the effects more consistently across all spell types. The lightning bolts, for example, no longer linger around. The launch effects also always play for point-blank collisions (more particle effects)

- The network message broadcasting for point-blank collisions has also been cleaned up slightly, so that the special 'broadcaster' variable is no longer needed.

