### PR TITLE
Adding ability to exclude specific IPs from max session count.

### DIFF
--- a/Source/ACE.Common/NetworkSettings.cs
+++ b/Source/ACE.Common/NetworkSettings.cs
@@ -42,6 +42,6 @@ namespace ACE.Common
         /// </remarks>
         [System.ComponentModel.DefaultValue(new string[] { })]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-        public string[] AllowUlimitedSessionsFromIPAddresses { get; set; }
+        public string[] AllowUnlimitedSessionsFromIPAddresses { get; set; }
     }
 }

--- a/Source/ACE.Common/NetworkSettings.cs
+++ b/Source/ACE.Common/NetworkSettings.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace ACE.Common
 {
@@ -33,5 +34,14 @@ namespace ACE.Common
         [System.ComponentModel.DefaultValue(-1)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public int MaximumAllowedSessionsPerIPAddress { get; set; }
+
+        /// <summary>
+        /// Will allow the given IP addresses to have unlimited sessions - recommend only use this for Admins
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        [System.ComponentModel.DefaultValue(new string[] { })]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public string[] AllowUlimitedSessionsFromIPAddresses { get; set; }
     }
 }

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -21,7 +21,8 @@
 
      // AllowUlimitedSessionsFromIPs, default []
      // Will allow the given IP addresses to have unlimited sessions - recommend only use this for Admins/Devs
-     "AllowUlimitedSessionsFromIPAddresses": []
+     // Example: [ "127.0.0.1", "8.8.8.8" ]
+     "AllowUnlimitedSessionsFromIPAddresses": []
     },
 
     "Accounts": {

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -17,7 +17,11 @@
 
       // MaximumAllowedSessionsPerIPAddress, default: -1
       // -1 means unlimited connections per IP Address.
-      "MaximumAllowedSessionsPerIPAddress": -1
+      "MaximumAllowedSessionsPerIPAddress": -1,
+
+     // AllowUlimitedSessionsFromIPs, default []
+     // Will allow the given IP addresses to have unlimited sessions - recommend only use this for Admins/Devs
+     "AllowUlimitedSessionsFromIPAddresses": []
     },
 
     "Accounts": {

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -21,7 +21,8 @@
 
      // AllowUlimitedSessionsFromIPs, default []
      // Will allow the given IP addresses to have unlimited sessions - recommend only use this for Admins/Devs
-     "AllowUlimitedSessionsFromIPAddresses": []
+     // Example: [ "127.0.0.1", "8.8.8.8" ]
+     "AllowUnlimitedSessionsFromIPAddresses": []
     },
 
     "Accounts": {

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -17,7 +17,11 @@
 
       // MaximumAllowedSessionsPerIPAddress, default: -1
       // -1 means unlimited connections per IP Address.
-      "MaximumAllowedSessionsPerIPAddress": -1
+      "MaximumAllowedSessionsPerIPAddress": -1,
+
+     // AllowUlimitedSessionsFromIPs, default []
+     // Will allow the given IP addresses to have unlimited sessions - recommend only use this for Admins/Devs
+     "AllowUlimitedSessionsFromIPAddresses": []
     },
 
     "Accounts": {

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -114,7 +114,7 @@ namespace ACE.Server.Network.Managers
                     {
                         log.DebugFormat("Login Request from {0}", endPoint);
 
-                        var ipAllowsUnlimited = ConfigManager.Config.Server.Network.AllowUlimitedSessionsFromIPAddresses.Contains(endPoint.Address.ToString());
+                        var ipAllowsUnlimited = ConfigManager.Config.Server.Network.AllowUnlimitedSessionsFromIPAddresses.Contains(endPoint.Address.ToString());
                         if (ipAllowsUnlimited || ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress == -1 || GetSessionEndpointTotalByAddressCount(endPoint.Address) < ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress)
                         {
                             var session = FindOrCreateSession(connectionListener, endPoint);

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -114,7 +114,8 @@ namespace ACE.Server.Network.Managers
                     {
                         log.DebugFormat("Login Request from {0}", endPoint);
 
-                        if (ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress == -1 || GetSessionEndpointTotalByAddressCount(endPoint.Address) < ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress)
+                        var ipAllowsUnlimited = ConfigManager.Config.Server.Network.AllowUlimitedSessionsFromIPAddresses.Contains(endPoint.Address.ToString());
+                        if (ipAllowsUnlimited || ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress == -1 || GetSessionEndpointTotalByAddressCount(endPoint.Address) < ConfigManager.Config.Server.Network.MaximumAllowedSessionsPerIPAddress)
                         {
                             var session = FindOrCreateSession(connectionListener, endPoint);
                             if (session != null)


### PR DESCRIPTION
This will allow an IP exception list for the max number of sessions per IP.  The use case for this would be for accounts that may have multiple bot accounts (buffbot, craftbot, portalbot), but still may want to actively play their non-bot characters.  Or in the instance where an admin/dev needs to do testing of content across multiple accounts.