### PR TITLE
fixing fellowship spell messages

### DIFF
--- a/Source/ACE.Server/Entity/Spell.cs
+++ b/Source/ACE.Server/Entity/Spell.cs
@@ -131,6 +131,8 @@ namespace ACE.Server.Entity
 
         public bool IsTracking => !Flags.HasFlag(SpellFlags.NonTrackingProjectile);
 
+        public bool IsFellowshipSpell => Flags.HasFlag(SpellFlags.FellowshipSpell);
+
         public List<uint> TryBurnComponents(Player player)
         {
             var consumed = new List<uint>();

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -380,7 +380,7 @@ namespace ACE.Server.WorldObjects
             var player = this as Player;
             var creature = this as Creature;
 
-            var spellTarget = !spell.IsSelfTargeted ? target as Creature : creature;
+            var spellTarget = !spell.IsSelfTargeted || spell.IsFellowshipSpell ? target as Creature : creature;
 
             if (this is Gem || this is Food || this is Hook)
                 spellTarget = target as Creature;


### PR DESCRIPTION
before:

Self:

You cast Superior Frore Ward on yourself
You cast Superior Frore Ward on yourself, refreshing Superior Frore Ward

Target: (no message, no enchantment, although there are visual effects on target)

---

after:

Self:

You cast Superior Frore Ward on yourself
You cast Superior Frore Ward on fellow

Target:

Fellow cast Superior Frore Ward on you

most likely only a bug with fellowship enchantments for MagicSchool.LifeMagic