### PR TITLE
fix exception when giving mana to an item w/ ItemMaxMana, but not ItemCurMana

### DIFF
--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -86,7 +86,7 @@ namespace ACE.Server.WorldObjects
                         useResult = WeenieError.ActionCancelled;
                     else
                     {
-                        if (!target.DeleteObject(player))
+                        if (!player.TryConsumeFromInventoryWithNetworking(target) && !player.TryDequipObjectWithNetworking(target.Guid, out _, Player.DequipObjectAction.ConsumeItem))
                         {
                             log.Error($"Failed to remove {target.Name} from player inventory.");
                             player.Session.Network.EnqueueSend(new GameEventUseDone(player.Session, WeenieError.ActionCancelled));

--- a/Source/ACE.Server/WorldObjects/ManaStone.cs
+++ b/Source/ACE.Server/WorldObjects/ManaStone.cs
@@ -176,7 +176,9 @@ namespace ACE.Server.WorldObjects
                 }
                 else if (target.ItemMaxMana.HasValue && target.ItemMaxMana.Value > 0)
                 {
-                    if (target.ItemCurMana.Value >= target.ItemMaxMana.Value)
+                    var targetItemCurMana = target.ItemCurMana ?? 0;
+
+                    if (targetItemCurMana >= target.ItemMaxMana)
                     {
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"The {target.Name} is already full of mana.", ChatMessageType.Broadcast));
                     }
@@ -186,9 +188,9 @@ namespace ACE.Server.WorldObjects
 
                         // The Mana Stone gives 3,267 points of mana to the Protective Drudge Charm.
 
-                        var targetManaNeeded = target.ItemCurMana.HasValue ? (target.ItemMaxMana.Value - target.ItemCurMana.Value) : target.ItemMaxMana.Value;
+                        var targetManaNeeded = target.ItemMaxMana.Value - targetItemCurMana;
                         var manaToPour = Math.Min(targetManaNeeded, ItemCurMana.Value);
-                        target.ItemCurMana += manaToPour;
+                        target.ItemCurMana = targetItemCurMana + manaToPour;
                         var msg = $"The Mana Stone gives {manaToPour:N0} points of mana to the {target.Name}.";
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
@@ -148,24 +148,24 @@ namespace ACE.Server.WorldObjects
 
         public bool DeleteObject(Container rootOwner = null)
         {
-            var result = false;
+            var success = false;
 
             if (Wielder != null)
             {
                 if (Wielder is Player player)
-                    result = player.TryDequipObjectWithNetworking(Guid, out _, Player.DequipObjectAction.ConsumeItem);
+                    success = player.TryDequipObjectWithNetworking(Guid, out _, Player.DequipObjectAction.ConsumeItem);
                 else if (Wielder is Creature creature)
-                    result = creature.TryUnwieldObjectWithBroadcasting(Guid, out _, out _);
+                    success = creature.TryUnwieldObjectWithBroadcasting(Guid, out _, out _);
             }
             else if (rootOwner != null)
             {
                 if (rootOwner is Player player)
-                    result = player.TryRemoveFromInventoryWithNetworking(Guid, out _, Player.RemoveFromInventoryAction.ConsumeItem);
+                    success = player.TryRemoveFromInventoryWithNetworking(Guid, out _, Player.RemoveFromInventoryAction.ConsumeItem);
                 else
-                    result = rootOwner.TryRemoveFromInventory(Guid);
+                    success = rootOwner.TryRemoveFromInventory(Guid);
             }
             Destroy();
-            return result;
+            return success;
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Decay.cs
@@ -146,26 +146,23 @@ namespace ACE.Server.WorldObjects
                 Destroy();
         }
 
-        public bool DeleteObject(Container rootOwner = null)
+        public void DeleteObject(Container rootOwner = null)
         {
-            var success = false;
-
             if (Wielder != null)
             {
                 if (Wielder is Player player)
-                    success = player.TryDequipObjectWithNetworking(Guid, out _, Player.DequipObjectAction.ConsumeItem);
+                    player.TryDequipObjectWithNetworking(Guid, out _, Player.DequipObjectAction.ConsumeItem);
                 else if (Wielder is Creature creature)
-                    success = creature.TryUnwieldObjectWithBroadcasting(Guid, out _, out _);
+                    creature.TryUnwieldObjectWithBroadcasting(Guid, out _, out _);
             }
             else if (rootOwner != null)
             {
                 if (rootOwner is Player player)
-                    success = player.TryRemoveFromInventoryWithNetworking(Guid, out _, Player.RemoveFromInventoryAction.ConsumeItem);
+                    player.TryRemoveFromInventoryWithNetworking(Guid, out _, Player.RemoveFromInventoryAction.ConsumeItem);
                 else
-                    success = rootOwner.TryRemoveFromInventory(Guid);
+                    rootOwner.TryRemoveFromInventory(Guid);
             }
             Destroy();
-            return success;
         }
     }
 }


### PR DESCRIPTION
- /ci 30187
- /ci manastonegreat
- double click mana stone
- click 30187 - Hunter's Crystal

Hunter's Crystal has ItemMaxMana=10000, but ItemCurMana=null

the server gets an exception, although it doesn't crash the server. the player is then locked in perma hourglass state.

the correct behavior from retail needs to be confirmed here. could mana stones give mana to items where ItemMaxMana has value, but ItemCurMana=null?

at the minimum, it shouldn't get an exception / lock player into perma hourglass state..

one thing to note about this, if this was possible in retail, then the current ace logic would then consider the rare to be in the 'potential pool' of items to give mana to afterwards, if the player double clicks a mana stone, and then clicks their character