### PR TITLE
send recall animations as actions instead of forward commands

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -92,8 +92,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling home.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionHouseRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -159,8 +162,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.LifestoneRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the lifestone.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionLifestoneRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -216,8 +222,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.MarketplaceRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionMarketplaceRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -291,8 +300,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.AllegianceHometownRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the Allegiance hometown.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionAllegianceHometownRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -381,8 +393,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the Allegiance housing.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionHouseRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -457,8 +472,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PK Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionPkArenaRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 
@@ -534,8 +552,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
+            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+            motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
+
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PKL Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motionPkArenaRecall);
+            EnqueueBroadcastMotion(motion);
 
             var startPos = new Position(Location);
 

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -92,11 +92,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling home.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var recallChain = new ActionChain();
+                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.HouseRecall }, 1.0f, MotionStance.NonCombat);
+                recallChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -94,18 +94,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling home.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var recallChain = new ActionChain();
-                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.HouseRecall }, 1.0f, MotionStance.NonCombat);
-                recallChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.HouseRecall);
 
             var startPos = new Position(Location);
 
@@ -173,18 +162,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the lifestone.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var actionChain = new ActionChain();
-                EnqueueMotionAction(actionChain, new List<MotionCommand>() { MotionCommand.LifestoneRecall }, 1.0f, MotionStance.NonCombat);
-                actionChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.LifestoneRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.LifestoneRecall);
 
             var startPos = new Position(Location);
 
@@ -242,18 +220,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var actionChain = new ActionChain();
-                EnqueueMotionAction(actionChain, new List<MotionCommand>() { MotionCommand.MarketplaceRecall }, 1.0f, MotionStance.NonCombat);
-                actionChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.MarketplaceRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.MarketplaceRecall);
 
             var startPos = new Position(Location);
 
@@ -329,18 +296,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the Allegiance hometown.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var recallChain = new ActionChain();
-                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.AllegianceHometownRecall }, 1.0f, MotionStance.NonCombat);
-                recallChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.AllegianceHometownRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.AllegianceHometownRecall);
 
             var startPos = new Position(Location);
 
@@ -431,18 +387,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the Allegiance housing.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var recallChain = new ActionChain();
-                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.HouseRecall }, 1.0f, MotionStance.NonCombat);
-                recallChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.HouseRecall);
 
             var startPos = new Position(Location);
 
@@ -519,18 +464,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PK Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var recallChain = new ActionChain();
-                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.PKArenaRecall }, 1.0f, MotionStance.NonCombat);
-                recallChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.PKArenaRecall);
 
             var startPos = new Position(Location);
 
@@ -608,18 +542,7 @@ namespace ACE.Server.WorldObjects
 
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PKL Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
 
-            if (FastTick)
-            {
-                var recallChain = new ActionChain();
-                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.PKArenaRecall }, 1.0f, MotionStance.NonCombat);
-                recallChain.EnqueueChain();
-            }
-            else
-            {
-                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-                motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
-                EnqueueBroadcastMotion(motion);
-            }
+            SendRecallAnimation(MotionCommand.PKArenaRecall);
 
             var startPos = new Position(Location);
 
@@ -648,6 +571,22 @@ namespace ACE.Server.WorldObjects
             });
 
             actionChain.EnqueueChain();
+        }
+
+        private void SendRecallAnimation(MotionCommand motionCommand)
+        {
+            if (FastTick)
+            {
+                var actionChain = new ActionChain();
+                EnqueueMotionAction(actionChain, new List<MotionCommand>() { motionCommand }, 1.0f, MotionStance.NonCombat);
+                actionChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, motionCommand);
+                EnqueueBroadcastMotion(motion);
+            }
         }
 
         public DateTime LastTeleportTime;

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -162,11 +162,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.LifestoneRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the lifestone.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var actionChain = new ActionChain();
+                EnqueueMotionAction(actionChain, new List<MotionCommand>() { MotionCommand.LifestoneRecall }, 1.0f, MotionStance.NonCombat);
+                actionChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.LifestoneRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 
@@ -222,11 +231,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.MarketplaceRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the marketplace.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var actionChain = new ActionChain();
+                EnqueueMotionAction(actionChain, new List<MotionCommand>() { MotionCommand.MarketplaceRecall }, 1.0f, MotionStance.NonCombat);
+                actionChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.MarketplaceRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 
@@ -300,11 +318,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.AllegianceHometownRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the Allegiance hometown.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var recallChain = new ActionChain();
+                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.AllegianceHometownRecall }, 1.0f, MotionStance.NonCombat);
+                recallChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.AllegianceHometownRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 
@@ -393,11 +420,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is recalling to the Allegiance housing.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var recallChain = new ActionChain();
+                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.HouseRecall }, 1.0f, MotionStance.NonCombat);
+                recallChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.HouseRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 
@@ -472,11 +508,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PK Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var recallChain = new ActionChain();
+                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.PKArenaRecall }, 1.0f, MotionStance.NonCombat);
+                recallChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 
@@ -552,11 +597,20 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(updateCombatMode);
             }
 
-            var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
-            motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
-
             EnqueueBroadcast(new GameMessageSystemChat($"{Name} is going to the PKL Arena.", ChatMessageType.Recall), LocalBroadcastRange, ChatMessageType.Recall);
-            EnqueueBroadcastMotion(motion);
+
+            if (FastTick)
+            {
+                var recallChain = new ActionChain();
+                EnqueueMotionAction(recallChain, new List<MotionCommand>() { MotionCommand.PKArenaRecall }, 1.0f, MotionStance.NonCombat);
+                recallChain.EnqueueChain();
+            }
+            else
+            {
+                var motion = new Motion(MotionStance.NonCombat, MotionCommand.Ready);
+                motion.MotionState.AddCommand(this, MotionCommand.PKArenaRecall);
+                EnqueueBroadcastMotion(motion);
+            }
 
             var startPos = new Position(Location);
 


### PR DESCRIPTION
This fixes some anomalies with the player restarting the recall animation after a jump, and the player appearing in falling state at the destination when this happens

There is still an open issue where the server should possibly be preventing the player from going into combat state after landing from the jump. The player is already set to IsBusy on the server during the recall animation, which prevents them from performing any actual combat actions. The client does not appear to go into busy state during the recall.

Thanks to @CrimsonMage for reporting this issue