### PR TITLE
Update Corpse permission conditions

### DIFF
--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -140,22 +140,22 @@ namespace ACE.Server.WorldObjects
                 return true;
 
             // players can loot monsters they killed
-            if (KillerId != null && player.Guid.Full == KillerId || IsLooted)
+            if (KillerId != null && player.Guid.Full == KillerId || IsLooted && !CorpseGeneratedRare)
                 return true;
 
-            // players can /permit other players to loot their corpse
-            if (player.HasLootPermission(new ObjectGuid(VictimId.Value)))
+            // players can /permit other players to loot their corpse if not killed by another player killer.
+            if (player.HasLootPermission(new ObjectGuid(VictimId.Value)) && PkLevel != PKLevel.PK)
                 return true;
 
-            // all players can loot monster corpses after 1/2 decay time
-            if (TimeToRot != null && TimeToRot < HalfLife && !new ObjectGuid(VictimId.Value).IsPlayer())
+            // all players can loot monster corpses after 1/2 decay time except if corpse generates a rare
+            if (TimeToRot != null && TimeToRot < HalfLife && !new ObjectGuid(VictimId.Value).IsPlayer() && !CorpseGeneratedRare)
                 return true;
 
-            // players in the same fellowship as the killer w/ loot sharing enabled
+            // players in the same fellowship as the killer w/ loot sharing enabled except if corpse generates a rare
             if (player.Fellowship != null && player.Fellowship.ShareLoot)
             {
                 var onlinePlayer = PlayerManager.GetOnlinePlayer(KillerId ?? 0);
-                if (onlinePlayer != null && onlinePlayer.Fellowship != null && player.Fellowship == onlinePlayer.Fellowship)
+                if (onlinePlayer != null && onlinePlayer.Fellowship != null && player.Fellowship == onlinePlayer.Fellowship && !CorpseGeneratedRare)
                     return true;
             }
             return false;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -303,14 +303,20 @@ namespace ACE.Server.WorldObjects
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your corpse is located at ({corpse.Location.GetMapCoordStr()}).", ChatMessageType.Broadcast));
                 }
 
-                if (!player.IsPKDeath(killer) && !player.IsPKLiteDeath(killer))
+                var isPKdeath = player.IsPKDeath(killer);
+                var isPKLdeath = player.IsPKLiteDeath(killer);
+
+                if (isPKdeath)
+                    corpse.PkLevel = PKLevel.PK;
+
+                if (!isPKdeath && !isPKLdeath)
                 {
                     var miserAug = player.AugmentationLessDeathItemLoss * 5;
                     if (miserAug > 0)
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your augmentation has reduced the number of items you can lose by {miserAug}!", ChatMessageType.Broadcast));
                 }
 
-                if (dropped.Count == 0 && !player.IsPKLiteDeath(killer))
+                if (dropped.Count == 0 && !isPKLdeath)
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have retained all your items. You do not need to recover your corpse!", ChatMessageType.Broadcast));
             }
             else


### PR DESCRIPTION
- Corpses that generate rares can only be looted by killer
- Corpses for players killed by other players can only be looted by killer and victim, no permit/consent allowed