### PR TITLE
improving monster sticky melee -- moving sticky update before position / distance check

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -105,12 +105,12 @@ namespace ACE.Server.WorldObjects
                 //MaxRange = MaxMeleeRange;   // FIXME: server position sync
             }
 
+            if (PhysicsObj.IsSticky)
+                UpdatePosition();
+
             // get distance to target
             var targetDist = GetDistanceToTarget();
             //Console.WriteLine($"{Name} ({Guid}) - Dist: {targetDist}");
-
-            if (PhysicsObj.PositionManager?.StickyManager != null && PhysicsObj.PositionManager.StickyManager.TargetID != 0)
-                UpdatePosition();
 
             if (CurrentAttack != CombatType.Missile)
             {


### PR DESCRIPTION
Repro steps:

- /create tuskerguard
- continuously walk backwards

Expected:

- Tusker Guard runs to target, stickies to them, takes a swing, then repeats this process

Actual:

- Tusker Guard continuously runs to target / stays stickied to them, but does not take swing