### PR TITLE
Add order to BiotaPropertiesPalette

### DIFF
--- a/Database/Updates/Shard/2020-04-07-00-Add-Order-To-Biota-Properties-Palette.sql
+++ b/Database/Updates/Shard/2020-04-07-00-Add-Order-To-Biota-Properties-Palette.sql
@@ -1,0 +1,4 @@
+USE ace_shard;
+
+ALTER TABLE `biota_properties_palette` 
+ADD COLUMN `order` TINYINT(3) UNSIGNED NULL DEFAULT NULL AFTER `length`;

--- a/Source/ACE.Database/Adapter/BiotaConverter.cs
+++ b/Source/ACE.Database/Adapter/BiotaConverter.cs
@@ -116,7 +116,7 @@ namespace ACE.Database.Adapter
             {
                 result.PropertiesPalette = new Collection<PropertiesPalette>();
 
-                foreach (var record in biota.BiotaPropertiesPalette)
+                foreach (var record in biota.BiotaPropertiesPalette.OrderBy(r => r.Order))
                 {
                     var newEntity = new PropertiesPalette
                     {
@@ -557,9 +557,11 @@ namespace ACE.Database.Adapter
 
             if (biota.PropertiesPalette != null)
             {
-                foreach (var value in biota.PropertiesPalette)
+                for (int i = 0; i < biota.PropertiesPalette.Count; i++)
                 {
-                    var entity = new BiotaPropertiesPalette { ObjectId = biota.Id, SubPaletteId = value.SubPaletteId, Offset = value.Offset, Length = value.Length };
+                    var value = biota.PropertiesPalette[i];
+
+                    var entity = new BiotaPropertiesPalette { ObjectId = biota.Id, SubPaletteId = value.SubPaletteId, Offset = value.Offset, Length = value.Length, Order = (byte)i };
 
                     result.BiotaPropertiesPalette.Add(entity);
                 }

--- a/Source/ACE.Database/Adapter/BiotaUpdater.cs
+++ b/Source/ACE.Database/Adapter/BiotaUpdater.cs
@@ -177,21 +177,28 @@ namespace ACE.Database.Adapter
 
             if (sourceBiota.PropertiesPalette != null)
             {
-                foreach (var value in sourceBiota.PropertiesPalette)
+                for (int i = 0; i < sourceBiota.PropertiesPalette.Count; i++)
                 {
-                    BiotaPropertiesPalette existingValue = targetBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.SubPaletteId == value.SubPaletteId && r.Offset == value.Offset && r.Length == value.Length);
+                    var value = sourceBiota.PropertiesPalette[i];
+
+                    BiotaPropertiesPalette existingValue = targetBiota.BiotaPropertiesPalette.FirstOrDefault(r => r.Order == i);
 
                     if (existingValue == null)
                     {
-                        existingValue = new BiotaPropertiesPalette { ObjectId = sourceBiota.Id, SubPaletteId = value.SubPaletteId, Offset = value.Offset, Length = value.Length };
+                        existingValue = new BiotaPropertiesPalette { ObjectId = sourceBiota.Id };
 
                         targetBiota.BiotaPropertiesPalette.Add(existingValue);
                     }
+
+                    existingValue.SubPaletteId = value.SubPaletteId;
+                    existingValue.Offset = value.Offset;
+                    existingValue.Length = value.Length;
+                    existingValue.Order = (byte)i;
                 }
             }
             foreach (var value in targetBiota.BiotaPropertiesPalette)
             {
-                if (sourceBiota.PropertiesPalette == null || !sourceBiota.PropertiesPalette.Any(p => p.SubPaletteId == value.SubPaletteId && p.Offset == value.Offset && p.Length == value.Length))
+                if (sourceBiota.PropertiesPalette == null || value.Order == null || value.Order >= sourceBiota.PropertiesPalette.Count)
                     context.BiotaPropertiesPalette.Remove(value);
             }
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
@@ -10,6 +10,7 @@ namespace ACE.Database.Models.Shard
         public uint SubPaletteId { get; set; }
         public ushort Offset { get; set; }
         public ushort Length { get; set; }
+        public byte? Order { get; set; }
 
         public virtual Biota Object { get; set; }
     }

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -1030,6 +1030,8 @@ namespace ACE.Database.Models.Shard
 
                 entity.Property(e => e.Offset).HasColumnName("offset");
 
+                entity.Property(e => e.Order).HasColumnName("order");
+
                 entity.Property(e => e.SubPaletteId).HasColumnName("sub_Palette_Id");
 
                 entity.HasOne(d => d.Object)

--- a/Source/ACE.Entity/Models/Biota.cs
+++ b/Source/ACE.Entity/Models/Biota.cs
@@ -30,7 +30,7 @@ namespace ACE.Entity.Models
         public IDictionary<int, float /* probability */> PropertiesSpellBook { get; set; }
 
         public IList<PropertiesAnimPart> PropertiesAnimPart { get; set; }
-        public ICollection<PropertiesPalette> PropertiesPalette { get; set; }
+        public IList<PropertiesPalette> PropertiesPalette { get; set; }
         public IList<PropertiesTextureMap> PropertiesTextureMap { get; set; }
 
         // Properties for all world objects that typically aren't modified over the original weenie

--- a/Source/ACE.Entity/Models/IWeenie.cs
+++ b/Source/ACE.Entity/Models/IWeenie.cs
@@ -29,7 +29,7 @@ namespace ACE.Entity.Models
         IDictionary<int, float /* probability */> PropertiesSpellBook { get; set; }
 
         IList<PropertiesAnimPart> PropertiesAnimPart { get; set; }
-        ICollection<PropertiesPalette> PropertiesPalette { get; set; }
+        IList<PropertiesPalette> PropertiesPalette { get; set; }
         IList<PropertiesTextureMap> PropertiesTextureMap { get; set; }
 
         // Properties for all world objects that typically aren't modified over the original weenie

--- a/Source/ACE.Entity/Models/PropertiesAnimPartExtensions.cs
+++ b/Source/ACE.Entity/Models/PropertiesAnimPartExtensions.cs
@@ -54,20 +54,5 @@ namespace ACE.Entity.Models
                 rwLock.ExitReadLock();
             }
         }
