### PR TITLE
ensure mana conversion is trained to get any benefit from the skill

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -109,12 +109,14 @@ namespace ACE.Server.WorldObjects
                 baseCost += spell.ManaMod * (uint)numFellows;
             }
 
-            if (spell.Flags.HasFlag(SpellFlags.IgnoresManaConversion))
+            var manaConversion = caster.GetCreatureSkill(Skill.ManaConversion);
+
+            if (manaConversion.AdvancementClass < SkillAdvancementClass.Trained || spell.Flags.HasFlag(SpellFlags.IgnoresManaConversion))
                 return baseCost;
 
             var difficulty = spell.PowerMod;   // modified power difficulty
 
-            var mana_conversion_skill = (uint)Math.Round(caster.GetCreatureSkill(Skill.ManaConversion).Current * GetWeaponManaConversionModifier(caster));
+            var mana_conversion_skill = (uint)Math.Round(manaConversion.Current * GetWeaponManaConversionModifier(caster));
 
             var manaCost = GetManaCost(difficulty, baseCost, mana_conversion_skill);
 


### PR DESCRIPTION
Mana Conversion is listed as 'unusable' in client when not trained

Assuming unusable skills are truly unusable when not trained (aside from the magic school outliers)

Search ACE discord #general for 'mana conv' or 'Yeonan' for relevant discussion from 8/14/2020