### PR TITLE
update base magic crit rate for 11-2002 iron coast release notes

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -187,7 +187,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    LifeMagic(spell, out uint damage, out bool critical, out enchantmentStatus, this, item, true);
+                    LifeMagic(spell, out uint damage, out enchantmentStatus, this, item, true);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(Guid, spell.TargetEffect, spell.Formula.Scale));
 

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -308,7 +308,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    var targetDeath = LifeMagic(spell, out uint damage, out bool critical, out var msg, target);
+                    var targetDeath = LifeMagic(spell, out uint damage, out var msg, target);
 
                     if (spell.MetaSpellType != SpellType.LifeProjectile)
                     {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -893,7 +893,7 @@ namespace ACE.Server.WorldObjects
                                 VoidMagic(target, spell, caster);
                                 break;
                             case MagicSchool.LifeMagic:
-                                LifeMagic(spell, out uint damage, out bool critical, out var enchantmentStatus, target, caster);
+                                LifeMagic(spell, out uint damage, out var enchantmentStatus, target, caster);
                                 break;
                         }
                     }
@@ -1126,7 +1126,7 @@ namespace ACE.Server.WorldObjects
                         }
                     }
 
-                    targetDeath = LifeMagic(spell, out uint damage, out bool critical, out enchantmentStatus, target, caster);
+                    targetDeath = LifeMagic(spell, out uint damage, out enchantmentStatus, target, caster);
 
                     if (spell.MetaSpellType != SpellType.LifeProjectile)
                     {
@@ -1322,7 +1322,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    LifeMagic(spell, out uint damage, out bool critical, out enchantmentStatus, player);
+                    LifeMagic(spell, out uint damage, out enchantmentStatus, player);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(player.Guid, spell.TargetEffect, spell.Formula.Scale));
                     break;

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -243,12 +243,11 @@ namespace ACE.Server.WorldObjects
                     var critterBuffsForPlayer = buffsForPlayer.Where(k => k.Spell.School == MagicSchool.CreatureEnchantment).ToList();
                     var itemBuffsForPlayer = buffsForPlayer.Where(k => k.Spell.School == MagicSchool.ItemEnchantment).ToList();
 
