### PR TITLE
adding support for cloak damage reduction procs

### DIFF
--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -1,3 +1,5 @@
+using System;
+
 using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Server.Network.GameMessages.Messages;
@@ -13,17 +15,14 @@ namespace ACE.Server.Entity
         /// Rolls for a chance at procing a cloak spell
         /// If successful, casts the spell
         /// </summary>
-        public static bool TryProcSpell(Creature defender, WorldObject attacker, float damage_percent)
+        public static bool TryProcSpell(Creature defender, WorldObject attacker, WorldObject cloak, float damage_percent)
         {
-            var cloak = defender.EquippedCloak;
-
-            if (cloak == null)
-                return false;
+            if (cloak == null) return false;
 
             if (!RollProc(damage_percent))
                 return false;
 
-            return HandleProc(defender, attacker, cloak);
+            return HandleProcSpell(defender, attacker, cloak);
         }
 
         /// <summary>
@@ -34,6 +33,7 @@ namespace ACE.Server.Entity
         public static bool RollProc(float damage_percent)
         {
             // TODO: find retail formula
+            // TODO: cloak level multiplier
             var chance = damage_percent * ChanceMod;
 
             if (chance < 1.0f)
@@ -48,9 +48,9 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Casts the cloak proc spell
         /// </summary>
-        public static bool HandleProc(Creature defender, WorldObject attacker, WorldObject cloak)
+        public static bool HandleProcSpell(Creature defender, WorldObject attacker, WorldObject cloak)
         {
-            if (!cloak.HasProc) return false;
+            if (cloak.ProcSpell == null) return false;
 
             var spell = new Spell(cloak.ProcSpell.Value);
 
@@ -88,6 +88,70 @@ namespace ACE.Server.Entity
         public static bool IsCloak(WorldObject wo)
         {
             return wo.ValidLocations == EquipMask.Cloak;
+        }
+
+        /// <summary>
+        /// The amount of damage reduced by a cloak proced with PropertyInt.CloakWeaveProc=2
+        /// </summary>
+        public static readonly int DamageReductionAmount = 200;
+
+        /// <summary>
+        /// Returns the reduced damage amount when a cloak procs
+        /// with PropertyInt.CloakWeaveProc=2
+        /// </summary>
+        public static uint GetReducedAmount(uint damage)
+        {
+            if (damage > DamageReductionAmount)
+                return (uint)(damage - DamageReductionAmount);
+            else
+                return 0;
+        }
+
+        public static int GetReducedAmount(int damage)
+        {
+            return Math.Max(0, damage - DamageReductionAmount);
+        }
+
+        public static float GetReducedAmount(float damage)
+        {
+            return Math.Max(0, damage - DamageReductionAmount);
+        }
+
+        /// <summary>
+        /// Sends the message to attacker and defender when cloak is proced with PropertyInt.CloakWeaveProc=2
+        /// </summary>
+        public static void ShowMessage(Creature defender, WorldObject attacker, int origDamage, int reducedDamage)
+        {
+            var suffix = $"reduced the damage from {origDamage} to {reducedDamage}!";
+
+            if (defender is Player playerDefender)
+                playerDefender.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your cloak {suffix}", ChatMessageType.Magic));
+
+            // send message to attacker?
+            if (attacker is Player playerAttacker)
+                playerAttacker.Session.Network.EnqueueSend(new GameMessageSystemChat($"The cloak of {defender.Name} {suffix}", ChatMessageType.Magic));
+        }
+
+        public static void ShowMessage(Creature defender, WorldObject attacker, float origDamage, float reducedDamage)
+        {
+            ShowMessage(defender, attacker, (int)Math.Round(origDamage), (int)Math.Round(reducedDamage));
+        }
+
+        /// <summary>
+        /// Returns TRUE If cloak has a damage reduction proc
+        /// Matches client logic
+        /// </summary>
+        public static bool HasDamageProc(WorldObject cloak)
+        {
+            return cloak?.CloakWeaveProc == 2;
+        }
+
+        /// <summary>
+        /// Returns TRUE if cloak has a spell proc
+        /// </summary>
+        public static bool HasProcSpell(WorldObject cloak)
+        {
+            return cloak?.ProcSpell != null;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -467,25 +467,14 @@ namespace ACE.Server.WorldObjects
 
             var equippedCloak = EquippedCloak;
 
-            if (equippedCloak?.CloakWeaveProc == 2)
+            if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(percent))
             {
-                var cloakProc = Cloak.RollProc(percent);
+                var reducedAmount = Cloak.GetReducedAmount(amount);
 
-                if (cloakProc)
-                {
-                    var reducedAmount = (uint)Math.Round(Math.Max(0, _amount - 200));
+                Cloak.ShowMessage(this, source, amount, reducedAmount);
 
-                    var suffix = $"reduced the damage from {amount} down to {reducedAmount}!";
-
-                    Session.Network.EnqueueSend(new GameMessageSystemChat($"Your cloak {suffix}", ChatMessageType.Magic));
-
-                    // send message to attacker?
-                    if (source is Player playerSource)
-                        playerSource.Session.Network.EnqueueSend(new GameMessageSystemChat($"The cloak of {Name} {suffix}", ChatMessageType.Magic));
-
-                    amount = reducedAmount;
-                    percent = (float)amount / Health.MaxValue;
-                }
+                amount = reducedAmount;
+                percent = (float)amount / Health.MaxValue;
             }
 
             // update health
@@ -533,8 +522,8 @@ namespace ACE.Server.WorldObjects
             if (percent >= 0.1f)
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.Wound1, 1.0f));
 
