### PR TITLE
handle appraisal for * unenchantable body parts

### DIFF
--- a/Source/ACE.Server/Network/Structure/ArmorLevel.cs
+++ b/Source/ACE.Server/Network/Structure/ArmorLevel.cs
@@ -56,13 +56,15 @@ namespace ACE.Server.Network.Structure
                 totalAL += baseAL + modAL;
             }
 
+            // doesn't handle negatives?
+            totalAL = Math.Max(0, totalAL);
+
             // if all layers for this body part are unenchantable,
             // send totalAL + 9999 for client to display *
             if (!layers.Any(i => i.IsEnchantable))
                 totalAL += 9999;
 
-            // doesn't handle negatives?
-            return (uint)Math.Max(0, totalAL);
+            return (uint)totalAL;
         }
 
         /// <summary>

--- a/Source/ACE.Server/Network/Structure/ArmorLevel.cs
+++ b/Source/ACE.Server/Network/Structure/ArmorLevel.cs
@@ -56,6 +56,11 @@ namespace ACE.Server.Network.Structure
                 totalAL += baseAL + modAL;
             }
 
+            // if all layers for this body part are unenchantable,
+            // send totalAL + 9999 for client to display *
+            if (!layers.Any(i => i.IsEnchantable))
+                totalAL += 9999;
+
             // doesn't handle negatives?
             return (uint)Math.Max(0, totalAL);
         }


### PR DESCRIPTION
``* = Unenchantable`` is seen in the client appraisal window for creatures

in CharExamineUI::SetAppraiseInfo:

```
    v43 = _prof->base_armor_head;
    if ( v43 < 9999 )
      AC1Legacy::PStringBase<char>::sprintf(&armorStr1, "%d", _prof->base_armor_head);
    else
      AC1Legacy::PStringBase<char>::sprintf(&armorStr1, "*%d", v43 - 9999);
```

sending 9999 + actual value for any body parts where all layers are unenchantable