### PR TITLE
Lugian hammer

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -33,22 +33,22 @@ namespace ACE.Server.Factories
             {
                 case 0:
                     // Heavy Weapons
-                    subtype = ThreadSafeRandom.Next(0, LootTables.HeavyWeaponsMatrix.Length);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.HeavyWeaponsMatrix.Length - 1);
                     weaponWeenie = LootTables.HeavyWeaponsMatrix[subtype][eleType];
                     break;
                 case 1:
                     // Light Weapons
-                    subtype = ThreadSafeRandom.Next(0, LootTables.LightWeaponsMatrix.Length);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.LightWeaponsMatrix.Length - 1);
                     weaponWeenie = LootTables.LightWeaponsMatrix[subtype][eleType];
                     break;
                 case 2:
                     // Finesse Weapons;
-                    subtype = ThreadSafeRandom.Next(0, LootTables.FinesseWeaponsMatrix.Length);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.FinesseWeaponsMatrix.Length - 1);
                     weaponWeenie = LootTables.FinesseWeaponsMatrix[subtype][eleType];
                     break;
                 default:
                     // Two handed
-                    subtype = ThreadSafeRandom.Next(0, LootTables.TwoHandedWeaponsMatrix.Length);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.TwoHandedWeaponsMatrix.Length - 1);
                     weaponWeenie = LootTables.TwoHandedWeaponsMatrix[subtype][eleType];
                     break;
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -33,22 +33,22 @@ namespace ACE.Server.Factories
             {
                 case 0:
                     // Heavy Weapons
-                    subtype = ThreadSafeRandom.Next(0, 23);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.HeavyWeaponsMatrix.Length);
                     weaponWeenie = LootTables.HeavyWeaponsMatrix[subtype][eleType];
                     break;
                 case 1:
                     // Light Weapons
-                    subtype = ThreadSafeRandom.Next(0, 19);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.LightWeaponsMatrix.Length);
                     weaponWeenie = LootTables.LightWeaponsMatrix[subtype][eleType];
                     break;
                 case 2:
                     // Finesse Weapons;
-                    subtype = ThreadSafeRandom.Next(0, 21);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.FinesseWeaponsMatrix.Length);
                     weaponWeenie = LootTables.FinesseWeaponsMatrix[subtype][eleType];
                     break;
                 default:
                     // Two handed
-                    subtype = ThreadSafeRandom.Next(0, 11);
+                    subtype = ThreadSafeRandom.Next(0, LootTables.TwoHandedWeaponsMatrix.Length);
                     weaponWeenie = LootTables.TwoHandedWeaponsMatrix[subtype][eleType];
                     break;
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories
             {
                 case 0:
                     // Heavy Weapons
-                    subtype = ThreadSafeRandom.Next(0, 22);
+                    subtype = ThreadSafeRandom.Next(0, 23);
                     weaponWeenie = LootTables.HeavyWeaponsMatrix[subtype][eleType];
                     break;
                 case 1:
@@ -43,7 +43,7 @@ namespace ACE.Server.Factories
                     break;
                 case 2:
                     // Finesse Weapons;
-                    subtype = ThreadSafeRandom.Next(0, 22);
+                    subtype = ThreadSafeRandom.Next(0, 21);
                     weaponWeenie = LootTables.FinesseWeaponsMatrix[subtype][eleType];
                     break;
                 default:
@@ -95,14 +95,15 @@ namespace ACE.Server.Factories
                         case 0:
                         case 1:
                         case 2:
+                        case 3:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 18);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 22);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Axe);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Axe);
                             break;
-                        case 3:
                         case 4:
                         case 5:
+                        case 6:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 20);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 20);
 
@@ -116,36 +117,36 @@ namespace ACE.Server.Factories
                                 damageVariance = GetVariance(wieldSkillType, LootWeaponType.DaggerMulti);
                             }
                             break;
-                        case 6:
                         case 7:
                         case 8:
                         case 9:
+                        case 10:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 22);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 18);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Mace);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Mace);
                             break;
-                        case 10:
                         case 11:
                         case 12:
+                        case 13:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 15);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 25);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spear);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Spear);
                             break;
-                        case 13:
                         case 14:
+                        case 15:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 25);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 15);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Staff);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Staff);
                             break;
-                        case 15:
                         case 16:
                         case 17:
                         case 18:
                         case 19:
                         case 20:
