### PR TITLE
EnchantmentWithCaching Audit + Improvements

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -225,15 +225,18 @@ namespace ACE.Server.WorldObjects
 
                 return;
             }
+
             var target = spell.School == MagicSchool.ItemEnchantment && !spell.HasItemCategory ? item : this;
 
             // Retrieve enchantment on target and remove it, if present
-            if (target.EnchantmentManager.HasSpell(spellId))
+            var propertiesEnchantmentRegistry = target.EnchantmentManager.GetEnchantment(spellId, item.Guid.Full);
+
+            if (propertiesEnchantmentRegistry != null)
             {
                 if (!silent)
-                    target.EnchantmentManager.Remove(target.EnchantmentManager.GetEnchantment(spellId, item.Guid.Full));
+                    target.EnchantmentManager.Remove(propertiesEnchantmentRegistry);
                 else
-                    target.EnchantmentManager.Dispel(target.EnchantmentManager.GetEnchantment(spellId, item.Guid.Full));
+                    target.EnchantmentManager.Dispel(propertiesEnchantmentRegistry);
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -82,12 +82,9 @@ namespace ACE.Server.WorldObjects.Managers
         {
             var spells = new List<PropertiesEnchantmentRegistry>();
 
-            var enchantments = from e in WorldObject.Biota.PropertiesEnchantmentRegistry.Clone(WorldObject.BiotaDatabaseLock)
-                group e by e.SpellCategory
-                into categories
-                select categories.OrderByDescending(c => c.LayerId).First();
+            var topLayerEnchantments = WorldObject.Biota.PropertiesEnchantmentRegistry.GetEnchantmentsTopLayer(WorldObject.BiotaDatabaseLock);
 
-            foreach (var enchantment in enchantments)
+            foreach (var enchantment in topLayerEnchantments)
             {
                 if (enchantment.SpellId > SpellCategory_Cooldown)
                     continue;

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -39,7 +39,7 @@ namespace ACE.Server.WorldObjects.Managers
         /// <summary>
         /// Returns TRUE If this object has a vitae penalty
         /// </summary>
-        public bool HasVitae => WorldObject.Biota.PropertiesEnchantmentRegistry.HasEnchantment((uint)SpellId.Vitae, WorldObject.BiotaDatabaseLock);
+        public virtual bool HasVitae => WorldObject.Biota.PropertiesEnchantmentRegistry.HasEnchantment((uint)SpellId.Vitae, WorldObject.BiotaDatabaseLock);
 
         /// <summary>
         /// Constructs a new EnchantmentManager for a WorldObject

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -24,6 +24,19 @@ namespace ACE.Server.WorldObjects.Managers
             }
         }
 
+        private bool? hasVitae;
+
+        public override bool HasVitae
+        {
+            get
+            {
+                if (hasVitae == null)
+                    hasVitae = base.HasVitae;
+
+                return hasVitae.Value;
+            }
+        }
+
         /// <summary>
         /// Constructs a new EnchantmentManager for a WorldObject
         /// </summary>
@@ -145,6 +158,7 @@ namespace ACE.Server.WorldObjects.Managers
         private void ClearCache()
         {
             hasEnchantments = null;
+            hasVitae = null;
 
             attributeModCache.Clear();
             vitalModAdditiveCache.Clear();


### PR DESCRIPTION
Overall, there was very little that could be improved. Caching is used properly throughout the entire object, except where improved in this PR.

HasVitae is now cached

Creature.RemoveItemSpell now involves one less lock/loop for every time a spell is found that needs to be removed


Networking AppraiseInfo sends all the active enchantments for MagicSchool.Item

The previous method cloned the entire collection and then ran this query:
- group e by e.SpellCategory
                into categories
                select categories.OrderByDescending(c => c.LayerId).First();

The new method uses the existing GetTopLayer without cloning the entire collection. It uses the following query:
- group e by e.SpellCategory
                    into categories
                    select categories.OrderByDescending(c => c.PowerLevel).ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId)).First();

All the existing GetEnchantmentsTopLayer queries were converted from OrderBy LayerId to PowerLevel. The AppraiseInfo was the only hold out.

I believe this is a correct fix/improvement.