### PR TITLE
fix a bug with Proficiency and negative timeDiff if server clock goes back in time

### DIFF
--- a/Source/ACE.Server/Entity/Proficiency.cs
+++ b/Source/ACE.Server/Entity/Proficiency.cs
@@ -71,7 +71,7 @@ namespace ACE.Server.Entity
 
                 if (totalXPGranted > 10000)
                 {
-                    log.Warn($"Proficiency.OnSuccessUse({player.Name}, {skill.Skill}, {difficulty}) - totalXPGranted: {totalXPGranted}");
+                    log.Warn($"Proficiency.OnSuccessUse({player.Name}, {skill.Skill}, {difficulty}) - totalXPGranted: {totalXPGranted:N0}");
                 }
 
                 var maxLevel = Player.GetMaxLevel();


### PR DESCRIPTION
This fixes https://github.com/ACEmulator/ACE/issues/3152

timeScale becomes negative, eventually gets cast to a uint