### PR TITLE
Fix LanguageString

### DIFF
--- a/Source/ACE.DatLoader/FileTypes/LanguageString.cs
+++ b/Source/ACE.DatLoader/FileTypes/LanguageString.cs
@@ -16,7 +16,10 @@ namespace ACE.DatLoader.FileTypes
             Id = reader.ReadUInt32();
             uint strLen = reader.ReadCompressedUInt32();
             if (strLen > 0)
-                CharBuffer = reader.ReadPString(strLen);
+            {
+                byte[] thestring = reader.ReadBytes((int)strLen);
+                CharBuffer = System.Text.Encoding.Default.GetString(thestring);
+            }
         }
     }
 }


### PR DESCRIPTION
This is from OptimShi. I verified the string is now correct. Interestingly enough, tests still passed before with truncated strings.

All tests still pass