### PR TITLE
fixing bug with marketplace recall

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -208,10 +208,15 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            var updateCombatMode = new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat);
+            if (CombatMode != CombatMode.NonCombat)
+            {
+                // this should be handled by a different thing, probably a function that forces player into peacemode
+                var updateCombatMode = new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.CombatMode, (int)CombatMode.NonCombat);
+                SetCombatMode(CombatMode.NonCombat);
+                Session.Network.EnqueueSend(updateCombatMode);
+            }
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            Session.Network.EnqueueSend(updateCombatMode); // this should be handled by a different thing, probably a function that forces player into peacemode
             EnqueueBroadcastMotion(motionMarketplaceRecall);
 
             var startPos = new Position(Location);


### PR DESCRIPTION
Repro steps:
- /pk pk
- go into magic combat mode
- /mp
- observe: /mp immediately goes into non-combat mode and makes the magic combat bar disappear from the client (correctly). however, the player is still left in magic combat mode on the server
- after recalled to mp, try to go into magic combat mode again
- observe: the magic combat bar comes up on the player's screen, but they remain in non-combat stance
- try to cast a spell

Expected:
- Player goes into magic combat stance correctly, and is able to cast a spell normally

Actual:
- Player doesn't go into magic combat stance the first time, and gets a Busy / stance error when trying to cast a spell

Also a subtle animation timing bug with many of these recall commands: if the player starts from a combat mode, the animation timer is not taking the switch from combat stance -> non-combat stance into account.

When performing these actions from a combat stance, the recall happens slightly faster than it should.