### PR TITLE
fix spell stack calculation issue with set spells in multiple sets

### DIFF
--- a/Source/ACE.Entity/Models/PropertiesEnchantmentRegistryExtensions.cs
+++ b/Source/ACE.Entity/Models/PropertiesEnchantmentRegistryExtensions.cs
@@ -216,11 +216,15 @@ namespace ACE.Entity.Models
 
                 var valuesByStatModTypeAndKey = value.Where(e => (e.StatModType & statModType) == statModType && e.StatModKey == statModKey || (handleMultiple && (e.StatModType & multipleStat) == multipleStat && e.StatModKey == 0));
 
+                // 3rd spell id sort added for Gauntlet Damage Boost I / Gauntlet Damage Boost II, which is contained in multiple sets, and can overlap
+                // without this sorting criteria, it's already matched up to the client, but produces logically incorrect results for server spell stacking
+                // confirmed this bug still exists in acclient Enchantment.Duel(), unknown if it existed in retail server
+
                 var results = from e in valuesByStatModTypeAndKey
                     group e by e.SpellCategory
                     into categories
                     //select categories.OrderByDescending(c => c.LayerId).First();
-                    select categories.OrderByDescending(c => c.PowerLevel).ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId)).First();
+                    select categories.OrderByDescending(c => c.PowerLevel).ThenByDescending(c => Level8AuraSelfSpells.Contains(c.SpellId)).ThenByDescending(c => c.SpellId).First();
 
                 return results.ToList();
             }

--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -96,10 +96,20 @@ namespace ACE.Server.Entity
                         var spellDuration = equip ? double.PositiveInfinity : spell.Duration;
                         var entryDuration = entry.Duration == -1 ? double.PositiveInfinity : entry.Duration;
 
-                        if (spellDuration >= entryDuration)
+                        if (spellDuration > entryDuration)
                             Surpass.Add(entry);
-                        else
+                        else if (spellDuration < entryDuration)
                             Surpassed.Add(entry);
+                        else
+                        {
+                            // fallback on spell id, for overlapping set spells in multiple sets, where the different 'level' names each have the same spellLevel and powerLevel?
+                            // ie. for Gauntlet Damage Boost I and II
+                            // this bug still exists in acclient visual enchantment display, unknown whether this bug existed on retail server
+                            if (spell.Id > entry.SpellId)
+                                Surpass.Add(entry);
+                            else
+                                Surpassed.Add(entry);
+                        }
                     }
                 }
                 else if (powerLevel < entry.PowerLevel)


### PR DESCRIPTION
repro steps:

/ci shirt
/ci pants
appraise shirt, /additemspell 6330
appraise pants, /additemspell 6331

equip shirt pants in different order, and notice discrepancies in the following areas: the spell the server thinks is at the top of the stack (matches client, in current master), and the spell the client thinks is at the top of the stack

this seems to be a bug on both the client and server. this patch fixes it for the server (unknown if retail server has this issue), but the visual display anomaly will still remain on the client