### PR TITLE
updating heal/harm spell message for player caster on remote target

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -457,12 +457,14 @@ namespace ACE.Server.WorldObjects
                             string msg;
                             if (spell.IsBeneficial)
                             {
-                                msg = $"You cast {spell.Name} and restore {boost} points of {srcVital} to {spellTarget.Name}.";
+                                //msg = $"You cast {spell.Name} and restore {boost} points of {srcVital} to {spellTarget.Name}.";
+                                msg = $"With {spell.Name} you restore {boost} points of {srcVital} to {spellTarget.Name}.";
                                 enchantmentStatus.Message = new GameMessageSystemChat(msg, ChatMessageType.Magic);
                             }
                             else
                             {
-                                msg = $"You cast {spell.Name} and drain {Math.Abs(boost)} points of {srcVital} from {spellTarget.Name}.";
+                                //msg = $"You cast {spell.Name} and drain {Math.Abs(boost)} points of {srcVital} from {spellTarget.Name}.";
+                                msg = $"With {spell.Name} you drain {Math.Abs(boost)} points of {srcVital} from {spellTarget.Name}.";
                                 enchantmentStatus.Message = new GameMessageSystemChat(msg, ChatMessageType.Magic);
                             }
                         }


### PR DESCRIPTION
Matched to retail message in pcaps via info from Trevis and Optimshi

```
You cast Heal Self I and restore 0 points of your health.

With Incantation of Heal Other you restore 150 points of health to Lothnar.
With Harm Other II you drain 10 points of health from Large Silver Rat.

Widgeon IV casts Incantation of Heal Other and restores 56 points of your health.
Void Knight casts Harm Other IV and drains 7 points of your health.
```