### PR TITLE
fixing bandits dual wielding bow + melee

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -112,12 +112,9 @@ namespace ACE.Server.WorldObjects
             {
                 GenerateWieldList();
 
-                if (!(this is CombatPet)) //combat pets normally wouldn't have these items, but due to subbing in code currently, sometimes they do. this skips them for now.
-                {
-                    GenerateWieldedTreasure();
+                GenerateWieldedTreasure();
 
-                    EquipInventoryItems();
-                }
+                EquipInventoryItems();
 
                 // TODO: fix tod data
                 Health.Current = Health.MaxValue;

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -522,15 +522,17 @@ namespace ACE.Server.WorldObjects
             {
                 var wo = WorldObjectFactory.CreateNewWorldObject(item);
 
-                if (wo == null) continue;
+                if (wo != null)
+                    TryAddToInventory(wo);
 
-                var equipped = false;
+                // handled in EquipInventoryItems()
+                /*var equipped = false;
 
                 if (wo.ValidLocations != null)
                     equipped = TryWieldObject(wo, (EquipMask)wo.ValidLocations);
 
-                if (!equipped)
-                    TryAddToInventory(wo);
+                if (!equipped)*/
+                    
             }
         }
 
@@ -653,7 +655,18 @@ namespace ACE.Server.WorldObjects
             var wieldedTreasure = GenerateWieldedTreasureSets(table);
 
             foreach (var item in wieldedTreasure)
+            {
                 TryAddToInventory(item);
+
+                // handled in EquipInventoryItems()
+
+                /*var equipped = false;
+
+                if (item.ValidLocations != null)
+                    equipped = TryWieldObject(item, (EquipMask)item.ValidLocations);
+
+                if (!equipped)*/
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Inventory.cs
@@ -281,19 +281,21 @@ namespace ACE.Server.WorldObjects
         public void EquipInventoryItems(bool weaponsOnly = false)
         {
             var items = weaponsOnly ? SelectWieldedWeapons() : SelectWieldedTreasure();
-            if (items != null)
-            {
-                foreach (var item in items)
-                {
-                    //Console.WriteLine($"{Name} equipping {item.Name}");
 
-                    if (item.ValidLocations != null)
-                    {
-                        TryRemoveFromInventory(item.Guid);
-                        var result = TryWieldObjectWithBroadcasting(item, item.ValidLocations ?? 0);
-                        //Console.WriteLine($"{Name} tried to equip {item.Name}, result={result}");
-                    }
-                }
+            if (items == null) return;
+
+            foreach (var item in items)
+            {
+                if (item.ValidLocations == null)
+                    continue;
+
+                //Console.WriteLine($"{Name} equipping {item.Name}");
+
+                if (!TryRemoveFromInventory(item.Guid))
+                    continue;
+
+                if (!TryWieldObject(item, item.ValidLocations ?? 0))
+                    TryAddToInventory(item);
             }
         }
     }


### PR DESCRIPTION
Repro steps:
/create bandit

Expected:
Bandit is wielding normal weapons

Actual:
Bandit frequently spawns incorrectly wielding a bow and a melee weapon simultaneously

I tried implementing this PR a few different ways, and this is the current version. It changes things up a tad in CreateList and WieldedTreasure being wielded slightly, but it seems like it should produce the same results, with the expected behavior and bugs fixed