### PR TITLE
update cloak proc rate based on player feedback

### DIFF
--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -46,7 +46,7 @@ namespace ACE.Server.Entity
 
             if (itemLevel < 1) return false;
 
-            var maxProcRate = 0.25f + itemLevel * 0.01f;
+            var maxProcRate = 0.25f + (itemLevel - 1) * 0.0125f;
 
             var chance = Math.Min(damage_percent, maxProcRate);
 

--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -9,7 +9,10 @@ namespace ACE.Server.Entity
 {
     public class Cloak
     {
-        private static readonly float ChanceMod = 1.0f;
+        /// <summary>
+        /// The maximum frequency of cloak procs, in seconds
+        /// </summary>
+        private static readonly float MinDelay = 5.0f;
 
         /// <summary>
         /// Rolls for a chance at procing a cloak spell
@@ -33,19 +36,27 @@ namespace ACE.Server.Entity
         public static bool RollProc(WorldObject cloak, float damage_percent)
         {
             // TODO: find retail formula
-            // TODO: cloak level multiplier - Added 6/19/2020 HQ (Still need retail numbers) Updated with Riggs suggestions
+
+            var currentTime = Time.GetUnixTime();
+
+            if (currentTime - cloak.UseTimestamp < MinDelay)
+                return false;
 
             var itemLevel = cloak.ItemLevel ?? 0;
 
-            var chanceMod = ChanceMod + itemLevel * 0.02f;
-            if (itemLevel < 1)
-                chanceMod = 0.0f;
+            var maxProcRate = 0.25f + itemLevel * 0.01f;
 
-            var chance = damage_percent * chanceMod;
+            var chance = Math.Min(damage_percent, maxProcRate);
 
             var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
 
-            return rng < chance;
+            if (rng < chance)
+            {
+                cloak.UseTimestamp = currentTime;
+                return true;
+            }
+            else
+                return false;
         }
 
         /// <summary>

--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -44,6 +44,8 @@ namespace ACE.Server.Entity
 
             var itemLevel = cloak.ItemLevel ?? 0;
 
+            if (itemLevel < 1) return false;
+
             var maxProcRate = 0.25f + itemLevel * 0.01f;
 
             var chance = Math.Min(damage_percent, maxProcRate);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -11,7 +11,7 @@ namespace ACE.Server.WorldObjects
 {
     partial class WorldObject
     {
-        protected double? UseTimestamp
+        public double? UseTimestamp
         {
             get => GetProperty(PropertyFloat.UseTimestamp);
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.UseTimestamp); else SetProperty(PropertyFloat.UseTimestamp, value.Value); }


### PR DESCRIPTION
This is still an 'invented' formula, but is in response to the player feedback about cloak proc rates being too high, esp. for the -200 proc

Here are the #s for the base proc rates for specific damage %s, and the chance of procing for a string of hits for that damage %:

Current proc rates: https://pastebin.com/P6QVFkze

New proc rates (base): https://pastebin.com/LaL6DDUS
New proc rates (level 5 cloak): https://pastebin.com/CAJgzwqX

For strings of low hits, the proc rates were fine. The issue was when the player took high damage, the cloak was procing way too often. The new formula simply adds a cap to the max proc rate. The item level increases this max proc rate

Current scale:

0
1 25%
2 26.25%
3 27.5%
4 28.75%
5 30%

Other scales considered:

0
1 25%
2 27%
3 29%
4 31%
5 33%

0
1 20%
2 22.5%
3 25%
4 27.5%
5 30%

From testing, 33% seems like it would be a bit too high, and 20% seems like it would be a bit too low. I like the idea of a higher variance between cloak levels, however while 25-30% might seem like a small variance, the difference should be noticeable especially for the higher damage hits.