### PR TITLE
update wielded treasure roll to be closer to retail

### DIFF
--- a/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
+++ b/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
@@ -1040,5 +1040,10 @@ namespace ACE.Database
                 return results;
             }
         }
+
+        public void ClearWieldedTreasureCache()
+        {
+            cachedWieldedTreasure.Clear();
+        }
     }
 }

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -3455,7 +3455,7 @@ namespace ACE.Server.Command.Handlers
 
                 var itemName = wo?.Name ?? "Unknown";
 
-                CommandHandlerHelper.WriteOutputInfo(session, $"{prefix}- {item.Item.WeenieClassId} - {itemName} ({item.Item.Probability * 100}%)"));
+                CommandHandlerHelper.WriteOutputInfo(session, $"{prefix}- {item.Item.WeenieClassId} - {itemName} ({item.Item.Probability * 100}%)");
 
                 if (item.Subset != null)
                     OutputWieldedTreasureSet(session, item.Subset, depth + 1);

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -3418,8 +3418,8 @@ namespace ACE.Server.Command.Handlers
             session.Player.HandleActionGetAndWieldItem(itemGuid, equipMask);
         }
 
-        [CommandHandler("show-wield-tree", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Shows the WieldedTreasure tree for a Creature")]
-        public static void HandleShowWieldTree(Session session, params string[] parameters)
+        [CommandHandler("show-wielded-treasure", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Shows the WieldedTreasure table for a Creature", "wcid")]
+        public static void HandleShowWieldedTreasure(Session session, params string[] parameters)
         {
             if (!uint.TryParse(parameters[0], out var wcid))
             {
@@ -3449,16 +3449,34 @@ namespace ACE.Server.Command.Handlers
         {
             var prefix = new string(' ', depth * 2);
 
+            var totalProbability = 0.0f;
+            var spacer = false;
+
             foreach (var item in set.Items)
             {
+                if (totalProbability >= 1.0f)
+                {
+                    totalProbability = 0.0f;
+                    //spacer = true;
+                }
+                totalProbability += item.Item.Probability;
+
                 var wo = WorldObjectFactory.CreateNewWorldObject(item.Item.WeenieClassId);
 
                 var itemName = wo?.Name ?? "Unknown";
 
+                if (spacer)
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, "");
+                    spacer = false;
+                }
                 CommandHandlerHelper.WriteOutputInfo(session, $"{prefix}- {item.Item.WeenieClassId} - {itemName} ({item.Item.Probability * 100}%)");
 
                 if (item.Subset != null)
+                {
                     OutputWieldedTreasureSet(session, item.Subset, depth + 1);
+                    //spacer = true;
+                }
             }
         }
     }

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2204,6 +2204,8 @@ namespace ACE.Server.Command.Handlers.Processors
                     mode = CacheType.Spell;
                 if (parameters[0].Contains("weenie", StringComparison.OrdinalIgnoreCase))
                     mode = CacheType.Weenie;
+                if (parameters[0].Contains("wield", StringComparison.OrdinalIgnoreCase))
+                    mode = CacheType.WieldedTreasure;
             }
 
             if (mode.HasFlag(CacheType.Landblock))
@@ -2230,17 +2232,24 @@ namespace ACE.Server.Command.Handlers.Processors
                 CommandHandlerHelper.WriteOutputInfo(session, "Clearing weenie cache");
                 DatabaseManager.World.ClearWeenieCache();
             }
+
+            if (mode.HasFlag(CacheType.WieldedTreasure))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, "Clearing wielded treasure cache");
+                DatabaseManager.World.ClearWieldedTreasureCache();
+            }
         }
 
         [Flags]
         public enum CacheType
         {
-            None      = 0x0,
-            Landblock = 0x1,
-            Recipe    = 0x2,
-            Spell     = 0x4,
-            Weenie    = 0x8,
-            All       = 0xFFFF
+            None            = 0x0,
+            Landblock       = 0x1,
+            Recipe          = 0x2,
+            Spell           = 0x4,
+            Weenie          = 0x8,
+            WieldedTreasure = 0x10,
+            All             = 0xFFFF
         };
 
         public static FileType GetFileType(string filename)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Equipment.cs
@@ -53,13 +53,22 @@ namespace ACE.Server.WorldObjects
         {
             var wieldedTreasure = new List<WorldObject>();
 
-            var rng = ThreadSafeRandom.Next(0.0f, set.TotalProbability);
+            var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
             var probability = 0.0f;
+            var rolled = false;
 
             foreach (var item in set.Items)
             {
+                if (probability >= 1.0f)
+                {
+                    probability = 0.0f;
+                    rolled = false;
+                }
                 probability += item.Item.Probability;
-                if (rng >= probability) continue;
+
+                if (rng >= probability || rolled) continue;
+
+                rolled = true;
 
                 // item roll successful, spawn item in creature inventory
                 var wo = CreateWieldedTreasure(item.Item);
@@ -70,9 +79,8 @@ namespace ACE.Server.WorldObjects
                 // traverse into possible subsets
                 if (item.Subset != null)
                     wieldedTreasure.AddRange(GenerateWieldedTreasureSet(item.Subset));
-
-                break;
             }
+
             return wieldedTreasure;
         }
 


### PR DESCRIPTION
a set with 117% probability, for example, should be interpreted as 2 sets: the first set having a 100% chance of rolling one of the items in the range of 0.0-1.0, and the second set having a 17% chance of rolling an item in the > 1.0 range

this is similar to how the createlist probabilities work

previously ace was only performing 1 roll for this, between 0.0-1.17

also adds /show-wielded-treasure &lt;creature wcid&gt; developer command