### PR TITLE
fixing some spell messages for item spells

### DIFF
--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -128,7 +128,11 @@ namespace ACE.Server.WorldObjects
 
                 return;
             }
-            TryCastSpell(spell, player);
+
+            // should be 'You cast', instead of 'Item cast'
+            // omitting the item caster here, so player is also used for enchantment registry caster,
+            // which could prevent some scenarios with spamming enchantments from multiple food sources to protect against dispels
+            player.TryCastSpell(spell, player, null, false);
         }
 
         public Sound GetUseSound()

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -130,7 +130,10 @@ namespace ACE.Server.WorldObjects
             {
                 var spell = new Spell((uint)SpellDID);
 
-                TryCastSpell(spell, player, this, false);
+                // should be 'You cast', instead of 'Item cast'
+                // omitting the item caster here, so player is also used for enchantment registry caster,
+                // which could prevent some scenarios with spamming enchantments from multiple gem sources to protect against dispels
+                player.TryCastSpell(spell, player, null, false);
             }
 
             if (UseCreateContractId > 0)

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1000,8 +1000,8 @@ namespace ACE.Server.WorldObjects
             LastSuccessCast_Time = Time.GetUnixTime();
 
             WorldObject caster = this;
-            if (isWeaponSpell)
-                caster = GetEquippedWand();
+            //if (isWeaponSpell)
+                //caster = GetEquippedWand();
 
             // verify after windup, still consumes mana
             if (spell.MetaSpellType == SpellType.Dispel && !VerifyDispelPKStatus(this, target))


### PR DESCRIPTION
For spells from consuming food/drinks and activating gems, and the 'built-in' spells in the first slot of wands, the caster should be the player, and not the food/gem/casting item. The message for all of these should be 'You cast', and not 'Item cast'

Omitting the casting item in the full WorldObject_Magic pipeline, so that the player is entered into the enchantment registry, and not the item. This could prevent scenarios where multiple food items that each cast spells could be spammed, effectively protecting against dispels (similar to the Blackmoor's Favor issue)