### PR TITLE
adding /reload-loot-tables for admins to hotswap loot profiles

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -17,6 +18,7 @@ using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Entity;
 using ACE.Server.Factories;
+using ACE.Server.Factories.Entity;
 using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameMessages.Messages;
@@ -3159,6 +3161,25 @@ namespace ACE.Server.Command.Handlers
             }
 
             obj.SendUpdatePosition(true);
+        }
+
+        [CommandHandler("reload-loot-tables", AccessLevel.Admin, CommandHandlerFlag.None, "reloads the latest data from the loot tables", "optional profile folder")]
+        public static void HandleReloadLootTables(Session session, params string[] parameters)
+        {
+            var sep = Path.DirectorySeparatorChar;
+
+            var folder = $"..{sep}..{sep}..{sep}..{sep}Factories{sep}Tables{sep}";
+            if (parameters.Length > 0)
+                folder = parameters[1];
+
+            var di = new DirectoryInfo(folder);
+
+            if (!di.Exists)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"{folder} not found");
+                return;
+            }
+            LootSwap.UpdateTables(folder);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Entity/LootParser.cs
+++ b/Source/ACE.Server/Factories/Entity/LootParser.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using ACE.Entity.Enum;
+using ACE.Server.Factories.Enum;
+
+using WeenieClassName = ACE.Server.Factories.Enum.WeenieClassName;
+
+namespace ACE.Server.Factories.Entity
+{
+    public class LootParser
+    {
+        public static Dictionary<string, object> ParseFile(string filename)
+        {
+            var lines = File.ReadAllLines(filename);
+
+            var tables = new Dictionary<string, object>();
+
+            //Console.WriteLine($"Parsed {filename}");
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+
+                if (line.Contains("List<"))
+                    continue;
+
+                if (!line.Contains("ChanceTable<") || !line.Contains(" = new") || !line.Contains("()"))
+                    continue;
+
+                if (line.Contains("readonly") || line.EndsWith(";"))
+                    continue;
+
+                var table = ParseChanceTable(lines, i);
+
+                tables.Add(table.tableName, table.table);
+            }
+            return tables;
+        }
+
+        private static (string tableName, object table) ParseChanceTable(string[] lines, int startLine)
+        {
+            var line = lines[startLine];
+
+            var tableType = GetTableType(line);
+            var tableName = GetTableName(line);
+
+            //Console.WriteLine($" - {tableName}");
+
+            object chanceTable = null;
+
+            switch (tableType)
+            {
+                case TreasureTableType.ChanceInt:
+                    chanceTable = ParseChanceTable_Int(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceSpell:
+                    chanceTable = ParseChanceTable_Spell(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceWcid:
+                    chanceTable = ParseChanceTable_Wcid(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceBool:
+                    chanceTable = ParseChanceTable_Bool(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceHeritage:
+                    chanceTable = ParseChanceTable_Heritage(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceItemType:
+                    chanceTable = ParseChanceTable_ItemType(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceArmorType:
+                    chanceTable = ParseChanceTable_ArmorType(lines, startLine);
+                    break;
+
+                case TreasureTableType.ChanceWeaponType:
+                    chanceTable = ParseChanceTable_WeaponType(lines, startLine);
+                    break;
+
+                default:
+                    Console.WriteLine($"Unknown table type {tableType}");
+                    break;
+            }
+
+            return (tableName, chanceTable);
+        }
+
+        public static ChanceTable<int> ParseChanceTable_Int(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<int>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"(\d+),\s+([\d.]+)");
+
+                if (!match.Success || !int.TryParse(match.Groups[1].Value, out var val) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((val, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<SpellId> ParseChanceTable_Spell(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<SpellId>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"SpellId.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out SpellId spell) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((spell, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<WeenieClassName> ParseChanceTable_Wcid(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<WeenieClassName>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"WeenieClassName.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out WeenieClassName wcid) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((wcid, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<bool> ParseChanceTable_Bool(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<bool>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"\(\s+([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !bool.TryParse(match.Groups[1].Value, out var val) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((val, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<TreasureHeritageGroup> ParseChanceTable_Heritage(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<TreasureHeritageGroup>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"TreasureHeritageGroup.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out TreasureHeritageGroup heritage) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((heritage, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<TreasureItemType_Orig> ParseChanceTable_ItemType(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<TreasureItemType_Orig>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"TreasureItemType_Orig.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out TreasureItemType_Orig itemType) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((itemType, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<TreasureArmorType> ParseChanceTable_ArmorType(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<TreasureArmorType>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"TreasureArmorType.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out TreasureArmorType armorType) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((armorType, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static ChanceTable<TreasureWeaponType> ParseChanceTable_WeaponType(string[] lines, int startLine)
+        {
+            var chanceTable = new ChanceTable<TreasureWeaponType>();
+
+            for (var i = startLine + 1; i < lines.Length; i++)
+            {
+                var line = lines[i].Trim();
+
+                if (line.Length < 2)
+                    continue;
+
+                if (line.Length == 2)
+                    break;
+
+                if (line.StartsWith("//"))
+                    continue;
+
+                var match = Regex.Match(line, @"TreasureWeaponType.([^,]+),\s+([\d.]+)");
+
+                if (!match.Success || !System.Enum.TryParse(match.Groups[1].Value, out TreasureWeaponType weaponType) || !float.TryParse(match.Groups[2].Value, out var chance))
+                {
+                    Console.WriteLine($"Couldn't parse {line}");
+                    continue;
+                }
+                chanceTable.Add((weaponType, chance));
+            }
+
+            return chanceTable;
+        }
+
+        public static TreasureTableType GetTableType(string line)
+        {
+            var match = Regex.Match(line, @"<([^>]+)");
+
+            if (!match.Success)
+                return TreasureTableType.Undef;
+
+            switch (match.Groups[1].Value)
+            {
+                case "int":
+                    return TreasureTableType.ChanceInt;
+                case "SpellId":
+                    return TreasureTableType.ChanceSpell;
+                case "WeenieClassName":
+                    return TreasureTableType.ChanceWcid;
+                case "bool":
+                    return TreasureTableType.ChanceBool;
+                case "TreasureHeritageGroup":
+                    return TreasureTableType.ChanceHeritage;
+                case "TreasureItemType_Orig":
+                    return TreasureTableType.ChanceItemType;
+                case "TreasureArmorType":
+                    return TreasureTableType.ChanceArmorType;
+                case "TreasureWeaponType":
+                    return TreasureTableType.ChanceWeaponType;
+            }
+            return TreasureTableType.Undef;
+        }
+
+        public static string GetTableName(string line)
+        {
+            var match = Regex.Match(line, @"> ([^ ]+)");
+
+            if (!match.Success)
+                return null;
+
+            return match.Groups[1].Value;
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/Entity/LootSwap.cs
+++ b/Source/ACE.Server/Factories/Entity/LootSwap.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using ACE.Server.Factories.Enum;
+
+namespace ACE.Server.Factories.Entity
+{
+    public static class LootSwap
+    {
+        public static void UpdateTables(string path)
+        {
+            var timer = Stopwatch.StartNew();
+
+            var types = Reflection.GetTypes("ACE.Server.Factories.Tables");
+
+            var files = new Dictionary<string, Dictionary<string, object>>();
+
+            ParseFolder(path, files);
+
+            UpdateTables(types, files);
+
+            timer.Stop();
+
+            // ~0.2s
+            Console.WriteLine();
+            Console.WriteLine($"Updated loot tables in {timer.Elapsed.TotalSeconds}s");
+            Console.WriteLine();
+        }
+
+        private static HashSet<string> excludeList = new HashSet<string>()
+        {
+            "GemMaterialChance.cs",         // todo
+            "TreasureItemTypeChances.cs"
+        };
+
+        private static void ParseFolder(string folder, Dictionary<string, Dictionary<string, object>> files)
+        {
+            var di = new DirectoryInfo(folder);
+
+            if (!di.Exists)
+            {
+                Console.WriteLine($"{folder} not found");
+                return;
+            }
+
+            var _files = di.GetFiles();
+
+            foreach (var file in _files)
+            {
+                if (!file.Name.EndsWith(".cs"))
+                    continue;
+
+                if (excludeList.Contains(file.Name))
+                    continue;
+
+                var className = file.Name.Replace(".cs", "");
+                var result = LootParser.ParseFile(file.FullName);
+                files.Add(className, result);
+            }
+
+            var subfolders = di.GetDirectories();
+
+            foreach (var subfolder in subfolders)
+                ParseFolder(subfolder.FullName, files);
+        }
+
+        private static void UpdateTables(Dictionary<string, Type> types, Dictionary<string, Dictionary<string, object>> files)
+        {
+            foreach (var kvp in types)
+            {
+                var className = kvp.Key;
+                var type = kvp.Value;
+
+                if (!files.TryGetValue(className, out var newTables))
+                {
+                    //Console.WriteLine($"Couldn't find {className} in files");
+                    continue;
+                }
+
+                var fields = Reflection.GetFields(type);
+
+                Console.WriteLine($"Updated {className}");
+
+                foreach (var field in fields)
+                {
+                    if (!newTables.TryGetValue(field.field.Name, out var newTable))
+                    {
+                        //Console.WriteLine($"Couldn't find {field.field.Name} in {className}.cs");
+                        continue;
+                    }
+                    //Console.WriteLine($" - {field.field.Name}");
+                    UpdateTable(field.field, newTable);
+                }
+            }
+        }
+
+        private static void UpdateTable(FieldInfo field, object newTable)
+        {
+            //Console.WriteLine($"Updating {field.Name}");
+
+            field.SetValue(null, newTable);
+        }
+
+        public static class Reflection
+        {
+            public static Dictionary<string, Type> GetTypes(string prefix)
+            {
+                var assembly = Assembly.GetExecutingAssembly();
+
+                var types = assembly.GetTypes();
+
+                return types.Where(i => i.FullName.StartsWith(prefix)).ToDictionary(i => i.FullName.Substring(i.FullName.LastIndexOf('.') + 1), i => i);
+            }
+
+            public static List<(TreasureTableType tableType, FieldInfo field)> GetFields(Type type)
+            {
+                var fields = type.GetFields(BindingFlags.NonPublic | BindingFlags.Static);
+
+                var filtered = new List<(TreasureTableType tableType, FieldInfo field)>();
+
+                foreach (var field in fields)
+                {
+                    var fieldName = field.FieldType.FullName;
+
+                    if (!fieldName.Contains("ChanceTable"))
+                        continue;
+
+                    if (fieldName.Contains("System.Collections.Generic.List"))
+                        continue;
+
+                    if (fieldName.Contains("System.Int32"))
+                        filtered.Add((TreasureTableType.ChanceInt, field));
+                    else if (fieldName.Contains("SpellId"))
+                        filtered.Add((TreasureTableType.ChanceSpell, field));
+                    else if (fieldName.Contains("WeenieClassName"))
+                        filtered.Add((TreasureTableType.ChanceWcid, field));
+                    else if (fieldName.Contains("Boolean"))
+                        filtered.Add((TreasureTableType.ChanceBool, field));
+                    else if (fieldName.Contains("TreasureItemType_Orig"))
+                        filtered.Add((TreasureTableType.ChanceItemType, field));
+                    else if (fieldName.Contains("TreasureHeritageGroup"))
+                        filtered.Add((TreasureTableType.ChanceHeritage, field));
+                    else if (fieldName.Contains("TreasureArmorType"))
+                        filtered.Add((TreasureTableType.ChanceArmorType, field));
+                    else if (fieldName.Contains("TreasureWeaponType"))
+                        filtered.Add((TreasureTableType.ChanceWeaponType, field));
+                }
+                return filtered;
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Factories/Enum/TreasureArmorType.cs
+++ b/Source/ACE.Server/Factories/Enum/TreasureArmorType.cs
@@ -1,5 +1,3 @@
-using Org.BouncyCastle.Bcpg;
-
 namespace ACE.Server.Factories.Enum
 {
     public enum TreasureArmorType

--- a/Source/ACE.Server/Factories/Enum/TreasureTableType.cs
+++ b/Source/ACE.Server/Factories/Enum/TreasureTableType.cs
@@ -1,0 +1,17 @@
+namespace ACE.Server.Factories.Enum
+{
+    public enum TreasureTableType
+    {
+        Undef,
+        ChanceInt,
+        ChanceSpell,
+        ChanceWcid,
+        ChanceBool,
+
+        ChanceGem,
+        ChanceHeritage,
+        ChanceItemType,
+        ChanceArmorType,
+        ChanceWeaponType,
+    }
+}

--- a/Source/ACE.Server/Factories/Tables/AetheriaChance.cs
+++ b/Source/ACE.Server/Factories/Tables/AetheriaChance.cs
@@ -7,13 +7,13 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class AetheriaChance
     {
-        private static readonly ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.60f ),
             ( 2, 0.40f ),
         };
 
-        private static readonly ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.550f ),
             ( 2, 0.345f ),
@@ -22,7 +22,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // lack of data samples here for 4+
-        private static readonly ChanceTable<int> T7_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T7_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.55000f ),
             ( 2, 0.34475f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // also lack of data samples for level 5,
         // there was possibly no indication it was more common than t7
-        private static readonly ChanceTable<int> T8_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T8_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.0200f ),
             ( 2, 0.5500f ),

--- a/Source/ACE.Server/Factories/Tables/ArmorModVsTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorModVsTypeChance.cs
@@ -44,32 +44,32 @@ namespace ACE.Server.Factories.Tables
 
         // starting with a more conservative table found in the cache, until this data is verified more
 
-        private static readonly ChanceTable<int> ArmorModVsType_T2_QualityLevel = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorModVsType_T2_QualityLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static readonly ChanceTable<int> ArmorModVsType_T3_QualityLevel = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorModVsType_T3_QualityLevel = new ChanceTable<int>()
         {
             ( 1, 0.5f ),
             ( 2, 0.5f ),
         };
 
-        private static readonly ChanceTable<int> ArmorModVsType_T4_QualityLevel = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorModVsType_T4_QualityLevel = new ChanceTable<int>()
         {
             ( 1, 0.25f ),
             ( 2, 0.50f ),
             ( 3, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> ArmorModVsType_T5_QualityLevel = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorModVsType_T5_QualityLevel = new ChanceTable<int>()
         {
             ( 2, 0.25f ),
             ( 3, 0.50f ),
             ( 4, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> ArmorModVsType_T6_T8_QualityLevel = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorModVsType_T6_T8_QualityLevel = new ChanceTable<int>()
         {
             ( 2, 0.25f ),
             ( 3, 0.35f ),

--- a/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ArmorTypeChance.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables
 {
     public static class ArmorTypeChance
     {
-        private static readonly ChanceTable<TreasureArmorType> T1_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T1_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.34f ),
             ( TreasureArmorType.StuddedLeather, 0.33f ),
             ( TreasureArmorType.Chainmail,      0.33f ),
         };
 
-        private static readonly ChanceTable<TreasureArmorType> T2_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T2_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.25f ),
             ( TreasureArmorType.StuddedLeather, 0.25f ),
@@ -23,7 +23,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Platemail,      0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureArmorType> T3_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T3_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.22f ),
             ( TreasureArmorType.StuddedLeather, 0.22f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static readonly ChanceTable<TreasureArmorType> T4_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T4_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.16f ),
             ( TreasureArmorType.StuddedLeather, 0.16f ),
@@ -45,7 +45,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static readonly ChanceTable<TreasureArmorType> T5_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T5_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.15f ),
             ( TreasureArmorType.StuddedLeather, 0.15f ),
@@ -57,7 +57,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureArmorType.Overrobe,       0.02f ),    // added
         };
 
-        private static readonly ChanceTable<TreasureArmorType> T6_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T6_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.12f ),
             ( TreasureArmorType.StuddedLeather, 0.12f ),
@@ -73,7 +73,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // added, from mag-loot logs
-        private static readonly ChanceTable<TreasureArmorType> T7_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T7_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.11f ),
             ( TreasureArmorType.StuddedLeather, 0.11f ),
@@ -91,7 +91,7 @@ namespace ACE.Server.Factories.Tables
         };
 
 
-        private static readonly ChanceTable<TreasureArmorType> T8_Chances = new ChanceTable<TreasureArmorType>()
+        private static ChanceTable<TreasureArmorType> T8_Chances = new ChanceTable<TreasureArmorType>()
         {
             ( TreasureArmorType.Leather,        0.10f ),
             ( TreasureArmorType.StuddedLeather, 0.10f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/ArmorCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/ArmorCantrips.cs
@@ -134,7 +134,7 @@ namespace ACE.Server.Factories.Tables
             }
         }
 
-        private static readonly ChanceTable<SpellId> armorCantrips = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> armorCantrips = new ChanceTable<SpellId>()
         {
             ( SpellId.CANTRIPSTRENGTH1,                    0.02f ),
             ( SpellId.CANTRIPENDURANCE1,                   0.02f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/CantripChance.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +7,6 @@ using log4net;
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Entity;
 using ACE.Server.Managers;
-using System;
 
 namespace ACE.Server.Factories.Tables
 {
@@ -14,26 +14,26 @@ namespace ACE.Server.Factories.Tables
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.95f ),
             ( 1, 0.05f ),
         };
 
-        private static readonly ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.90f ),
             ( 1, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.725f ),
             ( 1, 0.250f ),
             ( 2, 0.025f ),
         };
 
-        private static readonly ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.62f ),
             ( 1, 0.32f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.005f ),
         };
 
-        private static readonly ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.40f ),
             ( 1, 0.42f ),
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.001f ),
         };
 
-        private static readonly ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.25f ),
             ( 1, 0.40f ),
@@ -60,7 +60,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.001f ),
         };
 
-        private static readonly ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.81f ),
             ( 2, 0.17f ),
@@ -86,43 +86,43 @@ namespace ACE.Server.Factories.Tables
         }
 
 
-        private static readonly ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static readonly ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.97f ),
             ( 2, 0.03f ),
         };
 
-        private static readonly ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.90f ),
             ( 2, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.85f ),
             ( 2, 0.15f ),
         };
 
-        private static readonly ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.80f ),
             ( 2, 0.20f ),
         };
 
