### PR TITLE
updating PetDevice Structure==0 message

### DIFF
--- a/Source/ACE.Server/WorldObjects/PetDevice.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice.cs
@@ -105,7 +105,8 @@ namespace ACE.Server.WorldObjects
 
             if (Structure == 0)
             {
-                player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, "You must refill the essence to use it again."));
+                //player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, "You must refill the essence to use it again."));
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat("Your summoning device does not have enough charges to function!", ChatMessageType.Broadcast));
                 return;
             }
 


### PR DESCRIPTION
From @OptimShi and retail pcaps:

UpdateEnchantment (the cooldown)
TextboxString "Your summoning device does not have enough charges to function!"
UseDone