### PR TITLE
fixing able to launch spell projectiles through some doors still

### DIFF
--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1305,8 +1305,7 @@ namespace ACE.Server.Physics
             if (spellCollide)
             {
                 // send initial CO as ethereal
-                WeenieObj.WorldObject.Ethereal = true;
-                //WeenieObj.WorldObject.SetProperty(PropertyBool.Ethereal, true);
+                WeenieObj.WorldObject.SetProperty(PropertyBool.Ethereal, true);
             }
 
             if (!SetPositionInternal(transition))

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1305,9 +1305,8 @@ namespace ACE.Server.Physics
             if (spellCollide)
             {
                 // send initial CO as ethereal
-                // fixme?
-                //WeenieObj.WorldObject.Ethereal = true;
-                WeenieObj.WorldObject.SetProperty(PropertyBool.Ethereal, true);
+                WeenieObj.WorldObject.Ethereal = true;
+                //WeenieObj.WorldObject.SetProperty(PropertyBool.Ethereal, true);
             }
 
             if (!SetPositionInternal(transition))
@@ -3351,9 +3350,10 @@ namespace ACE.Server.Physics
                 // prev_has_contact and missile state params swapped?
                 var profile = obj.build_collision_profile(this, obj.TransientState.HasFlag(TransientStateFlags.Contact), velocityCollide);
 
-                // ??
+                // ObjID and obj are custom parameters added by ace
+                // if obj. and obj) are the same, all of these calls seem to effectively get dropped
+                // is this intended for 1-way collisions??
                 obj.WeenieObj.DoCollision(profile, ObjID, obj);
-                //obj.WeenieObj.DoCollision(profile, ObjID, this);
 
                 collided = true;
             }

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 
 using ACE.Common;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
 using ACE.Server.Physics.Animation;
@@ -1304,7 +1305,9 @@ namespace ACE.Server.Physics
             if (spellCollide)
             {
                 // send initial CO as ethereal
-                WeenieObj.WorldObject.Ethereal = true;
+                // fixme?
+                //WeenieObj.WorldObject.Ethereal = true;
+                WeenieObj.WorldObject.SetProperty(PropertyBool.Ethereal, true);
             }
 
             if (!SetPositionInternal(transition))
@@ -3345,10 +3348,12 @@ namespace ACE.Server.Physics
             if (obj.State.HasFlag(PhysicsState.ReportCollisions) && !State.HasFlag(PhysicsState.IgnoreCollisions) && obj.WeenieObj != null)
             {
                 // acclient might have a bug here,
-                // prev_has_contact and missie state params swapped?
+                // prev_has_contact and missile state params swapped?
                 var profile = obj.build_collision_profile(this, obj.TransientState.HasFlag(TransientStateFlags.Contact), velocityCollide);
 
+                // ??
                 obj.WeenieObj.DoCollision(profile, ObjID, obj);
+                //obj.WeenieObj.DoCollision(profile, ObjID, this);
 
                 collided = true;
             }


### PR DESCRIPTION
Repro steps:
- /teleloc 0x89040339 [50.012718 -8.942079 24.004999] -0.010417 0.000000 0.000000 -0.999946
- stand at point-blank range to the closed door
- target one of the wisps behind the door
- /modifybool spell_projectile_ethereal false (default retail state, just ensuring)
- launch spell projectile

Expected:
spell projectile explodes on closed door

Actual:
spell projectile goes through this particular closed door

Note that with spell_projectile_ethereal true, the expected behavior happened already

Thanks for Ulrik for reporting this issue!