### PR TITLE
updating /permit logic to be closer to retail by default

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -517,6 +517,7 @@ namespace ACE.Server.Managers
                 ("loot_quality_mod", new Property<bool>(true, "if FALSE then the loot quality modifier of a Death Treasure profile does not affect loot generation")),
                 ("npc_hairstyle_fullrange", new Property<bool>(false, "if TRUE, allows generated creatures to use full range of hairstyles. Retail only allowed first nine (0-8) out of 51")),
                 ("override_encounter_spawn_rates", new Property<bool>(false, "if enabled, landblock encounter spawns are overidden by double properties below.")),
+                ("permit_corpse_all", new Property<bool>(false, "If TRUE, /permit grants permittees access to all corpses of the permitter. Defaults to FALSE as per retail, where /permit only grants access to 1 locked corpse")),
                 ("player_config_command", new Property<bool>(false, "If enabled, players can use /config to change their settings via text commands")),
                 ("player_receive_immediate_save", new Property<bool>(false, "if enabled, when the player receives items from an NPC, they will be saved immediately")),
                 ("pk_server", new Property<bool>(false, "set this to TRUE for darktide servers")),

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -137,6 +137,16 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
+        /// When a permittee opens a locked corpse of a permitter,
+        /// the permitter is removed from the permittee's LootPermissions table by default, as per retail only allowing them to open 1 locked corpse
+        /// however, the permittee still has access to repeatedly open/close this corpse
+        /// Player corpses only become available to all after the corpse owner opens/closes, and not after permittees open/close
+        /// with this combination of factors, a table is required here to keep track of which permittees opened a permitter's locked corpse,
+        /// so they can repeatedly open/close it
+        /// </summary>
+        private HashSet<uint> permitteeOpened = null;
+
+        /// <summary>
         /// Returns TRUE if input player has permission to loot this corpse
         /// </summary>
         public bool HasPermission(Player player)
@@ -149,8 +159,29 @@ namespace ACE.Server.WorldObjects
             if (KillerId != null && player.Guid.Full == KillerId || IsLooted && !CorpseGeneratedRare)
                 return true;
 
+            var victimGuid = new ObjectGuid(VictimId.Value);
+
             // players can /permit other players to loot their corpse if not killed by another player killer.
-            if (player.HasLootPermission(new ObjectGuid(VictimId.Value)) && PkLevel != PKLevel.PK)
+            if (player.HasLootPermission(victimGuid) && PkLevel != PKLevel.PK)
+            {
+                if (!PropertyManager.GetBool("permit_corpse_all").Item)
+                {
+                    // this is the retail default. see the comments for 'permitteeOpened' for an explanation of why this table is needed
+                    if (permitteeOpened == null)
+                        permitteeOpened = new HashSet<uint>();
+
+                    // these are technically side effects, and HasPermission() is not the best place for this logic to mutate state,
+                    // however with the current lone calling pattern for corpse ActOnUse -> TryOpen -> HasPermission -> Open
+                    // if HasPermission returns true, the corpse is always opened, ie. there's no chance of 'the corpse is already in use' or any other failure cases,
+                    // as those pre-verifications have already happened before this function is called
+
+                    permitteeOpened.Add(player.Guid.Full);
+
+                    player.LootPermission.Remove(victimGuid);
+                }
+                return true;
+            }
+            if (permitteeOpened != null && permitteeOpened.Contains(player.Guid.Full))
                 return true;
 
             // all players can loot monster corpses after 1/2 decay time except if corpse generates a rare
@@ -167,7 +198,7 @@ namespace ACE.Server.WorldObjects
             return false;
         }
 
-        public bool IsLooted;
+        public bool IsLooted { get; set; }
 
         /// <summary>
         /// The number of seconds before all players can loot a monster corpse
@@ -179,8 +210,23 @@ namespace ACE.Server.WorldObjects
         {
             base.Close(player);
 
-            if (VictimId != null && !new ObjectGuid(VictimId.Value).IsPlayer())
+            if (VictimId == null)
+                return;
+
+            var victimGuid = new ObjectGuid(VictimId.Value);
+
+            if (!victimGuid.IsPlayer())
+            {
+                // monster corpses -- after anyone with access to the locked corpse loots,
+                // becomes open to anyone? or only after the killer loots?
                 IsLooted = true;
+            }
+            else
+            {
+                // player corpses -- after corpse owner loots, becomes open to anyone?
+                if (player.Guid == victimGuid)
+                    IsLooted = true;
+            }
         }
 
         public bool CorpseGeneratedRare


### PR DESCRIPTION
Currently in ACE, when a player uses /permit to grant access to another player to loot their corpse, this permission remains in effect until it automatically expires after 1 hour, the permitter removes the permission, or the permittee logs out.

In retail, after the permittee opened a locked corpse of the permitter, their permission for other locked corpses of the permitter was revoked at that point.

There are a few details with this, thank you very much to the community for having a discussion about this in Discord for figuring out the details:

- When a permittee opens/closes the locked corpse of a permitter, the corpse does not become available for anyone to access afterwards. Thus, it differs from the corpse owner opening/closing their corpse in this way. When a corpse owner opens/closes their corpse, it is then available for anyone to open afterwards.

- However, when a permittee opens/closes a locked corpse of a permitter, even though the permitter is then removed from the permittee's LootPermissions table, the permittee still has access to repeatedly open/close the corpse they gained access to. With this combination of factors, the 'permitteeOpened' table was added to Corpse

- The LootPermissions table remains stored on the permittees, same as it was before in ACE, which matches retail. If the permitter logs out, the permittee continues to have access to open 1 locked corpse. If the permittee logs out, they lose their granted permissions, same as in retail. Reference: http://acpedia.org/wiki/Death_and_Corpse_Commands

A new server option has also been added, permit_corpse_all, which defaults to false, as per retail. If the server operator wishes to restore previous behavior in ACE, where /permit grants access to all corpses instead of 1 corpse, this can be optionally set to True.

This PR also adds some logic that was possibly missing to Corpse.Close() for player corpses. After a corpse owner loots their own corpse (opener == victimId), the corpse should then supposedly become available for anyone to open afterwards.

TODO: when LootPermissions expires, a message was sent to the permittee that they no longer have access to loot the corpses of permitter. This would require some kind of LootPermissions_Heartbeat on the permittees. Find out if this message was sent only if the permissions expired naturally, or if it was also sent after successfully opening a permitted corpse.

This PR was tested programmatically via unit testing