### PR TITLE
Fix Unhook

### DIFF
--- a/Source/ACE.Server/Factories/WorldObjectFactory.cs
+++ b/Source/ACE.Server/Factories/WorldObjectFactory.cs
@@ -25,7 +25,7 @@ namespace ACE.Server.Factories
         /// </summary>
         public static WorldObject CreateWorldObject(Weenie weenie, ObjectGuid guid)
         {
-            if (weenie == null || guid == ObjectGuid.Invalid)
+            if (weenie == null)
                 return null;
 
             var objWeenieType = weenie.WeenieType;


### PR DESCRIPTION
ObjectGuid.Invalid is a valid use case for CreateWorldObject