### PR TITLE
Fix cross-thread TryProcEquippedItems which results in landblock spel…

### DIFF
--- a/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
+++ b/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
@@ -2,6 +2,8 @@ using System;
 
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
@@ -80,7 +82,16 @@ namespace ACE.Server.WorldObjects
 
                 // handle target procs
                 if (damageEvent != null && damageEvent.HasDamage)
-                    sourceCreature?.TryProcEquippedItems(targetCreature, false);
+                {
+                    // Ok... if we got here, we're likely in the parallel landblock physics processing.
+                    // We're currently on the thread for worldObject, but we're wanting to perform some work on sourceCreature which can result in a new spell being created
+                    // and added to the sourceCreature's current landblock, which, could be on a separate thread.
+                    // Any chance of a cross landblock group transfer (and thus cross thread), must be managed by WorldManager for thread safety.
+                    if (sourceCreature.CurrentLandblock == null || sourceCreature.CurrentLandblock == worldObject.CurrentLandblock)
+                        sourceCreature.TryProcEquippedItems(targetCreature, false);
+                    else
+                        WorldManager.EnqueueAction(new ActionEventDelegate(() => sourceCreature.TryProcEquippedItems(targetCreature, false)));
+                }
             }
 
             worldObject.CurrentLandblock?.RemoveWorldObject(worldObject.Guid, showError: !worldObject.PhysicsObj.entering_world);


### PR DESCRIPTION
…l projectile

Scenario:
- Player casts spell at far away creature.
- Before spell hits creature, Player teleports to another landblock far away that is on a different landblock group, and thus, potentially a different thread.
- Spell hits creature.
-- Impact calls TryProcEquippedItems() on Player, which results in a spell projectile being added to the players landblock (cross thread operation).

This removes the cross thread operation and makes WorldManager handle it, which is appropriate.