### PR TITLE
more CMT fixes for players

### DIFF
--- a/Source/ACE.DatLoader/FileTypes/CombatManeuverTable.cs
+++ b/Source/ACE.DatLoader/FileTypes/CombatManeuverTable.cs
@@ -62,19 +62,21 @@ namespace ACE.DatLoader.FileTypes
             public Dictionary<AttackType, List<MotionCommand>> Table = new Dictionary<AttackType, List<MotionCommand>>();
         }
 
-        public MotionCommand GetMotion(MotionStance stance, AttackHeight attackHeight, AttackType attackType, MotionCommand prevMotion)
+        public static readonly List<MotionCommand> Invalid = new List<MotionCommand>() { MotionCommand.Invalid };
+
+        public List<MotionCommand> GetMotion(MotionStance stance, AttackHeight attackHeight, AttackType attackType, MotionCommand prevMotion)
         {
             if (!Stances.TryGetValue(stance, out var attackHeights))
-                return MotionCommand.Invalid;
+                return Invalid;
 
             if (!attackHeights.Table.TryGetValue(attackHeight, out var attackTypes))
-                return MotionCommand.Invalid;
+                return Invalid;
 
             if (!attackTypes.Table.TryGetValue(attackType, out var maneuvers))
-                return MotionCommand.Invalid;
+                return Invalid;
 
-            if (maneuvers.Count == 1)
-                return maneuvers[0];
+            //if (maneuvers.Count == 1)
+                //return maneuvers[0];
 
             /*Console.WriteLine($"CombatManeuverTable({Id:X8}).GetMotion({stance}, {attackHeight}, {attackType}) - found {maneuvers.Count} maneuvers");
             foreach (var maneuver in maneuvers)
@@ -85,7 +87,7 @@ namespace ACE.DatLoader.FileTypes
             // BackhandMed
 
             // rng, or alternate?
-            for (var i = 0; i < maneuvers.Count; i++)
+            /*for (var i = 0; i < maneuvers.Count; i++)
             {
                 var maneuver = maneuvers[i];
 
@@ -97,7 +99,11 @@ namespace ACE.DatLoader.FileTypes
                         return maneuvers[0];
                 }
             }
-            return maneuvers[0];
+            return maneuvers[0];*/
+
+            // if the CMT contains > 1 entires for this lookup, return both
+            // the code determines which motion to use based on the power bar
+            return maneuvers;
         }
 
         public void ShowCombatTable()

--- a/Source/ACE.DatLoader/FileTypes/CombatManeuverTable.cs
+++ b/Source/ACE.DatLoader/FileTypes/CombatManeuverTable.cs
@@ -101,7 +101,7 @@ namespace ACE.DatLoader.FileTypes
             }
             return maneuvers[0];*/
 
-            // if the CMT contains > 1 entires for this lookup, return both
+            // if the CMT contains > 1 entries for this lookup, return both
             // the code determines which motion to use based on the power bar
             return maneuvers;
         }

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -324,22 +324,19 @@ namespace ACE.Server.Command.Handlers
                 ChatPacket.SendServerMessage(session, "Test Message " + i, ChatMessageType.Broadcast);
         }
 
-        [CommandHandler("animation", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Sends a MovementEvent to you.", "uint\n")]
+        [CommandHandler("animation", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Sends a MovementEvent to you.", "MotionCommand\n")]
         public static void Animation(Session session, params string[] parameters)
         {
-            uint animationId;
-
-            try
+            if (!Enum.TryParse(parameters[0], out MotionCommand motionCommand))
             {
-                animationId = Convert.ToUInt32(parameters[0]);
-            }
-            catch (Exception)
-            {
-                ChatPacket.SendServerMessage(session, "Invalid Animation value", ChatMessageType.Broadcast);
+                ChatPacket.SendServerMessage(session, $"MotionCommand: {parameters[0]} not found", ChatMessageType.Broadcast);
                 return;
             }
+            var stance = session.Player.CurrentMotionState.Stance;
 
-            session.Player.EnqueueBroadcastMotion(new Motion(session.Player, (MotionCommand)animationId));
+            ChatPacket.SendServerMessage(session, $"Playing animation {stance}.{motionCommand}", ChatMessageType.Broadcast);
+
+            session.Player.EnqueueBroadcastMotion(new Motion(stance, motionCommand));
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -409,16 +409,27 @@ namespace ACE.Server.WorldObjects
 
             var weapon = GetEquippedMeleeWeapon();
 
+            // for reference: https://www.youtube.com/watch?v=MUaD53D9c74
+            // a player with 1/2 power bar, or slightly below half
+            // doing the backswing, well above 33%
+            var subdivision = 0.33f;
+
             if (weapon != null)
             {
                 AttackType = weapon.GetAttackType(CurrentMotionState.Stance, PowerLevel, offhand);
+                if (weapon.IsThrustSlash)
+                    subdivision = 0.66f;
             }
             else
             {
                 AttackType = PowerLevel > KickThreshold ? AttackType.Kick : AttackType.Punch;
             }
 
-            var motion = CombatTable.GetMotion(CurrentMotionState.Stance, AttackHeight.Value, AttackType, PrevMotionCommand);
+            var motions = CombatTable.GetMotion(CurrentMotionState.Stance, AttackHeight.Value, AttackType, PrevMotionCommand);
+
+            // higher-powered animation always in first slot ?
+            var motion = motions.Count > 1 && PowerLevel < subdivision ? motions[1] : motions[0];
+
             PrevMotionCommand = motion;
 
             //Console.WriteLine($"{motion}");

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -969,7 +969,28 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public static readonly float ThrustThreshold = 0.25f;
+        // from the Dark Majesty strategy guide, page 150:
+
+        // -   0 - 1/3 sec. Power-up Time = High Stab
+        // - 1/3 - 2/3 sec. Power-up Time = High Backhand
+        // -       2/3 sec+ Power-up Time = High Slash
+
+        public static readonly float ThrustThreshold = 0.33f;
+
+        /// <summary>
+        /// Returns TRUE if this is a thrust/slash weapon,
+        /// or if this weapon uses 2 different attack types based on the ThrustThreshold
+        /// </summary>
+        public bool IsThrustSlash
+        {
+            get
+            {
+                return W_AttackType.HasFlag(AttackType.Slash | AttackType.Thrust) ||
+                       W_AttackType.HasFlag(AttackType.DoubleSlash | AttackType.DoubleThrust) ||
+                       W_AttackType.HasFlag(AttackType.TripleSlash | AttackType.TripleThrust) ||
+                       W_AttackType.HasFlag(AttackType.DoubleSlash);  // stiletto
+            }
+        }
 
         public AttackType GetAttackType(MotionStance stance, float powerLevel, bool offhand)
         {


### PR DESCRIPTION
This fixes the issue where certain combat maneuvers are cycling through 2 separate animations

These 2 separate animations should correspond to 2 different power levels

Thanks to @CrimsonMage for discussing this issue