### PR TITLE
fix edge cases for player missile 'out of range' check succeeding, but actual velocity calc failing

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -185,6 +185,17 @@ namespace ACE.Server.WorldObjects
 
             //Console.WriteLine($"Velocity: {velocity}");
 
+            if (velocity == Vector3.Zero)
+            {
+                // pre-check succeeded, but actual velocity calculation failed
+                SendWeenieError(WeenieError.MissileOutOfRange);
+
+                // this prevents the accuracy bar from refilling when 'repeat attacks' is enabled
+                Attacking = false;
+                OnAttackDone();
+                return;
+            }
+
             var actionChain = new ActionChain();
             var launchTime = EnqueueMotion(actionChain, aimLevel);
 


### PR DESCRIPTION
Repro steps:

In Player_Missile.cs, line 152, comment out the following block of code:

```
            if (!TargetInRange(target))
            {
                // this must also be sent to actually display the transient message
                SendWeenieError(WeenieError.MissileOutOfRange);

                // this prevents the accuracy bar from refilling when 'repeat attacks' is enabled
                OnAttackDone();

                return;
            }
```

/create drudgewoodtarget, and then run away, so it is on the very edge of radar range
disable the 'fast missiles' character option
launch some arrows at it, then repeatedly take a few steps backwards, repeating
eventually you should find a point where the player stops aiming way up high, and instead aims very low, and launches an arrow into the ground

there are some edge cases where the 'TargetInRange' pre-check can succeed, but then the actual velocity calculation fails. In these cases, the inner trajectory functions will return the initialized value of Vector3.Zero, which should never happen for a successful calculation. These cases should also be considered 'out of range'