-
-
-        public static void Add(this IList<PropertiesAnimPart> value, IList<PropertiesAnimPart> entries, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterWriteLock();
-            try
-            {
-                foreach (var entry in entries)
-                    value.Add(entry);
-            }
-            finally
-            {
-                rwLock.ExitWriteLock();
-            }
-        }
     }
 }

--- a/Source/ACE.Entity/Models/PropertiesPaletteExtensions.cs
+++ b/Source/ACE.Entity/Models/PropertiesPaletteExtensions.cs
@@ -6,7 +6,7 @@ namespace ACE.Entity.Models
 {
     public static class PropertiesPaletteExtensions
     {
-        public static int GetCount(this ICollection<PropertiesPalette> value, ReaderWriterLockSlim rwLock)
+        public static int GetCount(this IList<PropertiesPalette> value, ReaderWriterLockSlim rwLock)
         {
             if (value == null)
                 return 0;
@@ -22,7 +22,7 @@ namespace ACE.Entity.Models
             }
         }
 
-        public static List<PropertiesPalette> Clone(this ICollection<PropertiesPalette> value, ReaderWriterLockSlim rwLock)
+        public static List<PropertiesPalette> Clone(this IList<PropertiesPalette> value, ReaderWriterLockSlim rwLock)
         {
             if (value == null)
                 return null;
@@ -38,7 +38,7 @@ namespace ACE.Entity.Models
             }
         }
 