-                    bool crit = false;
                     uint dmg = 0;
                     EnchantmentStatus ec;
                     lifeBuffsForPlayer.ForEach(spl =>
                     {
-                        bool casted = targetPlayer.LifeMagic(spl.Spell, out dmg, out crit, out ec, targetPlayer, this);
+                        bool casted = targetPlayer.LifeMagic(spl.Spell, out dmg, out ec, targetPlayer, this);
                     });
                     critterBuffsForPlayer.ForEach(spl =>
                     {

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -738,7 +738,7 @@ namespace ACE.Server.WorldObjects
 
                 if (sourcePlayer != null)
                 {
-                    var critProt = critDefended ? " Your target's Critical Protection augmentation allows them to avoid your critical hit!" : "";
+                    var critProt = critDefended ? " Your critical hit was avoided with their augmentation!" : "";
 
                     var attackerMsg = $"{critMsg}{overpowerMsg}{sneakMsg}You {verb} {target.Name} for {amount} points with {Spell.Name}.{critProt}";
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -755,7 +755,7 @@ namespace ACE.Server.WorldObjects
 
                 if (targetPlayer != null)
                 {
-                    var critProt = critDefended ? " Your Critical Protection augmentation allows you to avoid a critical hit!" : "";
+                    var critProt = critDefended ? " Your augmentation allows you to avoid a critical hit!" : "";
 
                     var defenderMsg = $"{critMsg}{overpowerMsg}{sneakMsg}{ProjectileSource.Name} {plural} you for {amount} points with {Spell.Name}.{critProt}";
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -78,7 +78,7 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case MagicSchool.LifeMagic:
-                    var targetDeath = LifeMagic(spell, out uint damage, out bool critical, out status, target, caster);
+                    var targetDeath = LifeMagic(spell, out uint damage, out status, target, caster);
                     if (targetDeath && target is Creature targetCreature)
                     {
                         targetCreature.OnDeath(new DamageHistoryInfo(this), DamageType.Health, false);
@@ -246,9 +246,8 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a Life Magic spell
         /// </summary>
-        protected bool LifeMagic(Spell spell, out uint damage, out bool critical, out EnchantmentStatus enchantmentStatus, WorldObject target = null, WorldObject itemCaster = null, bool equip = false)
+        protected bool LifeMagic(Spell spell, out uint damage, out EnchantmentStatus enchantmentStatus, WorldObject target = null, WorldObject itemCaster = null, bool equip = false)
         {
-            critical = false;
             string srcVital, destVital;
             enchantmentStatus = new EnchantmentStatus(spell);
             GameMessageSystemChat targetMsg = null;
@@ -478,7 +477,7 @@ namespace ACE.Server.WorldObjects
 
                             //var sourcePlayer = source as Player;
                             //if (sourcePlayer != null && sourcePlayer.Fellowship != null)
-                            //sourcePlayer.Fellowship.OnVitalUpdate(sourcePlayer);
+                                //sourcePlayer.Fellowship.OnVitalUpdate(sourcePlayer);
 
                             break;
                     }
@@ -503,7 +502,7 @@ namespace ACE.Server.WorldObjects
 
                             //var destPlayer = destination as Player;
                             //if (destPlayer != null && destPlayer.Fellowship != null)
-                            //destPlayer.Fellowship.OnVitalUpdate(destPlayer);
+                                //destPlayer.Fellowship.OnVitalUpdate(destPlayer);
 
                             break;
                     }
@@ -752,7 +751,7 @@ namespace ACE.Server.WorldObjects
             // redirect creature dispels to life magic
             if (spell.MetaSpellType == SpellType.Dispel)
             {
-                LifeMagic(spell, out uint damage, out bool critical, out var enchantmentStatus, target);
+                LifeMagic(spell, out uint damage, out var enchantmentStatus, target);
                 return enchantmentStatus;
             }
             return CreateEnchantment(target ?? itemCaster ?? this, itemCaster ?? this, spell, equip);
@@ -768,7 +767,7 @@ namespace ACE.Server.WorldObjects
             // redirect item dispels to life magic
             if (spell.MetaSpellType == SpellType.Dispel)
             {
-                LifeMagic(spell, out uint damage, out bool critical, out enchantmentStatus, target, itemCaster, equip);
+                LifeMagic(spell, out uint damage, out enchantmentStatus, target, itemCaster, equip);
                 return enchantmentStatus;
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -271,9 +271,14 @@ namespace ACE.Server.WorldObjects
             return critRate;
         }
 
-        // http://acpedia.org/wiki/Announcements_-_2002/08_-_Atonement#Letter_to_the_Players
+        // http://acpedia.org/wiki/Announcements_-_2002/08_-_Atonement#Letter_to_the_Players - 2% originally
 
-        private const float defaultMagicCritFrequency = 0.02f;      // 2% base chance
+        // http://acpedia.org/wiki/Announcements_-_2002/11_-_The_Iron_Coast#Release_Notes
+        // The chance for causing a critical hit with magic, both with and without a Critical Strike wand, has been increased.
+        // what this was actually increased to for base, was never stated directly in the dev notes
+        // speculation is that it was 5%, to align with the minimum that CS magic scales from
+
+        private const float defaultMagicCritFrequency = 0.05f;
 
         /// <summary>
         /// Returns the critical chance for the current magic weapon
@@ -578,7 +583,7 @@ namespace ACE.Server.WorldObjects
         // Critical Strike for War Magic currently scales from 5% critical hit chance to 25% critical hit chance at maximum effectiveness.
         // In July, the maximum effectiveness will be increased to 50% chance.
 
-        public static float MinCriticalStrikeMagicMod = 0.05f;
+        //public static float MinCriticalStrikeMagicMod = 0.05f;
 
         public static float MaxCriticalStrikeMod = 0.5f;
 
@@ -629,12 +634,16 @@ namespace ACE.Server.WorldObjects
             // This code is checking if the player has reached the skill threshold for receiving the 5% bonus
             // (base skill 90 in PvE, base skill 120 in PvP)
 
-            var criticalStrikeMod = skillType == ImbuedSkillType.Magic ? defaultMagicCritFrequency : defaultPhysicalCritFrequency;
+            /*var criticalStrikeMod = skillType == ImbuedSkillType.Magic ? defaultMagicCritFrequency : defaultPhysicalCritFrequency;
 
             var minEffective = skillType == ImbuedSkillType.Magic ? MinCriticalStrikeMagicMod : defaultPhysicalCritFrequency;
 
             if (baseMod >= minEffective)
-                criticalStrikeMod = baseMod;
+                criticalStrikeMod = baseMod;*/
+
+            var defaultCritFrequency = skillType == ImbuedSkillType.Magic ? defaultMagicCritFrequency : defaultPhysicalCritFrequency;
+
+            var criticalStrikeMod = Math.Max(defaultCritFrequency, baseMod);
 
             //Console.WriteLine($"CriticalStrikeMod: {criticalStrikeMod}");
 


### PR DESCRIPTION
http://acpedia.org/wiki/Announcements_-_2002/11_-_The_Iron_Coast#Release_Notes

"The chance for causing a critical hit with magic, both with and without a Critical Strike wand, has been increased."

Thanks to Xenocide for tracking down some solid dev notes for this!

Also updated the critical protection augmentation feedback messages for magic to match retail pcaps. It differed slightly from the messages for physical.