-        private static readonly ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.15f ),
             ( 2, 0.60f ),
             ( 3, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.02f ),
             ( 2, 0.46f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/JewelryCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/JewelryCantrips.cs
@@ -112,7 +112,7 @@ namespace ACE.Server.Factories.Tables
             }
         }
 
-        private static readonly ChanceTable<SpellId> jewelryCantrips = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> jewelryCantrips = new ChanceTable<SpellId>()
         {
             ( SpellId.CANTRIPARMOR1,                       0.03f ),
             ( SpellId.CANTRIPACIDWARD1,                    0.03f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/MeleeCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/MeleeCantrips.cs
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables
             }
         }
 
-        private static readonly ChanceTable<SpellId> meleeCantrips = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> meleeCantrips = new ChanceTable<SpellId>()
         {
             ( SpellId.CANTRIPLIGHTWEAPONSAPTITUDE1, 0.11f ),        // gets mutated into weapon skill aptitude,
                                                                     // with a 10% chance to mutate into dual wield aptitude for heavy/light/finesse

--- a/Source/ACE.Server/Factories/Tables/Cantrips/MissileCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/MissileCantrips.cs
@@ -67,7 +67,7 @@ namespace ACE.Server.Factories.Tables
             }
         }
 
-        private static readonly ChanceTable<SpellId> missileCantrips = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> missileCantrips = new ChanceTable<SpellId>()
         {
             ( SpellId.CANTRIPMISSILEWEAPONSAPTITUDE1, 0.10f ),
 

--- a/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/NumCantrips.cs
@@ -7,26 +7,26 @@ namespace ACE.Server.Factories.Tables
 {
     public static class NumCantrips
     {
-        private static readonly ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T1_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.95f ),
             ( 1, 0.05f ),
         };
 
-        private static readonly ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T2_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.90f ),
             ( 1, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T3_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.725f ),
             ( 1, 0.250f ),
             ( 2, 0.025f ),
         };
 
-        private static readonly ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T4_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.62f ),
             ( 1, 0.32f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.005f ),
         };
 
-        private static readonly ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T5_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.40f ),
             ( 1, 0.42f ),
@@ -43,7 +43,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.001f ),
         };
 
-        private static readonly ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T6_NumCantrips = new ChanceTable<int>()
         {
             ( 0, 0.25f ),
             ( 1, 0.40f ),
@@ -53,7 +53,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.001f ),
         };
 
-        private static readonly ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
+        private static ChanceTable<int> T7_T8_NumCantrips = new ChanceTable<int>()
         {
             ( 1, 0.81f ),
             ( 2, 0.17f ),
@@ -78,43 +78,43 @@ namespace ACE.Server.Factories.Tables
             return numCantrips[profile.Tier - 1].Roll(profile.LootQualityMod);
         }
 
-        private static readonly ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T1_T2_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static readonly ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T3_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.97f ),
             ( 2, 0.03f ),
         };
 
-        private static readonly ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T4_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.90f ),
             ( 2, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T5_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.85f ),
             ( 2, 0.15f ),
         };
 
-        private static readonly ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.80f ),
             ( 2, 0.20f ),
         };
 
-        private static readonly ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.15f ),
             ( 2, 0.60f ),
             ( 3, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>()
         {
             ( 1, 0.02f ),
             ( 2, 0.46f ),

--- a/Source/ACE.Server/Factories/Tables/Cantrips/WandCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/WandCantrips.cs
@@ -77,7 +77,7 @@ namespace ACE.Server.Factories.Tables
         // war elemental casters: void magic aptitude
         // void elemental casters: war magic aptitude
 
-        private static readonly ChanceTable<SpellId> casterCantrips = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> casterCantrips = new ChanceTable<SpellId>()
         {
             ( SpellId.CANTRIPCREATUREENCHANTMENTAPTITUDE1, 0.05f ),
             ( SpellId.CANTRIPITEMENCHANTMENTAPTITUDE1,     0.05f ),

--- a/Source/ACE.Server/Factories/Tables/CasterSlotSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/CasterSlotSpells.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables
 {
     public static class CasterSlotSpells
     {
-        private static readonly ChanceTable<SpellId> orbSpells = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> orbSpells = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthOther1,     0.05f ),
             ( SpellId.EnduranceOther1,    0.05f ),
@@ -25,7 +25,7 @@ namespace ACE.Server.Factories.Tables
             ( SpellId.ManaRenewalOther1,  0.10f ),
         };
 
-        private static readonly ChanceTable<SpellId> wandStaffSpells = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> wandStaffSpells = new ChanceTable<SpellId>()
         {
             ( SpellId.WhirlingBlade1,     0.14f ),
             ( SpellId.ForceBolt1,         0.14f ),
@@ -36,7 +36,7 @@ namespace ACE.Server.Factories.Tables
             ( SpellId.LightningBolt1,     0.15f ),
         };
 
-        private static readonly ChanceTable<SpellId> netherSpells = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> netherSpells = new ChanceTable<SpellId>()
         {
             ( SpellId.Corruption1,            0.20f ),
             ( SpellId.NetherArc1,             0.20f ),

--- a/Source/ACE.Server/Factories/Tables/CloakChance.cs
+++ b/Source/ACE.Server/Factories/Tables/CloakChance.cs
@@ -9,25 +9,25 @@ namespace ACE.Server.Factories.Tables
 {
     public static class CloakChance
     {
-        private static readonly ChanceTable<int> T1_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T1_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 1.0f )
         };
 
-        private static readonly ChanceTable<int> T2_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T2_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.99f ),
             ( 2, 0.01f ),
         };
 
-        private static readonly ChanceTable<int> T3_T4_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T3_T4_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.44f ),
             ( 2, 0.55f ),
             ( 3, 0.01f ),
         };
 
-        private static readonly ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T5_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.04f ),
             ( 2, 0.40f ),
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.01f ),
         };
 
-        private static readonly ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T6_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 1, 0.04f ),
             ( 2, 0.30f ),
@@ -43,7 +43,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.01f ),
         };
 
