### PR TITLE
Workaround fix for intermittent corpse save failures

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -304,23 +304,6 @@ namespace ACE.Database
                 {
                     firstException = ex;
 
-                    if (biota.WeenieType == (int)WeenieType.Corpse && biota.WeenieClassId == (uint)WeenieClassName.W_CORPSE_CLASS && ex.GetFullMessage().Contains("Unknown column 'order' in 'field list'"))
-                    {
-                        // unknown how this column keeps deleting, but it is likely a bug that is a result of auto (world only?) database updates that repros under currently unknown conditions
-                        // attempt to correct shard database missing order column
-
-                        try
-                        {
-                            context.Database.ExecuteSqlCommand("ALTER TABLE `biota_properties_palette` ADD COLUMN `order` TINYINT(3) UNSIGNED NULL DEFAULT NULL AFTER `length`;");
-
-                            log.Debug($"[DATABASE] DoSaveBiota 0x{biota.Id:X8}:{biota.GetProperty(PropertyString.Name)} restored missing order column to biota_properties_palette table");
-                        }
-                        catch (Exception ex2)
-                        {
-                            log.Debug($"[DATABASE] DoSaveBiota 0x{biota.Id:X8}:{biota.GetProperty(PropertyString.Name)} failed to restore missing order column to biota_properties_palette table: {ex2.GetFullMessage()}");
-                        }
-                    }
-
                     goto retry;
                 }
 

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -303,7 +303,6 @@ namespace ACE.Database
                 if (firstException == null)
                 {
                     firstException = ex;
-
                     goto retry;
                 }
 

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -303,6 +303,24 @@ namespace ACE.Database
                 if (firstException == null)
                 {
                     firstException = ex;
+
+                    if (biota.WeenieType == (int)WeenieType.Corpse && biota.WeenieClassId == (uint)WeenieClassName.W_CORPSE_CLASS && ex.GetFullMessage().Contains("Unknown column 'order' in 'field list'"))
+                    {
+                        // unknown how this column keeps deleting, but it is likely a bug that is a result of auto (world only?) database updates that repros under currently unknown conditions
+                        // attempt to correct shard database missing order column
+
+                        try
+                        {
+                            context.Database.ExecuteSqlCommand("ALTER TABLE `biota_properties_palette` ADD COLUMN `order` TINYINT(3) UNSIGNED NULL DEFAULT NULL AFTER `length`;");
+
+                            log.Debug($"[DATABASE] DoSaveBiota 0x{biota.Id:X8}:{biota.GetProperty(PropertyString.Name)} restored missing order column to biota_properties_palette table");
+                        }
+                        catch (Exception ex2)
+                        {
+                            log.Debug($"[DATABASE] DoSaveBiota 0x{biota.Id:X8}:{biota.GetProperty(PropertyString.Name)} failed to restore missing order column to biota_properties_palette table: {ex2.GetFullMessage()}");
+                        }
+                    }
+
                     goto retry;
                 }
 

--- a/Source/ACE.Database/ShardDatabaseOfflineTools.cs
+++ b/Source/ACE.Database/ShardDatabaseOfflineTools.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using log4net;
 
 using ACE.Common;
+using ACE.Common.Extensions;
 using ACE.Database.Models.Shard;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -958,6 +959,41 @@ namespace ACE.Database
             }
 
             log.Info($"2020-04-11-00-Update-Character-SpellBars.sql patch has been successfully installed. Before opening world to players, make sure you've run fix-spell-bars command from console");
+        }
+
+        /// <summary>
+        /// <para>unknown how this column keeps deleting, but it is likely a bug that is a result of auto (world only?) database updates that repros under currently unknown conditions</para>
+        /// this checks for and attempts to correct shard database missing order column
+        /// </summary>
+        public static void CheckForBiotaPropertiesPaletteOrderColumnInShard()
+        {
+            log.Info($"Checking for order column in biota_properties_palette table in shard database...");
+
+            using (var context = new ShardDbContext())
+            {
+                try
+                {
+                    var result = context.BiotaPropertiesPalette.FirstOrDefault();
+                }
+                catch (Exception ex)
+                {
+                    log.Warn("order column in biota_properties_palette table in shard database is missing! Attempting to fix...");
+                    try
+                    {
+                        context.Database.ExecuteSqlCommand("ALTER TABLE `biota_properties_palette` ADD COLUMN `order` TINYINT(3) UNSIGNED NULL DEFAULT NULL AFTER `length`;");
+
+                        var result = context.BiotaPropertiesPalette.FirstOrDefault();
+                    }
+                    catch (Exception ex2)
+                    {
+                        log.Fatal($"Unable to restore order column in biota_properties_palette table in shard database due to following error: {ex2.GetFullMessage()}");
+                        Environment.Exit(1);
+                        return;
+                    }
+                }
+            }
+
+            log.Info($"Successfully verified order column in biota_properties_palette table in shard database!");
         }
     }
 }

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -181,6 +181,8 @@ namespace ACE.Server
             // This should only be enabled manually. To enable it, simply uncomment this line
             //ACE.Database.OfflineTools.Shard.BiotaGuidConsolidator.ConsolidateBiotaGuids(0xC0000000, out int numberOfBiotasConsolidated, out int numberOfErrors);
 
+            ShardDatabaseOfflineTools.CheckForBiotaPropertiesPaletteOrderColumnInShard();
+
             log.Info("Initializing ServerManager...");
             ServerManager.Initialize();
 


### PR DESCRIPTION
This patch attempts to workaround the order column for biota_properties_palette table being removed from shard database which causes corpse save failures.

It is unknown what exactly causes this table to lose this column but this workaround corrects it and retries saving