### PR TITLE
updating Surge of Affliction + show_dot_messages for something more appropriate

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1166,18 +1166,23 @@ namespace ACE.Server.WorldObjects.Managers
         {
             var dots = new List<PropertiesEnchantmentRegistry>();
             var netherDots = new List<PropertiesEnchantmentRegistry>();
+            var aetheriaDots = new List<PropertiesEnchantmentRegistry>();
             var heals = new List<PropertiesEnchantmentRegistry>();
 
             foreach (var enchantment in enchantments)
             {
                 // combine DoTs from multiple sources
                 if (enchantment.StatModKey == (int)PropertyInt.DamageOverTime)
-                    dots.Add(enchantment);
-
-                if (enchantment.StatModKey == (int)PropertyInt.NetherOverTime)
+                {
+                    if (enchantment.SpellCategory == SpellCategory.AetheriaProcDamageOverTimeRaising)
+                        aetheriaDots.Add(enchantment);
+                    else
+                        dots.Add(enchantment);
+                }
+                else if (enchantment.StatModKey == (int)PropertyInt.NetherOverTime)
                     netherDots.Add(enchantment);
 
-                if (enchantment.StatModKey == (int)PropertyInt.HealOverTime)
+                else if (enchantment.StatModKey == (int)PropertyInt.HealOverTime)
                     heals.Add(enchantment);
             }
 
@@ -1187,6 +1192,9 @@ namespace ACE.Server.WorldObjects.Managers
 
             if (netherDots.Count > 0)
                 ApplyDamageTick(netherDots, DamageType.Nether);
+
+            if (aetheriaDots.Count > 0)
+                ApplyDamageTick(aetheriaDots, DamageType.Undef, true);
 
             // apply healing over time (HoTs)
             if (heals.Count > 0)
@@ -1224,7 +1232,7 @@ namespace ACE.Server.WorldObjects.Managers
         /// Applies 1 tick of damage from a DoT spell
         /// </summary>
         /// <param name="enchantments">The damage over time (DoT) spells</param>
-        public void ApplyDamageTick(List<PropertiesEnchantmentRegistry> enchantments, DamageType damageType)
+        public void ApplyDamageTick(List<PropertiesEnchantmentRegistry> enchantments, DamageType damageType, bool aetheria = false)
         {
             var creature = WorldObject as Creature;
             if (creature == null || creature.IsDead) return;
@@ -1307,7 +1315,7 @@ namespace ACE.Server.WorldObjects.Managers
                 var damageSourcePlayer = damager as Player;
                 if (damageSourcePlayer != null)
                 {
-                    creature.TakeDamageOverTime_NotifySource(damageSourcePlayer, damageType, amount);
+                    creature.TakeDamageOverTime_NotifySource(damageSourcePlayer, damageType, amount, aetheria);
 
                     if (creature.IsAlive)
                         creature.EmoteManager.OnDamage(damageSourcePlayer);

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -309,34 +309,41 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void TakeDamageOverTime_NotifySource(Player source, DamageType damageType, float amount, bool aetheria = false)
         {
-            if (PropertyManager.GetBool("show_dot_messages").Item)
+            if (!PropertyManager.GetBool("show_dot_messages").Item)
+                return;
+
+            var iAmount = (uint)Math.Round(amount);
+
+            var notifyType = damageType == DamageType.Undef ? DamageType.Health : damageType;
+
+            string verb = null, plural = null;
+            var percent = amount / Health.MaxValue;
+            Strings.GetAttackVerb(notifyType, percent, ref verb, ref plural);
+
+            string msg = null;
+
+            var type = ChatMessageType.CombatSelf;
+
+            if (damageType == DamageType.Nether)
             {
-                var iAmount = (uint)Math.Round(amount);
-
-                // damage text notification
-                string msg = null;
-                var type = ChatMessageType.CombatSelf;
-
-                if (damageType == DamageType.Nether || aetheria)
-                {
-                    var notifyType = aetheria ? DamageType.Health : damageType;
-
-                    string verb = null, plural = null;
-                    var percent = amount / Health.MaxValue;
-                    Strings.GetAttackVerb(notifyType, percent, ref verb, ref plural);
-
-                    if (damageType == DamageType.Nether)
-                        msg = $"You {verb} {Name} for {iAmount} points of periodic nether damage!";
-                    else
-                        msg = $"With Surge of Affliction you {verb} {iAmount} points of health from {Name}!";
-
-                    type = ChatMessageType.Magic;
-                }
-                else
-                    msg = $"You bleed {Name} for {iAmount} points of periodic damage!";
-
-                source.SendMessage(msg, type);
+                msg = $"You {verb} {Name} for {iAmount} points of periodic nether damage!";
+                type = ChatMessageType.Magic;
             }
+            else if (aetheria)
+            {
+                msg = $"With Surge of Affliction you {verb} {iAmount} points of health from {Name}!";
+                type = ChatMessageType.Magic;
+            }
+            else
+            {
+                /*var skill = source.GetCreatureSkill(Skill.DirtyFighting);
+                var attack = skill.AdvancementClass == SkillAdvancementClass.Specialized ? "Bleeding Assault" : "Bleeding Blow";
+                msg = $"With {attack} you {verb} {iAmount} points of health from {Name}!";*/
+
+                msg = $"You bleed {Name} for {iAmount} points of periodic health damage!";
+                type = ChatMessageType.CombatSelf;
+            }
+            source.SendMessage(msg, type);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -307,7 +307,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Notifies the damage over time (DoT) source player of the tick damage amount
         /// </summary>
-        public void TakeDamageOverTime_NotifySource(Player source, DamageType damageType, float amount)
+        public void TakeDamageOverTime_NotifySource(Player source, DamageType damageType, float amount, bool aetheria = false)
         {
             if (PropertyManager.GetBool("show_dot_messages").Item)
             {
@@ -317,12 +317,19 @@ namespace ACE.Server.WorldObjects
                 string msg = null;
                 var type = ChatMessageType.CombatSelf;
 
-                if (damageType == DamageType.Nether)
+                if (damageType == DamageType.Nether || aetheria)
                 {
+                    var notifyType = aetheria ? DamageType.Health : damageType;
+
                     string verb = null, plural = null;
                     var percent = amount / Health.MaxValue;
-                    Strings.GetAttackVerb(damageType, percent, ref verb, ref plural);
-                    msg = $"You {verb} {Name} for {iAmount} points of periodic nether damage!";
+                    Strings.GetAttackVerb(notifyType, percent, ref verb, ref plural);
+
+                    if (damageType == DamageType.Nether)
+                        msg = $"You {verb} {Name} for {iAmount} points of periodic nether damage!";
+                    else
+                        msg = $"With Surge of Affliction you {verb} {iAmount} points of health from {Name}!";
+
                     type = ChatMessageType.Magic;
                 }
                 else


### PR DESCRIPTION
This also fixes the error messages that were being thrown by MagTools:
```
<{Mag-Tools}>: Unable to parse damage element from: You bleed <name> for <amount> points of periodic damage!
```