-        private static readonly ChanceTable<int> T7_T8_ItemMaxLevel = new ChanceTable<int>()
+        private static ChanceTable<int> T7_T8_ItemMaxLevel = new ChanceTable<int>()
         {
             ( 2, 0.45f ),
             ( 3, 0.50f ),

--- a/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GearRatingChance.cs
@@ -11,19 +11,19 @@ namespace ACE.Server.Factories.Tables
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 
-        private static readonly ChanceTable<bool> RatingChance = new ChanceTable<bool>()
+        private static ChanceTable<bool> RatingChance = new ChanceTable<bool>()
         {
             ( false, 0.75f ),
             ( true,  0.25f ),
         };
 
-        private static readonly ChanceTable<int> ArmorRating = new ChanceTable<int>()
+        private static ChanceTable<int> ArmorRating = new ChanceTable<int>()
         {
             ( 1, 0.95f ),
             ( 2, 0.05f ),
         };
 
-        private static readonly ChanceTable<int> ClothingJewelryRating = new ChanceTable<int>()
+        private static ChanceTable<int> ClothingJewelryRating = new ChanceTable<int>()
         {
             ( 1, 0.70f ),
             ( 2, 0.25f ),

--- a/Source/ACE.Server/Factories/Tables/GemClassChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GemClassChance.cs
@@ -7,20 +7,20 @@ namespace ACE.Server.Factories.Tables
 {
     public static class GemClassChance
     {
-        private static readonly ChanceTable<int> T1_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T1_Chances = new ChanceTable<int>()
         {
             ( 1, 0.9f ),
             ( 2, 0.1f ),
         };
 
-        private static readonly ChanceTable<int> T2_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T2_Chances = new ChanceTable<int>()
         {
             ( 1, 0.6f ),
             ( 2, 0.3f ),
             ( 3, 0.1f ),
         };
 
-        private static readonly ChanceTable<int> T3_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T3_Chances = new ChanceTable<int>()
         {
             ( 1, 0.2f ),
             ( 2, 0.5f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables
             ( 4, 0.1f ),
         };
 
-        private static readonly ChanceTable<int> T4_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T4_Chances = new ChanceTable<int>()
         {
             ( 1, 0.05f ),
             ( 2, 0.25f ),
@@ -37,7 +37,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.15f ),
         };
 
-        private static readonly ChanceTable<int> T5_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T5_Chances = new ChanceTable<int>()
         {
             ( 3, 0.2f ),
             ( 4, 0.4f ),
@@ -45,7 +45,7 @@ namespace ACE.Server.Factories.Tables
             ( 6, 0.2f ),
         };
 
-        private static readonly ChanceTable<int> T6_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T6_Chances = new ChanceTable<int>()
         {
             ( 4, 0.2f ),
             ( 5, 0.3f ),

--- a/Source/ACE.Server/Factories/Tables/GemMaterialChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GemMaterialChance.cs
@@ -11,7 +11,7 @@ namespace ACE.Server.Factories.Tables
 {
     public static class GemMaterialChance
     {
-        private static readonly ChanceTable<GemResult> class1_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class1_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.gemagate,         MaterialType.Agate),         0.13f ),
             ( new GemResult(WeenieClassName.gemazurite,       MaterialType.Azurite),       0.13f ),
@@ -23,7 +23,7 @@ namespace ACE.Server.Factories.Tables
             ( new GemResult(WeenieClassName.gemwhitequartz,   MaterialType.WhiteQuartz),   0.12f ),
         };
 
-        private static readonly ChanceTable<GemResult> class2_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class2_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.gemamber,         MaterialType.Amber),         0.10f ),
             ( new GemResult(WeenieClassName.gembloodstone,    MaterialType.Bloodstone),    0.10f ),
@@ -37,7 +37,7 @@ namespace ACE.Server.Factories.Tables
             ( new GemResult(WeenieClassName.gemredjade,       MaterialType.RedJade),       0.10f ),
         };
 
-        private static readonly ChanceTable<GemResult> class3_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class3_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.gemamethyst,      MaterialType.Amethyst),      0.11f ),
             ( new GemResult(WeenieClassName.gemblackgarnet,   MaterialType.BlackGarnet),   0.11f ),
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories.Tables
             ( new GemResult(WeenieClassName.gemzircon,        MaterialType.Zircon),        0.12f ),
         };
 
-        private static readonly ChanceTable<GemResult> class4_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class4_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.gemaquamarine,    MaterialType.Aquamarine),    0.20f ),
             ( new GemResult(WeenieClassName.gemgreengarnet,   MaterialType.GreenGarnet),   0.20f ),
@@ -59,7 +59,7 @@ namespace ACE.Server.Factories.Tables
             ( new GemResult(WeenieClassName.gemyellowtopaz,   MaterialType.YellowTopaz),   0.20f ),
         };
 
-        private static readonly ChanceTable<GemResult> class5_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class5_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.gemblackopal,     MaterialType.BlackOpal),     0.20f ),
             ( new GemResult(WeenieClassName.gemfireopal,      MaterialType.FireOpal),      0.20f ),
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables
             ( new GemResult(WeenieClassName.gemwhitesapphire, MaterialType.WhiteSapphire), 0.20f ),
         };
 
-        private static readonly ChanceTable<GemResult> class6_materialChance = new ChanceTable<GemResult>()
+        private static ChanceTable<GemResult> class6_materialChance = new ChanceTable<GemResult>()
         {
             ( new GemResult(WeenieClassName.jeweldiamond,     MaterialType.Diamond),       0.13f ),
             ( new GemResult(WeenieClassName.jewelemerald,     MaterialType.Emerald),       0.29f ),

--- a/Source/ACE.Server/Factories/Tables/HeritageChance.cs
+++ b/Source/ACE.Server/Factories/Tables/HeritageChance.cs
@@ -12,130 +12,130 @@ namespace ACE.Server.Factories.Tables
 
         // this is used as a pre-roll into some of the ClothingWcid, ArmorWcid, and WeaponWcid tables
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile1 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile1 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    1.00f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile2 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile2 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Gharundim,  1.00f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile3 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile3 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Sho,        1.00f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile4 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile4 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.75f ),
             ( TreasureHeritageGroup.Gharundim,  0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile5 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile5 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.75f ),
             ( TreasureHeritageGroup.Sho,        0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile6 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile6 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.25f ),
             ( TreasureHeritageGroup.Gharundim,  0.75f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile7 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile7 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Gharundim,  0.75f ),
             ( TreasureHeritageGroup.Sho,        0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile8 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile8 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.25f ),
             ( TreasureHeritageGroup.Sho,        0.75f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile9 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile9 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Gharundim,  0.25f ),
             ( TreasureHeritageGroup.Sho,        0.75f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile10 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile10 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.50f ),
             ( TreasureHeritageGroup.Gharundim,  0.50f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile11 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile11 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.50f ),
             ( TreasureHeritageGroup.Sho,        0.50f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile12 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile12 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Gharundim,  0.50f ),
             ( TreasureHeritageGroup.Sho,        0.50f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile13 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile13 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.80f ),
             ( TreasureHeritageGroup.Gharundim,  0.10f ),
             ( TreasureHeritageGroup.Sho,        0.10f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile14 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile14 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.10f ),
             ( TreasureHeritageGroup.Gharundim,  0.80f ),
             ( TreasureHeritageGroup.Sho,        0.10f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile15 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile15 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.10f ),
             ( TreasureHeritageGroup.Gharundim,  0.10f ),
             ( TreasureHeritageGroup.Sho,        0.80f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile16 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile16 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.50f ),
             ( TreasureHeritageGroup.Gharundim,  0.25f ),
             ( TreasureHeritageGroup.Sho,        0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile17 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile17 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.25f ),
             ( TreasureHeritageGroup.Gharundim,  0.50f ),
             ( TreasureHeritageGroup.Sho,        0.25f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile18 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile18 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.25f ),
             ( TreasureHeritageGroup.Gharundim,  0.25f ),
             ( TreasureHeritageGroup.Sho,        0.50f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile19 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile19 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.34f ),
             ( TreasureHeritageGroup.Gharundim,  0.33f ),
             ( TreasureHeritageGroup.Sho,        0.33f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile20 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile20 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Viamontian, 1.00f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile21 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile21 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.Aluvian,    0.25f ),
             ( TreasureHeritageGroup.Gharundim,  0.25f ),
@@ -145,17 +145,17 @@ namespace ACE.Server.Factories.Tables
 
         // added
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile22 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile22 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.CelestialHand, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile23 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile23 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.EldrytchWeb,   1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureHeritageGroup> heritageProfile24 = new ChanceTable<TreasureHeritageGroup>()
+        private static ChanceTable<TreasureHeritageGroup> heritageProfile24 = new ChanceTable<TreasureHeritageGroup>()
         {
             ( TreasureHeritageGroup.RadiantBlood,  1.0f ),
         };

