### PR TITLE
fixing kill task credit from last damager -> damage history, adding new server option to match retail bug for summoning and kill task credits by default

### DIFF
--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -239,9 +239,16 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Returns TRUE if damage history contains wo as recent attacker
         /// </summary>
-        public bool HasDamager(WorldObject wo)
+        /// <param name="nonZero">If TRUE, attacker must have TotalDamage > 0</param>
+        public bool HasDamager(WorldObject wo, bool nonZero = false)
         {
-            return TotalDamage.ContainsKey(wo.Guid);
+            if (!TotalDamage.TryGetValue(wo.Guid, out var totalDamage))
+                return false;
+
+            if (nonZero)
+                return totalDamage.TotalDamage > 0;
+            else
+                return true;
         }
 
         public override string ToString()

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -489,6 +489,7 @@ namespace ACE.Server.Managers
                 ("allow_door_hold", new Property<bool>(true, "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players")),
                 ("allow_jump_loot", new Property<bool>(true, "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation")),
                 ("allow_pkl_bump", new Property<bool>(true, "enables retail behavior where /pkl checks for entry collisions, bumping the player position over if standing on another PKLite. This effectively enables /pkl door skipping from retail")),
+                ("allow_summoning_killtask_multicredit", new Property<bool>(true, "enables retail behavior where a summoner can get multiple killtask credits from a monster")),
                 ("assess_creature_mod", new Property<bool>(false, "(non-retail function) If enabled, re-enables former skill formula, when assess creature skill is not trained or spec'ed")),
                 ("chess_enabled", new Property<bool>(true, "if FALSE then chess will be disabled")),
                 ("client_movement_formula", new Property<bool>(false, "If enabled, server uses DoMotion/StopMotion self-client movement methods instead of apply_raw_movement")),

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -39,8 +39,15 @@ namespace ACE.Server.WorldObjects
             IsTurning = false;
             IsMoving = false;
 
-            QuestManager.OnDeath(lastDamager?.TryGetAttacker());
-            
+            //QuestManager.OnDeath(lastDamager?.TryGetAttacker());
+
+            if (KillQuest != null)
+                OnDeath_HandleKillTask(KillQuest);
+            if (KillQuest2 != null)
+                OnDeath_HandleKillTask(KillQuest2);
+            if (KillQuest3 != null)
+                OnDeath_HandleKillTask(KillQuest3);
+
             if (!IsOnNoDeathXPLandblock)
                 OnDeath_GrantXP();
 
@@ -198,6 +205,124 @@ namespace ACE.Server.WorldObjects
                     playerDamager.EarnLuminance(totalLuminance, XpType.Kill);
                 }
             }
