### PR TITLE
enlightenment doesn't boost untrained / unusable skills

### DIFF
--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -215,7 +215,7 @@ namespace ACE.Server.WorldObjects.Entity
             if (AdvancementClass == SkillAdvancementClass.Specialized && player.LumAugSkilledSpec != 0)
                 total += (uint)player.LumAugSkilledSpec * 2;
 
-            if (player.Enlightenment != 0)
+            if (AdvancementClass >= SkillAdvancementClass.Trained && player.Enlightenment != 0)
                 total += (uint)player.Enlightenment;
 
             return total;


### PR DESCRIPTION
Verified the other properties in GetAugBonus() from augs and lum augs do boost the untrained / unusable skills... Enlightenment is the only outlier there