+                        case 21:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 20);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 20);
 
@@ -158,7 +159,7 @@ namespace ACE.Server.Factories
                                 damageVariance = GetVariance(wieldSkillType, LootWeaponType.SwordMulti);
                             }
                             break;
-                        case 21:
+                        case 22:
                         default:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 20);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 20);
@@ -269,7 +270,6 @@ namespace ACE.Server.Factories
                         case 7:
                         case 8:
                         case 9:
-                        case 10:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 22);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 18);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Mace);
@@ -278,26 +278,26 @@ namespace ACE.Server.Factories
                             if (subtype == 9)
                                 damageVariance = GetVariance(wieldSkillType, LootWeaponType.Jitte);
                             break;
+                        case 10:
                         case 11:
-                        case 12:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 15);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 25);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Spear);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Spear);
                             break;
+                        case 12:
                         case 13:
-                        case 14:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 25);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 15);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Staff);
                             damageVariance = GetVariance(wieldSkillType, LootWeaponType.Staff);
                             break;
+                        case 14:
                         case 15:
                         case 16:
                         case 17:
                         case 18:
                         case 19:
-                        case 20:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 20);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 20);
                             damage = GetMeleeMaxDamage(wieldSkillType, wieldDiff, LootWeaponType.Sword);
@@ -309,7 +309,7 @@ namespace ACE.Server.Factories
                                 damageVariance = GetVariance(wieldSkillType, LootWeaponType.SwordMulti);
                             }
                             break;
-                        case 21:
+                        case 20:
                         default:
                             weaponDefense = GetMaxDamageMod(profile.Tier, 20);
                             weaponOffense = GetMaxDamageMod(profile.Tier, 20);

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -202,6 +202,7 @@ namespace ACE.Server.Factories
             new int[] { 301, 3750, 3751, 3752, 3753 }, // Battle Axe
             new int[] { 344, 3865, 3866, 3867, 3868 }, // Silifi
             new int[] { 31769, 31770, 31771, 31772, 31768 }, // War Axe
+            new int[] { 31764, 31765, 31766, 31767, 31763 }, // Lugian Hammer
             new int[] { 22440, 22441, 22442, 22443, 22444 }, // Dirk
             new int[] { 30601, 30602, 30603, 30604, 30605 }, // Stiletto
             new int[] { 319, 3794, 3795, 3796, 3797 }, // Jambiya
@@ -240,7 +241,7 @@ namespace ACE.Server.Factories
             new int[] { 338, 22164, 22165, 22166, 22167 }, // Quarter Staff
             new int[] { 350, 3877, 3878, 3879, 3880 }, // Broad Sword
             new int[] { 31759, 31760, 31761, 31762, 31758 }, // Dericost Blade
-            new int[] { 45099, 45099, 45099, 45099, 45099 }, // Epee - Placeholders, as not yet in database
+            new int[] { 45099, 45099, 45099, 45099, 45099 }, // Epee
             new int[] { 324, 3810, 3811, 3812, 3813 }, // Kaskara
             new int[] { 30571, 30572, 30573, 30574, 30575 }, // Spada
             new int[] { 340, 3853, 3854, 3855, 3856 },// Shamshir
@@ -260,7 +261,6 @@ namespace ACE.Server.Factories
             new int[] { 313, 3774, 3775, 3776, 3777 }, // Dabus
             new int[] { 356, 3897, 3898, 3899, 3900 }, // Tofun
             new int[] { 321, 3802, 3803, 3804, 3805 }, // Jitte
-            new int[] { 31774, 31775, 31776, 31777, 31773 }, // Stone Mace
             new int[] { 308, 3762, 3763, 3764, 3765 }, // Budiaq
             new int[] { 7771, 7795, 7796, 7797, 7798 }, // Naginata
             new int[] { 30606, 30607, 30608, 30609, 30610 }, // Bastone


### PR DESCRIPTION
- Set subtype ThreadSafeRandom.Next() upper bounds to array.Length - 1
- Reorder the MutateMeleeWeapon() subtype case statements because of the addition and removal mentioned below
- Add the Lugian Hammer weenies to the HeavyWeaponsMatrix array
- Remove unneeded comment, in the LightWeaponsMatrix array
- Remove duplicate Board with Nail weenies mislabeled as Stone Mace, in the FinesseWeaponsMatrix array