-        public static void CopyTo(this ICollection<PropertiesPalette> value, ICollection<PropertiesPalette> destination, ReaderWriterLockSlim rwLock)
+        public static void CopyTo(this IList<PropertiesPalette> value, ICollection<PropertiesPalette> destination, ReaderWriterLockSlim rwLock)
         {
             if (value == null)
                 return;
@@ -52,21 +52,6 @@ namespace ACE.Entity.Models
             finally
             {
                 rwLock.ExitReadLock();
-            }
-        }
-
-
-        public static void Add(this ICollection<PropertiesPalette> value, ICollection<PropertiesPalette> entries, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterWriteLock();
-            try
-            {
-                foreach (var entry in entries)
-                    value.Add(entry);
-            }
-            finally
-            {
-                rwLock.ExitWriteLock();
             }
         }
     }

--- a/Source/ACE.Entity/Models/PropertiesTextureMapExtensions.cs
+++ b/Source/ACE.Entity/Models/PropertiesTextureMapExtensions.cs
@@ -25,8 +25,8 @@ namespace ACE.Entity.Models
         public static List<PropertiesTextureMap> Clone(this IList<PropertiesTextureMap> value, ReaderWriterLockSlim rwLock)
         {
             if (value == null)
-
                 return null;
+
             rwLock.EnterReadLock();
             try
             {
@@ -52,21 +52,6 @@ namespace ACE.Entity.Models
             finally
             {
                 rwLock.ExitReadLock();
-            }
-        }
-
-
-        public static void Add(this IList<PropertiesTextureMap> value, IList<PropertiesTextureMap> entries, ReaderWriterLockSlim rwLock)
-        {
-            rwLock.EnterWriteLock();
-            try
-            {
-                foreach (var entry in entries)
-                    value.Add(entry);
-            }
-            finally
-            {
-                rwLock.ExitWriteLock();
             }
         }
     }

--- a/Source/ACE.Entity/Models/Weenie.cs
+++ b/Source/ACE.Entity/Models/Weenie.cs
@@ -30,7 +30,7 @@ namespace ACE.Entity.Models
         public IDictionary<int, float /* probability */> PropertiesSpellBook { get; set; }
 
         public IList<PropertiesAnimPart> PropertiesAnimPart { get; set; }
-        public ICollection<PropertiesPalette> PropertiesPalette { get; set; }
+        public IList<PropertiesPalette> PropertiesPalette { get; set; }
         public IList<PropertiesTextureMap> PropertiesTextureMap { get; set; }
 
         // Properties for all world objects that typically aren't modified over the original weenie

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -245,18 +245,11 @@ namespace ACE.Server.WorldObjects
                 // Pull and save objdesc for correct corpse apperance at time of death
                 var objDesc = CalculateObjDesc();
 
-                if (corpse.Biota.PropertiesAnimPart == null)
-                    corpse.Biota.PropertiesAnimPart = new List<PropertiesAnimPart>();
-                corpse.Biota.PropertiesAnimPart.Add(objDesc.AnimPartChanges, BiotaDatabaseLock);
+                corpse.Biota.PropertiesAnimPart = objDesc.AnimPartChanges.Clone(corpse.BiotaDatabaseLock);
 
-                if (corpse.Biota.PropertiesPalette == null)
-                    corpse.Biota.PropertiesPalette = new Collection<PropertiesPalette>();
-                corpse.Biota.PropertiesPalette.Add(objDesc.SubPalettes, BiotaDatabaseLock);
+                corpse.Biota.PropertiesPalette = objDesc.SubPalettes.Clone(corpse.BiotaDatabaseLock);
 
-                if (corpse.Biota.PropertiesTextureMap == null)
-                    corpse.Biota.PropertiesTextureMap = new List<PropertiesTextureMap>();
-                foreach (var textureChange in objDesc.TextureChanges)
-                    corpse.Biota.PropertiesTextureMap.Add(new PropertiesTextureMap { PartIndex = textureChange.PartIndex, OldTexture = textureChange.OldTexture, NewTexture = textureChange.NewTexture });
+                corpse.Biota.PropertiesTextureMap = objDesc.TextureChanges.Clone(corpse.BiotaDatabaseLock);
             }
 
             // use the physics location for accuracy,


### PR DESCRIPTION
This fixes corpse palette ordering after a server restart.

This has a shard database update that is required.