### PR TITLE
adding pvp modifier for cloak damage procs, as per retail

### DIFF
--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -111,26 +111,44 @@ namespace ACE.Server.Entity
         /// </summary>
         public static readonly int DamageReductionAmount = 200;
 
+        public static int GetDamageReductionAmount(WorldObject source)
+        {
+            var damageReductionAmount = DamageReductionAmount;
+
+            // https://asheron.fandom.com/wiki/Master_of_Arms
+            // Cloaks with the chance to reduce incoming damage by 200 have been reduced to 100 for PvP circumstances.
+            if (source is Player)
+                damageReductionAmount /= 2;
+
+            return damageReductionAmount;
+        }
+
         /// <summary>
         /// Returns the reduced damage amount when a cloak procs
         /// with PropertyInt.CloakWeaveProc=2
         /// </summary>
-        public static uint GetReducedAmount(uint damage)
+        public static uint GetReducedAmount(WorldObject source, uint damage)
         {
-            if (damage > DamageReductionAmount)
-                return (uint)(damage - DamageReductionAmount);
+            var damageReductionAmount = GetDamageReductionAmount(source);
+
+            if (damage > damageReductionAmount)
+                return (uint)(damage - damageReductionAmount);
             else
                 return 0;
         }
 
-        public static int GetReducedAmount(int damage)
+        public static int GetReducedAmount(WorldObject source, int damage)
         {
-            return Math.Max(0, damage - DamageReductionAmount);
+            var damageReductionAmount = GetDamageReductionAmount(source);
+
+            return Math.Max(0, damage - damageReductionAmount);
         }
 
-        public static float GetReducedAmount(float damage)
+        public static float GetReducedAmount(WorldObject source, float damage)
         {
-            return Math.Max(0, damage - DamageReductionAmount);
+            var damageReductionAmount = GetDamageReductionAmount(source);
+
+            return Math.Max(0, damage - damageReductionAmount);
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -470,7 +470,7 @@ namespace ACE.Server.WorldObjects
 
             if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(equippedCloak, percent))
             {
-                var reducedAmount = Cloak.GetReducedAmount(amount);
+                var reducedAmount = Cloak.GetReducedAmount(source, amount);
 
                 Cloak.ShowMessage(this, source, amount, reducedAmount);
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -691,7 +691,7 @@ namespace ACE.Server.WorldObjects
 
                 if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(equippedCloak, percent))
                 {
-                    var reducedDamage = Cloak.GetReducedAmount(damage);
+                    var reducedDamage = Cloak.GetReducedAmount(ProjectileSource, damage);
 
                     Cloak.ShowMessage(target, ProjectileSource, damage, reducedDamage);
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -422,7 +422,7 @@ namespace ACE.Server.WorldObjects
 
                         if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(equippedCloak, percent))
                         {
-                            var reduced = -Cloak.GetReducedAmount(-tryBoost);
+                            var reduced = -Cloak.GetReducedAmount(this, -tryBoost);
 
                             Cloak.ShowMessage(spellTarget, this, -tryBoost, -reduced);
 
@@ -571,7 +571,7 @@ namespace ACE.Server.WorldObjects
 
                         if (equippedCloak != null && Cloak.HasDamageProc(equippedCloak) && Cloak.RollProc(equippedCloak, percent))
                         {
-                            var reduced = Cloak.GetReducedAmount(srcVitalChange);
+                            var reduced = Cloak.GetReducedAmount(this, srcVitalChange);
 
                             Cloak.ShowMessage(spellTarget, this, srcVitalChange, reduced);
 


### PR DESCRIPTION
https://asheron.fandom.com/wiki/Master_of_Arms
Cloaks with the chance to reduce incoming damage by 200 have been reduced to 100 for PvP circumstances.

Thanks to Jkurs for reporting this issue