### PR TITLE
replacing MapScope concept with Indoors to fix Ancient Caves dungeon... MapScope wasn't a thing, afaik

### DIFF
--- a/Source/ACE.Entity/LandblockId.cs
+++ b/Source/ACE.Entity/LandblockId.cs
@@ -48,7 +48,23 @@ namespace ACE.Entity
 
         public byte LandcellY => Convert.ToByte(Landcell & 0x7);
 
-        public MapScope MapScope => (MapScope)((Raw & 0x0F00) >> 8);
+        // not sure where this logic came from, i don't think MapScope.IndoorsSmall and MapScope.IndoorsLarge was a thing?
+        //public MapScope MapScope => (MapScope)((Raw & 0x0F00) >> 8);
+        public MapScope MapScope
+        {
+            // TODO: port the updated version of Position and Landblock from Instancing branch, get rid of this MapScope thing..
+            get
+            {
+                var cell = Raw & 0xFFFF;
+
+                if (cell < 0x100)
+                    return MapScope.Outdoors;
+                else if (cell < 0x200)
+                    return MapScope.IndoorsSmall;
+                else
+                    return MapScope.IndoorsLarge;
+            }
+        }
 
         public static bool operator ==(LandblockId c1, LandblockId c2)
         {

--- a/Source/ACE.Entity/LandblockId.cs
+++ b/Source/ACE.Entity/LandblockId.cs
@@ -50,7 +50,9 @@ namespace ACE.Entity
 
         // not sure where this logic came from, i don't think MapScope.IndoorsSmall and MapScope.IndoorsLarge was a thing?
         //public MapScope MapScope => (MapScope)((Raw & 0x0F00) >> 8);
-        public MapScope MapScope
+
+        // just nuking this now, keeping this code here for reference
+        /*public MapScope MapScope
         {
             // TODO: port the updated version of Position and Landblock from Instancing branch, get rid of this MapScope thing..
             get
@@ -64,7 +66,9 @@ namespace ACE.Entity
                 else
                     return MapScope.IndoorsLarge;
             }
-        }
+        }*/
+
+        public bool Indoors => (Raw & 0xFFFF) >= 0x100;
 
         public static bool operator ==(LandblockId c1, LandblockId c2)
         {

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -72,7 +72,7 @@ namespace ACE.Entity
         public float RotationY { get; set; }
         public float RotationZ { get; set; }
 
-        public bool Indoors => landblockId.MapScope != MapScope.Outdoors;
+        public bool Indoors => landblockId.Indoors;
 
         /// <summary>
         /// Returns the normalized 2D heading direction


### PR DESCRIPTION
good loc:
0x00D10FFF [231.740707 -69.822220 -5.995000] 0.666223 0.000000 0.000000 -0.745753

bad loc:
0x00D1101E [240.058197 -69.525620 -5.995000] 0.989331 0.000000 0.000000 0.145685