### PR TITLE
update equipment ratings to Gear* properties

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Rating.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Rating.cs
@@ -196,7 +196,7 @@ namespace ACE.Server.WorldObjects
 
             // equipment ratings
             // TODO: caching?
-            var equipment = EquippedObjects.Values.Sum(i => i.DamageRating ?? 0);
+            var equipment = EquippedObjects.Values.Sum(i => i.GearDamage ?? 0);
 
             // weakness as negative damage rating?
             // TODO: this should be factored in as a separate weakness rating...
@@ -225,7 +225,7 @@ namespace ACE.Server.WorldObjects
 
             // equipment ratings
             // TODO: caching?
-            var equipment = EquippedObjects.Values.Sum(i => i.DamageResistRating ?? 0);
+            var equipment = EquippedObjects.Values.Sum(i => i.GearDamageResist ?? 0);
 
             // nether DoTs as negative DRR?
             // TODO: this should be factored in as a separate nether damage rating...
@@ -282,13 +282,17 @@ namespace ACE.Server.WorldObjects
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritRating);
 
+            // equipment ratings
+            // TODO: caching?
+            var equipment = EquippedObjects.Values.Sum(i => i.GearCrit ?? 0);
+
             // augmentations
             var augBonus = 0;
 
             if (this is Player player)
                 augBonus = player.AugmentationCriticalExpertise;
 
-            return critChanceRating + enchantments + augBonus;
+            return critChanceRating + equipment + enchantments + augBonus;
         }
 
         public int GetCritDamageRating()
@@ -301,7 +305,7 @@ namespace ACE.Server.WorldObjects
 
             // equipment ratings
             // TODO: caching?
-            var equipment = EquippedObjects.Values.Sum(i => i.CritDamageRating ?? 0);
+            var equipment = EquippedObjects.Values.Sum(i => i.GearCritDamage ?? 0);
 
             // augmentations
             var augBonus = 0;
@@ -326,8 +330,12 @@ namespace ACE.Server.WorldObjects
             // additive enchantments
             var enchantments = EnchantmentManager.GetRating(PropertyInt.CritResistRating);
 
+            // equipment ratings
+            // TODO: caching?
+            var equipment = EquippedObjects.Values.Sum(i => i.GearCritResist ?? 0);
+
             // no augs / lum augs?
-            return critResistRating + enchantments;
+            return critResistRating + equipment + enchantments;
         }
 
         public int GetCritDamageResistRating()
@@ -340,7 +348,7 @@ namespace ACE.Server.WorldObjects
 
             // equipment ratings
             // TODO: caching?
-            var equipment = EquippedObjects.Values.Sum(i => i.CritDamageResistRating ?? 0);
+            var equipment = EquippedObjects.Values.Sum(i => i.GearCritDamageResist ?? 0);
 
             var lumAugBonus = 0;
             if (this is Player player)

--- a/Source/ACE.Server/WorldObjects/PetDevice.cs
+++ b/Source/ACE.Server/WorldObjects/PetDevice.cs
@@ -30,42 +30,6 @@ namespace ACE.Server.WorldObjects
             set { if (value.HasValue) SetProperty(PropertyInt.PetClass, value.Value); else RemoveProperty(PropertyInt.PetClass); }
         }
 
-        public int? GearDamage
-        {
-            get => GetProperty(PropertyInt.GearDamage);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearDamage, value.Value); else RemoveProperty(PropertyInt.GearDamage); }
-        }
-
-        public int? GearDamageResist
-        {
-            get => GetProperty(PropertyInt.GearDamageResist);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearDamageResist, value.Value); else RemoveProperty(PropertyInt.GearDamageResist); }
-        }
-
-        public int? GearCritDamage
-        {
-            get => GetProperty(PropertyInt.GearCritDamage);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearCritDamage, value.Value); else RemoveProperty(PropertyInt.GearCritDamage); }
-        }
-
-        public int? GearCritDamageResist
-        {
-            get => GetProperty(PropertyInt.GearCritDamageResist);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearCritDamageResist, value.Value); else RemoveProperty(PropertyInt.GearCritDamageResist); }
-        }
-
-        public int? GearCrit
-        {
-            get => GetProperty(PropertyInt.GearCrit);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearCrit, value.Value); else RemoveProperty(PropertyInt.GearCrit); }
-        }
-
-        public int? GearCritResist
-        {
-            get => GetProperty(PropertyInt.GearCritResist);
-            set { if (value.HasValue) SetProperty(PropertyInt.GearCritResist, value.Value); else RemoveProperty(PropertyInt.GearCritResist); }
-        }
-
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
         /// </summary>

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -2944,5 +2944,59 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyInt.CloakWeaveProc);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.CloakWeaveProc); else SetProperty(PropertyInt.CloakWeaveProc, value.Value); }
         }
+
+        /// <summary>
+        /// The Damage Rating on a non-creature item
+        /// </summary>
+        public int? GearDamage
+        {
+            get => GetProperty(PropertyInt.GearDamage);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearDamage); else SetProperty(PropertyInt.GearDamage, value.Value); }
+        }
+
+        /// <summary>
+        /// The Damage Resistance Rating on a non-creature item
+        /// </summary>
+        public int? GearDamageResist
+        {
+            get => GetProperty(PropertyInt.GearDamageResist);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearDamageResist); else SetProperty(PropertyInt.GearDamageResist, value.Value); }
+        }
+
+        /// <summary>
+        /// The Crit Damage Rating on a non-creature item
+        /// </summary>
+        public int? GearCritDamage
+        {
+            get => GetProperty(PropertyInt.GearCritDamage);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearCritDamage); else SetProperty(PropertyInt.GearCritDamage, value.Value); }
+        }
+
+        /// <summary>
+        /// The Crit Damage Resistance Rating on a non-creature item
+        /// </summary>
+        public int? GearCritDamageResist
+        {
+            get => GetProperty(PropertyInt.GearCritDamageResist);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearCritDamageResist); else SetProperty(PropertyInt.GearCritDamageResist, value.Value); }
+        }
+
+        /// <summary>
+        /// The Crit Chance Rating on a non-creature item
+        /// </summary>
+        public int? GearCrit
+        {
+            get => GetProperty(PropertyInt.GearCrit);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearCrit); else SetProperty(PropertyInt.GearCrit, value.Value); }
+        }
+
+        /// <summary>
+        /// The Crit Chance Resistance Rating on a non-creature item
+        /// </summary>
+        public int? GearCritResist
+        {
+            get => GetProperty(PropertyInt.GearCritResist);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.GearCritResist); else SetProperty(PropertyInt.GearCritResist, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
For equipment ratings, such as Damage Rating on a piece of armor, ACE was previously looking at the DamageRating property on the armor, where it should have been looking at the GearDamage property, similar to PetDevices.

This can be seen in retail pcaps. previously in ACE, when appraising a piece of armor with a DamageRating, the rating was not visible in the appraisal window. It required the player equipping the armor, and seeing their character appraisal damage rating go up before.

With GearDamage, the armor appraisal window correctly shows the Damage Rating

(note that no data in ace world db, or lootgen currently assigns ratings to equipped items yet, afaik. this was purely a bug with the preliminary code added to support this feature in the future, and was only accessible by manually using /setproperty to assign a rating to an equippable item)