--- a/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
+++ b/Source/ACE.Server/Factories/Tables/PetDeviceChance.cs
@@ -7,25 +7,25 @@ namespace ACE.Server.Factories.Tables
 {
     public static class PetDeviceChance
     {
-        private static readonly ChanceTable<int> T1_T3_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T1_T3_PetLevelChances = new ChanceTable<int>()
         {
             ( 50, 1.0f )
         };
 
-        private static readonly ChanceTable<int> T4_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T4_PetLevelChances = new ChanceTable<int>()
         {
             ( 50, 0.75f ),
             ( 80, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T5_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T5_PetLevelChances = new ChanceTable<int>()
         {
             ( 50,  0.15f ),
             ( 80,  0.65f ),
             ( 100, 0.20f ),
         };
 
-        private static readonly ChanceTable<int> T6_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T6_PetLevelChances = new ChanceTable<int>()
         {
             ( 80,  0.15f ),
             ( 100, 0.25f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables
             ( 150, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T7_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T7_PetLevelChances = new ChanceTable<int>()
         {
             ( 100, 0.15f ),
             ( 125, 0.25f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables
             ( 180, 0.10f ),
         };
 
-        private static readonly ChanceTable<int> T8_PetLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T8_PetLevelChances = new ChanceTable<int>()
         {
             ( 100, 0.0125f ),
             ( 125, 0.025f ),

--- a/Source/ACE.Server/Factories/Tables/ScrollLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/ScrollLevelChance.cs
@@ -7,34 +7,34 @@ namespace ACE.Server.Factories.Tables
 {
     public static class ScrollLevelChance
     {
-        private static readonly ChanceTable<int> T1_ScrollLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T1_ScrollLevelChances = new ChanceTable<int>()
         {
             ( 1, 0.25f ),
             ( 2, 0.50f ),
             ( 3, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T2_ScrollLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T2_ScrollLevelChances = new ChanceTable<int>()
         {
             ( 3, 0.25f ),
             ( 4, 0.50f ),
             ( 5, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T3_ScrollLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T3_ScrollLevelChances = new ChanceTable<int>()
         {
             ( 5, 0.25f ),
             ( 6, 0.50f ),
             ( 7, 0.25f )
         };
 
-        private static readonly ChanceTable<int> T4_ScrollLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T4_ScrollLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.50f ),
             ( 7, 0.50f )
         };
 
-        private static readonly ChanceTable<int> T5_T8_ScrollLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T5_T8_ScrollLevelChances = new ChanceTable<int>()
         {
             ( 7, 1.00f )
         };

--- a/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
+++ b/Source/ACE.Server/Factories/Tables/SpellLevelChance.cs
@@ -17,7 +17,7 @@ namespace ACE.Server.Factories.Tables
             8: 7-8 (should be 6-8)
         */
 
-        private static readonly ChanceTable<int> T1_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T1_SpellLevelChances = new ChanceTable<int>()
         {
             // 15/60/25?
             ( 1, 0.25f ),
@@ -25,47 +25,47 @@ namespace ACE.Server.Factories.Tables
             ( 3, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> T2_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T2_SpellLevelChances = new ChanceTable<int>()
         {
             ( 3, 0.25f ),
             ( 4, 0.50f ),
             ( 5, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> T3_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T3_SpellLevelChances = new ChanceTable<int>()
         {
             ( 4, 0.25f ),
             ( 5, 0.50f ),
             ( 6, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> T4_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T4_SpellLevelChances = new ChanceTable<int>()
         {
             ( 5, 0.75f ),
             ( 6, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> T5_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T5_SpellLevelChances = new ChanceTable<int>()
         {
             ( 5, 0.30f ),
             ( 6, 0.50f ),
             ( 7, 0.20f ),
         };
 
-        private static readonly ChanceTable<int> T6_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T6_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.60f ),
             ( 7, 0.40f ),
         };
 
-        private static readonly ChanceTable<int> T7_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T7_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.25f ),
             ( 7, 0.50f ),
             ( 8, 0.25f ),
         };
 
-        private static readonly ChanceTable<int> T8_SpellLevelChances = new ChanceTable<int>()
+        private static ChanceTable<int> T8_SpellLevelChances = new ChanceTable<int>()
         {
             ( 6, 0.15f ),
             ( 7, 0.50f ),

--- a/Source/ACE.Server/Factories/Tables/SpellSelectionTable.cs
+++ b/Source/ACE.Server/Factories/Tables/SpellSelectionTable.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Factories.Tables
         // thanks to Sapphire Knight and Butterflygolem for helping to figure this part out!
 
         // gems
-        private static readonly ChanceTable<SpellId> spellSelectionGroup1 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup1 = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthSelf1,            0.06f ),
             ( SpellId.EnduranceSelf1,           0.06f ),
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // jewelry
-        private static readonly ChanceTable<SpellId> spellSelectionGroup2 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup2 = new ChanceTable<SpellId>()
         {
             ( SpellId.MagicResistanceSelf1,     0.08f ),
             ( SpellId.ArmorSelf1,               0.05f ),
@@ -69,7 +69,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // crowns
-        private static readonly ChanceTable<SpellId> spellSelectionGroup3 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup3 = new ChanceTable<SpellId>()
         {
             ( SpellId.LeadershipMasterySelf1,   0.10f ),
             ( SpellId.ImpregnabilitySelf1,      0.10f ),
@@ -90,7 +90,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // orbs
-        private static readonly ChanceTable<SpellId> spellSelectionGroup4 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup4 = new ChanceTable<SpellId>()
         {
             ( SpellId.LifeMagicMasterySelf1,           0.20f ),
             ( SpellId.CreatureEnchantmentMasterySelf1, 0.15f ),
@@ -104,7 +104,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // wands, staffs, sceptres, batons
-        private static readonly ChanceTable<SpellId> spellSelectionGroup5 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup5 = new ChanceTable<SpellId>()
         {
             ( SpellId.WarMagicMasterySelf1,            0.25f ),
             ( SpellId.WillpowerSelf1,                  0.15f ),
@@ -118,7 +118,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // one-handed melee weapons
-        private static readonly ChanceTable<SpellId> spellSelectionGroup6 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup6 = new ChanceTable<SpellId>()
         {
             ( SpellId.QuicknessSelf1,            0.25f ),
             ( SpellId.StrengthSelf1,             0.15f ),
@@ -130,7 +130,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // bracers, breastplates, coats, cuirasses, girths, hauberks, pauldrons, chest armor, sleeves
-        private static readonly ChanceTable<SpellId> spellSelectionGroup7 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup7 = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthSelf1,         0.25f ),
             ( SpellId.EnduranceSelf1,        0.25f ),
@@ -142,7 +142,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // shields
-        private static readonly ChanceTable<SpellId> spellSelectionGroup8 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup8 = new ChanceTable<SpellId>()
         {
             ( SpellId.ImpregnabilitySelf1,  0.15f ),
             ( SpellId.InvulnerabilitySelf1, 0.15f ),
@@ -155,7 +155,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // gauntlets
-        private static readonly ChanceTable<SpellId> spellSelectionGroup9 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup9 = new ChanceTable<SpellId>()
         {
             ( SpellId.CoordinationSelf1,          0.22f ),
             ( SpellId.ShieldMasterySelf1,         0.12f ),
@@ -168,7 +168,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // helms, basinets, helmets, coifs, cowls, heaumes, kabutons
-        private static readonly ChanceTable<SpellId> spellSelectionGroup10 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup10 = new ChanceTable<SpellId>()
         {
             ( SpellId.MagicResistanceSelf1,      0.15f ),
             ( SpellId.ImpregnabilitySelf1,       0.10f ),
@@ -189,7 +189,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // boots, chiran sandals, sollerets
-        private static readonly ChanceTable<SpellId> spellSelectionGroup11 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup11 = new ChanceTable<SpellId>()
         {
             ( SpellId.QuicknessSelf1,             0.23f ),
             ( SpellId.HeavyWeaponsMasterySelf1,   0.10f ),
@@ -204,7 +204,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // breeches, jerkins, shirts, pants, tunics, doublets, trousers, pantaloons
-        private static readonly ChanceTable<SpellId> spellSelectionGroup12 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup12 = new ChanceTable<SpellId>()
         {
             ( SpellId.ArmorSelf1,               0.30f ),
             ( SpellId.AcidProtectionSelf1,      0.10f ),
@@ -217,7 +217,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // caps, qafiyas, turbans, fezs, berets
-        private static readonly ChanceTable<SpellId> spellSelectionGroup13 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup13 = new ChanceTable<SpellId>()
         {
             ( SpellId.FocusSelf1,                      0.04f ),
             ( SpellId.WillpowerSelf1,                  0.04f ),
@@ -254,7 +254,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // cloth gloves (1 entry?)
-        private static readonly ChanceTable<SpellId> spellSelectionGroup14 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup14 = new ChanceTable<SpellId>()
         {
             ( SpellId.CoordinationSelf1,               0.04f ),
             ( SpellId.QuicknessSelf1,                  0.04f ),
@@ -284,7 +284,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // greaves, leggings, tassets, leather pants
-        private static readonly ChanceTable<SpellId> spellSelectionGroup15 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup15 = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthSelf1,         0.25f ),
             ( SpellId.QuicknessSelf1,        0.25f ),
@@ -295,7 +295,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // dinnerware
-        private static readonly ChanceTable<SpellId> spellSelectionGroup16 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup16 = new ChanceTable<SpellId>()
         {
             ( SpellId.AlchemyMasterySelf1,     0.09f ),
             ( SpellId.CookingMasterySelf1,     0.09f ),
@@ -317,7 +317,7 @@ namespace ACE.Server.Factories.Tables
         // added
 
         // missile weapons, two-handed weapons
-        private static readonly ChanceTable<SpellId> spellSelectionGroup17 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup17 = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthSelf1,             0.16f ),
             ( SpellId.EnduranceSelf1,            0.15f ),
@@ -329,7 +329,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // shoes, loafers, slippers, sandals
-        private static readonly ChanceTable<SpellId> spellSelectionGroup18 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup18 = new ChanceTable<SpellId>()
         {
             ( SpellId.StrengthSelf1,              0.06f ),
             ( SpellId.QuicknessSelf1,             0.06f ),
@@ -351,7 +351,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // nether caster
-        private static readonly ChanceTable<SpellId> spellSelectionGroup19 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup19 = new ChanceTable<SpellId>()
         {
             ( SpellId.VoidMagicMasterySelf1,           0.25f ),
             ( SpellId.WillpowerSelf1,                  0.15f ),
@@ -365,7 +365,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // leather cap (1 entry?)
-        private static readonly ChanceTable<SpellId> spellSelectionGroup20 = new ChanceTable<SpellId>()
+        private static ChanceTable<SpellId> spellSelectionGroup20 = new ChanceTable<SpellId>()
         {
             ( SpellId.RecklessnessMasterySelf1,        0.075f ),
             ( SpellId.LockpickMasterySelf1,            0.075f ),

--- a/Source/ACE.Server/Factories/Tables/TreasureProfile_Item.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureProfile_Item.cs
@@ -9,37 +9,37 @@ namespace ACE.Server.Factories.Tables
     {
         // indexed by TreasureDeath.ItemTreasureTypeSelectionChances
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile1 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile1 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile2 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile2 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Armor,     1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile3 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile3 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Scroll,    1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile4 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile4 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Clothing,  1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile5 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile5 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Jewelry,   1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile6 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile6 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Gem,       1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile7 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile7 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.ArtObject, 1.0f ),
         };
@@ -47,7 +47,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// The second most common ItemProfile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile8 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile8 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.125f ),
             ( TreasureItemType_Orig.Armor,     0.125f ),
@@ -62,7 +62,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// The most common ItemProfile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile9 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile9 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.20f ),
             ( TreasureItemType_Orig.Armor,     0.20f ),
@@ -74,7 +74,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.PetDevice, 0.20f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile10 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile10 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    0.30f ),
             ( TreasureItemType_Orig.Armor,     0.30f ),
@@ -82,7 +82,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.PetDevice, 0.20f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> itemProfile11 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> itemProfile11 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Clothing,  0.25f ),
             ( TreasureItemType_Orig.Jewelry,   0.25f ),

--- a/Source/ACE.Server/Factories/Tables/TreasureProfile_MagicItem.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureProfile_MagicItem.cs
@@ -9,37 +9,37 @@ namespace ACE.Server.Factories.Tables
     {
         // indexed by TreasureDeath.MagicItemTreasureTypeSelectionChances
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile1 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile1 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,    1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile2 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile2 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Armor,     1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile3 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile3 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Scroll,    1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile4 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile4 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Clothing,  1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile5 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile5 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Jewelry,   1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile6 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile6 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Gem,       1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile7 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile7 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.ArtObject, 1.0f ),
         };
@@ -47,7 +47,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// A very common MagicItem profile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile8 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile8 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,             0.15f ),
             ( TreasureItemType_Orig.Armor,              0.15f ),
@@ -63,7 +63,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// A very common MagicItem profile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile9 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile9 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,             0.30f ),
             ( TreasureItemType_Orig.Armor,              0.30f ),
@@ -76,7 +76,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.EncapsulatedSpirit, 0.005f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile10 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile10 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,             0.30f ),
             ( TreasureItemType_Orig.Armor,              0.30f ),
@@ -87,7 +87,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.EncapsulatedSpirit, 0.005f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile11 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile11 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Jewelry,            0.33f ),
             ( TreasureItemType_Orig.Gem,                0.34f ),
@@ -96,7 +96,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureItemType_Orig.EncapsulatedSpirit, 0.005f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile12 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile12 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Scroll,             0.40f ),
             ( TreasureItemType_Orig.Jewelry,            0.20f ),
@@ -108,53 +108,53 @@ namespace ACE.Server.Factories.Tables
 
         // added
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile13 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile13 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyBreastplate, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile14 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile14 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyGauntlets, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile15 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile15 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyGirth, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile16 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile16 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyGreaves, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile17 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile17 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyHelm, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile18 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile18 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyPauldrons, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile19 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile19 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyTassets, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile20 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile20 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietyVambraces, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile21 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile21 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SocietySollerets, 1.0f ),
         };
 
         // Legendary Chest
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile22 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile22 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,             0.35f ),
             ( TreasureItemType_Orig.Armor,              0.35f ),
@@ -165,7 +165,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // Legendary Magic Chest
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile23 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile23 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Clothing,           0.30f ),
             ( TreasureItemType_Orig.Jewelry,            0.20f ),
@@ -174,7 +174,7 @@ namespace ACE.Server.Factories.Tables
         };
 
         // Mana Forge Chest
-        private static readonly ChanceTable<TreasureItemType_Orig> magicItemProfile24 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> magicItemProfile24 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Weapon,           0.20f ),
             ( TreasureItemType_Orig.Armor,            0.20f ),

--- a/Source/ACE.Server/Factories/Tables/TreasureProfile_Mundane.cs
+++ b/Source/ACE.Server/Factories/Tables/TreasureProfile_Mundane.cs
@@ -9,32 +9,32 @@ namespace ACE.Server.Factories.Tables
     {
         // indexed by TreasureDeath.MundaneItemTypeSelectionChances
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile1 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile1 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Consumable,     1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile2 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile2 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.HealKit,        1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile3 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile3 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Lockpick,       1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile4 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile4 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.SpellComponent, 1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile5 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile5 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.ManaStone,      1.0f ),
         };
 
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile6 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile6 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Pyreal,         1.0f ),
         };
@@ -42,7 +42,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// The most common MundaneItem profile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile7 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile7 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Pyreal,         0.17f ),
             ( TreasureItemType_Orig.Consumable,     0.17f ),
@@ -55,7 +55,7 @@ namespace ACE.Server.Factories.Tables
         /// <summary>
         /// The second most common MundaneItem profile
         /// </summary>
-        private static readonly ChanceTable<TreasureItemType_Orig> mundaneProfile8 = new ChanceTable<TreasureItemType_Orig>()
+        private static ChanceTable<TreasureItemType_Orig> mundaneProfile8 = new ChanceTable<TreasureItemType_Orig>()
         {
             ( TreasureItemType_Orig.Pyreal,         0.34f ),
             ( TreasureItemType_Orig.SpellComponent, 0.33f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
@@ -11,7 +11,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class ArmorWcids
     {
-        private static readonly ChanceTable<WeenieClassName> LeatherWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> LeatherWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.buckler,                 0.07f ),
             ( WeenieClassName.capleather,              0.02f ),
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tassetsleathernew,       0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> StuddedLeatherWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> StuddedLeatherWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldkite,                0.04f ),
             ( WeenieClassName.shieldround,               0.04f ),
@@ -56,7 +56,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tassetsstuddedleather,     0.07f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> ChainmailWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ChainmailWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldkitelarge,      0.04f ),
             ( WeenieClassName.shieldroundlarge,     0.04f ),
@@ -79,7 +79,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // platemail - aluvian
-        private static readonly ChanceTable<WeenieClassName> PlatemailWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> PlatemailWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldtower,          0.08f ),
             ( WeenieClassName.helmhorned,           0.02f ),
@@ -101,7 +101,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // platemail - gharu'ndim
-        private static readonly ChanceTable<WeenieClassName> ScalemailWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ScalemailWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldtower,          0.07f ),
             ( WeenieClassName.baigha,               0.02f ),
@@ -125,7 +125,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // platemail - sho
-        private static readonly ChanceTable<WeenieClassName> YoroiWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> YoroiWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldtower,        0.08f ),
             ( WeenieClassName.kabuton,            0.02f ),
@@ -146,7 +146,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // heritage low - aluvian
-        private static readonly ChanceTable<WeenieClassName> CeldonWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> CeldonWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.girthceldon,       0.25f ),
             ( WeenieClassName.breastplateceldon, 0.25f ),
@@ -155,21 +155,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // heritage low - gharu'ndim
-        private static readonly ChanceTable<WeenieClassName> AmuliWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> AmuliWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.coatamullian,     0.50f ),
             ( WeenieClassName.leggingsamullian, 0.50f ),
         };
 
         // heritage low - sho
-        private static readonly ChanceTable<WeenieClassName> KoujiaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> KoujiaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.breastplatekoujia, 0.33f ),
             ( WeenieClassName.leggingskoujia,    0.34f ),
             ( WeenieClassName.sleeveskoujia,     0.33f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> CovenantWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> CovenantWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldcovenant,      0.10f ),
             ( WeenieClassName.helmcovenant,        0.10f ),
@@ -184,7 +184,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // heritage high - aluvian
-        private static readonly ChanceTable<WeenieClassName> LoricaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> LoricaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bootslorica,       0.16f ),
             ( WeenieClassName.gauntletslorica,   0.16f ),
@@ -195,7 +195,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // heritage high - gharu'ndim
-        private static readonly ChanceTable<WeenieClassName> NariyidWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> NariyidWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bootsnariyid,       0.14f ),
             ( WeenieClassName.gauntletsnariyid,   0.14f ),
@@ -207,7 +207,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // heritage high - sho
-        private static readonly ChanceTable<WeenieClassName> ChiranWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ChiranWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.sandalschiran,   0.20f ),
             ( WeenieClassName.gauntletschiran, 0.20f ),
@@ -221,7 +221,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // viamontian platemail
         // introduced 07-2005 - throne of destiny
         // equivalent to platemail / scalemail / yoroi
-        private static readonly ChanceTable<WeenieClassName> DiforsaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> DiforsaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shieldtower,        0.08f ),
             ( WeenieClassName.helmdiforsa,        0.02f ),
@@ -246,7 +246,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // viamontian heritage low
         // introduced 07-2005 - throne of destiny
         // equivalent to celdon / amuli / koujia
-        private static readonly ChanceTable<WeenieClassName> TenassaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> TenassaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.breastplatetenassa, 0.33f ),
             ( WeenieClassName.leggingstenassa,    0.34f ),
@@ -256,7 +256,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // viamontian heritage high
         // introduced 07-2005 - throne of destiny
         // equivalent to lorica / nariyid / chiran
-        private static readonly ChanceTable<WeenieClassName> AlduressaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> AlduressaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bootsalduressa,     0.20f ),
             ( WeenieClassName.gauntletsalduressa, 0.20f ),
@@ -267,7 +267,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // olthoi armor, t7+
         // introduced 08-2008 - ancient powers
-        private static readonly ChanceTable<WeenieClassName> OlthoiWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OlthoiWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37191_olthoigauntlets,   0.10f ),
             ( WeenieClassName.ace37193_olthoigirth,       0.10f ),
