### PR TITLE
Add PropertiesBodyPart to the Weenie/Biota hybrid

### DIFF
--- a/Source/ACE.Entity/Adapter/WeenieConverter.cs
+++ b/Source/ACE.Entity/Adapter/WeenieConverter.cs
@@ -130,12 +130,19 @@ namespace ACE.Entity.Adapter
                     result.PropertiesAttribute2nd.Add(kvp.Key, kvp.Value.Clone());
             }
 
-            if (weenie.PropertiesBodyPart != null && (instantiateEmptyCollections || weenie.PropertiesBodyPart.Count > 0))
+            if (referenceWeenieCollectionsForCommonProperties)
             {
-                result.PropertiesBodyPart = new Dictionary<CombatBodyPart, PropertiesBodyPart>(weenie.PropertiesBodyPart.Count);
+                result.PropertiesBodyPart = weenie.PropertiesBodyPart;
+            }
+            else
+            {
+                if (weenie.PropertiesBodyPart != null && (instantiateEmptyCollections || weenie.PropertiesBodyPart.Count > 0))
+                {
+                    result.PropertiesBodyPart = new Dictionary<CombatBodyPart, PropertiesBodyPart>(weenie.PropertiesBodyPart.Count);
 
-                foreach (var kvp in weenie.PropertiesBodyPart)
-                    result.PropertiesBodyPart.Add(kvp.Key, kvp.Value.Clone());
+                    foreach (var kvp in weenie.PropertiesBodyPart)
+                        result.PropertiesBodyPart.Add(kvp.Key, kvp.Value.Clone());
+                }
             }
 
             if (weenie.PropertiesSkill != null && (instantiateEmptyCollections || weenie.PropertiesSkill.Count > 0))


### PR DESCRIPTION
This adds PropertiesBodyPart to the already established pattern for weenie collecitons that don't change.

The existing ones are:
weenie.PropertiesCreateList;
weenie.PropertiesEmote;
weenie.PropertiesEventFilter;
weenie.PropertiesGenerator;

This simply causes the Biota to reference the Weenie collection directly, instead of cloning it.

This should provide a very very small runtime memory improvement