### PR TITLE
ensure object is on landblock for /removeinst

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -1312,7 +1312,8 @@ namespace ACE.Server.Command.Handlers.Processors
         public static void RemoveInstance(Session session, bool confirmed = false)
         {
             var wo = CommandHandlerHelper.GetLastAppraisedObject(session);
-            if (wo == null) return;
+
+            if (wo?.Location == null) return;
 
             var landblock = (ushort)wo.Location.Landblock;
 


### PR DESCRIPTION
This fixes a potential crash if magtools automatically does a background appraisal of an inventory object before /removeinst is run

Possible todo: since /removeinst is only run on landblock objects, we should be able to use 'currently selected target' instead of 'last appraised target' here

Negative on the last suggestion -- selected object only works for things with health / mana, so this wouldn't work for things like generators