### PR TITLE
Make sure UIQueue NetworkMessages are sent in order

### DIFF
--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -803,6 +803,8 @@ namespace ACE.Server.Network
 
                         foreach (MessageFragment fragment in fragments)
                         {
+                            bool fragmentSkipped = false;
+
                             // Is this a large fragment and does it have a tail that needs sending?
                             if (!fragment.TailSent && availableSpace >= fragment.TailSize)
                             {
@@ -819,9 +821,16 @@ namespace ACE.Server.Network
                                 packet.Fragments.Add(spf);
                                 availableSpace -= spf.Length;
                             }
+                            else
+                                fragmentSkipped = true;
+
                             // If message is out of data, set to remove it
                             if (fragment.DataRemaining <= 0)
                                 removeList.Add(fragment);
+
+                            // UIQueue messages must go out in order. Otherwise, you might see an NPC's tells in an order that doesn't match their defined emotes.
+                            if (fragmentSkipped && group == GameMessageGroup.UIQueue)
+                                break;
                         }
 
                         // Remove all completed messages


### PR DESCRIPTION
This fixes out of order NPC emotes, like this one:

https://github.com/ACEmulator/ACE-World-16PY-Patches/blob/master/Database/Patches/2008-08-AncientPowers/9%20WeenieDefaults/Creature/Human/38388%20Kirina%20of%20the%20Celestial%20Hand.sql#L116