@@ -283,7 +283,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // olthoi heritage armor, t7+
         // introduced 08-2008 - ancient powers
-        private static readonly ChanceTable<WeenieClassName> OlthoiCeldonWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OlthoiCeldonWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37189_olthoiceldongauntlets,   0.14f ),
             ( WeenieClassName.ace37192_olthoiceldongirth,       0.14f ),
@@ -294,7 +294,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37214_olthoiceldonbreastplate, 0.14f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> OlthoiAmuliWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OlthoiAmuliWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37188_olthoiamuligauntlets, 0.20f ),
             ( WeenieClassName.ace37196_olthoiamulihelm,      0.20f ),
@@ -303,7 +303,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37299_olthoiamulicoat,      0.20f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> OlthoiKoujiaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OlthoiKoujiaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37190_olthoikoujiagauntlets,   0.20f ),
             ( WeenieClassName.ace37198_olthoikoujiakabuton,     0.20f ),
@@ -312,7 +312,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37215_olthoikoujiabreastplate, 0.20f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> OlthoiAlduressaWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OlthoiAlduressaWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37187_olthoialduressagauntlets, 0.20f ),
             ( WeenieClassName.ace37195_olthoialduressahelm,      0.20f ),
@@ -323,21 +323,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // society armor
         // introduced: 08-2008 - ancient powers
-        private static readonly ChanceTable<WeenieClassName> CelestialHandWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> CelestialHandWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace38463_celestialhandbreastplate, 0.34f ),
             ( WeenieClassName.ace38464_celestialhandgauntlets,   0.33f ),
             ( WeenieClassName.ace38465_celestialhandgirth,       0.33f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> EldrytchWebWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> EldrytchWebWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace38472_eldrytchwebbreastplate, 0.34f ),
             ( WeenieClassName.ace38473_eldrytchwebgauntlets,   0.33f ),
             ( WeenieClassName.ace38474_eldrytchwebgirth,       0.33f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> RadiantBloodWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> RadiantBloodWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace38481_radiantbloodbreastplate, 0.34f ),
             ( WeenieClassName.ace38482_radiantbloodgauntlets,   0.33f ),
@@ -346,7 +346,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // empyrean, tier 6+
         // introduced 05-2010 - celebration
-        private static readonly ChanceTable<WeenieClassName> HaebreanWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> HaebreanWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace42749_haebreanbreastplate, 0.11f ),
             ( WeenieClassName.ace42750_haebreangauntlets,   0.11f ),
@@ -361,7 +361,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // empyrean, tier 6+
         // introduced 07-2010 - filling in the blanks
-        private static readonly ChanceTable<WeenieClassName> KnorrAcademyWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> KnorrAcademyWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace43048_knorracademybreastplate, 0.12f ),
             ( WeenieClassName.ace43049_knorracademygauntlets,   0.11f ),
@@ -376,7 +376,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // tier 6+ leather
         // introduced: 03-2011 - hidden in shadows
-        private static readonly ChanceTable<WeenieClassName> SedgemailLeatherWcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SedgemailLeatherWcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace43828_sedgemailleathervest,      0.17f ),
             ( WeenieClassName.ace43829_sedgemailleathercowl,      0.17f ),
@@ -388,7 +388,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // over-robes
         // introduced: 10-2011 - cloak of darkness
-        private static readonly ChanceTable<WeenieClassName> OverRobe_T3_T5_Wcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OverRobe_T3_T5_Wcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace44799_faranoverrobe,      0.25f ),     // aluvian? t3+
             ( WeenieClassName.ace44800_dhovestandoverrobe, 0.25f ),     // gharu'ndim? t3+
@@ -396,7 +396,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace44802_vestirioverrobe,    0.25f ),     // viamontian? t3+
         };
 
-        private static readonly ChanceTable<WeenieClassName> OverRobe_T6_T8_Wcids = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> OverRobe_T6_T8_Wcids = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace44799_faranoverrobe,      0.20f ),     // aluvian? t3+
             ( WeenieClassName.ace44800_dhovestandoverrobe, 0.20f ),     // gharu'ndim? t3+

--- a/Source/ACE.Server/Factories/Tables/Wcids/ClothingWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ClothingWcids.cs
@@ -13,7 +13,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // shoes: 20%
         // hat:   14%
         // gloves: 8%
-        private static readonly ChanceTable<WeenieClassName> ClothingWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ClothingWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shirtbaggy,   0.06f ),
             ( WeenieClassName.tunicbaggy,   0.06f ),
@@ -35,7 +35,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // hat: 20%
         // shoes: 17%
         // gloves: 9%
-        private static readonly ChanceTable<WeenieClassName> ClothingWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ClothingWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.breechesbaggy, 0.07f ),
             ( WeenieClassName.pantsbaggy,    0.07f ),
@@ -60,7 +60,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // shoes: 17%
         // hat: 16%
         // gloves: 9%
-        private static readonly ChanceTable<WeenieClassName> ClothingWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ClothingWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shirtbaggy,    0.06f ),
             ( WeenieClassName.capcloth,      0.08f ),
@@ -84,7 +84,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // hat: 18%
         // shoes: 15%
         // gloves: 10%
-        private static readonly ChanceTable<WeenieClassName> ClothingWcids_Viamontian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ClothingWcids_Viamontian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shirtviamontfancy,   0.11f ),
             ( WeenieClassName.shirtviamontpoet,    0.11f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/CoalescedManaWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/CoalescedManaWcids.cs
@@ -8,18 +8,18 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class CoalescedManaWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace42518_coalescedmana, 1.0f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace42518_coalescedmana, 0.75f ),
             ( WeenieClassName.ace42517_coalescedmana, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace42518_coalescedmana, 0.25f ),
             ( WeenieClassName.ace42517_coalescedmana, 0.50f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ConsumeWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class ConsumeWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.apple,           0.01f ),
             ( WeenieClassName.bread,           0.01f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminatincture, 0.08f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthdraught,   0.08f ),
             ( WeenieClassName.manadraught,     0.08f ),
@@ -41,7 +41,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminaelixir,   0.08f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthpotion,    0.08f ),
             ( WeenieClassName.manapotion,      0.08f ),
@@ -54,7 +54,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminabrew,     0.08f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthtincture,  0.08f ),
             ( WeenieClassName.manatincture,    0.08f ),
@@ -67,7 +67,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminatonic,    0.08f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthelixir,    0.08f ),
             ( WeenieClassName.manaelixir,      0.08f ),
