### PR TITLE
Adding extra options for AutoApplyWorldCustomizations

### DIFF
--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace ACE.Common
@@ -44,10 +45,29 @@ namespace ACE.Common
         /// <summary>
         /// After updating to latest world database, automatically import further customizations
         /// AutoUpdateWorldDatabase must be true for this option to be used
+        /// SQL files will be executed given the sort order of the full paths of the files
         /// </summary>
         [System.ComponentModel.DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool AutoApplyWorldCustomizations { get; set; }
+
+        /// <summary>
+        /// When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
+        /// all .sql files in the following directories.
+        /// This process will still use ./Content by default, or the the config_properties_string
+        /// value for 'content_folder' if it exists
+        /// </summary>
+        [System.ComponentModel.DefaultValue(new string[] { })]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public string[] WorldCustomizationAddedPaths { get; set; }
+
+        /// <summary>
+        /// When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
+        /// this will cause the file search to retrieve all files recursively from each directory
+        /// </summary>
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool RecurseWorldCustomizationPaths { get; set; }
 
         /// <summary>
         /// Automatically apply new updates to databases upon startup if they haven't yet been applied

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -189,6 +189,7 @@
     // all .sql files in the following directories.
     // This process will still use ./Content by default, or the the config_properties_string
     // value for 'content_folder' if it exists
+    // Example: [ "C:\MyContent", "C:\FTPRoot\Editor1Content", "C:\FTPRoot\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],
 
      // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -189,7 +189,7 @@
     // all .sql files in the following directories.
     // This process will still use ./Content by default, or the the config_properties_string
     // value for 'content_folder' if it exists
-    // Example: [ "C:\MyContent", "C:\FTPRoot\Editor1Content", "C:\FTPRoot\Editor2Content" ]
+    // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],
 
      // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -182,6 +182,17 @@
 
     // After updating to latest world database, automatically import further customizations
     // AutoUpdateWorldDatabase must be true for this option to be used
-    "AutoApplyWorldCustomizations": true
+    // SQL files will be executed given the sort order of the full paths of the files
+    "AutoApplyWorldCustomizations": true,
+
+    // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
+    // all .sql files in the following directories.
+    // This process will still use ./Content by default, or the the config_properties_string
+    // value for 'content_folder' if it exists
+    "WorldCustomizationAddedPaths": [],
+
+     // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
+     // this will cause the file search to retrieve all files recursively from each directory
+     "RecurseWorldCustomizationPaths": true
   }
 }

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -189,6 +189,7 @@
     // all .sql files in the following directories.
     // This process will still use ./Content by default, or the the config_properties_string
     // value for 'content_folder' if it exists
+    // Example: [ "C:\MyContent", "C:\FTPRoot\Editor1Content", "C:\FTPRoot\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],
 
      // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -189,7 +189,7 @@
     // all .sql files in the following directories.
     // This process will still use ./Content by default, or the the config_properties_string
     // value for 'content_folder' if it exists
-    // Example: [ "C:\MyContent", "C:\FTPRoot\Editor1Content", "C:\FTPRoot\Editor2Content" ]
+    // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
     "WorldCustomizationAddedPaths": [],
 
      // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -182,6 +182,17 @@
 
     // After updating to latest world database, automatically import further customizations
     // AutoUpdateWorldDatabase must be true for this option to be used
-    "AutoApplyWorldCustomizations": true
+    // SQL files will be executed given the sort order of the full paths of the files
+    "AutoApplyWorldCustomizations": true,
+
+    // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
+    // all .sql files in the following directories.
+    // This process will still use ./Content by default, or the the config_properties_string
+    // value for 'content_folder' if it exists
+    "WorldCustomizationAddedPaths": [],
+
+     // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
+     // this will cause the file search to retrieve all files recursively from each directory
+     "RecurseWorldCustomizationPaths": true
   }
 }


### PR DESCRIPTION
Adding 2 optional options for the auto application of world customization.  
A configurable array of added paths to source SQL files from on top  of the default/configurable value.
And secondly an option to search the individual paths recursively for SQL files.

This helps with enabling content teams to have their own content strategy as far as how they structure their output in different places with different levels of organization.