### PR TITLE
updating WeaponMissileDefense / WeaponMagicDefense rolls to eor formula

### DIFF
--- a/Source/ACE.Server/Factories/Entity/MissileMagicDefense.cs
+++ b/Source/ACE.Server/Factories/Entity/MissileMagicDefense.cs
@@ -6,7 +6,7 @@ namespace ACE.Server.Factories.Entity
     {
         // WeaponMissileDefense / WeaponMagicDefense
 
-        private static ChanceTable<float> T1_T6_Defense = new ChanceTable<float>()
+        private static readonly ChanceTable<float> T1_T6_Defense = new ChanceTable<float>()
         {
             ( 1.005f, 0.10f ),
             ( 1.010f, 0.20f ),
@@ -15,7 +15,7 @@ namespace ACE.Server.Factories.Entity
             ( 1.025f, 0.10f ),
         };
 
-        private static ChanceTable<float> T7_T8_Defense = new ChanceTable<float>()
+        private static readonly ChanceTable<float> T7_T8_Defense = new ChanceTable<float>()
         {
             ( 1.005f, 0.05f ),
             ( 1.010f, 0.10f ),

--- a/Source/ACE.Server/Factories/Entity/MissileMagicDefense.cs
+++ b/Source/ACE.Server/Factories/Entity/MissileMagicDefense.cs
@@ -1,0 +1,42 @@
+using ACE.Common;
+
+namespace ACE.Server.Factories.Entity
+{
+    public static class MissileMagicDefense
+    {
+        // WeaponMissileDefense / WeaponMagicDefense
+
+        private static ChanceTable<float> T1_T6_Defense = new ChanceTable<float>()
+        {
+            ( 1.005f, 0.10f ),
+            ( 1.010f, 0.20f ),
+            ( 1.015f, 0.40f ),
+            ( 1.020f, 0.20f ),
+            ( 1.025f, 0.10f ),
+        };
+
+        private static ChanceTable<float> T7_T8_Defense = new ChanceTable<float>()
+        {
+            ( 1.005f, 0.05f ),
+            ( 1.010f, 0.10f ),
+            ( 1.015f, 0.15f ),
+            ( 1.020f, 0.20f ),
+            ( 1.025f, 0.20f ),
+            ( 1.030f, 0.15f ),
+            ( 1.035f, 0.10f ),
+            ( 1.040f, 0.05f ),
+        };
+
+        public static float? Roll(int tier)
+        {
+            // preliminary roll: 10% chance
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
+            if (rng >= 0.1f) return null;
+
+            if (tier < 7)
+                return T1_T6_Defense.Roll();
+            else
+                return T7_T8_Defense.Roll();
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -2,7 +2,7 @@ using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Database;
 using ACE.Entity.Enum;
-using ACE.Server.Entity;
+using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Tables;
 using ACE.Server.WorldObjects;
 
@@ -214,9 +214,6 @@ namespace ACE.Server.Factories
                     wieldSkillType = Skill.WarMagic;
             }
 
-            // Setting MagicD and MissileD Bonuses to null (some weenies have a value)
-            wo.WeaponMagicDefense = null;
-            wo.WeaponMissileDefense = null;
             // Not sure why this is here, guessing some wienies have it by default
             wo.ItemSkillLevelLimit = null;
 
@@ -241,8 +238,9 @@ namespace ACE.Server.Factories
 
             // Setting Weapon defensive mods 
             wo.WeaponDefense = GetWieldReqMeleeDMod(wield, profile);
-            wo.WeaponMagicDefense = GetMagicMissileDMod(profile.Tier);
-            wo.WeaponMissileDefense = GetMagicMissileDMod(profile.Tier);
+
+            wo.WeaponMissileDefense = MissileMagicDefense.Roll(profile.Tier);
+            wo.WeaponMagicDefense = MissileMagicDefense.Roll(profile.Tier);
 
             // Setting weapon Offensive Mods
             if (elementalDamageMod > 1.0f)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
-using ACE.Server.Entity;
+using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Tables;
 using ACE.Server.WorldObjects;
 
@@ -82,8 +82,8 @@ namespace ACE.Server.Factories
             double weaponOffense = 0;
 
             // Properties for weapons
-            double magicD = GetMagicMissileDMod(profile.Tier);
-            double missileD = GetMagicMissileDMod(profile.Tier);
+            var missileD = MissileMagicDefense.Roll(profile.Tier);
+            var magicD = MissileMagicDefense.Roll(profile.Tier);
 
             int gemCount = 0;
             if (wo.GemCode != null)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -4,7 +4,7 @@ using ACE.Common;
 using ACE.Database.Models.World;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
-using ACE.Server.Entity;
+using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Tables;
 using ACE.Server.WorldObjects;
 
@@ -64,11 +64,12 @@ namespace ACE.Server.Factories
             MutateBurden(wo, profile.Tier, true);
 
             // MeleeD/MagicD/Missile Bonus
-            wo.WeaponMagicDefense = GetMagicMissileDMod(profile.Tier);
-            wo.WeaponMissileDefense = GetMagicMissileDMod(profile.Tier);
             double meleeDMod = GetWieldReqMeleeDMod(wieldDifficulty, profile);
             if (meleeDMod > 0.0f)
                 wo.WeaponDefense = meleeDMod;
+
+            wo.WeaponMissileDefense = MissileMagicDefense.Roll(profile.Tier);
+            wo.WeaponMagicDefense = MissileMagicDefense.Roll(profile.Tier);
 
             // Damage
             wo.DamageMod = GetMissileDamageMod(wieldDifficulty, wo.GetProperty(PropertyInt.WeaponType));


### PR DESCRIPTION
Sampled from about 100k items from eor magloot logs

The tier divisions were found to be t1-t6, and t7-t8

These were the exact chances for each outcome