### PR TITLE
matching mattekar claw damage types up to retail

### DIFF
--- a/Source/ACE.Entity/Enum/DamageType.cs
+++ b/Source/ACE.Entity/Enum/DamageType.cs
@@ -20,7 +20,11 @@ namespace ACE.Entity.Enum
         Stamina     = 0x100,
         Mana        = 0x200,
         Nether      = 0x400,
-        Base        = 0x10000000
+        Base        = 0x10000000,
+
+        // helpers
+        Physical    = Slash | Pierce | Bludgeon,
+        Elemental   = Cold | Fire | Acid | Electric,
     };
 
     public static class DamageTypeExtensions
@@ -52,13 +56,21 @@ namespace ACE.Entity.Enum
             return EnumHelper.HasMultiple((uint)damageType);
         }
 
-        public static DamageType SelectDamageType(this DamageType damageType)
+        public static DamageType SelectDamageType(this DamageType damageType, float? powerLevel = null)
         {
-            var damageTypes = EnumHelper.GetFlags(damageType);
+            if (powerLevel == null)
+            {
+                // select random damage type
+                var damageTypes = EnumHelper.GetFlags(damageType);
 
-            var rng = ThreadSafeRandom.Next(1, damageTypes.Count - 1);
+                var rng = ThreadSafeRandom.Next(1, damageTypes.Count - 1);
 
-            return (DamageType)damageTypes[rng];
+                return (DamageType)damageTypes[rng];
+            }
+
+            var playerTypes = powerLevel < 0.33f ? damageType & DamageType.Physical : damageType & ~DamageType.Physical;
+
+            return playerTypes.SelectDamageType();
         }
     }
 }

--- a/Source/ACE.Entity/Enum/DamageType.cs
+++ b/Source/ACE.Entity/Enum/DamageType.cs
@@ -70,6 +70,9 @@ namespace ACE.Entity.Enum
 
             var playerTypes = powerLevel < 0.33f ? damageType & DamageType.Physical : damageType & ~DamageType.Physical;
 
+            if (playerTypes == DamageType.Undef)
+                playerTypes = damageType;
+
             return playerTypes.SelectDamageType();
         }
     }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -1044,7 +1044,9 @@ namespace ACE.Server.WorldObjects
                     return DamageType.Slash;
             }
 
-            return damageType.SelectDamageType();
+            var powerLevel = combatType == CombatType.Melee ? (float?)PowerLevel : null;
+
+            return damageType.SelectDamageType(powerLevel);
         }
 
         public WorldObject HandArmor => EquippedObjects.Values.FirstOrDefault(i => (i.ClothingPriority & CoverageMask.Hands) > 0);


### PR DESCRIPTION
Currently in ACE, when either a weapon or a monster body part contains multiple DamageTypes, a random damage type is selected for each swing. An example of one of these weapons would be 9420 - Mattekar Claw.

In retail, the DamageType for the Mattekar Claw was tied to the PowerLevel of the swing, and worked similarly to Piercing/Slash weapons. When the power slider was set < 33%, a thrust would be performed w/ Piercing damage. Anything greater would be a Slashing attack.

For monsters, they always attack with PowerLevel = 0.5 simulated, as per retail. So to retain the existing ability for a monster body part with multiple DamageTypes, the existing RNG logic for monsters is kept the same.

For players, instead of adding a special case specifically for Slashing | Fire for the Mattekar Claw, general logic has been added to make this work with any combination. So if someone decides to add custom content with a Bludgeoning | Cold hammer or whatever in the future, it will work the same way. The pool of potential DamageTypes is split between Physical for < 33%, and Elemental / Non-Physical for above.