### PR TITLE
Revert "fixing shade=0, from optimshi (#2870)"

### DIFF
--- a/Source/ACE.Database/SQLFormatters/SQLWriter.cs
+++ b/Source/ACE.Database/SQLFormatters/SQLWriter.cs
@@ -268,7 +268,7 @@ namespace ACE.Database.SQLFormatters
             treasure += $"{WeenieNames[item.WeenieClassId]} ({item.WeenieClassId})";
             if (item.PaletteId > 0)
                 treasure += $" | Palette: {Enum.GetName(typeof(PaletteTemplate), item.PaletteId)} ({item.PaletteId})";
-            if (item.Shade >= 0)
+            if (item.Shade > 0)
                 treasure += $" | Shade: {item.Shade}";
             treasure += $" | Probability: {item.Probability * 100}%";
 

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2301,7 +2301,7 @@ namespace ACE.Server.Command.Handlers
 
                     if (wearable.Palette > 0)
                         worldObject.PaletteTemplate = wearable.Palette;
-                    if (wearable.Shade >= 0)
+                    if (wearable.Shade > 0)
                         worldObject.Shade = wearable.Shade;
 
                     player.TryEquipObjectWithNetworking(worldObject, worldObject.ValidLocations ?? 0);
@@ -2323,7 +2323,7 @@ namespace ACE.Server.Command.Handlers
 
                     if (containable.Palette > 0)
                         worldObject.PaletteTemplate = containable.Palette;
-                    if (containable.Shade >= 0)
+                    if (containable.Shade > 0)
                         worldObject.Shade = containable.Shade;
                     player.TryAddToInventory(worldObject);
                 }

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -260,10 +260,10 @@ namespace ACE.Server.Entity
                 if (Biota.PaletteId.HasValue && Biota.PaletteId > 0)
                     wo.PaletteBaseId = Biota.PaletteId;
 
-                if (Biota.Shade.HasValue && Biota.Shade >= 0)
+                if (Biota.Shade.HasValue && Biota.Shade > 0)
                     wo.Shade = Biota.Shade;
 
-                if ((Biota.Shade.HasValue && Biota.Shade >= 0) || (Biota.PaletteId.HasValue && Biota.PaletteId > 0))
+                if ((Biota.Shade.HasValue && Biota.Shade > 0) || (Biota.PaletteId.HasValue && Biota.PaletteId > 0))
                     wo.CalculateObjDesc(); // to update icon
 
                 if (Biota.StackSize.HasValue && Biota.StackSize > 0)

--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -400,7 +400,7 @@ namespace ACE.Server.Factories
                 wo.PaletteTemplate = item.Palette;
 
             // if treasure, this is probability instead of shade
-            if (!isTreasure && item.Shade >= 0)
+            if (!isTreasure && item.Shade > 0)
                 wo.Shade = item.Shade;
 
             return wo;

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -843,7 +843,7 @@ namespace ACE.Server.WorldObjects
 
                 if (item.Palette > 0)
                     wo.PaletteTemplate = item.Palette;
-                if (item.Shade >= 0)
+                if (item.Shade > 0)
                     wo.Shade = item.Shade;
                 if (item.StackSize > 1)
                     wo.SetStackSize(item.StackSize);

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -208,7 +208,7 @@ namespace ACE.Server.WorldObjects
                 {
                     if (item.Palette > 0)
                         wo.PaletteTemplate = item.Palette;
-                    if (item.Shade >= 0)
+                    if (item.Shade > 0)
                         wo.Shade = item.Shade;
                     wo.ContainerId = Guid.Full;
                     wo.CalculateObjDesc(); // i don't like firing this but this triggers proper icons, the way vendors load inventory feels off to me in this method.

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -23,7 +23,7 @@ namespace ACE.Server.WorldObjects
                 if (item.Palette > 0)
                     wo.PaletteTemplate = item.Palette;
 
-                if (item.Shade >= 0)
+                if (item.Shade > 0)
                     wo.Shade = item.Shade;
 
                 if (item.StackSize > 0)
@@ -79,7 +79,7 @@ namespace ACE.Server.WorldObjects
             if (item.PaletteId > 0)
                 wo.PaletteTemplate = (int)item.PaletteId;
 
-            if (item.Shade >= 0)
+            if (item.Shade > 0)
                 wo.Shade = item.Shade;
 
             if (item.StackSize > 0)


### PR DESCRIPTION
This reverts commit 640847bf55f1de011f3d0a44569782f5c88a1895.

This patch causes the Pathwarden armor to appear as the wrong color (incorrect black color)

I think it might have something to do with null coalescing, ie. maybe the original data format had a way to distinguish between 'no shade' / null shade and shade=0

The current data format appears to be using non-nullables, so I'm not sure how to make this distinction with the current data format

Sending a revert for this patch until someone can chime in with the proper solution