### PR TITLE
Fix writability issue with opening "blank/empty" books.

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionBookData.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionBookData.cs
@@ -9,7 +9,9 @@ namespace ACE.Server.Network.GameAction.Actions
         {
             var bookGuid = message.Payload.ReadUInt32();
 
-            Console.WriteLine($"0xAA - BookData({bookGuid:X8}) - unused?");
+            //Console.WriteLine($"0xAA - BookData({bookGuid:X8}) - unused?");
+
+            session.Player.ReadBook(bookGuid);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Book.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Book.cs
@@ -25,7 +25,7 @@ namespace ACE.Server.WorldObjects
 
                 string authorName;
                 if (book.ScribeName != null)
-                    authorName = ScribeName;
+                    authorName = book.ScribeName;
                 else
                     authorName = "";
 

--- a/Source/ACE.Server/WorldObjects/Player_Book.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Book.cs
@@ -1,11 +1,58 @@
 
 using ACE.Entity;
+using ACE.Entity.Models;
 using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.WorldObjects
 {
     partial class Player
     {
+        public void ReadBook(uint bookGuid)
+        {
+            // This appears to have been sent in response 0x00AA (not pcapped)
+            // When a book is blank, client automatically adds a "blank" page after opening and then sends 0x00AA, expecting this reponse or the page/book is not writable or usable, unless it is closed and opened again
+
+            // TODO: Do we want to throttle this request, like appraisals?
+
+            var book = FindObject(new ObjectGuid(bookGuid), SearchLocations.MyInventory | SearchLocations.LastUsedHook, out var container, out var rootOwner, out var wasEquipped) as Book;
+            if (book == null) return;
+
+            // found book
+            if (book != null)
+            {
+                int maxChars = book.Biota.PropertiesBook.MaxNumCharsPerPage;
+                int maxPages = book.Biota.PropertiesBook.MaxNumPages;
+
+                string authorName;
+                if (book.ScribeName != null)
+                    authorName = ScribeName;
+                else
+                    authorName = "";
+
+                //string authorAccount;
+                //if (book.ScribeAccount != null)
+                //    authorAccount = ScribeAccount;
+                //else
+                //    authorAccount = "";
+
+                //uint authorID = ScribeIID ?? 0xFFFFFFFF;
+                uint authorID = (book.ScribeIID.HasValue) ? (uint)book.ScribeIID : 0xFFFFFFFF;
+
+                var pages = book.Biota.PropertiesBookPageData.Clone(book.BiotaDatabaseLock);
+
+                bool ignoreAuthor = book.IgnoreAuthor ?? false;
+
+                string inscription;
+                if (book.Inscription != null)
+                    inscription = Inscription;
+                else
+                    inscription = "";
+
+                var bookDataResponse = new GameEventBookDataResponse(Session, book.Guid.Full, maxChars, maxPages, pages, inscription, authorID, authorName, ignoreAuthor);
+                Session.Network.EnqueueSend(bookDataResponse);
+            }
+        }
+
         public void ReadBookPage(uint bookGuid, int pageNum)
         {
             // This is completely unused. 

--- a/Source/ACE.Server/WorldObjects/Player_Book.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Book.cs
@@ -44,7 +44,7 @@ namespace ACE.Server.WorldObjects
 
                 string inscription;
                 if (book.Inscription != null)
-                    inscription = Inscription;
+                    inscription = book.Inscription;
                 else
                     inscription = "";
 

--- a/Source/ACE.Server/WorldObjects/Player_Book.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Book.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.WorldObjects
         public void ReadBook(uint bookGuid)
         {
             // This appears to have been sent in response 0x00AA (not pcapped)
-            // When a book is blank, client automatically adds a "blank" page after opening and then sends 0x00AA, expecting this reponse or the page/book is not writable or usable, unless it is closed and opened again
+            // When a book is blank, client automatically adds a "blank" page after opening, gets a GameEventBookAddPageResponse success and then sends 0x00AA, expecting this response or the page/book is not writable or usable, unless it is closed and opened again
 
             // TODO: Do we want to throttle this request, like appraisals?
 


### PR DESCRIPTION
When a book is blank, client automatically adds a "blank" page after opening, sends it to server and upon successful page add response it then sends 0x00AA, expecting BookData response or the page/book is not writable or usable, unless it is closed and opened again.

This fixes that.