### PR TITLE
adjust cleave logic based on player convos and retail vid

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -157,5 +157,32 @@ namespace ACE.Server.WorldObjects
             }
             return cleaveTargets;
         }
+
+        public bool IsCleaveable(Creature creature)
+        {
+            if (creature == null || !creature.Attackable || creature.Teleporting || creature.IsDead)
+                return false;
+
+            var player = this as Player;
+
+            if (player != null && creature is Player && player.CheckPKStatusVsTarget(player, creature, null) != null)
+                return false;
+
+            if (creature is CombatPet && (player != null || this is CombatPet))
+                return false;
+
+            // no objects in cleave range
+            var distSquared = Location.SquaredDistanceTo(creature.Location);
+            if (distSquared > CleaveRangeSq)
+                return false;
+
+            // only cleave in front of attacker
+            var angle = GetAngle(creature);
+            if (Math.Abs(angle) > CleaveAngle / 2.0f)
+                return false;
+
+            // found cleavable object
+            return true;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -292,6 +292,8 @@ namespace ACE.Server.WorldObjects
                 actionChain.AddDelaySeconds(attackFrames[i] * animLength - prevTime);
                 prevTime = attackFrames[i] * animLength;
 
+                var swingNum = i;
+
                 actionChain.AddAction(this, () =>
                 {
                     if (IsDead)
@@ -310,14 +312,14 @@ namespace ACE.Server.WorldObjects
                         targetProc = true;
                     }
 
-                    if (i == 0 && weapon != null && weapon.IsCleaving)
+                    if (swingNum == 0 && weapon != null && weapon.IsCleaving)
                         cleave = GetCleaveTarget(creature, weapon);
 
                     if (cleave != null)
                     {
                         foreach (var cleaveHit in cleave)
                         {
-                            if (i == 0 || IsCleaveable(cleaveHit))
+                            if (swingNum == 0 || IsCleaveable(cleaveHit))
                                 DamageTarget(cleaveHit, weapon);
 
                             // target procs don't happen for cleaving

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -282,6 +282,8 @@ namespace ACE.Server.WorldObjects
             var prevTime = 0.0f;
             bool targetProc = false;
 
+            List<Creature> cleave = null;
+
             for (var i = 0; i < numStrikes; i++)
             {
                 // are there animation hooks for damage frames?
@@ -308,13 +310,18 @@ namespace ACE.Server.WorldObjects
                         targetProc = true;
                     }
 
-                    if (weapon != null && weapon.IsCleaving)
-                    {
-                        var cleave = GetCleaveTarget(creature, weapon);
-                        foreach (var cleaveHit in cleave)
-                            DamageTarget(cleaveHit, weapon);
+                    if (i == 0 && weapon != null && weapon.IsCleaving)
+                        cleave = GetCleaveTarget(creature, weapon);
 
-                        // target procs don't happen for cleaving
+                    if (cleave != null)
+                    {
+                        foreach (var cleaveHit in cleave)
+                        {
+                            if (i == 0 || IsCleaveable(cleaveHit))
+                                DamageTarget(cleaveHit, weapon);
+
+                            // target procs don't happen for cleaving
+                        }
                     }
                 });
 


### PR DESCRIPTION
Scenario: A player attacks with a 2-handed weapon that can cleave 1 additional target.

With the previous logic, it was possible to kill a maximum of 3 targets with the 2 swings: the first swing kills the main target, and kills 1 add. The subsequent swing is always locked onto the main target, so the second attack against the dying main target is ineffective. But for the adds, each swing was previously re-selecting any valid nearby adds.

Here is a retail video demonstrating that the 2nd swing would still be locked onto the original add, and that each swing would not re-select any new adds:

https://youtu.be/F4rRCjiFqoI?t=578 (9:40-9:41)

So in essence, the adds are only selected once on the first swing, and the subsequent swing remains locked onto those same adds.