### PR TITLE
Fix Exception in Allegiance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Allegiance.cs
@@ -100,7 +100,6 @@ namespace ACE.Server.WorldObjects
         {
             //Console.WriteLine($"Allegiance({monarch}): monarch constructor");
 
-            InitializePropertyDictionaries();
             Init(monarch);
         }
 


### PR DESCRIPTION
based on the stack trace provided, this should resolve the issue.

I don't really understand how this ctor works.
 public Allegiance(ObjectGuid monarch)
typically when you ctor a WorldObject, the base() needs to be called.