### PR TITLE
Made console commands consistent with in-game

### DIFF
--- a/Source/ACE.Server/Command/CommandManager.cs
+++ b/Source/ACE.Server/Command/CommandManager.cs
@@ -136,6 +136,11 @@ namespace ACE.Server.Command
             }
             var commandSplit = commandLine.Split(' ',StringSplitOptions.RemoveEmptyEntries);
             command = commandSplit[0];
+
+            // remove leading '/' or '@' if erroneously entered in console
+            if(command.StartsWith("/") || command.StartsWith("@"))
+                command = command.Substring(1);
+
             parameters = new string[commandSplit.Length - 1];
 
             Array.Copy(commandSplit, 1, parameters, 0, commandSplit.Length - 1);

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ACEmulator Change Log
 
+### 2020-05-22
+[OptimShi]
+* Allowed console commands to start with "/" or "@". Would previously respond with "Invalid Command" if the command started with a "/" or "@".
+
 ### 2020-03-02
 [Mag-nus]
 * Added ACE.Database.WorldDatabaseWithEntityCache class


### PR DESCRIPTION
Allowed console commands to start with "/" or "@". Would previously respond with "Invalid Command" if the command started with a "/" or "@". Also allows commands to be used consistent with the "acecommands" output.