### PR TITLE
Update Vendor generator sys to match EoR usage

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -570,6 +570,7 @@ namespace ACE.Server.Managers
                 ("use_turbine_chat", new Property<bool>(true, "enables or disables global chat channels (General, LFG, Roleplay, Trade, Olthoi, Society, Allegience)")),
                 ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
                 ("version_info_enabled", new Property<bool>(false, "toggles the /aceversion player command")),
+                ("vendor_shop_uses_generator", new Property<bool>(false, "enables or disables vendors using generator system in addition to createlist to create artificial scarcity")),
                 ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world"))
                 );
 

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -87,11 +87,7 @@ namespace ACE.Server.WorldObjects
 
             if (!PropertyManager.GetBool("vendor_shop_uses_generator").Item)
             {
-                foreach (var profile in GeneratorProfiles.ToList())
-                {
-                    if (profile.Biota.WhereCreate.HasFlag(RegenLocationType.Shop))
-                        GeneratorProfiles.Remove(profile);
-                }
+                GeneratorProfiles.RemoveAll(p => p.Biota.WhereCreate.HasFlag(RegenLocationType.Shop));
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -205,7 +205,7 @@ namespace ACE.Server.WorldObjects
             if (inventoryloaded)
                 return;
 
-            var itemsForSale = new Dictionary<int, uint>();
+            var itemsForSale = new Dictionary<(uint weenieClassId, int paletteTemplate, double shade), uint>();
 
             foreach (var item in Biota.PropertiesCreateList.Where(x => x.DestinationType == DestinationType.Shop))
             {
@@ -220,11 +220,10 @@ namespace ACE.Server.WorldObjects
                     wo.ContainerId = Guid.Full;
                     wo.CalculateObjDesc();
 
-                    var itemHashCode = GetForSaleItemHashCode(wo);
-                    if (!itemsForSale.ContainsKey(itemHashCode)) // lets skip dupes if there are any
+                    if (!itemsForSale.ContainsKey((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0))) // lets skip dupes if there are any
                     {
                         DefaultItemsForSale.Add(wo.Guid, wo);
-                        itemsForSale.Add(itemHashCode, wo.Guid.Full);
+                        itemsForSale.Add((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0), wo.Guid.Full);
                     }
                     else
                         wo.Destroy(false);
@@ -246,11 +245,10 @@ namespace ACE.Server.WorldObjects
                         wo.ContainerId = Guid.Full;
                         wo.CalculateObjDesc();
 
-                        var itemHashCode = GetForSaleItemHashCode(wo);
-                        if (!itemsForSale.ContainsKey(itemHashCode))
+                        if (!itemsForSale.ContainsKey((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0))) 
                         {
                             DefaultItemsForSale.Add(wo.Guid, wo);
-                            itemsForSale.Add(itemHashCode, wo.Guid.Full);
+                            itemsForSale.Add((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0), wo.Guid.Full);
                         }
                         else
                             wo.Destroy(false);
@@ -259,17 +257,6 @@ namespace ACE.Server.WorldObjects
             }
 
             inventoryloaded = true;
-        }
-
-        private int GetForSaleItemHashCode(WorldObject worldObject)
-        {
-            int hash = 0;
-
-            hash = (hash * 397) ^ worldObject.WeenieClassId.GetHashCode();
-            hash = (hash * 397) ^ worldObject.PaletteTemplate.GetHashCode();
-            hash = (hash * 397) ^ worldObject.Shade.GetHashCode();
-
-            return hash;
         }
 
         public void AddDefaultItem(WorldObject item)

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -205,7 +205,7 @@ namespace ACE.Server.WorldObjects
             if (inventoryloaded)
                 return;
 
-            var itemsForSale = new Dictionary<(uint weenieClassId, int paletteTemplate, double shade), uint>();
+            var itemsForSale = new Dictionary<int, uint>();
 
             foreach (var item in Biota.PropertiesCreateList.Where(x => x.DestinationType == DestinationType.Shop))
             {
@@ -220,10 +220,11 @@ namespace ACE.Server.WorldObjects
                     wo.ContainerId = Guid.Full;
                     wo.CalculateObjDesc();
 
-                    if (!itemsForSale.ContainsKey((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0))) // lets skip dupes if there are any
+                    var itemHashCode = GetForSaleItemHashCode(wo);
+                    if (!itemsForSale.ContainsKey(itemHashCode)) // lets skip dupes if there are any
                     {
                         DefaultItemsForSale.Add(wo.Guid, wo);
-                        itemsForSale.Add((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0), wo.Guid.Full);
+                        itemsForSale.Add(itemHashCode, wo.Guid.Full);
                     }
                     else
                         wo.Destroy(false);
@@ -245,10 +246,11 @@ namespace ACE.Server.WorldObjects
                         wo.ContainerId = Guid.Full;
                         wo.CalculateObjDesc();
 
-                        if (!itemsForSale.ContainsKey((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0))) 
+                        var itemHashCode = GetForSaleItemHashCode(wo);
+                        if (!itemsForSale.ContainsKey(itemHashCode))
                         {
                             DefaultItemsForSale.Add(wo.Guid, wo);
-                            itemsForSale.Add((wo.WeenieClassId, wo.PaletteTemplate ?? 0, wo.Shade ?? 0), wo.Guid.Full);
+                            itemsForSale.Add(itemHashCode, wo.Guid.Full);
                         }
                         else
                             wo.Destroy(false);
@@ -257,6 +259,17 @@ namespace ACE.Server.WorldObjects
             }
 
             inventoryloaded = true;
+        }
+
+        private int GetForSaleItemHashCode(WorldObject worldObject)
+        {
+            int hash = 0;
+
+            hash = (hash * 397) ^ worldObject.WeenieClassId.GetHashCode();
+            hash = (hash * 397) ^ worldObject.PaletteTemplate.GetHashCode();
+            hash = (hash * 397) ^ worldObject.Shade.GetHashCode();
+
+            return hash;
         }
 
         public void AddDefaultItem(WorldObject item)


### PR DESCRIPTION
According to PCAPs vendors didn't seem to be making use of the Shop generator system to gate/limit amount of purchases or create stock scarcity.

This fixes shop spam for these items from 16py data