### PR TITLE
Landblock SpawnEncounters threading improvement

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -272,11 +272,11 @@ namespace ACE.Server.Entity
 
                 if (wo == null) continue;
 
-                var xPos = Math.Clamp(encounter.CellX * 24.0f, 0.5f, 191.5f);
-                var yPos = Math.Clamp(encounter.CellY * 24.0f, 0.5f, 191.5f);
-
                 actionQueue.EnqueueAction(new ActionEventDelegate(() =>
                 {
+                    var xPos = Math.Clamp(encounter.CellX * 24.0f, 0.5f, 191.5f);
+                    var yPos = Math.Clamp(encounter.CellY * 24.0f, 0.5f, 191.5f);
+
                     var pos = new Physics.Common.Position();
                     pos.ObjCellID = (uint)(Id.Landblock << 16) | 1;
                     pos.Frame = new Physics.Animation.AFrame(new Vector3(xPos, yPos, 0), Quaternion.Identity);

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -275,46 +275,46 @@ namespace ACE.Server.Entity
                 var xPos = Math.Clamp(encounter.CellX * 24.0f, 0.5f, 191.5f);
                 var yPos = Math.Clamp(encounter.CellY * 24.0f, 0.5f, 191.5f);
 
-                var pos = new Physics.Common.Position();
-                pos.ObjCellID = (uint)(Id.Landblock << 16) | 1;
-                pos.Frame = new Physics.Animation.AFrame(new Vector3(xPos, yPos, 0), Quaternion.Identity);
-                pos.adjust_to_outside();
-
-                pos.Frame.Origin.Z = PhysicsLandblock.GetZ(pos.Frame.Origin);
-
-                wo.Location = new Position(pos.ObjCellID, pos.Frame.Origin, pos.Frame.Orientation);
-
-                var sortCell = LScape.get_landcell(pos.ObjCellID) as SortCell;
-                if (sortCell != null && sortCell.has_building())
-                    continue;
-
-                if (PropertyManager.GetBool("override_encounter_spawn_rates").Item)
-                {
-                    wo.RegenerationInterval = PropertyManager.GetDouble("encounter_regen_interval").Item;
-
-                    wo.ReinitializeHeartbeats();
-
-                    if (wo.Biota.PropertiesGenerator != null)
-                    {
-                        // While this may be ugly, it's done for performance reasons.
-                        // Common weenie properties are not cloned into the bota on creation. Instead, the biota references simply point to the weenie collections.
-                        // The problem here is that we want to update one of those common collection properties. If the biota is referencing the weenie collection,
-                        // then we'll end up updating the global weenie (from the cache), instead of just this specific biota.
-                        if (wo.Biota.PropertiesGenerator == wo.Weenie.PropertiesGenerator)
-                        {
-                            wo.Biota.PropertiesGenerator = new List<PropertiesGenerator>(wo.Weenie.PropertiesGenerator.Count);
-
-                            foreach (var record in wo.Weenie.PropertiesGenerator)
-                                wo.Biota.PropertiesGenerator.Add(record.Clone());
-                        }
-
-                        foreach (var profile in wo.Biota.PropertiesGenerator)
-                            profile.Delay = (float) PropertyManager.GetDouble("encounter_delay").Item;
-                    }
-                }
-
                 actionQueue.EnqueueAction(new ActionEventDelegate(() =>
                 {
+                    var pos = new Physics.Common.Position();
+                    pos.ObjCellID = (uint)(Id.Landblock << 16) | 1;
+                    pos.Frame = new Physics.Animation.AFrame(new Vector3(xPos, yPos, 0), Quaternion.Identity);
+                    pos.adjust_to_outside();
+
+                    pos.Frame.Origin.Z = PhysicsLandblock.GetZ(pos.Frame.Origin);
+
+                    wo.Location = new Position(pos.ObjCellID, pos.Frame.Origin, pos.Frame.Orientation);
+
+                    var sortCell = LScape.get_landcell(pos.ObjCellID) as SortCell;
+                    if (sortCell != null && sortCell.has_building())
+                        return;
+
+                    if (PropertyManager.GetBool("override_encounter_spawn_rates").Item)
+                    {
+                        wo.RegenerationInterval = PropertyManager.GetDouble("encounter_regen_interval").Item;
+
+                        wo.ReinitializeHeartbeats();
+
+                        if (wo.Biota.PropertiesGenerator != null)
+                        {
+                            // While this may be ugly, it's done for performance reasons.
+                            // Common weenie properties are not cloned into the bota on creation. Instead, the biota references simply point to the weenie collections.
+                            // The problem here is that we want to update one of those common collection properties. If the biota is referencing the weenie collection,
+                            // then we'll end up updating the global weenie (from the cache), instead of just this specific biota.
+                            if (wo.Biota.PropertiesGenerator == wo.Weenie.PropertiesGenerator)
+                            {
+                                wo.Biota.PropertiesGenerator = new List<PropertiesGenerator>(wo.Weenie.PropertiesGenerator.Count);
+
+                                foreach (var record in wo.Weenie.PropertiesGenerator)
+                                    wo.Biota.PropertiesGenerator.Add(record.Clone());
+                            }
+
+                            foreach (var profile in wo.Biota.PropertiesGenerator)
+                                profile.Delay = (float)PropertyManager.GetDouble("encounter_delay").Item;
+                        }
+                    }
+
                     AddWorldObject(wo);
                 }));
             }


### PR DESCRIPTION
Landblock.SpawnEncounters is run from a separate Task.

It does a lot of position/cell work on that task and only enqueues the AddWorldObject onto the thread safe ActionQueue.

I suspect these tasks were hitting AdjustCells at the same time LandblockManager is unloading landblocks (and thus cells).

This caused thread collisions on the AdjustCells dictionary.

Wrapping all this work up into the thread safe ActionQueue should solve the issue.