-            if (equippedCloak?.ProcSpell != null)
-                Cloak.TryProcSpell(this, source, percent);
+            if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak))
+                Cloak.TryProcSpell(this, source, equippedCloak, percent);
 
             // if player attacker, update PK timer
             if (source is Player attacker)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -678,30 +678,16 @@ namespace ACE.Server.WorldObjects
 
                 //Console.WriteLine($"Damage rating: " + Creature.ModToRating(damageRatingMod));
 
-                if (targetPlayer != null)
+                equippedCloak = target.EquippedCloak;
+
+                if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(percent))
                 {
-                    equippedCloak = targetPlayer.EquippedCloak;
+                    var reducedDamage = Cloak.GetReducedAmount(damage);
 
-                    if (equippedCloak?.CloakWeaveProc == 2)
-                    {
-                        var cloakProc = Cloak.RollProc(percent);
+                    Cloak.ShowMessage(target, ProjectileSource, damage, reducedDamage);
 
-                        if (cloakProc)
-                        {
-                            var reducedDamage = Math.Max(0, damage - 200);
-
-                            var suffix = $"reduced the damage from {Math.Round(damage)} down to {Math.Round(reducedDamage)}!";
-
-                            targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your cloak {suffix}", ChatMessageType.Magic));
-
-                            // send message to attacker?
-                            if (sourcePlayer != null)
-                                sourcePlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"The cloak of {target.Name} {suffix}", ChatMessageType.Magic));
-
-                            damage = reducedDamage;
-                            percent = damage / target.Health.MaxValue;
-                        }
-                    }
+                    damage = reducedDamage;
+                    percent = damage / target.Health.MaxValue;
                 }
 
                 amount = (uint)-target.UpdateVitalDelta(target.Health, (int)-Math.Round(damage));
@@ -760,8 +746,8 @@ namespace ACE.Server.WorldObjects
 
                 if (!nonHealth)
                 {
-                    if (equippedCloak?.ProcSpell != null)
-                        Cloak.TryProcSpell(target, ProjectileSource, percent);
+                    if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak) && Cloak.RollProc(percent))
+                        Cloak.HandleProcSpell(target, ProjectileSource, equippedCloak);
 
                     target.EmoteManager.OnDamage(sourcePlayer);
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -746,8 +746,8 @@ namespace ACE.Server.WorldObjects
 
                 if (!nonHealth)
                 {
-                    if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak) && Cloak.RollProc(percent))
-                        Cloak.HandleProcSpell(target, ProjectileSource, equippedCloak);
+                    if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak))
+                        Cloak.TryProcSpell(target, ProjectileSource, equippedCloak, percent);
 
                     target.EmoteManager.OnDamage(sourcePlayer);
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -470,10 +470,9 @@ namespace ACE.Server.WorldObjects
                         }
                     }
 
