### PR TITLE
add void damage modifier for player targets from retail

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -584,6 +584,7 @@ namespace ACE.Server.Managers
                 ("vendor_unique_rot_time", new Property<double>(300, "the number of seconds before unique items sold to vendors disappear")),
                 ("vitae_penalty", new Property<double>(0.05, "the amount of vitae penalty a player gets per death")),
                 ("vitae_penalty_max", new Property<double>(0.40, "the maximum vitae penalty a player can have")),
+                ("void_pvp_modifier", new Property<double>(0.5, "Scales the amount of damage players take from Void Magic. Defaults to 0.5, as per retail. For earlier content where DRR isn't as readily available, this can be adjusted for balance.")),
                 ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players"))
                 );
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1286,7 +1286,7 @@ namespace ACE.Server.WorldObjects.Managers
                 // Creatures under Asheron’s protection take half damage from any nether type spell.
 
                 if (targetPlayer != null && damageType == DamageType.Nether)
-                    tickAmount *= 0.5f;
+                    tickAmount *= (float)PropertyManager.GetDouble("void_pvp_modifier").Item;
 
                 // make sure the target's current health is not exceeded
                 if (tickAmountTotal + tickAmount >= creature.Health.Current)

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1262,7 +1262,8 @@ namespace ACE.Server.WorldObjects.Managers
                 }
 
                 // if a PKType with Enduring Enchantment has died, ensure they don't continue to take DoT from PK sources
-                if (WorldObject is Player _player && damager is Player && !_player.IsPKType)
+                var targetPlayer = WorldObject as Player;
+                if (targetPlayer != null && damager is Player && !targetPlayer.IsPKType)
                     continue;
 
                 // get damage / damage resistance rating here for now?
@@ -1280,6 +1281,12 @@ namespace ACE.Server.WorldObjects.Managers
                 //Console.WriteLine("NRR: " + Creature.NegativeModToRating(netherResistRatingMod));
 
                 tickAmount *= damageRatingMod * damageResistRatingMod * dotResistRatingMod;
+
+                // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
+                // Creatures under Asheron’s protection take half damage from any nether type spell.
+
+                if (targetPlayer != null && damageType == DamageType.Nether)
+                    tickAmount *= 0.5f;
 
                 // make sure the target's current health is not exceeded
                 if (tickAmountTotal + tickAmount >= creature.Health.Current)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -507,6 +507,15 @@ namespace ACE.Server.WorldObjects
                 finalDamage = baseDamage + critDamageBonus + skillBonus;
 
                 finalDamage *= elementalDamageMod * slayerMod * resistanceMod * absorbMod;
+
+                // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
+                // Creatures under Asheron’s protection take half damage from any nether type spell.
+
+                // applies to baseDamage, critDamageBonus, and skillBonus, as they are all derived from MinDamage / MaxDamage
+                // verified this is equivalent to doing the halving for the individual factors
+
+                if (targetPlayer != null && Spell.School == MagicSchool.VoidMagic)
+                    finalDamage *= 0.5f;    
             }
 
             // show debug info

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -515,7 +515,7 @@ namespace ACE.Server.WorldObjects
                 // verified this is equivalent to doing the halving for the individual factors
 
                 if (targetPlayer != null && Spell.School == MagicSchool.VoidMagic)
-                    finalDamage *= 0.5f;    
+                    finalDamage *= (float)PropertyManager.GetDouble("void_pvp_modifier").Item;
             }
 
             // show debug info


### PR DESCRIPTION
http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21

"Creatures under Asheron’s protection take half damage from any nether type spell."

I probably skimmed over this when originally researching Void Magic, and it didn't click with me that "creatures under Asheron's protection" meant "players". I might have misinterpreted as Lifestone Protection or something..