### PR TITLE
adjust SeenOutside logic

### DIFF
--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -335,7 +335,7 @@ namespace ACE.Server.Physics.Common
 
                 // use PVS / VisibleCells for EnvCells not seen outside
                 // (mostly dungeons, also some large indoor areas ie. caves)
-                if (cell is EnvCell envCell && !envCell.SeenOutside)
+                if (cell is EnvCell envCell)
                     return GetVisibleObjects(envCell, type);
 
                 // use current landblock + adjacents for outdoors,
@@ -365,6 +365,14 @@ namespace ACE.Server.Physics.Common
             {
                 if (envCell != null)
                     envCell.AddObjectListTo(visibleObjs);
+            }
+
+            // if SeenOutside, add objects from outdoor landblock
+            if (cell.SeenOutside)
+            {
+                var outsideObjs = PhysicsObj.CurLandblock.GetServerObjects(true).Where(i => !(i.CurCell is EnvCell indoors) || indoors.SeenOutside);
+
+                visibleObjs.AddRange(outsideObjs);
             }
 
             return ApplyFilter(visibleObjs, type).Where(i => !i.DatObject && i.ID != PhysicsObj.ID).Distinct().ToList();


### PR DESCRIPTION
Repro steps:

/teleloc 0x76E90187 [128.597122 131.423340 88.805008] -0.999902 0.000000 0.000000 -0.014001

observe: a door in the path ahead is invisible

take a step forward, door suddenly pops into visibility

expected:

door should be visible from 187

For EnvCells that are SeenOutside, the server was previously only getting the outside cells, and any other envCells that are also seen outside

It should be getting all of the VisibleCells, as well as the previous filter