### PR TITLE
adjusting 'casts -> cast' verbiage for item spells

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1805,12 +1805,12 @@ namespace ACE.Server.WorldObjects
             }
             else if (caster == this || target == this || caster != target)
             {
-                var prefix = caster == this ? "You cast" : $"{caster.Name} casts";
+                var casterName = caster == this ? "You" : caster.Name;
                 var targetName = target.Name;
                 if (target == this)
                     targetName = caster == this ? "yourself" : "you";
 
-                message = $"{prefix} {spell.Name} on {targetName}{suffix}";
+                message = $"{casterName} cast {spell.Name} on {targetName}{suffix}";
             }
 
             if (message != null)


### PR DESCRIPTION
From retail pcaps, when an item casts a spell on a player, the verbiage was 'cast' instead of 'casts'