### PR TITLE
Modify selling attuned items to vendors

### DIFF
--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -528,6 +528,10 @@ namespace ACE.Server.WorldObjects
                 if (item.GetProperty(PropertyBool.DestroyOnSell) ?? false)
                     resellItem = false;
 
+                // don't resell Attuned items that can be sold
+                if (item.Attuned == AttunedStatus.Attuned)
+                    resellItem = false;
+
                 // don't resell stackables?
                 if (item.MaxStackSize != null || item.MaxStructure != null)
                     resellItem = false;


### PR DESCRIPTION
- Modify the selling process for attuned items to prevent them from being resold, which could allow other players to obtain quest items that are sellable, without having performed the quest -- Item was supposed to be attuned to the original recipient anyways; allowing attuned item "transfers" via vendor seems like an exploit.
