### PR TITLE
Send current attacker message to client.

### DIFF
--- a/Source/ACE.Server/Entity/Spell.cs
+++ b/Source/ACE.Server/Entity/Spell.cs
@@ -238,11 +238,16 @@ namespace ACE.Server.Entity
         {
             get
             {
-                return Category == SpellCategory.DamageLowering     // encompasses both blood and spirit loather, inconsistent with spirit drinker in dat
-                    || Category == SpellCategory.DefenseModLowering
-                    || Category == SpellCategory.AttackModLowering
-                    || Category == SpellCategory.WeaponTimeLowering
-                    || Category == SpellCategory.ManaConversionModLowering;    // hermetic void, replaced hide value, unchanged category in dat
+                switch (Category)
+                {
+                    case SpellCategory.DamageLowering:            // encompasses both blood and spirit loather, inconsistent with spirit drinker in dat
+                    case SpellCategory.DefenseModLowering:
+                    case SpellCategory.AttackModLowering:
+                    case SpellCategory.WeaponTimeLowering:        // verified
+                    case SpellCategory.ManaConversionModLowering: // hermetic void, replaced hide value, unchanged category in dat
+                        return true;
+                }
+                return false;
             }
         }
 
@@ -250,11 +255,16 @@ namespace ACE.Server.Entity
         {
             get
             {
-                return MetaSpellType == SpellType.PortalLink
-                    || MetaSpellType == SpellType.PortalRecall
-                    || MetaSpellType == SpellType.PortalSending
-                    || MetaSpellType == SpellType.PortalSummon
-                    || MetaSpellType == SpellType.FellowPortalSending;
+                switch (MetaSpellType)
+                {
+                    case SpellType.PortalLink:
+                    case SpellType.PortalRecall:
+                    case SpellType.PortalSending:
+                    case SpellType.PortalSummon:
+                    case SpellType.FellowPortalSending:
+                        return true;
+                }
+                return false;
             }
         }
 
@@ -265,12 +275,17 @@ namespace ACE.Server.Entity
         {
             get
             {
-                return Category == SpellCategory.AttackModRaising
-                    || Category == SpellCategory.DamageRaising
-                    || Category == SpellCategory.DefenseModRaising
-                    || Category == SpellCategory.WeaponTimeRaising
-                    || Category == SpellCategory.ManaConversionModRaising
-                    || Category == SpellCategory.SpellDamageRaising;
+                switch (Category)
+                {
+                    case SpellCategory.AttackModRaising:
+                    case SpellCategory.DamageRaising:
+                    case SpellCategory.DefenseModRaising:
+                    case SpellCategory.WeaponTimeRaising:        // verified
+                    case SpellCategory.ManaConversionModRaising:
+                    case SpellCategory.SpellDamageRaising:
+                        return true;
+                }
+                return true;
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -251,12 +251,6 @@ namespace ACE.Server.WorldObjects
                     break;
             }
 
-            var targetPlayer = AttackTarget as Player;
-            if (targetPlayer != null)
-            {
-                targetPlayer.SendCurrentAttackerGuid(this.Guid);
-            }
-
             EmoteManager.OnAttack(AttackTarget);
 
             ResetAttack();

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -251,6 +251,12 @@ namespace ACE.Server.WorldObjects
                     break;
             }
 
+            var targetPlayer = AttackTarget as Player;
+            if (targetPlayer != null)
+            {
+                targetPlayer.SendCurrentAttackerGuid(this.Guid);
+            }
+
             EmoteManager.OnAttack(AttackTarget);
 
             ResetAttack();

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -199,7 +199,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void SetCurrentAttacker(Creature currentAttacker)
         {
-            if (CurrentAttacker != currentAttacker.Guid.Full)
+            if (currentAttacker == this || CurrentAttacker == currentAttacker.Guid.Full)
                 return;
 
             CurrentAttacker = currentAttacker.Guid.Full;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -767,6 +767,9 @@ namespace ACE.Server.WorldObjects
 
                     if (!targetPlayer.SquelchManager.Squelches.Contains(ProjectileSource, ChatMessageType.Magic))
                         targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat(defenderMsg, ChatMessageType.Magic));
+
+                    if (sourceCreature != null)
+                        targetPlayer.SetCurrentAttacker(sourceCreature);
                 }
 
                 if (!nonHealth)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -219,6 +219,9 @@ namespace ACE.Server.WorldObjects
 
                     targetPlayer.Session.Network.EnqueueSend(new GameMessageSound(targetPlayer.Guid, Sound.ResistSpell, 1.0f));
 
+                    if (casterCreature != null)
+                        targetPlayer.SetCurrentAttacker(casterCreature);
+
                     Proficiency.OnSuccessUse(targetPlayer, targetPlayer.GetCreatureSkill(Skill.MagicDefense), magicSkill);
                 }
 


### PR DESCRIPTION
Send the current attacker message to the client so that the client can
use the last attack keyboard shortcut to select the last attacker.

Note that these will be sent often when there are multiple attackers.
The message should only be sent when the attacker changes