### PR TITLE
fixing 'prismatic damage' message

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -160,11 +160,11 @@ namespace ACE.Server.Entity
             Attacker = attacker;
             Defender = defender;
 
-            CombatType = damageSource.ProjectileSource == null ? attacker.GetCombatType() : CombatType.Missile;
+            CombatType = damageSource.ProjectileSource == null ? CombatType.Melee : CombatType.Missile;
 
             DamageSource = damageSource;
 
-            Weapon = damageSource.ProjectileSource == null ? attacker.GetEquippedWeapon() : damageSource.ProjectileLauncher;
+            Weapon = damageSource.ProjectileSource == null ? attacker.GetEquippedMeleeWeapon() : damageSource.ProjectileLauncher;
 
             AttackType = attacker.AttackType;
             AttackHeight = attacker.AttackHeight ?? AttackHeight.Medium;
@@ -338,9 +338,9 @@ namespace ACE.Server.Entity
 
             EffectiveAttackSkill = attacker.GetEffectiveAttackSkill();
 
-            var attackType = attacker.GetCombatType();
+            //var attackType = attacker.GetCombatType();
 
-            EffectiveDefenseSkill = defender.GetEffectiveDefenseSkill(attackType);
+            EffectiveDefenseSkill = defender.GetEffectiveDefenseSkill(CombatType);
 
             var evadeChance = 1.0f - SkillCheck.GetSkillChance(EffectiveAttackSkill, EffectiveDefenseSkill);
             return (float)evadeChance;
@@ -365,7 +365,7 @@ namespace ACE.Server.Entity
                 }
             }
             else
-                DamageType = attacker.GetDamageType();
+                DamageType = attacker.GetDamageType(false, CombatType.Melee);
 
             // TODO: combat maneuvers for player?
             BaseDamageMod = attacker.GetBaseDamageMod(DamageSource);

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -105,6 +105,7 @@ namespace ACE.Server.WorldObjects
 
         public override CombatType GetCombatType()
         {
+            // this is an unsafe function, move away from this
             var weapon = GetEquippedWeapon();
 
             if (weapon == null || weapon.CurrentWieldedLocation != EquipMask.MissileWeapon)


### PR DESCRIPTION
Repro steps:

- Equip an elemental bow, and prismatic arrows
- Stand within melee range of target creature
- Start charging accuracy bar (setting to max makes it easier)
- While accuracy bar is charging up, swap to a different bow

Expected:

Client does some silliness here, instead of cancelling the attack, it starts stance swapping to change bows, and then does a melee attack in the middle of the stance swap. This happened in retail too, should be a normal melee attack

Actual:

Same thing happens on client, it sends accuracy bar charge up as power bar charge up / melee attack to server, but server was interpreting this as a missile attack w/ prismatic damage, based on the player wielding a bow (even though it sends as melee attack)

The source of this bug is in the GetCombatType() function. It is determining the CombatType of the physical attack by whether or not the player is currently wielding a missile weapon. This is an unsafe function.

The first thought would be to simply change this to the CombatMode of the player, however this needs to persist the state of the original attack. If I launch an arrow from far away, and then switch to melee or non-combat, it still needs to be interpreted as a missile attack when the arrow finally hits target

GetCombatType() was only being called for melee attacks in some places, ie. when ProjectileSource == null. I was wondering why this is, I think it was because GetCombatType() was the original function, and the ProjectileSource for missile attacks was a concept added to the codebase much later

The move away from GetCombatType() was added in the most significant places in DamageEvent to fix this bug, and start moving away from that function. However, there are still some other less significant places in the code that still call GetCombatType()... there aren't many, but this function should be eliminated completely eventually.

Tested with bow/arrows, atlatls, and thrown weapons... thrown weaps still have ProjectileLauncher set as the thrown weapon, so only finding melee weapons when that is null seems to work for all of these weapon types

Thanks to Spigot for reporting this issue!
