### PR TITLE
fix corpses spawning frozen in mid-air

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1,12 +1,13 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Net;
 using System.Threading;
 
 using log4net;
 
+using ACE.Common.Extensions;
 using ACE.Database;
 using ACE.Database.Models.Auth;
 using ACE.Database.Models.Shard;
@@ -18,9 +19,9 @@ using ACE.Server.Entity;
 using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Network;
+using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
-using ACE.Server.Network.Enum;
 using ACE.Server.WorldObjects.Entity;
 
 using Biota = ACE.Database.Models.Shard.Biota;
@@ -2015,7 +2016,8 @@ namespace ACE.Server.Command.Handlers
             }
 
             // determine the vital type
-            if (!Enum.TryParse(parameters[0], out PropertyAttribute2nd vitalAttr)) {
+            if (!Enum.TryParse(parameters[0], out PropertyAttribute2nd vitalAttr))
+            {
                 ChatPacket.SendServerMessage(session, "Invalid vital type, valid values are: Health,Stamina,Mana", ChatMessageType.Broadcast);
                 return;
             }
@@ -3050,7 +3052,7 @@ namespace ACE.Server.Command.Handlers
                 session.Network.EnqueueSend(new GameMessageSystemChat(info, ChatMessageType.Broadcast));
             }
         }
-      
+
         // cm <material type> <quantity> <ave. workmanship>
         [CommandHandler("cm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Create a salvage bag in your inventory", "<material_type>, optional: <structure> <workmanship> <num_items>")]
         public static void HandleCM(Session session, params string[] parameters)
@@ -3175,6 +3177,51 @@ namespace ACE.Server.Command.Handlers
             msg += "Clear resets to default.\nAll options ending with Fog are continuous.\nAll options ending with Fog2 are continuous and blank radar.\nAll options ending with Sound play once and do not repeat.";
 
             return msg;
+        }
+
+        [CommandHandler("movetome", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Moves the last appraised object to the current player location.")]
+        public static void HandleMoveToMe(Session session, params string[] parameters)
+        {
+            var obj = CommandHandlerHelper.GetLastAppraisedObject(session);
+
+            if (obj == null)
+                return;
+
+            if (obj.CurrentLandblock == null)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"{obj.Name} ({obj.Guid}) is not a landblock object", ChatMessageType.Broadcast));
+                return;
+            }
+
+            if (obj is Player)
+            {
+                HandleTeleToMe(session, new string[] { obj.Name });
+                return;
+            }
+
+            var prevLoc = obj.Location;
+            var newLoc = new Position(session.Player.Location);
+            newLoc.Rotation = prevLoc.Rotation;     // keep previous rotation
+
+            var setPos = new Physics.Common.SetPosition(newLoc.PhysPosition(), Physics.Common.SetPositionFlags.Teleport | Physics.Common.SetPositionFlags.Slide);
+            var result = obj.PhysicsObj.SetPosition(setPos);
+
+            if (result != Physics.Common.SetPositionError.OK)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to move {obj.Name} ({obj.Guid}) to current location: {result}", ChatMessageType.Broadcast));
+                return;
+
+            }
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Moving {obj.Name} ({obj.Guid}) to current location", ChatMessageType.Broadcast));
+
+            obj.Location = obj.PhysicsObj.Position.ACEPosition();
+
+            if (prevLoc.Landblock != obj.Location.Landblock)
+            {
+                LandblockManager.RelocateObjectForPhysics(obj, true);
+            }
+
+            obj.SendUpdatePosition(true);
         }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -3179,7 +3179,7 @@ namespace ACE.Server.Command.Handlers
             return msg;
         }
 
