### PR TITLE
Add aceversion command

### DIFF
--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -354,5 +354,20 @@ namespace ACE.Server.Command.Handlers
             }
             session.Player.PrevObjSend = DateTime.UtcNow;
         }
+
+        // show player ace server versions
+        [CommandHandler("aceversion", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Shows this server's version data")]
+        public static void HandleACEversion(Session session, params string[] parameters)
+        {
+            if (!PropertyManager.GetBool("version_info_enabled").Item)
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat("The command \"aceversion\" is not currently enabled on this server.", ChatMessageType.Broadcast));
+                return;
+            }
+
+            var msg = ServerBuildInfo.GetVersionInfo();
+
+            session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.WorldBroadcast));
+        }
     }
 }

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -560,6 +560,7 @@ namespace ACE.Server.Managers
                 ("updated_loot_system", new Property<bool>(false, "enables the most up-to-date version of the loot system")),
                 ("use_turbine_chat", new Property<bool>(true, "enables or disables global chat channels (General, LFG, Roleplay, Trade, Olthoi, Society, Allegience)")),
                 ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
+                ("version_info_enabled", new Property<bool>(false, "toggles the /aceversion player command")),
                 ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
                 );
 


### PR DESCRIPTION
Add `aceversion` command for players.

This can be used by players on bug reports as well as in getting assistance with debugging issues.

Command is disabled by default, but can be enabled by server operators with `version_info_enabled` property