### PR TITLE
updating GetXPMod() to handle both additive and multiplicative enchantments, adding GetXPAndLuminanceModifier() to apply enchantments and augmentations properly to both XP and luminance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -192,10 +192,6 @@ namespace ACE.Server.WorldObjects
 
                 var totalXP = (XpOverride ?? 0) * damagePercent;
 
-                // should this be passed upstream to fellowship / allegiance?
-                if (playerDamager.AugmentationBonusXp > 0)
-                    totalXP *= 1.0f + playerDamager.AugmentationBonusXp * 0.05f;
-
                 playerDamager.EarnXP((long)Math.Round(totalXP), XpType.Kill);
 
                 // handle luminance

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -682,18 +682,23 @@ namespace ACE.Server.WorldObjects.Managers
         }
 
         /// <summary>
-        /// Returns the modifier from XP enchantments, such as Augmented Understanding
+        /// Returns the additive bonus from XP enchantments, such as Augmented Understanding
         /// </summary>
-        /// <returns></returns>
-        public virtual float GetXPMod()
+        public virtual float GetXPBonus()
         {
             var enchantments = GetEnchantments(SpellCategory.TrinketXPRaising);
 
-            // multiplier
-            var modifier = 1.0f;
-            foreach (var enchantment in enchantments)
-                modifier *= enchantment.StatModValue;
+            // TODO: temporary code to handle both additive and multiplicative mods
+            // should be additive in database, update when everything is in sync
+            var modifier = 0.0f;
 
+            foreach (var enchantment in enchantments)
+            {
+                if (enchantment.StatModType.HasFlag(EnchantmentTypeFlags.Multiplicative))
+                    modifier += enchantment.StatModValue - 1.0f;
+                else
+                    modifier += enchantment.StatModValue;
+            }
             return modifier;
         }
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -169,7 +169,7 @@ namespace ACE.Server.WorldObjects.Managers
             armorModCache = null;
             armorModVsTypeModCache.Clear();
             ratingCache.Clear();
-            xpModCache = null;
+            xpBonusCache = null;
             resistLockpickCache = null;
         }
 
@@ -506,14 +506,14 @@ namespace ACE.Server.WorldObjects.Managers
             return value;
         }
 
-        private float? xpModCache;
+        private float? xpBonusCache;
 
-        public override float GetXPMod()
+        public override float GetXPBonus()
         {
-            if (xpModCache == null)
-                xpModCache = base.GetXPMod();
+            if (xpBonusCache == null)
+                xpBonusCache = base.GetXPBonus();
 
-            return xpModCache.Value;
+            return xpBonusCache.Value;
         }
 
         public override bool StartCooldown(WorldObject item)

--- a/Source/ACE.Server/WorldObjects/Player_Luminance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Luminance.cs
@@ -18,7 +18,10 @@ namespace ACE.Server.WorldObjects
 
             var modifier = PropertyManager.GetDouble("luminance_modifier").Item;
 
-            var m_amount = (long)Math.Round(amount * modifier);
+            // should this be passed upstream to fellowship?
+            var enchantment = GetXPAndLuminanceModifier(xpType);
+
+            var m_amount = (long)Math.Round(amount * enchantment * modifier);
 
             GrantLuminance(m_amount, xpType, shareType);
         }

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -483,7 +483,7 @@ namespace ACE.Server.WorldObjects
                 augBonus = AugmentationBonusXp * 0.05f;
 
             var modifier = 1.0f + enchantmentBonus + augBonus;
-            Console.WriteLine($"XPAndLuminanceModifier: {modifier}");
+            //Console.WriteLine($"XPAndLuminanceModifier: {modifier}");
 
             return modifier;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -25,7 +25,9 @@ namespace ACE.Server.WorldObjects
 
             // apply xp modifier
             var modifier = PropertyManager.GetDouble("xp_modifier").Item;
-            var enchantment = EnchantmentManager.GetXPMod();
+
+            // should this be passed upstream to fellowship / allegiance?
+            var enchantment = GetXPAndLuminanceModifier(xpType);
 
             var m_amount = (long)Math.Round(amount * enchantment * modifier);
 
@@ -467,6 +469,23 @@ namespace ACE.Server.WorldObjects
                 });
                 actionChain.EnqueueChain();
             }
+        }
+
+        /// <summary>
+        /// Returns the multiplier to XP and Luminance from Trinkets and Augmentations
+        /// </summary>
+        public float GetXPAndLuminanceModifier(XpType xpType)
+        {
+            var enchantmentBonus = EnchantmentManager.GetXPBonus();
+
+            var augBonus = 0.0f;
+            if (xpType == XpType.Kill && AugmentationBonusXp > 0)
+                augBonus = AugmentationBonusXp * 0.05f;
+
+            var modifier = 1.0f + enchantmentBonus + augBonus;
+            Console.WriteLine($"XPAndLuminanceModifier: {modifier}");
+
+            return modifier;
         }
     }
 }


### PR DESCRIPTION
support has been added to EnchantmentManager.GetXPMod() to handle both additive and multiplicative mods. Augmented Understanding 1-3 should be additive mods in the database, however transitioning everyone over to additive mods will be a multi-step process, to ensure if theres any people updating their servers slowly, or any people updating just 1 of either their database or the codebase, but not the other, are handled as best as possible.

EnchantmentManager.GetXPMod() has been renamed to GetXPBonus(), to more accurately reflect that it is now returning an additive bonus (0-based), instead of a multiplicative modifier (1-based)

A common function has been added, GetXPAndLuminanceModifier(), that returns the multiplier to XP and Luminance from enchantments (trinkets w/ augmented understanding) and augmentations (AugmentationBonusXP). The existing profile of AugmentationBonusXP has been kept, where it only applies to XP earned via hunting / killing creatures, as per the aug description. Both XP and Luminance now call this common function.

The augmentation logic was previously in the Creature_Death DamageHistory iterator, presumably as it was clearer to do it in there, since it only applied to XpType.Kill. However, this caused issues downstream for combining that multiplier with another multiplier, where it should have been an additive combine.

The note in the comments regarding passing XP and Luminance bonuses upstream to fellowships and potentially allegiances has been kept, so that readers of the code are aware of these aspects, and it can continue to be reviewed. This part should remain unchanged from current ACE functionality for XP. For Luminance, the enchantment/aug bonus works the same way as XP in ACE currently, ie. the bonuses from those sources will be passed upstream to fellowships.

The database update for Augmented Understanding 1-3 is purposefully being held back for a small amount of time, to avoid a situation where someone could update their database, but not their codebase. Waiting for most people to update their codebase first, as this version of the code handles both versions of the database properly.