### PR TITLE
adding magic/mundane item type selection profiles

### DIFF
--- a/Source/ACE.Server/Factories/Tables/TreasureMagicItemTypeChances_Orig.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureMagicItemTypeChances_Orig.cs
@@ -5,9 +5,9 @@ using ACE.Server.Factories.Enum;
 
 namespace ACE.Server.Factories.Tables
 {
-    public static class TreasureItemTypeChances_Orig
+    public static class TreasureMagicItemTypeChances_Orig
     {
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup1 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup1 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    1.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -18,7 +18,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup2 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup2 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     1.0f ),
@@ -29,7 +29,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup3 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup3 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -40,7 +40,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup4 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup4 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -51,7 +51,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup5 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup5 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -62,7 +62,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup6 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup6 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -73,7 +73,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup7 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup7 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
@@ -84,7 +84,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup8 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup8 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.15f ),
             ( TreasureItemType_Orig.Armor,     0.15f ),
@@ -95,55 +95,67 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.ArtObject, 0.14f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup9 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup9 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.30f ),
             ( TreasureItemType_Orig.Armor,     0.30f ),
-            ( TreasureItemType_Orig.Scroll,    0.20f ),
-            ( TreasureItemType_Orig.Clothing,  0.05f ),
-            ( TreasureItemType_Orig.Jewelry,   0.05f ),
+            ( TreasureItemType_Orig.Scroll,    0.10f ),
+            ( TreasureItemType_Orig.Clothing,  0.10f ),
+            ( TreasureItemType_Orig.Jewelry,   0.10f ),
             ( TreasureItemType_Orig.Gem,       0.05f ),
             ( TreasureItemType_Orig.ArtObject, 0.05f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup10 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup10 = new ChanceTable<TreasureItemType_Orig>()
         {
-            ( TreasureItemType_Orig.Weapon,    0.40f ),
-            ( TreasureItemType_Orig.Armor,     0.40f ),
+            ( TreasureItemType_Orig.Weapon,    0.30f ),
+            ( TreasureItemType_Orig.Armor,     0.30f ),
             ( TreasureItemType_Orig.Scroll,    0.20f ),
-            ( TreasureItemType_Orig.Clothing,  0.0f ),
-            ( TreasureItemType_Orig.Jewelry,   0.0f ),
+            ( TreasureItemType_Orig.Clothing,  0.10f ),
+            ( TreasureItemType_Orig.Jewelry,   0.10f ),
             ( TreasureItemType_Orig.Gem,       0.0f ),
             ( TreasureItemType_Orig.ArtObject, 0.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemTypeChancesGroup11 = new ChanceTable<TreasureItemType_Orig>()
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup11 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.0f ),
             ( TreasureItemType_Orig.Armor,     0.0f ),
             ( TreasureItemType_Orig.Scroll,    0.0f ),
-            ( TreasureItemType_Orig.Clothing,  0.25f ),
-            ( TreasureItemType_Orig.Jewelry,   0.25f ),
-            ( TreasureItemType_Orig.Gem,       0.25f ),
-            ( TreasureItemType_Orig.ArtObject, 0.25f ),
+            ( TreasureItemType_Orig.Clothing,  0.0f ),
+            ( TreasureItemType_Orig.Jewelry,   0.33f ),
+            ( TreasureItemType_Orig.Gem,       0.34f ),
+            ( TreasureItemType_Orig.ArtObject, 0.33f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> magicItemTypeChancesGroup12 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Weapon,    0.0f ),
+            ( TreasureItemType_Orig.Armor,     0.0f ),
+            ( TreasureItemType_Orig.Scroll,    0.40f ),
+            ( TreasureItemType_Orig.Clothing,  0.00f ),
+            ( TreasureItemType_Orig.Jewelry,   0.20f ),
+            ( TreasureItemType_Orig.Gem,       0.20f ),
+            ( TreasureItemType_Orig.ArtObject, 0.20f ),
         };
 
         /// <summary>
-        /// TreasureDeath.ItemTreasureTypeSelectionChances indexes into these profiles
+        /// TreasureDeath.MagicItemTreasureTypeSelectionChances indexes into these profiles
         /// </summary>
-        public static Dictionary<int, ChanceTable<TreasureItemType_Orig>> itemTypeChancesGroups = new Dictionary<int, ChanceTable<TreasureItemType_Orig>>()
+        public static Dictionary<int, ChanceTable<TreasureItemType_Orig>> magicItemTypeChancesGroups = new Dictionary<int, ChanceTable<TreasureItemType_Orig>>()
         {
-            { 1, itemTypeChancesGroup1 },
-            { 2, itemTypeChancesGroup2 },
-            { 3, itemTypeChancesGroup3 },
-            { 4, itemTypeChancesGroup4 },
-            { 5, itemTypeChancesGroup5 },
-            { 6, itemTypeChancesGroup6 },
-            { 7, itemTypeChancesGroup7 },
-            { 8, itemTypeChancesGroup8 },
-            { 9, itemTypeChancesGroup9 },
-            { 10, itemTypeChancesGroup10 },
-            { 11, itemTypeChancesGroup11 },
+            { 1, magicItemTypeChancesGroup1 },
+            { 2, magicItemTypeChancesGroup2 },
+            { 3, magicItemTypeChancesGroup3 },
+            { 4, magicItemTypeChancesGroup4 },
+            { 5, magicItemTypeChancesGroup5 },
+            { 6, magicItemTypeChancesGroup6 },
+            { 7, magicItemTypeChancesGroup7 },
+            { 8, magicItemTypeChancesGroup8 },
+            { 9, magicItemTypeChancesGroup9 },
+            { 10, magicItemTypeChancesGroup10 },
+            { 11, magicItemTypeChancesGroup11 },
+            { 12, magicItemTypeChancesGroup12 },
         };
     }
 }

