### PR TITLE
add treasure item type chance tables

### DIFF
--- a/Source/ACE.Server/Factories/Entity/TreasureItemTypeChance.cs
+++ b/Source/ACE.Server/Factories/Entity/TreasureItemTypeChance.cs
@@ -1,0 +1,16 @@
+using ACE.Server.Factories.Enum;
+
+namespace ACE.Server.Factories.Entity
+{
+    public class TreasureItemTypeChance
+    {
+        public TreasureItemType TreasureItemType;
+        public float Chance;
+
+        public TreasureItemTypeChance(TreasureItemType treasureItemType, float chance)
+        {
+            TreasureItemType = treasureItemType;
+            Chance = chance;
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/Enum/TreasureItemType.cs
+++ b/Source/ACE.Server/Factories/Enum/TreasureItemType.cs
@@ -1,0 +1,53 @@
+namespace ACE.Server.Factories.Enum
+{
+    // retail
+
+    /*public enum TreasureItemType
+    {
+        Undef,
+        Pyreal,
+        Gem,
+        Jewelry,
+        ArtObject,
+        Weapon,
+        Armor,
+        Clothing,
+        Scroll,
+        Caster,
+        ManaStone,
+        Consumable,
+        HealKit,
+        Lockpick,
+        SpellComponent,
+        LeatherArmor,
+        StuddedLeatherArmor,
+        ChainMailArmor,
+        CovenantArmor,
+        PlateMailArmor,
+        HeritageLowArmor,
+        HeritageHighArmor,
+        SwordWeapon,
+        MaceWeapon,
+        AxeWeapon,
+        SpearWeapon,
+        UnarmedWeapon,
+        StaffWeapon,
+        DaggerWeapon,
+        BowWeapon,
+        CrossbowWeapon,
+        AtlatlWeapon
+    }*/
+
+    // current ace
+    public enum TreasureItemType
+    {
+        Undef,
+        Gem,
+        Armor,
+        Clothing,
+        Cloak,
+        Weapon,
+        Jewelry,
+        Dinnerware
+    }
+}

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -8,10 +8,12 @@ using ACE.Common;
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
+using ACE.Server.Factories.Enum;
+using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
-using ACE.Entity.Enum.Properties;
 
 namespace ACE.Server.Factories
 {
@@ -40,17 +42,34 @@ namespace ACE.Server.Factories
         }
 
         // Enum used for adjusting the loot bias for the various types of Mana forge chests
-        public enum LootBias : uint
+        // TODO: port this over to TreasureItemTypeChances
+        /*[Flags]
+        public enum LootBias
         {
-            UnBiased = 0,
-            Armor = 1,
-            Weapons = 2,
-            SpellComps = 4,
-            Clothing = 8,
-            Jewelry = 16,
-            MagicEquipment = 31,
-            MixedEquipment = 31,
-        }
+            UnBiased   = 0x0,
+            Armor      = 0x1,
+            Weapons    = 0x2,
+            SpellComps = 0x4,
+            Clothing   = 0x8,
+            Jewelry    = 0x10,
+
+            MagicEquipment = Armor | Weapons | SpellComps | Clothing | Jewelry,
+            MixedEquipment = Armor | Weapons | SpellComps | Clothing | Jewelry
+        }*/
+
+        public enum LootBias
+        {
+            UnBiased,
+
+            Armor,
+            Weapons,
+            SpellComps,
+            Clothing,
+            Jewelry,
+
+            MagicEquipment,
+            MixedEquipment
+        };
 
         public static List<WorldObject> CreateRandomLootObjects(TreasureDeath profile)
         {
@@ -168,64 +187,63 @@ namespace ACE.Server.Factories
 
         public static WorldObject CreateRandomLootObjects(TreasureDeath profile, bool isMagical, LootBias lootBias = LootBias.UnBiased)
         {
-            WorldObject wo;
+            WorldObject wo = null;
 
-            // Adjusting rolls for changing drop rates for clothing - HarliQ 11/11/19 
+            var treasureItemTypeChances = isMagical ? TreasureItemTypeChances.DefaultMagical : TreasureItemTypeChances.DefaultNonMagical;
 
-            var type = lootBias switch
+            switch (lootBias)
             {
-                LootBias.Armor => 30,
-                LootBias.Weapons => 60,
-                LootBias.Jewelry => 90,
-                _ => ThreadSafeRandom.Next(1, 100),
-            };
-
-
-            // converting to a percentage base roll for items (to better align with retail drop rate data from Magnus) - HarliQ 11/11/19
-            // Gems 14%
-            // Armor 24%
-            // Weapons 30%
-            // Clothing 13%
-            // Cloaks 1%
-            // Jewelry 18%
-
-            switch (type)
-            {
-                case var rate when (rate < 15):
-                    // jewels (Gems)
-                    wo = CreateJewels(profile.Tier, isMagical);
-                    return wo;
-                case var rate when (rate > 14 && rate < 39):
-                    //armor
-                    wo = CreateArmor(profile, isMagical, true, lootBias);
-                    return wo;
-                case var rate when (rate > 38 && rate < 52):
-                    // clothing (shirts/pants)
-                    wo = CreateArmor(profile, isMagical, false, lootBias);
-                    return wo;
-                case var rate when (rate > 51 && rate < 53):
-                    // Cloaks  
-                    wo = CreateCloak(profile);
-                    return wo;
-                case var rate when (rate > 52 && rate < 83):
-                    // weapons (Melee/Missile/Casters)
-                    wo = CreateWeapon(profile, isMagical);
-                    return wo;
-                case var rate when (rate > 83 && rate < 93):
-                    // jewelry
-                    wo = CreateJewelry(profile, isMagical);
+                case LootBias.Armor:
+                    treasureItemTypeChances = TreasureItemTypeChances.Armor;
                     break;
-                default:
-                    if (isMagical)
-                        wo = CreateJewelry(profile, isMagical); // jewelry
-                    else
-                        // Added Dinnerware at tail end of distribution, as
-                        // they are mutable loot drops that don't belong with the non-mutable drops
-                        // TODO: Will likely need some adjustment/fine tuning
-                        wo = CreateDinnerware(profile.Tier); // dinnerware
+                case LootBias.Weapons:
+                    treasureItemTypeChances = TreasureItemTypeChances.Weapons;
+                    break;
+                case LootBias.Jewelry:
+                    treasureItemTypeChances = TreasureItemTypeChances.Jewelry;
+                    break;
+
+                case LootBias.MagicEquipment:
+                case LootBias.MixedEquipment:
+                    treasureItemTypeChances = TreasureItemTypeChances.MixedMagicEquipment;
                     break;
             }
 
+            var treasureItemType = TreasureItemTypeChances.Roll(treasureItemTypeChances);
+
+            switch (treasureItemType)
+            {
+                case TreasureItemType.Gem:
+                    wo = CreateJewels(profile.Tier, isMagical);
+                    break;
+
+                case TreasureItemType.Armor:
+                    wo = CreateArmor(profile, isMagical, true, lootBias);
+                    break;
+
+                case TreasureItemType.Clothing:
+                    wo = CreateArmor(profile, isMagical, false, lootBias);
+                    break;
+
+                case TreasureItemType.Cloak:
+                    wo = CreateCloak(profile);
+                    break;
+
+                case TreasureItemType.Weapon:
+                    wo = CreateWeapon(profile, isMagical);
+                    break;
+
+                case TreasureItemType.Jewelry:
+                    wo = CreateJewelry(profile, isMagical);
+                    break;
+
+                case TreasureItemType.Dinnerware:
+                    // Added Dinnerware at tail end of distribution, as
+                    // they are mutable loot drops that don't belong with the non-mutable drops
+                    // TODO: Will likely need some adjustment/fine tuning
+                    wo = CreateDinnerware(profile.Tier);
+                    break;
+            }
             return wo;
         }
 
@@ -2319,7 +2337,7 @@ namespace ACE.Server.Factories
                 return false;
 
             // secondary rng roll - pseudo curve table per tier
-            var roll = ChanceTables.Roll(tier);
+            var roll = QualityChance.Roll(tier);
 
             var bulk = isWeapon ? WeaponBulk : ArmorBulk;
             bulk *= (float)(wo.BulkMod ?? 1.0f);
@@ -2342,7 +2360,7 @@ namespace ACE.Server.Factories
 
         private static bool RollBurdenModChance(int tier)
         {
-            var chance = ChanceTables.QualityChancePerTier[tier - 1];
+            var chance = QualityChance.QualityChancePerTier[tier - 1];
 
             var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Test.cs
@@ -194,7 +194,7 @@ namespace ACE.Server.Factories
                             cantrip = true;
 
                         if (testItem.EquipmentSetId != null)
-                            equipmentSet = Enum.GetName(typeof(EquipmentSet), testItem.EquipmentSetId);
+                            equipmentSet = System.Enum.GetName(typeof(EquipmentSet), testItem.EquipmentSetId);
                         if (logstats == true)
                         {
                             ls.Armor += $"{testItem.ArmorLevel},{testItem.ItemDifficulty},{testItem.Value.Value},{testItem.EncumbranceVal},{testItem.EpicCantrips.Count},{testItem.LegendaryCantrips.Count},{equipmentSet},{testItem.Name}\n";
@@ -219,7 +219,7 @@ namespace ACE.Server.Factories
                         {
                             string cloakSet = "None ";
                             if (testItem.EquipmentSetId != null)
-                                cloakSet = Enum.GetName(typeof(EquipmentSet), testItem.EquipmentSetId);
+                                cloakSet = System.Enum.GetName(typeof(EquipmentSet), testItem.EquipmentSetId);
                             ls.CloakCount++;
                             if (logstats == true)
                             {

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -301,9 +301,9 @@ namespace ACE.Server.Factories
 
         public static readonly HashSet<uint> AetheriaWcids = new HashSet<uint>()
         {
-            Entity.Aetheria.AetheriaBlue,
-            Entity.Aetheria.AetheriaYellow,
-            Entity.Aetheria.AetheriaRed,
+            Server.Entity.Aetheria.AetheriaBlue,
+            Server.Entity.Aetheria.AetheriaYellow,
+            Server.Entity.Aetheria.AetheriaRed,
         };
 
         public static readonly int[,] HeavyWeaponDamageTable =

--- a/Source/ACE.Server/Factories/Tables/QualityChance.cs
+++ b/Source/ACE.Server/Factories/Tables/QualityChance.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 using log4net;
 using ACE.Common;
 
-namespace ACE.Server.Factories
+namespace ACE.Server.Factories.Tables
 {
-    public static class ChanceTables
+    public static class QualityChance
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/Source/ACE.Server/Factories/Tables/TreasureItemTypeChances.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureItemTypeChances.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using ACE.Common;
+using ACE.Server.Factories.Entity;
+using ACE.Server.Factories.Enum;
+
+namespace ACE.Server.Factories.Tables
+{
+    public static class TreasureItemTypeChances
+    {
+        // converting to a percentage base roll for items (to better align with retail drop rate data from Magnus) - HarliQ 11/11/19
+        // Gems 14%
+        // Armor 24%
+        // Weapons 30%
+        // Clothing 13%
+        // Cloaks 1%
+        // Jewelry 18%
+        // - jewelry - 10%
+        // - last 8% - is magical, more jewelry, else dinnerware
+
+        public static readonly List<TreasureItemTypeChance> DefaultMagical = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Gem, 0.14f),
+            new TreasureItemTypeChance(TreasureItemType.Armor, 0.24f),
+            new TreasureItemTypeChance(TreasureItemType.Weapon, 0.30f),
+            new TreasureItemTypeChance(TreasureItemType.Clothing, 0.13f),
+            new TreasureItemTypeChance(TreasureItemType.Cloak, 0.01f),
+            new TreasureItemTypeChance(TreasureItemType.Jewelry, 0.18f)
+        };
+
+        public static readonly List<TreasureItemTypeChance> DefaultNonMagical = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Gem, 0.14f),
+            new TreasureItemTypeChance(TreasureItemType.Armor, 0.24f),
+            new TreasureItemTypeChance(TreasureItemType.Weapon, 0.30f),
+            new TreasureItemTypeChance(TreasureItemType.Clothing, 0.13f),
+            new TreasureItemTypeChance(TreasureItemType.Cloak, 0.01f),
+            new TreasureItemTypeChance(TreasureItemType.Jewelry, 0.10f),
+            new TreasureItemTypeChance(TreasureItemType.Dinnerware, 0.08f)
+        };
+
+        // LootBias.Armor
+        public static readonly List<TreasureItemTypeChance> Armor = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Armor, 1.0f)
+        };
+
+        // LootBias.Weapons
+        public static readonly List<TreasureItemTypeChance> Weapons = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Weapon, 1.0f)
+        };
+
+        // LootBias.Jewelry
+        public static readonly List<TreasureItemTypeChance> Jewelry = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Jewelry, 1.0f)
+        };
+
+        // from Magnus loot logs - Container_Legendary_Chest_T8 (5,826 items)
+        // ~32.7% weapons, 35.6% armor, 14.1% clothing, 7.8% jewelry, 4.37% gems, 5.3% misc
+
+        // LootBias.MixedEquipment
+        // LootBias.MagicEquipment
+        /*public static readonly List<TreasureItemTypeChance> MixedMagicEquipment = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Weapon, 0.36f),
+            new TreasureItemTypeChance(TreasureItemType.Armor, 0.40f),
+            new TreasureItemTypeChance(TreasureItemType.Clothing, 0.15f),
+            new TreasureItemTypeChance(TreasureItemType.Jewelry, 0.08f),
+            //new TreasureItemTypeChance(TreasureItemType.Gem, 0.05f),    // 100% aetheria
+            //new TreasureItemTypeChance(TreasureItemType.Dinnerware, 0.05f)
+            new TreasureItemTypeChance(TreasureItemType.Cloak, 0.01f),
+        };*/
+
+        public static readonly List<TreasureItemTypeChance> MixedMagicEquipment = new List<TreasureItemTypeChance>()
+        {
+            new TreasureItemTypeChance(TreasureItemType.Armor, 0.30f),
+            new TreasureItemTypeChance(TreasureItemType.Weapon, 0.35f),
+            new TreasureItemTypeChance(TreasureItemType.Jewelry, 0.20f),
+            new TreasureItemTypeChance(TreasureItemType.Clothing, 0.14f),
+            //new TreasureItemTypeChance(TreasureItemType.Gem, 0.05f),    // 100% aetheria
+            //new TreasureItemTypeChance(TreasureItemType.Dinnerware, 0.05f)
+            new TreasureItemTypeChance(TreasureItemType.Cloak, 0.01f),
+        };
+
+        public static TreasureItemType Roll(List<TreasureItemTypeChance> chances)
+        {
+            var total = 0.0f;
+
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+
+            foreach (var chance in chances)
+            {
+                total += chance.Chance;
+
+                if (rng <= total)
+                    return chance.TreasureItemType;
+            }
+
+            // shouldn't happen, floating point imprecision?
+            return chances.Last().TreasureItemType;
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue with Mixed Equipment Chests (DeathTreasureType 2001) such as 48743 - Legendary Chest, where they shouldn't be spawning regular gems.

This can be seen in the Mag-Loot logs from retail, ie. Container_Legendary_Chest_T8.txt. From 5,826 items in there, 255 were gems, and 100% of those gems were Aetheria. No regular gems appeared to have spawned in these chests in retail.

Aetheria is currently an 'additive' separate from gems, which can still be selected via these profiles. The MundaneItemChance for these chests is 100, but the Min/Max mundane items are 0... this has the effect in ace currently of allowing Aetheria to be spawned as an additive to mundane, even when no other mundane items can spawn.

This PR builds on the existing LootBias enum, with a structure that more closely matches retail. Even though the LootBias enum had entries defined for MixedEquipment and MagicEquipment chests, it was currently unused by any of the lootgen logic.

The TreasureItemTypeChances class has been added, which defines the chances for each TreasureItemType, with different loot profiles possible there. Previously, ACE was using 1 'global' profile for the most part, with the option for LootBias to be passed in as Armor/Weapon/Jewelry, which restricted to only those TreasureItemTypes spawning.

This concept has been extended with data structure that more closely matches retail in TreasureItemTypeChances. The existing logic and profiles should still work exactly the same, and the Default/global profiles still exist and populated with the same data. The structure allows for new profiles to be easily defined, such as what was LootBias was moving towards before.

A new profile has been added for MixedEquipment and MagicEquipment (they were considered equivalent in the LootBias enum). The item type chance table for this profile has been set as a mixture between MagLoot logs for these chests, and the current global default in ace. These #s were adjusted and playtested for something that 'felt' good to me, but any of these #s can be further adjusted

Repro steps:

/teleloc 0xC6A90024 [104.717110 89.921745 42.005001] -0.839618 0.000000 0.000000 -0.543177
appraise a legendary chest
/crack
open chest
repeat

Expected:

no gems ever spawn, they should not exist in the profile

Actual:

regular gems were spawning previously