### PR TITLE
CanScaleQuestMinDelta

### DIFF
--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -54,7 +54,11 @@ namespace ACE.Server.Command.Handlers
                     Console.WriteLine($"Couldn't find quest {playerQuest.QuestName}");
                     continue;
                 }
-                var minDelta = (uint)(quest.MinDelta * PropertyManager.GetDouble("quest_mindelta_rate").Item);
+
+                var minDelta = quest.MinDelta;
+                if (QuestManager.CanScaleQuestMinDelta(quest))
+                    minDelta = (uint)(quest.MinDelta * PropertyManager.GetDouble("quest_mindelta_rate").Item);
+
                 text += $"{playerQuest.QuestName.ToLower()} - {playerQuest.NumTimesCompleted} solves ({playerQuest.LastTimeCompleted})";
                 text += $"\"{quest.Message}\" {quest.MaxSolves} {minDelta}";
 

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -299,6 +299,19 @@ namespace ACE.Server.Managers
         }
 
         /// <summary>
+        /// Some quests we do not want to scale MinDelta if "quest_mindelta_rate" has been set.
+        /// They may be things that are races against time, like Colo
+        /// </summary>
+        /// 
+        public static bool CanScaleQuestMinDelta(Database.Models.World.Quest quest)
+        {
+            if (quest.Name.StartsWith("ColoArena"))
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
         /// Returns the time remaining until the player can solve this quest again
         /// </summary>
         public TimeSpan GetNextSolveTime(string questFormat)
@@ -317,7 +330,12 @@ namespace ACE.Server.Managers
                 return TimeSpan.MaxValue;   // cannot solve this quest again - max solves reached / exceeded
 
             var currentTime = (uint)Time.GetUnixTime();
-            var nextSolveTime = playerQuest.LastTimeCompleted + (uint)(quest.MinDelta * PropertyManager.GetDouble("quest_mindelta_rate", 1).Item);
+            uint nextSolveTime;
+
+            if (CanScaleQuestMinDelta(quest))
+                nextSolveTime = playerQuest.LastTimeCompleted + (uint)(quest.MinDelta * PropertyManager.GetDouble("quest_mindelta_rate", 1).Item);
+            else
+                nextSolveTime = playerQuest.LastTimeCompleted + quest.MinDelta;
 
             if (currentTime >= nextSolveTime)
                 return TimeSpan.MinValue;   // can solve again now - next solve time expired

--- a/Source/ACE.Server/Managers/QuestManager.cs
+++ b/Source/ACE.Server/Managers/QuestManager.cs
@@ -302,7 +302,6 @@ namespace ACE.Server.Managers
         /// Some quests we do not want to scale MinDelta if "quest_mindelta_rate" has been set.
         /// They may be things that are races against time, like Colo
         /// </summary>
-        /// 
         public static bool CanScaleQuestMinDelta(Database.Models.World.Quest quest)
         {
             if (quest.Name.StartsWith("ColoArena"))


### PR DESCRIPTION
This fixes colo on servers where quest_mindelta_rate is not 1.

It allows other quest timers to be scaled, but keeps colo functioning as it did in retail.