### PR TITLE
Update to Proc Rates for Cloaks. 

### DIFF
--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -9,7 +9,7 @@ namespace ACE.Server.Entity
 {
     public class Cloak
     {
-        private static readonly float ChanceMod = 2.0f;
+        private static readonly float ChanceMod = 1.0f;
 
         /// <summary>
         /// Rolls for a chance at procing a cloak spell
@@ -35,9 +35,11 @@ namespace ACE.Server.Entity
             // TODO: find retail formula
             // TODO: cloak level multiplier - Added 6/19/2020 HQ (Still need retail numbers) Updated with Riggs suggestions
 
-            var itemMaxLevel = cloak.ItemMaxLevel ?? 0;
+            var itemLevel = cloak.ItemLevel ?? 0;
 
-            var chanceMod = ChanceMod + itemMaxLevel * 0.1f;
+            var chanceMod = ChanceMod + itemLevel * 0.02f;
+            if (itemLevel < 1)
+                chanceMod = 0.0f;
 
             var chance = damage_percent * chanceMod;
 


### PR DESCRIPTION
Cloaks that have not reached at least level 1 no longer produce proc spell.  Also update to Proc Rates for Cloaks.  Cloaks were pulling Max Level, not current cloak level.  Also adjusted Proc Rate.  Now depends more on damage percentage.