### PR TITLE
rewrite get_link to match closer to original acclient implementation

### DIFF
--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -412,7 +412,7 @@ namespace ACE.Server.Physics.Animation
 
             var key = style << 16;
             if (checkFirst)
-                key |= first & 0xFFFFF;
+                key |= first & 0xFFFFFF;
             Links.TryGetValue(key, out link);
             if (link == null)
                 return null;

--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -235,7 +235,7 @@ namespace ACE.Server.Physics.Animation
                 Cycles.TryGetValue(styleKey | (currState.Substate & 0xFFFFFF), out cycles);
                 if (cycles != null && (cycles.Bitfield & 1) == 0)
                 {
-                    Modifiers.TryGetValue(styleKey | motion, out motionData);
+                    Modifiers.TryGetValue(styleKey | (motion & 0xFFFFFF), out motionData);
                     if (motionData == null)
                         Modifiers.TryGetValue(motion & 0xFFFFFF, out motionData);
                     if (motionData != null)

--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -399,6 +399,12 @@ namespace ACE.Server.Physics.Animation
                     link.TryGetValue(substate, out var result);
                     return result;
                 }
+
+                if (StyleDefaults.TryGetValue(style, out var defaultMotion) && Links.TryGetValue((style << 16) | (substate & 0xFFFFFF), out var sublink))
+                {
+                    sublink.TryGetValue(defaultMotion, out var result);
+                    return result;
+                }
             }
             else
             {
@@ -407,22 +413,10 @@ namespace ACE.Server.Physics.Animation
                     link.TryGetValue(motion, out var result);
                     return result;
                 }
-            }
 
-            // ----
-            if (speed < 0.0f || substateSpeed < 0.0f)
-            {
-                if (StyleDefaults.TryGetValue(style, out var defaultStyle) && Links.TryGetValue((style << 16) | (substate & 0xFFFFFF), out var link))
+                if (Links.TryGetValue(style << 16, out var sublink))
                 {
-                    link.TryGetValue(defaultStyle, out var result);
-                    return result;
-                }
-            }
-            else
-            {
-                if (Links.TryGetValue(style << 16, out var link))
-                {
-                    link.TryGetValue(motion, out var result);
+                    sublink.TryGetValue(motion, out var result);
                     return result;
                 }
             }

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -159,7 +159,7 @@ namespace ACE.Server.WorldObjects
                 return null;
             }
 
-            var stanceKey = (uint)CurrentMotionState.Stance << 16 | ((uint)MotionCommand.Ready & 0xFFFFF);
+            var stanceKey = (uint)CurrentMotionState.Stance << 16 | ((uint)MotionCommand.Ready & 0xFFFFFF);
             motionTable.Links.TryGetValue(stanceKey, out var motions);
             if (motions == null)
             {


### PR DESCRIPTION
also fixes a possible logic flaw for reverse animations, when first lookup isn't found