@@ -80,7 +80,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staminaphiltre,  0.08f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healthtonic,     0.08f ),
             ( WeenieClassName.manatonic,       0.08f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class GenericWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowl,           0.09f ),
             ( WeenieClassName.chalice,        0.00f ),
@@ -24,7 +24,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tankard,        0.13f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowl,           0.08f ),
             ( WeenieClassName.chalice,        0.06f ),
@@ -40,7 +40,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tankard,        0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowl,           0.00f ),
             ( WeenieClassName.chalice,        0.23f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/HealKitWcids.cs
@@ -8,41 +8,41 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class HealKitWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitcrude,     0.75f ),
             ( WeenieClassName.healingkitplain,     0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitcrude,     0.25f ),
             ( WeenieClassName.healingkitplain,     0.50f ),
             ( WeenieClassName.healingkitgood,      0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitplain,     0.25f ),
             ( WeenieClassName.healingkitgood,      0.50f ),
             ( WeenieClassName.healingkitexcellent, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitgood,      0.25f ),
             ( WeenieClassName.healingkitexcellent, 0.50f ),
             ( WeenieClassName.healingkitpeerless,  0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitexcellent, 0.25f ),
             ( WeenieClassName.healingkitpeerless,  0.50f ),
             ( WeenieClassName.healingkittreated,   0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.healingkitpeerless,  0.25f ),
             ( WeenieClassName.healingkittreated,   0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
@@ -21,7 +21,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         // trinkets: drop rate 15% consistently per tier, 2.5% for each of the 6 trinkets
         // scaling the pre-t7 tables to 85% / 15%
 
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.amulet,        0.085f ),
             ( WeenieClassName.bracelet,      0.255f ),
@@ -38,7 +38,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41488_top,              0.025f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.amulet,        0.085f ),
             ( WeenieClassName.bracelet,      0.1275f ),
@@ -57,7 +57,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41488_top,              0.025f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.amulet,        0.0425f ),
             ( WeenieClassName.bracelet,      0.0425f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/LockpickWcids.cs
@@ -8,41 +8,41 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class LockpickWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickplain,    0.75f ),
             ( WeenieClassName.lockpickreliable, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickplain,    0.25f ),
             ( WeenieClassName.lockpickreliable, 0.50f ),
             ( WeenieClassName.lockpickgood,     0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickreliable, 0.25f ),
             ( WeenieClassName.lockpickgood,     0.50f ),
             ( WeenieClassName.lockpickexcell,   0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickgood,     0.25f ),
             ( WeenieClassName.lockpickexcell,   0.50f ),
             ( WeenieClassName.lockpicksuperb,   0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpickexcell,   0.25f ),
             ( WeenieClassName.lockpicksuperb,   0.50f ),
             ( WeenieClassName.lockpickpeer,     0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.lockpicksuperb,   0.25f ),
             ( WeenieClassName.lockpickpeer,     0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ManaStoneWcids.cs
@@ -8,41 +8,41 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class ManaStoneWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastoneminor,   0.75f ),
             ( WeenieClassName.manastonelesser,  0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastoneminor,   0.25f ),
             ( WeenieClassName.manastonelesser,  0.50f ),
             ( WeenieClassName.manastone,        0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonelesser,  0.25f ),
             ( WeenieClassName.manastone,        0.50f ),
             ( WeenieClassName.manastonemedium,  0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastone,        0.25f ),
             ( WeenieClassName.manastonemedium,  0.50f ),
             ( WeenieClassName.manastonegreater, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonemedium,  0.25f ),
             ( WeenieClassName.manastonegreater, 0.50f ),
             ( WeenieClassName.manastonemajor,   0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.manastonegreater, 0.25f ),
             ( WeenieClassName.manastonemajor,   0.75f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SpellComponentWcids.cs
@@ -9,39 +9,39 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SpellComponentWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   1.00f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   0.50f ),
             ( WeenieClassName.peascarabiron,   0.50f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarablead,   0.25f ),
             ( WeenieClassName.peascarabiron,   0.50f ),
             ( WeenieClassName.peascarabcopper, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabiron,   0.25f ),
             ( WeenieClassName.peascarabcopper, 0.50f ),
             ( WeenieClassName.peascarabsilver, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabcopper, 0.25f ),
             ( WeenieClassName.peascarabsilver, 0.50f ),
             ( WeenieClassName.peascarabgold,   0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.peascarabsilver, 0.25f ),
             ( WeenieClassName.peascarabgold,   0.50f ),
@@ -61,7 +61,7 @@ namespace ACE.Server.Factories.Tables.Wcids
         };
 
         // level 8 spell components have a chance of dropping in t7 / t8
-        private static readonly ChanceTable<bool> level8SpellComponentChance = new ChanceTable<bool>()
+        private static ChanceTable<bool> level8SpellComponentChance = new ChanceTable<bool>()
         {
             ( false, 0.6f ),
             ( true,  0.4f ),
@@ -85,7 +85,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             return table.Roll(profile.LootQualityMod);
         }
 
-        private static readonly ChanceTable<WeenieClassName> Quills = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Quills = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37363_quillofinfliction,    0.50f ),   // war/debuff (other)
             ( WeenieClassName.ace37364_quillofintrospection, 0.35f ),   // beneficial (self)
@@ -93,7 +93,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37362_quillofextraction,    0.05f ),   // drain (other)
         };
 
-        private static readonly ChanceTable<WeenieClassName> Inks = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Inks = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.ace37353_inkofformation,       0.30f ),   // self (can only be used with introspection quills)
             ( WeenieClassName.ace37360_inkofconveyance,      0.24f ),   // other (can only be used with benevolence, infliction, and extraction quills)

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
@@ -8,13 +8,13 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class AtlatlWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.atlatl,      0.50f ),
             ( WeenieClassName.atlatlroyal, 0.50f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.atlatl,                     0.25f ),
             ( WeenieClassName.atlatlroyal,                0.26f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31815_electricslingshot, 0.035f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.atlatlslashing,             0.075f ),
             ( WeenieClassName.atlatlpiercing,             0.075f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class BowWcids_Aluvian
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort, 0.50f ),
             ( WeenieClassName.bowlong,  0.25f ),
             ( WeenieClassName.bowwar,   0.25f )
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort,                     0.25f ),
             ( WeenieClassName.bowlong,                      0.13f ),
@@ -36,7 +36,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31801_electriccompoundbow, 0.035f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowslashing,                  0.075f ),
             ( WeenieClassName.bowpiercing,                  0.075f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class BowWcids_Gharundim
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort, 0.50f ),
             ( WeenieClassName.yag,      0.25f ),
             ( WeenieClassName.nayin,    0.25f )
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort,                     0.25f ),
             ( WeenieClassName.yag,                          0.13f ),
@@ -36,7 +36,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31801_electriccompoundbow, 0.035f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowslashing,                  0.075f ),
             ( WeenieClassName.bowpiercing,                  0.075f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class BowWcids_Sho
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort, 0.50f ),
             ( WeenieClassName.shouyumi, 0.25f ),
             ( WeenieClassName.yumi,     0.25f )
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowshort,                     0.25f ),
             ( WeenieClassName.shouyumi,                     0.13f ),
@@ -36,7 +36,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31801_electriccompoundbow, 0.035f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.bowslashing,                  0.075f ),
             ( WeenieClassName.bowpiercing,                  0.075f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class CasterWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             (WeenieClassName.orb,     0.25f ),
             (WeenieClassName.sceptre, 0.25f ),
@@ -16,7 +16,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             (WeenieClassName.wand,    0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.17f ),
             ( WeenieClassName.sceptre,                0.17f ),
@@ -40,7 +40,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.02f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.13f ),
             ( WeenieClassName.sceptre,                0.13f ),
@@ -64,7 +64,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.05f ),
             ( WeenieClassName.sceptre,                0.05f ),
@@ -88,7 +88,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43382_netherbaton,   0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T7_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T7_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.04f ),
             ( WeenieClassName.sceptre,                0.04f ),
@@ -120,7 +120,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace43383_netherstaff,   0.015f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.orb,                    0.036f ),
             ( WeenieClassName.sceptre,                0.036f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
@@ -8,14 +8,14 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class CrossbowWcids
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.crossbowlight,    0.50f ),
             ( WeenieClassName.crossbowheavy,    0.25f ),
             ( WeenieClassName.crossbowarbalest, 0.25f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.crossbowlight,                     0.25f ),
             ( WeenieClassName.crossbowheavy,                     0.13f ),
