### PR TITLE
adding missing piece for /lootgen dev command for aetheria and pet devices

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2282,7 +2282,7 @@ namespace ACE.Server.Command.Handlers
                 return;
             }
 
-            if (wo.TsysMutationData == null)
+            if (wo.TsysMutationData == null && !Aetheria.IsAetheria(wo.WeenieClassId) && !(wo is PetDevice))
             {
                 session.Network.EnqueueSend(new GameMessageSystemChat($"{wo.Name} ({wo.WeenieClassId}) missing PropertyInt.TsysMutationData", ChatMessageType.Broadcast));
                 return;


### PR DESCRIPTION
This is only for /lootgen dev command. Aetheria and PetDevices were already working fine in the regular lootgen system

The MutateItem() method used only by /lootgen dev command already had the logic for Aetheria and PetDevices, however an error was being shown beforehand, since these items do not contain PropertyInt.TsysMutationData