### PR TITLE
fix chickenhen move emote

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
@@ -365,7 +365,10 @@ namespace ACE.Server.WorldObjects
                     PhysicsObj.update_object();
                     UpdatePosition_SyncLocation();
                     SendUpdatePosition();
-                    AddMoveToTick();
+
+                    if (PhysicsObj.MovementManager.MoveToManager.FailProgressCount < 10)
+                        AddMoveToTick();
+
                     //Console.WriteLine($"{Name}.Position: {Location}");
                 }
             });

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -842,6 +842,9 @@ namespace ACE.Server.WorldObjects.Managers
                     if (!WorldObject.PlayersInRange(ClientMaxAnimRange))
                         break;
 
+                    if (WorldObject.PhysicsObj != null && WorldObject.PhysicsObj.IsMovingTo())
+                        break;
+
                     if (WorldObject == null || WorldObject.CurrentMotionState == null) break;
 
                     // TODO: REFACTOR ME


### PR DESCRIPTION
chickenhen has a NonCombat.Ready immediately after its Move emotes, with 0 delay in between. not sure if retail would have waited to perform the Ready until after the move was completed... ace emotes are currently setup to pre-calculate the delay to the next emote, and a variable delay / callback system is not implemented for this.

the way ExecuteMotion(Ready) is also called, it apparently stops the current Turning motion in progress, but does not call MoveToManager to stop the current MoveTo in progress. so MoveToManager was basically going into an infinite loop, detecting that no Turning progress was being made, and incrementing FailProgressCount each time, which the Move handler was not monitoring

the easiest fix for this is to just ignore Motion emotes if there is a MoveTo currently in progress (esp. for chickenhen Ready, which is a redundant emote that effectively does nothing here), and to also add a failsafe to check FailProgressCount in the Move handler