### PR TITLE
Improve PK LogOut to help prevent stuck characters

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -43,7 +43,7 @@ namespace ACE.Server.Managers
 
         public static WorldStatusState WorldStatus { get; private set; } = WorldStatusState.Closed;
 
-        private static readonly ActionQueue actionQueue = new ActionQueue();
+        public static readonly ActionQueue ActionQueue = new ActionQueue();
         public static readonly DelayManager DelayManager = new DelayManager();
 
         static WorldManager()
@@ -104,7 +104,7 @@ namespace ACE.Server.Managers
             {
                 log.Debug($"GetPossessedBiotasInParallel for {character.Name} took {(DateTime.UtcNow - start).TotalMilliseconds:N0} ms");
 
-                actionQueue.EnqueueAction(new ActionEventDelegate(() => DoPlayerEnterWorld(session, character, offlinePlayer.Biota, biotas)));
+                ActionQueue.EnqueueAction(new ActionEventDelegate(() => DoPlayerEnterWorld(session, character, offlinePlayer.Biota, biotas)));
             });
         }
 
@@ -293,7 +293,7 @@ namespace ACE.Server.Managers
 
         public static void EnqueueAction(IAction action)
         {
-            actionQueue.EnqueueAction(action);
+            ActionQueue.EnqueueAction(action);
         }
 
         private static readonly RateLimiter updateGameWorldRateLimiter = new RateLimiter(60, TimeSpan.FromSeconds(1));
@@ -351,7 +351,7 @@ namespace ACE.Server.Managers
 
                 // This will consist of PlayerEnterWorld actions, as well as other game world actions that require thread safety
                 ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.actionQueue_RunActions);
-                actionQueue.RunActions();
+                ActionQueue.RunActions();
                 ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.actionQueue_RunActions);
 
                 ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.DelayManager_RunActions);

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -551,15 +551,8 @@ namespace ACE.Server.WorldObjects
                 logoutChain.AddDelaySeconds(logoutAnimationLength);
 
                 // remove the player from landblock management -- after the animation has run
-                logoutChain.AddAction(this, () =>
+                logoutChain.AddAction(WorldManager.ActionQueue, () =>
                 {
-                    if (CurrentLandblock == null)
-                    {
-                        log.Debug($"0x{Guid}:{Name}.LogOut_Inner.logoutChain: CurrentLandblock is null, unable to remove from a landblock...");
-                        if (Location != null)
-                            log.Debug($"0x{Guid}:{Name}.LogOut_Inner.logoutChain: Location is not null, Location = {Location.ToLOCString()}");
-                    }
-
                     CurrentLandblock?.RemoveWorldObject(Guid, false);
                     SetPropertiesAtLogOut();
                     SavePlayerToDatabase();
@@ -579,6 +572,7 @@ namespace ACE.Server.WorldObjects
             }
             else
             {
+                // todo: verify these debug messages are still necessary.. I suspect they aren't and the entire if/else block can be removed
                 log.Debug($"0x{Guid}:{Name}.LogOut_Inner: CurrentLandblock is null");
                 if (Location != null)
                 {
@@ -594,6 +588,7 @@ namespace ACE.Server.WorldObjects
                 }
                 else
                     log.Debug($"0x{Guid}:{Name}.LogOut_Inner: Location is null");
+                // todo: verify the above debug code is necessary
                 SetPropertiesAtLogOut();
                 SavePlayerToDatabase();
                 PlayerManager.SwitchPlayerFromOnlineToOffline(this);


### PR DESCRIPTION
Instead of enqueueing the work onto the player, we now enqueue it onto the WorldManager ActionQueue.

When players were getting stuck, the players were becoming detached from the landblock before the logout animation finished. I don't know why.