### PR TITLE
adding non-standard server option 'fix_chest_missing_inventory_window' to fix chest bug

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -506,6 +506,7 @@ namespace ACE.Server.Managers
                 ("fellow_kt_killer", new Property<bool>(true, "if FALSE, fellowship kill tasks will share with the fellowship, even if the killer doesn't have the quest")),
                 ("fellow_kt_landblock", new Property<bool>(false, "if TRUE, fellowship kill tasks will share with landblock range (192 distance radius, or entire dungeon)")),
                 ("fellow_quest_bonus", new Property<bool>(false, "if TRUE, applies EvenShare formula to fellowship quest reward XP (300% max bonus, defaults to false in retail)")),
+                ("fix_chest_missing_inventory_window", new Property<bool>(false, "Very non-standard fix. This fixes an acclient bug where unlocking a chest, and then quickly opening it before the client has received the Locked=false update from server can result in the chest opening, but with the chest inventory window not displaying. Bug has a higher chance of appearing with more network latency.")),
                 ("gateway_ties_summonable", new Property<bool>(true, "if disabled, players cannot summon ties from gateways. defaults to enabled, as in retail")),
                 ("house_per_char", new Property<bool>(false, "if TRUE, allows 1 house per char instead of 1 house per account")),
                 ("house_purchase_requirements", new Property<bool>(true, "if disabled, requirements to purchase/rent house are not checked")),

--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -94,6 +94,9 @@ namespace ACE.Server.WorldObjects
 
             if (IsLocked)
             {
+                if (PropertyManager.GetBool("fix_chest_missing_inventory_window").Item)
+                    player.SendTransientError($"The {Name} is locked");
+
                 EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));
                 return new ActivationResult(false);
             }
@@ -218,7 +221,8 @@ namespace ACE.Server.WorldObjects
             if (DefaultLocked && !IsLocked)
             {
                 IsLocked = true;
-                EnqueueBroadcast(new GameMessagePublicUpdatePropertyBool(this, PropertyBool.Locked, IsLocked));
+                if (!PropertyManager.GetBool("fix_chest_missing_inventory_window").Item)
+                    EnqueueBroadcast(new GameMessagePublicUpdatePropertyBool(this, PropertyBool.Locked, IsLocked));
             }
 
             if (IsGenerator)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Networking.cs
@@ -825,7 +825,12 @@ namespace ACE.Server.WorldObjects
             if (WeenieType == WeenieType.Container || WeenieType == WeenieType.Corpse || WeenieType == WeenieType.Chest
                 || WeenieType == WeenieType.Hook || WeenieType == WeenieType.Storage)
             {
-                UpdateObjectDescriptionFlag(ObjectDescriptionFlag.Openable, !IsLocked);
+                var openable = !IsLocked;
+
+                if (WeenieType == WeenieType.Chest && !openable && PropertyManager.GetBool("fix_chest_missing_inventory_window").Item)
+                    openable = true;
+
+                UpdateObjectDescriptionFlag(ObjectDescriptionFlag.Openable, openable);
             }
 
             UpdateObjectDescriptionFlag(ObjectDescriptionFlag.Inscribable, Inscribable);


### PR DESCRIPTION
This is a relatively simple server modification to fix a bug in acclient / odd network protocol. It does some very non-standard things with ObjectDescriptionFlags.Openable for Chests though.

Repro steps:

- Find any locked chest, ie. /teleloc 0xC6A90024 [104.717110 89.921745 42.005001] -0.839618 0.000000 0.000000 -0.543177
- Open network lag simulator https://jagt.github.io/clumsy/, and simulate 500ms of UDP lag
- Appraise chest, confirm it takes ~1s for appraisal window to come up
- Type /crack, press enter, and then immediately press R to open chest (before unlock sound plays)

Expected:
Chest opens, and chest inventory window is displayed

Actual:
Chest opens, but no chest inventory window is displayed. Effectively wastes a key for the player

acclient:

ClientUISystem::OnViewContents:

```
  if ( obj == v9->requestedGroundObject
    && (obj != ACCWeenieObject::prevRequestObjectID || ACCWeenieObject::prevRequest != 4) )
  {
    CM_Item::SendNotice_SetGroundObject(v9->requestedGroundObject);
    ACCWeenieObject::RecordResponse(obj);
  }
```
  
When R is pressed before the unlock sound is heard, requestGroundObject == 0. Normally, this should be the id of the chest, ie. when R is pressed after the unlock sound

Tracing backwards, in ItemHolder::AttemptSetGroundObject:

```
    if ( v2->pwd._bitfield & 1 )
    {
      v5 = ClientUISystem::GetUISystem();
      ClientUISystem::SetGroundObject(v5, _objectID, 1);
      v1 = (ClientUISystem *)1;
    }
    else
    {
      if ( !((int (__thiscall *)(ACCWeenieObject *))v2->vfptr[11].__vecDelDtor)(v2) )
      {
        v4 = ACCWeenieObject::GetObjectNameWide(v2, &result, NAME_APPROPRIATE, 0);
        PStringBase<unsigned short>::PStringBase<unsigned short>(&errorText, 0, L"The %s is locked", v4->m_charbuffer);
        PStringBase<char>::~PStringBase<char>((CaseInsensitiveStringBase<PStringBase<char> > *)&result);
        StringInfo::StringInfo(&siError);
        StringInfo::SetLiteralValue(&siError, &errorText, 1);
        ECM_UI::SendNotice_DisplayStringInfo(0x1Au, &siError);
        StringInfo::~StringInfo(&siError);
        PStringBase<char>::~PStringBase<char>((CaseInsensitiveStringBase<PStringBase<char> > *)&errorText);
      }
      v1 = 0;
    }
```

pwd._bitfield & 1 is ObjectDescriptionFlags.Openable. If the chest is locked, the client automatically displays the message "The chest is locked", but then continues to send the request to the server to open the chest (presumably so the server can play the 'locked' sound)

This bug happens in the small window of time when there is a state difference for PropertyBool.IsLocked for the chest, between the client and the server. After the server has sent PropertyBool.IsLocked=false, but before the client has received it. If the client still thinks the chest is locked, but then the request to open it on the server succeeds (server state is unlocked, unlock state not yet received by client), it results in this bug.

Tracing the usage of ObjectDescriptionFlags.Openable in acclient, I haven't seen it used for much directly, aside from displaying this message automatically on the client. The client automatically updates its version of ObjectDescriptionFlags.Openable when it receives a PropertyBool.IsLocked update from the server, so that has been suppressed. However, when appraising the chest, it still correctly shows the 'Locked' status message, as PropertyBool.IsLocked can still be sent in the Appraisal properties, without the client updating the ObjectDescriptionFlags.

I have seen no anomalies from this patch yet. The only issue is that it goes off course for ObjectDescriptionFlags.Openable for chests. Other than that, I have seen no side effects in-game yet.

This is a non-standard server option, and not recommended generally.