### PR TITLE
Fix issue with event generators 0 RegenerationInterval spawning their init when turning on

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -664,7 +664,7 @@ namespace ACE.Server.WorldObjects
             }
             else
             {
-                if (this is Container)
+                if (this is Container || (!string.IsNullOrEmpty(GeneratorEvent) && RegenerationInterval == 0))
                     Generator_Regeneration();
 
                 if (InitCreate == 0)


### PR DESCRIPTION
`@teleloc 0x0287011C [70.305200 -35.835400 -11.995000] 0.000000 0.000000 0.000000 -1.000000`

`@smite all`

expect to see butterflies