### PR TITLE
Added Variance to Burden for Melee and Missile Weapons

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -2345,5 +2345,24 @@ namespace ACE.Server.Factories
             meleeMod += 1.0;
             return meleeMod;
         }
+        /// <summary>
+        /// Calculates Final Burden of an Item
+        /// <param name="existBurden"></param>
+        /// </summary>
+        private static int CalcBurden(int existBurden)
+        {
+            // From Retail data on Melee and Missile weapons, the min burden is about half of the max value.
+            // There is data to suggest the Float Property BULK_MOD_FLOAT is used to calculate burden.
+            // However there isn't any data on how its used, and that property is missing on existing base weenies, and unknown if that value was different across the same weenie types.
+            // Till that can be figured out, doing a random value between min (half of max) and max burden values (max being the encumbval on base weenie)
+            // TODO:
+            // Incorperate the use of Float Property BULK_MOD_FLOAT into calculating burden
+            // Add variance to armor burden
+
+            int finalBurden = ThreadSafeRandom.Next(existBurden / 2, existBurden);
+
+            return finalBurden;
+
+        }
     }         
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -2360,9 +2360,7 @@ namespace ACE.Server.Factories
             // Add variance to armor burden
 
             int finalBurden = ThreadSafeRandom.Next(existBurden / 2, existBurden);
-
             return finalBurden;
-
         }
     }         
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -339,6 +339,8 @@ namespace ACE.Server.Factories
             if (materialType > 0)
                 wo.MaterialType = (MaterialType)materialType;
             wo.ItemWorkmanship = workmanship;
+            // Burden
+            wo.EncumbranceVal = CalcBurden((int)wo.EncumbranceVal);
 
             // Weapon Stats
             wo.Damage = damage;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -41,6 +41,8 @@ namespace ACE.Server.Factories
             wo.GemCount = ThreadSafeRandom.Next(1, 5);
             wo.GemType = (MaterialType)ThreadSafeRandom.Next(10, 50);
             wo.LongDesc = wo.Name;
+            // Burden
+            wo.EncumbranceVal = CalcBurden((int)wo.EncumbranceVal);
 
             // MeleeD/MagicD/Missile Bonus
             wo.WeaponMagicDefense = GetMagicMissileDMod(profile.Tier); 


### PR DESCRIPTION
From Retail data on Melee and Missile weapons, the min burden is about half of the max value (of note, all casters are the same exact burden - 50).
There is data to suggest the Float Property BULK_MOD_FLOAT is used to calculate burden.
However there isn't any data on how its used, and that property is missing on existing base weenies, and unknown if that value was different across the same weenie types.
Till that can be figured out, doing a random value between min (half of max) and max burden values (max being the EncumbranceVal on base weenie)