### PR TITLE
add slayerMod to void dot tick calculation

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1262,7 +1262,8 @@ namespace ACE.Server.WorldObjects.Managers
                 }
 
                 // if a PKType with Enduring Enchantment has died, ensure they don't continue to take DoT from PK sources
-                if (WorldObject is Player _player && damager is Player && !_player.IsPKType)
+                var targetPlayer = WorldObject as Player;
+                if (targetPlayer != null && damager is Player && !targetPlayer.IsPKType)
                     continue;
 
                 // get damage / damage resistance rating here for now?
@@ -1280,6 +1281,12 @@ namespace ACE.Server.WorldObjects.Managers
                 //Console.WriteLine("NRR: " + Creature.NegativeModToRating(netherResistRatingMod));
 
                 tickAmount *= damageRatingMod * damageResistRatingMod * dotResistRatingMod;
+
+                // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
+                // Creatures under Asheron’s protection take half damage from any nether type spell.
+
+                if (targetPlayer != null && damageType == DamageType.Nether)
+                    tickAmount *= 0.5f;
 
                 // make sure the target's current health is not exceeded
                 if (tickAmountTotal + tickAmount >= creature.Health.Current)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -507,6 +507,15 @@ namespace ACE.Server.WorldObjects
                 finalDamage = baseDamage + critDamageBonus + skillBonus;
 
                 finalDamage *= elementalDamageMod * slayerMod * resistanceMod * absorbMod;
+
+                // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
+                // Creatures under Asheron’s protection take half damage from any nether type spell.
+
+                // applies to baseDamage, critDamageBonus, and skillBonus, as they are all derived from MinDamage / MaxDamage
+                // verified this is equivalent to doing the halving for the individual factors
+
+                if (targetPlayer != null && Spell.School == MagicSchool.VoidMagic)
+                    finalDamage *= 0.5f;    
             }
 
             // show debug info


### PR DESCRIPTION
weeping wand supposedly boosted void dot ticks in pvp

dirty fighting bleed dots were supposedly unaffected by any slayer properties on the weapon