### PR TITLE
adding createinst gap finder

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -1156,15 +1156,14 @@ namespace ACE.Server.Command.Handlers.Processors
                 }
             }
 
-
-            if (nextStaticGuid >= maxStaticGuid)
+            if (nextStaticGuid > maxStaticGuid)
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"Landblock {landblock:X4} has reached the maximum # of static guids", ChatMessageType.Broadcast));
                 return;
             }
 
             // create and spawn object
-            var entityWeenie = ACE.Database.Adapter.WeenieConverter.ConvertToEntityWeenie(weenie);
+            var entityWeenie = Database.Adapter.WeenieConverter.ConvertToEntityWeenie(weenie);
 
             var wo = WorldObjectFactory.CreateWorldObject(entityWeenie, new ObjectGuid(nextStaticGuid));
 
@@ -1294,13 +1293,36 @@ namespace ACE.Server.Command.Handlers.Processors
 
         public static uint GetNextStaticGuid(ushort landblock, List<LandblockInstance> instances)
         {
-            // TODO: eventually find gaps
+            var firstGuid = 0x70000000 | ((uint)landblock << 12);
+            var lastGuid = firstGuid | 0xFFF;
+
             var highestLandblockInst = instances.Where(i => i.Landblock == landblock).OrderByDescending(i => i.Guid).FirstOrDefault();
 
             if (highestLandblockInst == null)
-                return (uint)(0x70000000 | (landblock << 12));
-            else
-                return highestLandblockInst.Guid + 1;
+                return firstGuid;
+
+            var nextGuid = highestLandblockInst.Guid + 1;
+
+            if (nextGuid <= lastGuid)
+                return nextGuid;
+
+            // try more exhaustive search
+            return GetNextStaticGuid_GapFinder(landblock, instances) ?? nextGuid;
+        }
+
+        public static uint? GetNextStaticGuid_GapFinder(ushort landblock, List<LandblockInstance> instances)
+        {
+            var landblockGuids = instances.Where(i => i.Landblock == landblock).Select(i => i.Guid).ToHashSet();
+
+            var firstGuid = 0x70000000 | ((uint)landblock << 12);
+            var lastGuid = firstGuid | 0xFFF;
+
+            for (var guid = firstGuid; guid <= lastGuid; guid++)
+            {
+                if (!landblockGuids.Contains(guid))
+                    return guid;
+            }
+            return null;
         }
 
         [CommandHandler("removeinst", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, "Removes the last appraised object from the current landblock instances")]


### PR DESCRIPTION
Repro steps:

teleport to an empty landblock

/createinst tuskerguard
/createinst tuskerguard FFF
/createinst tuskerguard

Expected:

1. Creates a new landblock instance for tuskerguard, using the next free static guid for the landblock (ie. 000)
2. Creates another using the highest static guid for the landblock (FFF)
3. Creates another using the next actual free static guid for the landblock, taking gaps into account (ie. 001)

Actual:

For this set of repro steps, the old version also had a preliminary bug for FFF. It originally considered FFE to be the highest static guid for that landblock, due to an incorrect concern that adding 1 to FFF in landblock FFFF would overflow back to 0. This is not the case however, as FEFE is the max landblock, and everything is prefixed with 7XXYY instead of XXYY

With this >= changed to > in the old version and no other changes:

1. Creates a new landblock instance for tuskerguard, using the next free static guid for the landblock (ie. 000)
2. Creates another using the highest static guid for the landblock (FFF)
3. Gets an error that no more static guids are available for this landblock