-        [CommandHandler("movetome", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Moves the last appraised object to the current player location.")]
+        [CommandHandler("movetome", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, "Moves the last appraised object to the current player location.")]
         public static void HandleMoveToMe(Session session, params string[] parameters)
         {
             var obj = CommandHandlerHelper.GetLastAppraisedObject(session);

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2978,6 +2978,19 @@ namespace ACE.Server.Command.Handlers
             actionChain.EnqueueChain();
         }
 
+        [CommandHandler("showvelocity", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Shows the velocity of the last appraised object.")]
+        public static void HandleShowVelocity(Session session, params string[] parameters)
+        {
+            var obj = CommandHandlerHelper.GetLastAppraisedObject(session);
+
+            if (obj?.PhysicsObj == null)
+                return;
+
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Velocity: {obj.Velocity}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Physics.Velocity: {obj.PhysicsObj.Velocity}", ChatMessageType.Broadcast));
+            session.Network.EnqueueSend(new GameMessageSystemChat($"CachedVelocity: {obj.PhysicsObj.CachedVelocity}", ChatMessageType.Broadcast));
+        }
+
         [CommandHandler("bumpvelocity", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Bumps the velocity of the last appraised object.")]
         public static void HandleBumpVelocity(Session session, params string[] parameters)
         {

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2977,5 +2977,21 @@ namespace ACE.Server.Command.Handlers
             });
             actionChain.EnqueueChain();
         }
+
+        [CommandHandler("bumpvelocity", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Bumps the velocity of the last appraised object.")]
+        public static void HandleBumpVelocity(Session session, params string[] parameters)
+        {
+            var obj = CommandHandlerHelper.GetLastAppraisedObject(session);
+
+            if (obj?.PhysicsObj == null)
+                return;
+
+            var velocity = new Vector3(0, 0, 0.5f);
+
+            obj.Velocity = velocity;
+            obj.PhysicsObj.Velocity = velocity;
+
+            session.Network.EnqueueSend(new GameMessageVectorUpdate(obj));
+        }
     }
 }

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -289,5 +289,10 @@ namespace ACE.Server.Entity
         {
             return new Position(pos.ObjCellID, pos.Frame.Origin, pos.Frame.Orientation);
         }
+
+        public static Physics.Common.Position PhysPosition(this Position pos)
+        {
+            return new Physics.Common.Position(pos.Cell, new Physics.Animation.AFrame(pos.Pos, pos.Rotation));
+        }
     }
 }

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageUpdatePosition.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageUpdatePosition.cs
@@ -8,13 +8,13 @@ namespace ACE.Server.Network.GameMessages.Messages
     {
         public PositionPack PositionPack;
 
-        public GameMessageUpdatePosition(WorldObject worldObject)
+        public GameMessageUpdatePosition(WorldObject worldObject, bool adminMove = false)
             : base(GameMessageOpcode.UpdatePosition, GameMessageGroup.SmartboxQueue)
         {
             //Console.WriteLine($"Sending UpdatePosition for {worldObject.Name}");
 
             // todo: avoid create intermediate object
-            PositionPack = new PositionPack(worldObject);
+            PositionPack = new PositionPack(worldObject, adminMove);
 
             Writer.WriteGuid(worldObject.Guid);
             Writer.Write(PositionPack);

--- a/Source/ACE.Server/Network/Structure/PositionPack.cs
+++ b/Source/ACE.Server/Network/Structure/PositionPack.cs
@@ -33,7 +33,7 @@ namespace ACE.Server.Network.Structure
 
         public PositionPack() { }
 
-        public PositionPack(WorldObject wo)
+        public PositionPack(WorldObject wo, bool adminMove = false)
         {
             WorldObject = wo;
 
@@ -45,7 +45,12 @@ namespace ACE.Server.Network.Structure
             // note that this constructor increments the wo position sequence
             InstanceSequence = wo.Sequences.GetCurrentSequence(SequenceType.ObjectInstance);
             PositionSequence = wo.Sequences.GetNextSequence(SequenceType.ObjectPosition);
-            TeleportSequence = wo.Sequences.GetCurrentSequence(SequenceType.ObjectTeleport);
+
+            if (adminMove)
+                TeleportSequence = wo.Sequences.GetNextSequence(SequenceType.ObjectTeleport);
+            else
+                TeleportSequence = wo.Sequences.GetCurrentSequence(SequenceType.ObjectTeleport);
+
             ForcePositionSequence = wo.Sequences.GetCurrentSequence(SequenceType.ObjectForcePosition);
 
             Flags = BuildFlags();

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -363,7 +363,12 @@ namespace ACE.Server.WorldObjects
             }
 
             if (saveCorpse)
+            {
                 corpse.SaveBiotaToDatabase();
+
+                foreach (var item in corpse.Inventory.Values)
+                    item.SaveBiotaToDatabase();
+            }
         }
 
         public bool CanGenerateRare

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -256,7 +256,9 @@ namespace ACE.Server.WorldObjects
                     corpse.Biota.BiotaPropertiesTextureMap.Add(new Database.Models.Shard.BiotaPropertiesTextureMap { ObjectId = corpse.Guid.Full, Index = textureChange.PartIndex, OldId = textureChange.OldTexture, NewId = textureChange.NewTexture, Order = i++ });
             }
 
-            corpse.Location = new Position(Location);
+            // use the physics location for accuracy,
+            // especially while jumping
+            corpse.Location = PhysicsObj.Position.ACEPosition();
 
             corpse.VictimId = Guid.Full;
             corpse.Name = $"{prefix} of {Name}";
@@ -337,6 +339,12 @@ namespace ACE.Server.WorldObjects
 
             if (CanGenerateRare && killer != null)
                 corpse.GenerateRare(killer);
+
+            corpse.InitPhysicsObj();
+
+            // persist the original creature velocity (only used for falling) to corpse
+            corpse.PhysicsObj.Velocity = PhysicsObj.Velocity;
+            corpse.Velocity = PhysicsObj.Velocity;
 
             corpse.EnterWorld();
 

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -287,7 +287,9 @@ namespace ACE.Server.WorldObjects
 
             bool saveCorpse = false;
 
-            if (this is Player player)
+            var player = this as Player;
+
+            if (player != null)
             {
                 corpse.SetPosition(PositionType.Location, corpse.Location);
                 var dropped = player.CalculateDeathItems(corpse);
@@ -343,15 +345,19 @@ namespace ACE.Server.WorldObjects
             corpse.InitPhysicsObj();
 
             // persist the original creature velocity (only used for falling) to corpse
-            corpse.PhysicsObj.Velocity = PhysicsObj.Velocity;
-            corpse.Velocity = PhysicsObj.Velocity;
+            if (player != null && player.FastTick)
+            {
+                // only applies to PKs atm
+                corpse.PhysicsObj.Velocity = PhysicsObj.Velocity;
+                corpse.Velocity = PhysicsObj.Velocity;
+            }
 
             corpse.EnterWorld();
 
-            if (this is Player p)
+            if (player != null)
             {
                 if (corpse.PhysicsObj == null || corpse.PhysicsObj.Position == null)
-                    log.Debug($"[CORPSE] {Name}'s corpse (0x{corpse.Guid}) failed to spawn! Tried at {p.Location.ToLOCString()}");
+                    log.Debug($"[CORPSE] {Name}'s corpse (0x{corpse.Guid}) failed to spawn! Tried at {player.Location.ToLOCString()}");
                 else
                     log.Debug($"[CORPSE] {Name}'s corpse (0x{corpse.Guid}) is located at {corpse.PhysicsObj.Position}");
             }

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -313,7 +313,7 @@ namespace ACE.Server.WorldObjects
 
             var velocity = obj.Velocity;
 
-            obj.PhysicsObj.Velocity = velocity.Value;
+            obj.PhysicsObj.Velocity = velocity;
             obj.PhysicsObj.ProjectileTarget = target.PhysicsObj;
 
             obj.PhysicsObj.set_active(true);

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -758,7 +758,7 @@ namespace ACE.Server.WorldObjects
 
             var velocity = Velocity;
             //velocity = Vector3.Transform(velocity, Matrix4x4.Transpose(Matrix4x4.CreateFromQuaternion(rotation)));
-            PhysicsObj.Velocity = velocity.Value;
+            PhysicsObj.Velocity = velocity;
 
             if (target != null)
                 PhysicsObj.ProjectileTarget = target.PhysicsObj;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1481,7 +1481,7 @@ namespace ACE.Server.WorldObjects
                 }
 
                 // set orientation
-                var dir = Vector3.Normalize(sp.Velocity.Value);
+                var dir = Vector3.Normalize(sp.Velocity);
                 sp.PhysicsObj.Position.Frame.set_vector_heading(dir);
                 sp.Location.Rotation = sp.PhysicsObj.Position.Frame.Orientation;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 
 using ACE.DatLoader;
 using ACE.DatLoader.Entity;
@@ -364,17 +365,17 @@ namespace ACE.Server.WorldObjects
 
             if ((physicsDescriptionFlag & PhysicsDescriptionFlag.Velocity) != 0)
             {
-                writer.Write(Velocity.Value);
+                writer.Write(Velocity);
             }
 
             if ((physicsDescriptionFlag & PhysicsDescriptionFlag.Acceleration) != 0)
             {
-                writer.Write(Acceleration.Value);
+                writer.Write(Acceleration);
             }
 
             if ((physicsDescriptionFlag & PhysicsDescriptionFlag.Omega) != 0)
             {
-                writer.Write(Omega.Value);
+                writer.Write(Omega);
             }
 
             if ((physicsDescriptionFlag & PhysicsDescriptionFlag.DefaultScript) != 0)
@@ -478,13 +479,13 @@ namespace ACE.Server.WorldObjects
             if ((Translucency != null) && (Math.Abs(Translucency ?? 0) >= 0.001))
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Translucency;
 
-            if (Velocity != null)
+            if (Velocity != Vector3.Zero)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Velocity;
 
-            if (Acceleration != null)
+            if (Acceleration != Vector3.Zero)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Acceleration;
 
-            if (Omega != null)
+            if (Omega != Vector3.Zero)
                 physicsDescriptionFlag |= PhysicsDescriptionFlag.Omega;
 
             if (DefaultScriptId != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -402,11 +402,12 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Broadcast position updates to players within range
         /// </summary>
-        public void SendUpdatePosition()
+        /// <param name="adminMove">only used if admin is teleporting a non-player object</param>
+        public void SendUpdatePosition(bool adminMove = false)
         {
             //Console.WriteLine($"{Name}.SendUpdatePosition({Location.ToLOCString()})");
 
-            EnqueueBroadcast(new GameMessageUpdatePosition(this));
+            EnqueueBroadcast(new GameMessageUpdatePosition(this, adminMove));
 
             LastUpdatePosition = DateTime.UtcNow;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -636,11 +636,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.Translucency); else SetProperty(PropertyFloat.Translucency, value.Value); }
         }
 
-        public Vector3? Velocity = null;
+        // TODO: sync with physics -- these shouldn't be separate fields
+        public Vector3 Velocity { get; set; }
 
-        public Vector3? Acceleration = null;
+        public Vector3 Acceleration { get; set; }
 
-        public Vector3? Omega = null;
+        public Vector3 Omega { get; set; }
 
         public SetupModel CSetup => DatManager.PortalDat.ReadFromDat<SetupModel>(SetupTableId);
 


### PR DESCRIPTION
Repro steps:
- /god (for mega jump)
- /pk pk
- do a standing jump forward, @ full jump power
- type /rip in chat window immediately after leaving the ground

Expected:
- corpse spawns in midair, near the apex of the jump, and continues the previous trajectory of the jumping player, eventually falling back to the ground

Actual:
- corpse spawns frozen in midair, near the apex of the jump

This PR persists the physics velocity (used only for jumping) of the dying creature to the corpse, causing the expected behavior

I have confirmed that ACE is correctly / automatically updating the latest position of the corpse to the database, after it lands. This can be seen with using /reload-landblock after the corpse falls to the ground.

One caveat is: since Velocity is a runtime-only field, and not persisted to the database, corpses that are restored from the database with a position in the air will still not fall to the ground. This can be reproed with the previous steps, and then doing an unsafe shutdown of the server immediately after respawning. In this situation, the corpse was saved immediately to the database when created, but the unsafe shutdown prevents the server from saving the latest landblock state after the corpse has reached the ground position.

Some additional admin / dev commands have been added to aid in these scenarios. /movetome moves the last appraised object to the admin player. This can be useful for corpse retrieval.

A /bumpvelocity command has also been added, which gives the last appraised object a tiny bit of upwards velocity, which also has the amusing effect of causing floating corpses to visually fall to the ground.