+        }
+
+        /// <summary>
+        /// Handles the KillTask for a killed creature
+        /// </summary>
+        public void OnDeath_HandleKillTask(string killQuest)
+        {
+            var receivers = KillTask_GetEligibleReceivers(killQuest);
+
+            foreach (var receiver in receivers)
+            {
+                var damager = receiver.Value.TryGetAttacker();
+
+                var player = damager as Player;
+
+                if (player == null && receiver.Value.PetOwner != null)
+                    player = receiver.Value.TryGetPetOwner();
+
+                if (player != null)
+                    player.QuestManager.HandleKillTask(killQuest, this);
+            }
+        }
+
+        /// <summary>
+        /// Returns a flattened structure of eligible Players, Fellows, and CombatPets
+        /// </summary>
+        public Dictionary<ObjectGuid, DamageHistoryInfo> KillTask_GetEligibleReceivers(string killQuest)
+        {
+            // http://acpedia.org/wiki/Announcements_-_2012/12_-_A_Growing_Twilight#Release_Notes
+
+            var questName = QuestManager.GetQuestName(killQuest);
+
+            // we are using DamageHistoryInfo here, instead of Creature or WorldObjectInfo
+            // WeakReference<CombatPet> may be null for expired CombatPets, but we still need the WeakReference<PetOwner> references
+
+            var receivers = new Dictionary<ObjectGuid, DamageHistoryInfo>();
+
+            foreach (var kvp in DamageHistory.TotalDamage)
+            {
+                var damager = kvp.Value.TryGetAttacker();
+
+                var playerDamager = damager as Player;
+
+                if (playerDamager == null && kvp.Value.PetOwner != null)
+                {
+                    // handle combat pets
+                    playerDamager = kvp.Value.TryGetPetOwner();
+
+                    // only add combat pet to eligible receivers if player has quest, and allow_summoning_killtask_multicredit = true (default, retail)
+                    if (playerDamager != null && playerDamager.QuestManager.HasQuest(questName) && PropertyManager.GetBool("allow_summoning_killtask_multicredit").Item)
+                        receivers[kvp.Value.Guid] = kvp.Value;
+
+                    // regardless if combat pet is eligible, we still want to continue traversing to the pet owner, and possibly fellows
+
+                    // in a scenario where combat pet does 100% damage:
+
+                    // - regardless if allow_summoning_killtask_multicredit is enabled/disabled, it should continue traversing into pet owner and possibly their fellows
+
+                    // - if pet owner doesn't have kill task, and fellow_kt_killer=false, any fellows with the task should still receive 1 credit
+                }
+
+                if (playerDamager == null)
+                    continue;
+
+                // factors:
+                // - has quest
+                // - is killer (last damager, top damager, or any damager? in current context, considering it to be any damager)
+                // - has fellowship
+                // - server option: fellow_kt_killer
+                // - server option: fellow_kt_landblock
+
+                if (playerDamager.QuestManager.HasQuest(questName))
+                {
+                    // just add a fake DamageHistoryInfo for reference
+                    receivers[playerDamager.Guid] = new DamageHistoryInfo(playerDamager);
+                }
+                else if (PropertyManager.GetBool("fellow_kt_killer").Item)
+                {
+                    // if this option is enabled (retail default), the killer is required to have kill task
+                    // for it to share with fellowship
+                    continue;
+                }
+
+                // we want to add fellowship members in a flattened structure
+                // in this inner loop, instead of the outer loop
+
+                // scenarios:
+
+                // i am a summoner in a fellowship with 1 other player
+                // we both have a killtask
+
+                // - my combatpet does 100% damage to the monster
+                // result: i get 1 killtask credit, and my fellow gets 1 killtask credit
+
+                // - my combatpet does 50% damage to monster, and i do 50% damage
+                // result: i get 2 killtask credits (1 if allow_summoning_killtask_multicredit server option is disabled), and my fellow gets 1 killtask credit
+
+                // - my combatpet does 33% damage to monster, i do 33% damage, and fellow does 33% damage
+                // result: same as previous scenario
+
+                // 2 players not in a fellowship both have a killtask
+                // they each do 50% damage to monster
+
+                // result: both players receive killtask credit
+
+                if (playerDamager.Fellowship == null)
+                    continue;
+
+                // share with fellows in kill task range
+                var fellows = playerDamager.Fellowship.WithinRange(playerDamager);
+
+                foreach (var fellow in fellows)
+                {
+                    if (fellow.QuestManager.HasQuest(questName))
+                        receivers[fellow.Guid] = new DamageHistoryInfo(fellow);
+                }
+            }
+            return receivers;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a bug with KillTask processing for the following scenario:

- 2 players both have a kill task, but they are not in a fellowship
- They both do 50% damage to the mob

Expected:

- both players get credit for the kill task

Actual:

- only the last damager previously got credit for the kill task

Fundamentally, everything was being driven from 'last damager' before, with the player or combat pet that landed the killing blow. It would then optionally traverse into the fellowship for this last damager (or in the case of combat pets as the last damager, the combat pet's owner, and their fellowship)

The updated code moves this part of the system over to being driven from the killed monster's DamageHistory, which is a rolling history of all the damagers to the monster for the past 3 - 3.5 minutes.

An important function for this has been added which builds a flattened list of all the eligible receivers first. All players from the monster's damage history who have the KillTask are added as eligible players to receive credit for the task. This function also handles CombatPets.

An important aspect of this function is that it builds the list with a Dictionary, keyed by the eligible receiver guids. If 2 players with a kill task are both in a fellowship, and they each do 50% damage to the monster, we certainly don't want fellowship traversal for both players to add multiple entries for the same player.

However, there was a 'bug' in retail, where a summoner could receive multiple credits for a killtask. A server option has been added for this, 'allow_summoning_killtask_multicredit', which defaults to the retail value of true.

There are a lot of scenarios to consider with this, and many of them are commented in the code. An aspect that was considered thoroughly, but only briefly mentioned, is the concept of "the killer's fellowship is only traversed into when the killer has the kill task". This was the default behavior of retail for KillTask credit sharing with fellowships, however the concept of 'killer' is loosely defined. Is it the LastDamager, the TopDamager, or are all the players in the recent damage history considered 'killers'?

The previous version considered the killer to be the LastDamager, which presented this scenario:

- 2 players both have a kill task, but they are not in a fellowship
- Player A does 75% damage to the mob, and Player B does 25% damage and also lands the killing blow

With the previous version of the code, only Player B was receiving credit for the KillTask

With the new DamageHistory iteration, it becomes even more complicated. Consider the following scenario:

fellow_kt_killer = false, killer is not required to have killtask in order for it to share with their fellowship

- Fellowship A
  - Player 1 (has kill task)
  - Player 2 (has kill task)
- Fellowship B
  - Player 3 (doesn't have kill task)
  - Player 4 (has kill task)

only players 1 and 3 damage the monster
player 1 does 75% damage, and player 2 does 25% damage and lands the killing blow

with the previous version of the ace logic for kill tasks and fellowship sharing, where the killer is considered to be the LastDamager (player 3), only player 4 would have received kill task credit when fellow_kt_killer = false, since that non-standard server option removes the requirement for player 3 to have the kill task.

if fellow_kt_killer = true, no players would have previously received kill task credit.

with the updated logic, who receives kill task credit is dependent on if the killer is considered to be the LastDamager, TopDamager, or any damagers.

if killer is considered to be the LastDamager, as it was previously, then with the updated system, player 1 now receives killtask credit, and player 4 continues to receive credit as well

if killer is considered to be the TopDamager, only players 1 and 2 would receiver killtask credit, even if fellow_kt_killer = false, since fellowship traversal would only happen for the top damager (player 1)

if killer is considered to be any damager, then players 1, 2, and 4 would all receive kill task credit, in the above scenario

the currently implemented update considered killers to be anyone who directly damaged the monster

Another note about the current implementation of allow_summoning_killtask_multicredit - the multicredit bug only goes to the summoner directly, and not their fellowship. So if a summoner is in a fellowship with another player, and both players have the kill task:

- combat pet does 100% damage

summoner and fellow each get 1 credit

- combat pet does 50% damage, summoner does 50% damage
- combat pet does 33% damage, summoner does 33% damage, fellow does 33% damage

with allow_summoning_killtask_multicredit=true (default, retail): summoner gets 2 credits, fellow gets 1 credit
with allow_summoning_killtask_multicredit=false, summoner and fellow each get 1 credit