@@ -36,7 +36,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31808_electriccompoundcrossbow, 0.035f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.crossbowslashing,                  0.075f ),
             ( WeenieClassName.crossbowpiercing,                  0.075f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.Factories.Tables.Wcids
     {
         // hammers?
 
-        private static readonly ChanceTable<WeenieClassName> Hatchets = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Hatchets = new ChanceTable<WeenieClassName>()
         {
             // finesse - axe
             ( WeenieClassName.axehatchet,         0.40f ),
@@ -20,7 +20,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.axehatchetfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Shouonos = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Shouonos = new ChanceTable<WeenieClassName>()
         {
             // finesse - axe
             ( WeenieClassName.shouono,         0.40f ),
@@ -30,7 +30,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.shouonofrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Tungis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Tungis = new ChanceTable<WeenieClassName>()
         {
             // finesse - axe
             ( WeenieClassName.tungi,         0.40f ),
@@ -40,7 +40,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tungifrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Knives = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Knives = new ChanceTable<WeenieClassName>()
         {
             // finesse - dagger (multi-strike)
             ( WeenieClassName.knife,         0.40f ),
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.knifefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Lancets = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Lancets = new ChanceTable<WeenieClassName>()
         {
             // finesse - dagger (multi-strike)
             ( WeenieClassName.ace31794_lancet,          0.40f ),
@@ -60,7 +60,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31793_frostlancet,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Poniards = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Poniards = new ChanceTable<WeenieClassName>()
         {
             // finesse - dagger
             ( WeenieClassName.daggerponiard,         0.40f ),
@@ -70,7 +70,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.daggerponiardfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> BoardsWithNails = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> BoardsWithNails = new ChanceTable<WeenieClassName>()
         {
             // finesse - mace
             ( WeenieClassName.ace31774_boardwithnail,         0.40f ),
@@ -80,7 +80,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31773_frostboardwithnail,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Dabus = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Dabus = new ChanceTable<WeenieClassName>()
         {
             // finesse - mace
             ( WeenieClassName.dabus,         0.40f ),
@@ -90,7 +90,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dabusfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Jittes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Jittes = new ChanceTable<WeenieClassName>()
         {
             // finesse - mace
             ( WeenieClassName.jitte,         0.40f ),
@@ -100,7 +100,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.jittefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Tofuns = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Tofuns = new ChanceTable<WeenieClassName>()
         {
             // finesse - mace
             ( WeenieClassName.tofun,         0.40f ),
@@ -110,7 +110,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tofunfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Budiaqs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Budiaqs = new ChanceTable<WeenieClassName>()
         {
             // finesse - spear
             ( WeenieClassName.budiaq,         0.40f ),
@@ -120,7 +120,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.budiaqfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Naginatas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Naginatas = new ChanceTable<WeenieClassName>()
         {
             // finesse - spear
             ( WeenieClassName.swordstaff,         0.40f ),
@@ -130,7 +130,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordstafffrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Bastones = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Bastones = new ChanceTable<WeenieClassName>()
         {
             // finesse - staff
             ( WeenieClassName.staffmeleebastone,         0.40f ),
@@ -140,7 +140,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.staffmeleebastonefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Jos = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Jos = new ChanceTable<WeenieClassName>()
         {
             // finesse - staff
             ( WeenieClassName.jonew,         0.40f ),
@@ -150,7 +150,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.jofrostnew,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Sabras = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Sabras = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword
             ( WeenieClassName.swordsabra,         0.40f ),
@@ -160,7 +160,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordsabrafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Scimitars = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Scimitars = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword
             ( WeenieClassName.scimitar,         0.40f ),
@@ -170,7 +170,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.scimitarfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> ShortSwords = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> ShortSwords = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword
             ( WeenieClassName.swordshort,         0.40f ),
@@ -180,7 +180,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordshortfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Simis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Simis = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword
             ( WeenieClassName.simi,         0.40f ),
@@ -190,7 +190,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.simifrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Rapiers = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Rapiers = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword (multi-strike)
             ( WeenieClassName.swordrapier,              0.40f ),
@@ -200,7 +200,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace45107_frostrapier,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Yaojis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Yaojis = new ChanceTable<WeenieClassName>()
         {
             // finesse - sword
             ( WeenieClassName.yaoji,         0.40f ),
@@ -210,7 +210,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.yaojifrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Claws = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Claws = new ChanceTable<WeenieClassName>()
         {
             // finesse - unarmed
             ( WeenieClassName.ace31784_claw,          0.40f ),
@@ -220,7 +220,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31783_frostclaw,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> HandWraps = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> HandWraps = new ChanceTable<WeenieClassName>()
         {
             // finesse - unarmed
             ( WeenieClassName.ace45118_handwraps,          0.40f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class HeavyWeaponWcids
     {
-        private static readonly ChanceTable<WeenieClassName> BattleAxes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> BattleAxes = new ChanceTable<WeenieClassName>()
         {
             // heavy - axe
             ( WeenieClassName.axebattle,         0.40f ),
@@ -18,7 +18,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.axebattlefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> LugianHammers = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> LugianHammers = new ChanceTable<WeenieClassName>()
         {
             // heavy - axe
             ( WeenieClassName.ace31764_lugianhammer,          0.40f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31763_frostlugianhammer,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Silifis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Silifis = new ChanceTable<WeenieClassName>()
         {
             // heavy - axe
             ( WeenieClassName.silifi,         0.40f ),
@@ -38,7 +38,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.silififrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> WarAxes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> WarAxes = new ChanceTable<WeenieClassName>()
         {
             // heavy - axe
             ( WeenieClassName.ace31769_waraxe,          0.40f ),
@@ -48,7 +48,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31768_frostwaraxe,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Dirks = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Dirks = new ChanceTable<WeenieClassName>()
         {
             // heavy - dagger
             ( WeenieClassName.dirk,         0.40f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dirkfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Jambiyas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Jambiyas = new ChanceTable<WeenieClassName>()
         {
             // heavy - dagger (multi-strike)
             ( WeenieClassName.jambiya,         0.40f ),
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.jambiyafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Stilettos = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Stilettos = new ChanceTable<WeenieClassName>()
         {
             // heavy - dagger (multi-strike)
             ( WeenieClassName.daggerstiletto,         0.40f ),
@@ -78,7 +78,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.daggerstilettofrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> FlangedMaces = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> FlangedMaces = new ChanceTable<WeenieClassName>()
         {
             // heavy - mace
             ( WeenieClassName.maceflanged,         0.40f ),
@@ -88,7 +88,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.maceflangedfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Maces = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Maces = new ChanceTable<WeenieClassName>()
         {
             // heavy - mace
             ( WeenieClassName.mace,         0.40f ),
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.macefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Mazules = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Mazules = new ChanceTable<WeenieClassName>()
         {
             // heavy - mace
             ( WeenieClassName.macemazule,         0.40f ),
@@ -108,7 +108,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.macemazulefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> MorningStars = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> MorningStars = new ChanceTable<WeenieClassName>()
         {
             // heavy - mace
             ( WeenieClassName.morningstar,         0.40f ),
@@ -118,7 +118,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.morningstarfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Partizans = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Partizans = new ChanceTable<WeenieClassName>()
         {
             // heavy - spear
             ( WeenieClassName.spearpartizan,         0.40f ),
@@ -128,7 +128,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.spearpartizanfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> SpineGlaives = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SpineGlaives = new ChanceTable<WeenieClassName>()
         {
             // heavy - spear
             ( WeenieClassName.ace31779_spineglaive,         0.40f ),
@@ -138,7 +138,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31778_frostspineglaive,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Tridents = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Tridents = new ChanceTable<WeenieClassName>()
         {
             // heavy - spear
             ( WeenieClassName.trident,         0.40f ),
@@ -148,7 +148,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tridentfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Nabuts = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Nabuts = new ChanceTable<WeenieClassName>()
         {
             // heavy - staff
             ( WeenieClassName.nabutnew,         0.40f ),
@@ -158,7 +158,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.nabutfrostnew,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Sticks = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Sticks = new ChanceTable<WeenieClassName>()
         {
             // heavy - staff
             ( WeenieClassName.ace31788_stick,          0.40f ),
@@ -168,7 +168,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace31792_froststick,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Flamberges = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Flamberges = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.swordflamberge,         0.40f ),
@@ -178,7 +178,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordflambergefrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Kens = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Kens = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.ken,         0.40f ),
@@ -188,7 +188,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.kenfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> LongSwords = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> LongSwords = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.swordlong,         0.40f ),
@@ -198,7 +198,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordlongfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Schlagers = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Schlagers = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.ace45108_schlager,          0.40f ),
@@ -208,7 +208,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace45112_frostschlager,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Tachis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Tachis = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.tachi,         0.40f ),
@@ -218,7 +218,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tachifrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Takubas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Takubas = new ChanceTable<WeenieClassName>()
         {
             // heavy - sword
             ( WeenieClassName.takuba,         0.40f ),
@@ -228,7 +228,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.takubafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Cestus = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Cestus = new ChanceTable<WeenieClassName>()
         {
             // heavy - unarmed
             ( WeenieClassName.cestus,         0.40f ),
@@ -238,7 +238,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.cestusfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Nekodes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Nekodes = new ChanceTable<WeenieClassName>()
         {
             // heavy - unarmed
             ( WeenieClassName.nekode,         0.40f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/AxeWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/AxeWcids.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class AxeWcids
     {
-        private static readonly ChanceTable<WeenieClassName> AxeWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> AxeWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.axehand,           0.16f ),
             ( WeenieClassName.axehandacid,       0.04f ),
@@ -26,7 +26,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.warhammerfrost,    0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> AxeWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> AxeWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.tungi,             0.16f ),
             ( WeenieClassName.tungiacid,         0.04f ),
@@ -45,7 +45,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.warhammerfrost,    0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> AxeWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> AxeWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.shouono,           0.16f ),
             ( WeenieClassName.shouonoacid,       0.04f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Aluvian_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Aluvian_Sho.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class DaggerWcids_Aluvian_Sho
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.knife,          0.16f ),
             ( WeenieClassName.knifeacid,      0.04f ),
@@ -27,7 +27,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dirkfrost,      0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.knife,          0.06f ),
             ( WeenieClassName.knifeacid,      0.01f ),
@@ -46,7 +46,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dirkfrost,      0.10f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.knife,          0.01f ),
             ( WeenieClassName.knifeacid,      0.01f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/DaggerWcids_Gharundim.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class DaggerWcids_Gharundim
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T3_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T3_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.jambiya,         0.16f ),
             ( WeenieClassName.jambiyaacid,     0.04f ),
@@ -27,7 +27,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dirkfrost,       0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.jambiya,         0.06f ),
             ( WeenieClassName.jambiyaacid,     0.01f ),
@@ -46,7 +46,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.dirkfrost,       0.10f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.jambiya,         0.01f ),
             ( WeenieClassName.jambiyaacid,     0.01f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/MaceWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/MaceWcids.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class MaceWcids
     {
-        private static readonly ChanceTable<WeenieClassName> MaceWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> MaceWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.club,                0.13f ),
             ( WeenieClassName.clubacid,            0.03f ),
@@ -31,7 +31,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.clubspikedfrost,     0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> MaceWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> MaceWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.kasrullah,           0.13f ),
             ( WeenieClassName.kasrullahacid,       0.03f ),
@@ -55,7 +55,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.clubspikedfrost,     0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> MaceWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> MaceWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.jitte,               0.13f ),
             ( WeenieClassName.jitteacid,           0.03f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SpearWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SpearWcids.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SpearWcids
     {
-        private static readonly ChanceTable<WeenieClassName> SpearWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SpearWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.spear,              0.16f ),
             ( WeenieClassName.spearacid,          0.04f ),
@@ -26,7 +26,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordstafffrost,    0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> SpearWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SpearWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.budiaq,             0.16f ),
             ( WeenieClassName.budiaqacid,         0.04f ),
@@ -45,7 +45,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordstafffrost,    0.05f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> SpearWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SpearWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.yari,               0.16f ),
             ( WeenieClassName.yariacid,           0.04f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/StaffWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/StaffWcids.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class StaffWcids
     {
-        private static readonly ChanceTable<WeenieClassName> StaffWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> StaffWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.quarterstaffnew,         0.40f ),
             ( WeenieClassName.quarterstaffacidnew,     0.15f ),
@@ -16,7 +16,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.quarterstafffrostnew,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> StaffWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> StaffWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.nabutnew,         0.40f ),
             ( WeenieClassName.nabutacidnew,     0.15f ),
@@ -25,7 +25,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.nabutfrostnew,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> StaffWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> StaffWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.jonew,         0.40f ),
             ( WeenieClassName.joacidnew,     0.15f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Aluvian.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Aluvian.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SwordWcids_Aluvian
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,        0.10f ),
             ( WeenieClassName.swordshort,         0.12f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordbroadfrost,    0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,        0.06f ),
             ( WeenieClassName.swordshort,         0.06f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordbroadfrost,    0.04f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,        0.01f ),
             ( WeenieClassName.swordshort,         0.01f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Gharundim.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SwordWcids_Gharundim
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.10f ),
             ( WeenieClassName.simi,             0.12f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.takubafrost,      0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.06f ),
             ( WeenieClassName.simi,             0.06f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.takubafrost,      0.04f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.01f ),
             ( WeenieClassName.simi,             0.01f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/SwordWcids_Sho.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class SwordWcids_Sho
     {
-        private static readonly ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T1_T2_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.10f ),
             ( WeenieClassName.yaoji,            0.12f ),
@@ -33,7 +33,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tachifrost,       0.03f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T3_T4_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.06f ),
             ( WeenieClassName.yaoji,            0.06f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.tachifrost,       0.04f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> T5_T6_Chances = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.swordrapier,      0.01f ),
             ( WeenieClassName.yaoji,            0.01f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/UnarmedWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/Legacy/UnarmedWcids.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class UnarmedWcids
     {
-        private static readonly ChanceTable<WeenieClassName> UnarmedWcids_Aluvian = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> UnarmedWcids_Aluvian = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.cestus,         0.40f ),
             ( WeenieClassName.cestusacid,     0.15f ),
@@ -16,7 +16,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.cestusfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> UnarmedWcids_Gharundim = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> UnarmedWcids_Gharundim = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.katar,         0.40f ),
             ( WeenieClassName.kataracid,     0.15f ),
@@ -25,7 +25,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.katarfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> UnarmedWcids_Sho = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> UnarmedWcids_Sho = new ChanceTable<WeenieClassName>()
         {
             ( WeenieClassName.nekode,         0.40f ),
             ( WeenieClassName.nekodeacid,     0.15f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class LightWeaponWcids
     {
-        private static readonly ChanceTable<WeenieClassName> Dolabras = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Dolabras = new ChanceTable<WeenieClassName>()
         {
             // light - axe
             ( WeenieClassName.axedolabra,         0.40f ),
@@ -18,7 +18,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.axedolabrafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> HandAxes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> HandAxes = new ChanceTable<WeenieClassName>()
         {
             // light - axe
             ( WeenieClassName.axehand,         0.40f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.axehandfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Onos = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Onos = new ChanceTable<WeenieClassName>()
         {
             // light - axe
             ( WeenieClassName.ono,         0.40f ),
@@ -38,7 +38,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.onofrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> WarHammers = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> WarHammers = new ChanceTable<WeenieClassName>()
         {
             // light - axe
             ( WeenieClassName.warhammer,         0.40f ),
@@ -48,7 +48,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.warhammerfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Daggers = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Daggers = new ChanceTable<WeenieClassName>()
         {
             // light - dagger (multi-strike)
             ( WeenieClassName.dagger,         0.40f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.daggerfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Khanjars = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Khanjars = new ChanceTable<WeenieClassName>()
         {
             // light - dagger
             ( WeenieClassName.khanjar,         0.40f ),
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.khanjarfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Clubs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Clubs = new ChanceTable<WeenieClassName>()
         {
             // light - mace
             ( WeenieClassName.club,         0.40f ),
@@ -78,7 +78,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.clubfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Kasrullahs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Kasrullahs = new ChanceTable<WeenieClassName>()
         {
             // light - mace
             ( WeenieClassName.kasrullah,         0.40f ),
@@ -88,7 +88,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.kasrullahfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> SpikedClubs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> SpikedClubs = new ChanceTable<WeenieClassName>()
         {
             // light - mace
             ( WeenieClassName.clubspiked,         0.40f ),
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.clubspikedfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Spears = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Spears = new ChanceTable<WeenieClassName>()
         {
             // light - spear
             ( WeenieClassName.spear,         0.40f ),
@@ -108,7 +108,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.spearfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Yaris = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Yaris = new ChanceTable<WeenieClassName>()
         {
             // light - spear
             ( WeenieClassName.yari,         0.40f ),
@@ -118,7 +118,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.yarifrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> QuarterStaffs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> QuarterStaffs = new ChanceTable<WeenieClassName>()
         {
             // light - staff
             ( WeenieClassName.quarterstaffnew,         0.40f ),
@@ -128,7 +128,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.quarterstafffrostnew,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> BroadSwords = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> BroadSwords = new ChanceTable<WeenieClassName>()
         {
             // light - sword
             ( WeenieClassName.swordbroad,         0.40f ),
@@ -138,7 +138,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordbroadfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> DericostBlades = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> DericostBlades = new ChanceTable<WeenieClassName>()
         {
             // light - sword
             ( WeenieClassName.ace31759_dericostblade,          0.40f ),
@@ -150,7 +150,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         // epee?
 
-        private static readonly ChanceTable<WeenieClassName> Kaskaras = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Kaskaras = new ChanceTable<WeenieClassName>()
         {
             // light - sword
             ( WeenieClassName.kaskara,         0.40f ),
@@ -160,7 +160,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.kaskarafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Shamshirs = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Shamshirs = new ChanceTable<WeenieClassName>()
         {
             // light - sword
             ( WeenieClassName.shamshir,         0.40f ),
@@ -170,7 +170,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.shamshirfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Spadas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Spadas = new ChanceTable<WeenieClassName>()
         {
             // light - sword
             ( WeenieClassName.swordspada,         0.40f ),
@@ -180,7 +180,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.swordspadafrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Katars = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Katars = new ChanceTable<WeenieClassName>()
         {
             // light - unarmed
             ( WeenieClassName.katar,         0.40f ),
@@ -190,7 +190,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.katarfrost,    0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Knuckles = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Knuckles = new ChanceTable<WeenieClassName>()
         {
             // light - unarmed
             ( WeenieClassName.knuckles,         0.40f ),

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables.Wcids
 {
     public static class TwoHandedWeaponWcids
     {
-        private static readonly ChanceTable<WeenieClassName> GreatAxes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> GreatAxes = new ChanceTable<WeenieClassName>()
         {
             // two-handed - axe
             ( WeenieClassName.ace41052_greataxe,          0.40f ),
@@ -18,7 +18,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41056_frostgreataxe,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> GreatStarMaces = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> GreatStarMaces = new ChanceTable<WeenieClassName>()
         {
             // two-handed - mace
             ( WeenieClassName.ace41057_greatstarmace,          0.40f ),
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41061_frostgreatstarmace,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> KhandaHandledMaces = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> KhandaHandledMaces = new ChanceTable<WeenieClassName>()
         {
             // two-handed - mace
             ( WeenieClassName.ace41062_khandahandledmace,          0.40f ),
@@ -38,7 +38,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41066_frostkhandahandledmace,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Quadrelles = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Quadrelles = new ChanceTable<WeenieClassName>()
         {
             // two-handed - mace
             ( WeenieClassName.ace40623_quadrelle,          0.40f ),
@@ -48,7 +48,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace40627_frostquadrelle,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Tetsubos = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Tetsubos = new ChanceTable<WeenieClassName>()
         {
             // two-handed - mace
             ( WeenieClassName.ace40635_tetsubo,          0.40f ),
@@ -58,7 +58,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace40639_frosttetsubo,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Assagais = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Assagais = new ChanceTable<WeenieClassName>()
         {
             // two-handed - spear
             ( WeenieClassName.ace41036_assagai,          0.40f ),
@@ -68,7 +68,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41040_frostassagai,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Corsecas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Corsecas = new ChanceTable<WeenieClassName>()
         {
             // two-handed - spear
             ( WeenieClassName.ace40818_corsesca,          0.40f ),
@@ -78,7 +78,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace40822_frostcorsesca,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> MagariYaris = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> MagariYaris = new ChanceTable<WeenieClassName>()
         {
             // two-handed - spear
             ( WeenieClassName.ace41041_magariyari,          0.40f ),
@@ -88,7 +88,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41045_frostmagariyari,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Pikes = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Pikes = new ChanceTable<WeenieClassName>()
         {
             // two-handed - spear
             ( WeenieClassName.ace41046_pike,          0.40f ),
@@ -98,7 +98,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41050_frostpike,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Nodachis = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Nodachis = new ChanceTable<WeenieClassName>()
         {
             // two-handed - sword
             ( WeenieClassName.ace40760_nodachi,          0.40f ),
@@ -108,7 +108,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace40764_frostnodachi,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Shashqas = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Shashqas = new ChanceTable<WeenieClassName>()
         {
             // two-handed - sword
             ( WeenieClassName.ace41067_shashqa,          0.40f ),
@@ -118,7 +118,7 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace41071_frostshashqa,     0.15f ),
         };
 
-        private static readonly ChanceTable<WeenieClassName> Spadones = new ChanceTable<WeenieClassName>()
+        private static ChanceTable<WeenieClassName> Spadones = new ChanceTable<WeenieClassName>()
         {
             // two-handed - sword
             ( WeenieClassName.ace40618_spadone,          0.40f ),

--- a/Source/ACE.Server/Factories/Tables/WeaponTypeChance.cs
+++ b/Source/ACE.Server/Factories/Tables/WeaponTypeChance.cs
@@ -8,7 +8,7 @@ namespace ACE.Server.Factories.Tables
 {
     public static class WeaponTypeChance
     {
-        private static readonly ChanceTable<TreasureWeaponType> T1_T4_Chances = new ChanceTable<TreasureWeaponType>()
+        private static ChanceTable<TreasureWeaponType> T1_T4_Chances = new ChanceTable<TreasureWeaponType>()
         {
             // melee: 84%
             // missile: 12%
@@ -26,7 +26,7 @@ namespace ACE.Server.Factories.Tables
             ( TreasureWeaponType.Caster,   0.04f ),
         };
 
-        private static readonly ChanceTable<TreasureWeaponType> T5_T6_Chances = new ChanceTable<TreasureWeaponType>()
+        private static ChanceTable<TreasureWeaponType> T5_T6_Chances = new ChanceTable<TreasureWeaponType>()
         {
             // melee: 63%
             // missile: 27%
@@ -46,7 +46,7 @@ namespace ACE.Server.Factories.Tables
 
         // from magloot corpse logs
         // it appears they might have gotten rid of the tier chances
-        private static readonly ChanceTable<TreasureWeaponType> RetailChances = new ChanceTable<TreasureWeaponType>()
+        private static ChanceTable<TreasureWeaponType> RetailChances = new ChanceTable<TreasureWeaponType>()
         {
             // melee: 63%
             // missile: 20%

--- a/Source/ACE.Server/Factories/Tables/WorkmanshipChance.cs
+++ b/Source/ACE.Server/Factories/Tables/WorkmanshipChance.cs
@@ -7,7 +7,7 @@ namespace ACE.Server.Factories.Tables
 {
     public static class WorkmanshipChance
     {
-        private static readonly ChanceTable<int> T1_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T1_Chances = new ChanceTable<int>()
         {
             ( 1, 0.05f ),
             ( 2, 0.15f ),
@@ -16,7 +16,7 @@ namespace ACE.Server.Factories.Tables
             ( 5, 0.2f ),
         };
 
-        private static readonly ChanceTable<int> T2_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T2_Chances = new ChanceTable<int>()
         {
             ( 2, 0.05f ),
             ( 3, 0.15f ),
@@ -25,7 +25,7 @@ namespace ACE.Server.Factories.Tables
             ( 6, 0.2f ),
         };
 
-        private static readonly ChanceTable<int> T3_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T3_Chances = new ChanceTable<int>()
         {
             ( 3, 0.05f ),
             ( 4, 0.15f ),
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             ( 7, 0.2f ),
         };
 
-        private static readonly ChanceTable<int> T4_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T4_Chances = new ChanceTable<int>()
         {
             ( 3, 0.01f ),
             ( 4, 0.05f ),
@@ -44,7 +44,7 @@ namespace ACE.Server.Factories.Tables
             ( 8, 0.2f ),
         };
 
-        private static readonly ChanceTable<int> T5_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T5_Chances = new ChanceTable<int>()
         {
             ( 3, 0.01f ),
             ( 4, 0.03f ),
@@ -55,7 +55,7 @@ namespace ACE.Server.Factories.Tables
             ( 9, 0.05f ),
         };
 
-        private static readonly ChanceTable<int> T6_Chances = new ChanceTable<int>()
+        private static ChanceTable<int> T6_Chances = new ChanceTable<int>()
         {
             ( 4, 0.01f ),
             ( 5, 0.04f ),


### PR DESCRIPTION
this pr adds the ability for admins and devs to hotswap loot profiles at runtime with the /reload-loot-tables admin command

by default, if no parameters are specified, the latest loot table data from the source folder will be reloaded.

a 'loot profile folder' can also be specified, to easily hotswap between different loot table profiles

creating new loot profiles would just be cloning the ACE.Server/Factories/Table folder, and modifying it with any customizations specific to that profile.

```
reload-loot-tables

Updated ArmorModVsTypeChance
Updated ArmorTypeChance
Updated ArmorCantrips
Updated CantripChance
Updated JewelryCantrips
Updated MeleeCantrips
Updated MissileCantrips
Updated NumCantrips
Updated WandCantrips
Updated CasterSlotSpells
Updated CloakChance
Updated GearRatingChance
Updated GemClassChance
Updated GemCountChance
Updated HeritageChance
Updated MaterialTable
Updated PetDeviceChance
Updated QualityChance
Updated ScrollLevelChance
Updated SpellLevelChance
Updated SpellLevelProgression
Updated SpellSelectionTable
Updated ArmorSpells
Updated GemSpells
Updated JewelrySpells
Updated MeleeSpells
Updated MissileSpells
Updated ScrollSpells
Updated WandSpells
Updated TreasureProfile_Item
Updated TreasureProfile_MagicItem
Updated TreasureProfile_Mundane
Updated AetheriaWcids
Updated WeaponTypeChance
Updated WorkmanshipChance
Updated AetheriaChance
Updated ArmorWcids
Updated CloakWcids
Updated ClothingWcids
Updated CoalescedManaWcids
Updated ConsumeWcids
Updated GenericWcids
Updated HealKitWcids
Updated JewelryWcids
Updated LockpickWcids
Updated ManaStoneWcids
Updated PetDeviceWcids
Updated ScrollWcids
Updated SocietyArmorWcids
Updated SpellComponentWcids
Updated AtlatlWcids
Updated BowWcids_Aluvian
Updated BowWcids_Gharundim
Updated BowWcids_Sho
Updated CasterWcids
Updated CrossbowWcids
Updated FinesseWeaponWcids
Updated HeavyWeaponWcids
Updated AxeWcids
Updated DaggerWcids_Aluvian_Sho
Updated DaggerWcids_Gharundim
Updated MaceWcids
Updated SpearWcids
Updated StaffWcids
Updated SwordWcids_Aluvian
Updated SwordWcids_Gharundim
Updated SwordWcids_Sho
Updated UnarmedWcids
Updated LightWeaponWcids
Updated TwoHandedWeaponWcids
Updated WeaponWcids

Updated loot tables in 0.126916s
```