### PR TITLE
move void_pvp_modifier calcs for direct damage, based on feedback and data from void pvp players in retail

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1286,11 +1286,25 @@ namespace ACE.Server.WorldObjects.Managers
                     continue;
                 }
 
-                // if a PKType with Enduring Enchantment has died, ensure they don't continue to take DoT from PK sources
-                if (targetPlayer != null && damager is Player && !targetPlayer.IsPKType)
-                    continue;
-
                 var resistanceMod = creature.GetResistanceMod(damageType, damager, null);
+
+                var sourcePlayer = damager as Player;
+
+                if (sourcePlayer != null && targetPlayer != null)
+                {
+                    // if a PKType with Enduring Enchantment has died, ensure they don't continue to take DoT from PK sources
+                    if (!targetPlayer.IsPKType)
+                        continue;
+
+                    // void spell projectile direct damage was modified to apply this pvp modifier *on top of* the player's natural resistance to nether,
+                    // which supposedly brings the direct damage from void spells in pvp closer to retail
+
+                    // however, dots were already supposedly on par, so we replace resistanceMod with void_pvp_modifier for dots,
+                    // instead of applying it on top like direct damage
+
+                    if (damageType == DamageType.Nether)
+                        resistanceMod = (float)PropertyManager.GetDouble("void_pvp_modifier").Item;
+                }
 
                 // with the halvening, this actually seems like the fairest balance currently..
                 var useNetherDotDamageRating = targetPlayer != null;

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -846,7 +846,7 @@ namespace ACE.Server.WorldObjects
             // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
             // Creatures under Asheron’s protection take half damage from any nether type spell.
             if (damageType == DamageType.Nether)
-                return (float)PropertyManager.GetDouble("void_pvp_modifier").Item;
+                return 0.5f;
 
             // base strength and endurance give the player a natural resistance to damage,
             // which caps at 50% (equivalent to level 5 life prots)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -504,6 +504,15 @@ namespace ACE.Server.WorldObjects
 
                 resistanceMod = (float)Math.Max(0.0f, target.GetResistanceMod(resistanceType, this, null, weaponResistanceMod));
 
+                if (sourcePlayer != null && targetPlayer != null && Spell.DamageType == DamageType.Nether)
+                {
+                    // for direct damage from void spells in pvp,
+                    // apply void_pvp_modifier *on top of* the player's natural resistance to nether
+
+                    // this supposedly brings the direct damage from void spells in pvp closer to retail
+                    resistanceMod *= (float)PropertyManager.GetDouble("void_pvp_modifier").Item;
+                }
+
                 finalDamage = baseDamage + critDamageBonus + skillBonus;
 
                 finalDamage *= elementalDamageMod * slayerMod * resistanceMod * absorbMod;


### PR DESCRIPTION
The current feedback has been, for void pvp, dot damage is about on par with retail, but direct damage is still way too high

From the data provided from void pvp players in retail, it seemed like direct damage from void in pvp was still about double what it should be. This has me confused, because we were already applying this logic from retail dev notes:

```
            // http://acpedia.org/wiki/Announcements_-_11th_Anniversary_Preview#Void_Magic_and_You.21
            // Creatures under Asheron’s protection take half damage from any nether type spell.
```

The only thing I can imagine, is perhaps this logic applied *on top of* the player's natural resistance to void, instead of simply capping their natural resistance to void to 0.5

Some complications resulted from the original implementation of the void_pvp_modifier server config option, as that option was set to retail 0.5 by default, but it was acting more like a scalar for the player taking damage from any source, instead of just from pvp.

The logic has been modified so that void_pvp_modifier now correctly only applies to pvp situations. It has also been applied in a way that works slightly differently for dots, compared to direct damage. Since dots were already supposedly on par, we use a similar method as what was in use before -- void_pvp_modifier *replaces* the player's natural resistance to void in pvp scenarios, instead of factoring it on top like direct damage.

This should satisfy all of the current scenarios that I can think of