--- a/Source/ACE.Server/Factories/Tables/TreasureMundaneItemTypeChances_Orig.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureMundaneItemTypeChances_Orig.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+
+using ACE.Server.Factories.Entity;
+using ACE.Server.Factories.Enum;
+
+namespace ACE.Server.Factories.Tables
+{
+    public static class TreasureMundaneItemTypeChances_Orig
+    {
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup1 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.0f ),
+            ( TreasureItemType_Orig.Consumable,     1.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.0f ),
+            ( TreasureItemType_Orig.ManaStone,      0.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup2 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.0f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        1.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.0f ),
+            ( TreasureItemType_Orig.ManaStone,      0.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup3 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.0f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       1.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.0f ),
+            ( TreasureItemType_Orig.ManaStone,      0.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup4 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.0f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 1.0f ),
+            ( TreasureItemType_Orig.ManaStone,      0.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup5 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.0f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.0f ),
+            ( TreasureItemType_Orig.ManaStone,      1.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup6 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         1.0f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.0f ),
+            ( TreasureItemType_Orig.ManaStone,      0.0f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup7 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.17f ),
+            ( TreasureItemType_Orig.Consumable,     0.17f ),
+            ( TreasureItemType_Orig.HealKit,        0.16f ),
+            ( TreasureItemType_Orig.Lockpick,       0.16f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.17f ),
+            ( TreasureItemType_Orig.ManaStone,      0.17f ),
+        };
+
+        private static readonly ChanceTable<TreasureItemType_Orig> mundaneItemTypeChancesGroup8 = new ChanceTable<TreasureItemType_Orig>()
+        {
+            ( TreasureItemType_Orig.Pyreal,         0.34f ),
+            ( TreasureItemType_Orig.Consumable,     0.0f ),
+            ( TreasureItemType_Orig.HealKit,        0.0f ),
+            ( TreasureItemType_Orig.Lockpick,       0.0f ),
+            ( TreasureItemType_Orig.SpellComponent, 0.33f ),
+            ( TreasureItemType_Orig.ManaStone,      0.33f ),
+        };
+
+        /// <summary>
+        /// TreasureDeath.MundaneItemTreasureTypeSelectionChances indexes into these profiles
+        /// </summary>
+        public static Dictionary<int, ChanceTable<TreasureItemType_Orig>> mundaneItemTypeChancesGroups = new Dictionary<int, ChanceTable<TreasureItemType_Orig>>()
+        {
+            { 1, mundaneItemTypeChancesGroup1 },
+            { 2, mundaneItemTypeChancesGroup2 },
+            { 3, mundaneItemTypeChancesGroup3 },
+            { 4, mundaneItemTypeChancesGroup4 },
+            { 5, mundaneItemTypeChancesGroup5 },
+            { 6, mundaneItemTypeChancesGroup6 },
+            { 7, mundaneItemTypeChancesGroup7 },
+            { 8, mundaneItemTypeChancesGroup8 },
+        };
+    }
+}


### PR DESCRIPTION
This builds on PR https://github.com/ACEmulator/ACE/pull/3197

Similar to how 3197 mapped the treasure_death.ItemTreasureTypeSelectionChances column to chance tables, this does the same for MagicItems and MundaneItems