### PR TITLE
adding null check

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -514,7 +514,7 @@ namespace ACE.Server.WorldObjects
 
             if (searchLocations.HasFlag(SearchLocations.ObjectsKnownByMe))
             {
-                result = GetKnownObjects().FirstOrDefault(o => o.Guid == objectGuid);
+                result = GetKnownObjects()?.FirstOrDefault(o => o.Guid == objectGuid);
 
                 if (result != null)
                     return result;


### PR DESCRIPTION
This seems like it should be impossible, but there is a rare crash in Player_Inventory.cs on line 517

No idea how GetKnownObjects() could be returning null