### PR TITLE
add verification for AugmentationCost

### DIFF
--- a/Source/ACE.Server/WorldObjects/AugmentationDevice.cs
+++ b/Source/ACE.Server/WorldObjects/AugmentationDevice.cs
@@ -141,6 +141,12 @@ namespace ACE.Server.WorldObjects
             var availableXP = player.AvailableExperience ?? 0;
             var augCost = AugmentationCost ?? 0;
 
+            if (AugmentationCost == null)
+            {
+                player.EnqueueBroadcast(new GameMessageSystemChat($"{Name} is missing AugmentationCost", ChatMessageType.System));
+                return false;
+            }
+
             if (availableXP < augCost)
             {
                 player.SendWeenieError(WeenieError.AugmentationNotEnoughExperience);


### PR DESCRIPTION
AugmentationDevice.VerifyRequirements() was using AugmentationCost ?? 0, and the rest of the functions were using AugmentationCost directly

This had the effect of letting an AugmentationDevice w/ missing/bad data go through, resulting in undefined behavior afterwards, such as setting AvailableExperience to null

Adding check to AugmentationDevice.VerifyRequirements() to ensure AugmentationCost is not null