### PR TITLE
fix missing dequip calls from stackable merge

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1044,7 +1044,9 @@ namespace ACE.Server.WorldObjects
             }
             else // Movement is within the same pack or between packs in a container on the landblock
             {
-                if (itemRootOwner != null && !itemRootOwner.TryRemoveFromInventory(item.Guid))
+                var itemRootCreature = itemRootOwner as Creature;
+
+                if (itemRootOwner != null && !itemRootOwner.TryRemoveFromInventory(item.Guid) && (itemRootCreature == null || !itemRootCreature.TryDequipObject(item.Guid, out _, out _)))
                 {
                     Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, "TryRemoveFromInventory failed!")); // Custom error message
                     Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
@@ -1674,6 +1676,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionStackableSplitToContainer(uint stackId, uint containerId, int placementPosition, int amount)
         {
+            //Console.WriteLine($"{Name}.HandleActionStackableSplitToContainer({stackId:X8}, {containerId:X8}, {placementPosition}, {amount})");
+
             if (amount <= 0)
             {
                 log.WarnFormat("Player 0x{0:X8}:{1} tried to split item with invalid amount ({3}) 0x{2:X8}.", Guid.Full, Name, stackId, amount);
@@ -1863,6 +1867,8 @@ namespace ACE.Server.WorldObjects
 
         private bool DoHandleActionStackableSplitToContainer(WorldObject stack, Container stackFoundInContainer, Container stackRootOwner, Container container, Container containerRootOwner, WorldObject newStack, int placementPosition, int amount)
         {
+            //Console.WriteLine($"{Name}.DoHandleActionStackableSplitToContainer({stack?.Name}, {stackFoundInContainer?.Name}, {stackRootOwner?.Name}, {container?.Name}, {containerRootOwner?.Name}, {newStack?.Name}, {placementPosition}, {amount})");
+
             // Before we modify the original stack, we make sure we can add the new stack
             if (!container.TryAddToInventory(newStack, placementPosition, true))
             {
@@ -2018,6 +2024,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void HandleActionStackableMerge(uint mergeFromGuid, uint mergeToGuid, int amount)
         {
+            //Console.WriteLine($"HandleActionStackableMerge({mergeFromGuid:X8}, {mergeToGuid:X8}, {amount})");
+
             if (amount <= 0)
             {
                 log.WarnFormat("Player 0x{0}:{1} tried to merge item with invalid amount ({3}) 0x{2:X8}.", Guid.Full, Name, mergeFromGuid, amount);
@@ -2233,6 +2241,8 @@ namespace ACE.Server.WorldObjects
 
         private bool DoHandleActionStackableMerge(WorldObject sourceStack, WorldObject targetStack, int amount)
         {
+            //Console.WriteLine($"DoHandleActionStackableMerge({sourceStack?.Name}, {targetStack?.Name}, {amount})");
+
             var previousSourceStackCheck = sourceStack;
             //var previousTargetStackCheck = targetStack;
 
@@ -2257,7 +2267,9 @@ namespace ACE.Server.WorldObjects
 
                 if (sourceStackRootOwner != null) // item is contained and not on a landblock
                 {
-                    if (sourceStackRootOwner.TryRemoveFromInventory(sourceStack.Guid, out var stackToDestroy, true))
+                    var sourceStackRootCreature = sourceStackRootOwner as Creature;
+
+                    if (sourceStackRootOwner.TryRemoveFromInventory(sourceStack.Guid, out var stackToDestroy, true) || sourceStackRootCreature != null && sourceStackRootCreature.TryDequipObject(sourceStack.Guid, out stackToDestroy, out _))
                         stackToDestroy?.Destroy();
                     else
                     {


### PR DESCRIPTION
this fixes long-standing bug on server where merging from equipped ammo slot was not being handled correctly on server

repro steps:

/ci arrow 100
/ci arrow 100
equip one of the arrow stacks
double click the equipped arrows to dequip them

expected:

arrows are dequipped properly

actual:

arrows visibly disappear from equipped slot on client, but server actually returns an 'inventory saved failed', which the client might ignore / not be valid for this particular action, which the client sends as HandleActionStackableMerge.

this is because the server code was only checking for inventory item in some places, and was missing the check for equipped items

afterwards, if you try to equip the remaining stack of arrows, with the latest code you will get the error that there are already arrows equipped (which are now invisible to the client)

if you relog, the invisible arrows in the equipped slot will re-appear

---

previously, this was sort of just an invisible bug that was persisting on the server. when a player tries to equip new items, aside from some clothing slot checks, the full checks for overlap between wielded slots were not being performed before

a recent pr https://github.com/ACEmulator/ACE/pull/3339 added the remaining equipped slots overlap prevention, which brought this bug to light

in the current master, instead of allowing this bug to persist / grow, the server now correctly prevents any overlap from occurring