### PR TITLE
fixing more bugs from 3189

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -1000,8 +1000,8 @@ namespace ACE.Server.WorldObjects
             LastSuccessCast_Time = Time.GetUnixTime();
 
             WorldObject caster = this;
-            //if (isWeaponSpell)
-                //caster = GetEquippedWand();
+            if (isWeaponSpell)
+                caster = GetEquippedWand();
 
             // verify after windup, still consumes mana
             if (spell.MetaSpellType == SpellType.Dispel && !VerifyDispelPKStatus(this, target))

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -769,7 +769,7 @@ namespace ACE.Server.WorldObjects
                 case SpellType.FellowEnchantment:
 
                     damage = 0;
-                    if (itemCaster != null)
+                    if (itemCaster != null && equip)
                         enchantmentStatus = CreateEnchantment(spellTarget ?? target, itemCaster, spell, equip);
                     else
                         enchantmentStatus = CreateEnchantment(spellTarget ?? target, this, spell, equip);


### PR DESCRIPTION
3189 changed some stuff to make the built-in spell for 41465 Casting Stein say 'You cast', instead of 'Item cast', but ended up breaking other stuff, like ItemSpellcraft

This re-implements the fix in a better way to fix both scenarios