-                    // handle cloaks
-                    if (spellTarget != this && spellTarget.IsAlive && srcVital != null && srcVital.Equals("health") && boost < 0 && spellTarget.HasCloakEquipped)
+                    if (spellTarget != this && spellTarget.IsAlive && srcVital != null && srcVital.Equals("health") && boost < 0)
                     {
-
+                        // handle cloaks
                         if (spellTarget.HasCloakEquipped)
                         {
                             // ensure message is sent after enchantment.Message

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -490,15 +490,15 @@ namespace ACE.Server.WorldObjects
 
                     if (spellTarget != this && spellTarget.IsAlive && spell.VitalDamageType == DamageType.Health && boost < 0)
                     {
-                        var pct = (float)-boost / spellTarget.Health.MaxValue;
-
                         // handle cloak spell proc
-                        if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak) && Cloak.RollProc(pct))
+                        if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak))
                         {
+                            var pct = (float)-boost / spellTarget.Health.MaxValue;
+
                             // ensure message is sent after enchantment.Message
                             var actionChain = new ActionChain();
                             actionChain.AddDelayForOneTick();
-                            actionChain.AddAction(this, () => Cloak.HandleProcSpell(spellTarget, this, equippedCloak));
+                            actionChain.AddAction(this, () => Cloak.TryProcSpell(spellTarget, this, equippedCloak, pct));
                             actionChain.EnqueueChain();
                         }
 
@@ -660,15 +660,15 @@ namespace ACE.Server.WorldObjects
 
                     if (isDrain && spellTarget.IsAlive && spell.Source == PropertyAttribute2nd.Health)
                     {
-                        var pct = (float)srcVitalChange / spellTarget.Health.MaxValue;
-
                         // handle cloak spell proc
-                        if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak) && Cloak.RollProc(pct))
+                        if (equippedCloak != null && Cloak.HasProcSpell(equippedCloak))
                         {
+                            var pct = (float)srcVitalChange / spellTarget.Health.MaxValue;
+
                             // ensure message is sent after enchantment.Message
                             var actionChain = new ActionChain();
                             actionChain.AddDelayForOneTick();
-                            actionChain.AddAction(this, () => Cloak.HandleProcSpell(spellTarget, this, equippedCloak));
+                            actionChain.AddAction(this, () => Cloak.TryProcSpell(spellTarget, this, equippedCloak, pct));
                             actionChain.EnqueueChain();
                         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2922,5 +2922,16 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyDataId.TsysMutationFilter);
             set { if (!value.HasValue) RemoveProperty(PropertyDataId.TsysMutationFilter); else SetProperty(PropertyDataId.TsysMutationFilter, value.Value); }
         }
+
+        /// <summary>
+        /// Either 1 or 2 for cloaks
+        /// 1 = spell proc
+        /// 2 = damage reduction proc
+        /// </summary>
+        public int? CloakWeaveProc
+        {
+            get => GetProperty(PropertyInt.CloakWeaveProc);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.CloakWeaveProc); else SetProperty(PropertyInt.CloakWeaveProc, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
This starts to add support for PropertyInt.CloakWeaveProc=2 on cloaks, which was originally missed / possibly overlooked and assumed to be just another spell

Physical damage and spell projectiles are wired up for this proc type, with some life spells still pending after figuring out some more details

Updated: everything is now wired up: physical damage, spell projectiles, and life magic drain / harm other spells

Open questions:

- https://asheron.fandom.com/wiki/Cloaks has the message as 'Your cloak reduced the damage from 162 down to 0!'. Was this message sent only the wielder of the cloak, or was a version of the message also sent to the attacker, or broadcast to the local area, similar to Aetheria procs?

Resolved questions:

- Did this cloak proc message appear before or after the hit/damage message? Answer: before

- Did the hit/damage message have the original damage, or the reduced damage? Answer: reduced

