### PR TITLE
Add support for servers to periodically communicate with external services

### DIFF
--- a/Source/ACE.Common/GameConfiguration.cs
+++ b/Source/ACE.Common/GameConfiguration.cs
@@ -35,5 +35,7 @@ namespace ACE.Common
         public bool LandblockPreloading { get; set; }
 
         public List<PreloadedLandblocks> PreloadedLandblocks { get; set; }
+
+        public HeartbeatDefaults Heartbeat { get; set; }
     }
 }

--- a/Source/ACE.Common/HeartbeatDefaults.cs
+++ b/Source/ACE.Common/HeartbeatDefaults.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace ACE.Common
+{
+    public struct HeartbeatDefaults
+    {
+        /// <summary>
+        /// Whether hearbeats are enabled
+        /// </summary>
+        [System.ComponentModel.DefaultValue(true)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The heartbeat endpoint
+        /// </summary>
+        [System.ComponentModel.DefaultValue("https://heartbeat.treestats.net")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The heartbeat interval, in seconds
+        /// </summary>
+        [System.ComponentModel.DefaultValue(500)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public int Interval { get; set; }
+    }
+}

--- a/Source/ACE.Server/Managers/HeartbeatManager.cs
+++ b/Source/ACE.Server/Managers/HeartbeatManager.cs
@@ -88,7 +88,7 @@ namespace ACE.Server.Managers
                 }
                 catch (Exception e)
                 {
-                    log.Debug("Exception: " + e.Message);
+                    log.Debug("Exception while sending Heartbeat: " + e.Message);
                 }
             }
         }

--- a/Source/ACE.Server/Managers/HeartbeatManager.cs
+++ b/Source/ACE.Server/Managers/HeartbeatManager.cs
@@ -17,19 +17,31 @@ namespace ACE.Server.Managers
         /// <summary>
         /// The rate at which HeartbeatManager.Tick() executes
         /// </summary>
-        private static readonly RateLimiter updateHeartbeatManagerRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(10));
+        private static RateLimiter updateHeartbeatManagerRateLimiter;
 
-        private static Uri heartbeatUri;
+        /// <summary>
+        /// Endpoint to send heartbeats to
+        /// </summary>
+        private static Uri endpoint;
 
         public static void Initialize()
         {
+            //if (!ConfigManager.Config.Server.Heartbeat.Enabled)
+            //{
+            //    log.Debug("Not starting HeartbeatManager because it's disabled in config");
 
-            // TODO: Factor out into config
-            heartbeatUri = new Uri("https://servers.treestats.net/heartbeat");
+            //    return;
+            //}
+
+            // endpoint = new Uri(ConfigManager.Config.Server.Heartbeat.Endpoint);
+            endpoint = new Uri("https://treestats-servers.herokuapp.com/");
+
+            // updateHeartbeatManagerRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(ConfigManager.Config.Server.Heartbeat.Interval));
+            updateHeartbeatManagerRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(10));
         }
 
         /// <summary>
-        /// One-off class to aid in serializing the heartbeat's JSON payload
+        /// One-off class to help serialize the heartbeat's JSON payload
         /// </summary>
         private class HeartbeatBody
         {

--- a/Source/ACE.Server/Managers/HeartbeatManager.cs
+++ b/Source/ACE.Server/Managers/HeartbeatManager.cs
@@ -1,0 +1,88 @@
+using System;
+
+using log4net;
+
+using ACE.Common.Performance;
+using System.Net.Http;
+using System.Text;
+using ACE.Common;
+using Newtonsoft.Json;
+
+namespace ACE.Server.Managers
+{
+    public static class HeartbeatManager
+    {
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// The rate at which HeartbeatManager.Tick() executes
+        /// </summary>
+        private static readonly RateLimiter updateHeartbeatManagerRateLimiter = new RateLimiter(1, TimeSpan.FromSeconds(10));
+
+        private static Uri heartbeatUri;
+
+        public static void Initialize()
+        {
+
+            // TODO: Factor out into config
+            heartbeatUri = new Uri("https://servers.treestats.net/heartbeat");
+        }
+
+        /// <summary>
+        /// One-off class to aid in serializing the heartbeat's JSON payload
+        /// </summary>
+        private class HeartbeatBody
+        {
+            public string server;
+            public int online;
+            public bool pk_server;
+            public double xp_modifier;
+        }
+
+        /// <summary>
+        /// Runs every ~1 minute
+        /// </summary>
+        public static void Tick()
+        {
+
+            if (updateHeartbeatManagerRateLimiter.GetSecondsToWaitBeforeNextEvent() > 0)
+                return;
+
+            log.Debug($"HeartbeatManager.Tick()");
+
+            updateHeartbeatManagerRateLimiter.RegisterEvent();
+            DoHeartbeat();
+        }
+
+        public static void DoHeartbeat()
+        {
+            using (var client = new HttpClient())
+            {
+                HttpResponseMessage response;
+
+                try
+                {
+                    HeartbeatBody body = new HeartbeatBody
+                    {
+                        online = PlayerManager.GetOnlineCount(),
+                        server = ConfigManager.Config.Server.WorldName,
+                        xp_modifier = PropertyManager.GetDouble("xp_modifier").Item,
+                        pk_server = PropertyManager.GetBool("pk_server").Item
+                    };
+
+                    HttpContent content = new StringContent(JsonConvert.SerializeObject(body));
+                    response = client.PostAsync(heartbeatUri, content).Result;
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        log.Debug("Heartbeat Failed: " + response.Content);
+                    }
+                }
+                catch (Exception e)
+                {
+                    log.Debug("Exception: " + e.Message);
+                }
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/HeartbeatManager.cs
+++ b/Source/ACE.Server/Managers/HeartbeatManager.cs
@@ -43,12 +43,10 @@ namespace ACE.Server.Managers
         /// <summary>
         /// One-off class to help serialize the heartbeat's JSON payload
         /// </summary>
-        private class HeartbeatBody
+        private class HeartbeatPayload
         {
-            public string server;
-            public int online;
-            public bool pk_server;
-            public double xp_modifier;
+            public string WorldName;
+            public int OnlineCount;
         }
 
         /// <summary>
@@ -74,16 +72,14 @@ namespace ACE.Server.Managers
 
                 try
                 {
-                    HeartbeatBody body = new HeartbeatBody
+                    HeartbeatPayload body = new HeartbeatPayload
                     {
-                        online = PlayerManager.GetOnlineCount(),
-                        server = ConfigManager.Config.Server.WorldName,
-                        xp_modifier = PropertyManager.GetDouble("xp_modifier").Item,
-                        pk_server = PropertyManager.GetBool("pk_server").Item
+                        OnlineCount = PlayerManager.GetOnlineCount(),
+                        WorldName = ConfigManager.Config.Server.WorldName
                     };
 
                     HttpContent content = new StringContent(JsonConvert.SerializeObject(body));
-                    response = client.PostAsync(heartbeatUri, content).Result;
+                    response = client.PostAsync(endpoint, content).Result;
 
                     if (!response.IsSuccessStatusCode)
                     {

--- a/Source/ACE.Server/Managers/HeartbeatManager.cs
+++ b/Source/ACE.Server/Managers/HeartbeatManager.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Managers
         }
 
         /// <summary>
-        /// Runs every ~1 minute
+        /// Runs at intervals according to config
         /// </summary>
         public static void Tick()
         {

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -375,6 +375,8 @@ namespace ACE.Server.Managers
                     Thread.Sleep(sessionCount == 0 ? 10 : 1); // Relax the CPU more if no sessions are connected
 
                 Timers.PortalYearTicks += worldTickTimer.Elapsed.TotalSeconds;
+
+                HeartbeatManager.Tick();
             }
 
             // World has finished operations and concedes the thread to garbage collection

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -196,6 +196,9 @@ namespace ACE.Server
             log.Info("Starting PropertyManager...");
             PropertyManager.Initialize();
 
+            log.Info("Starting HeartbeatManager...");
+            HeartbeatManager.Initialize();
+
             log.Info("Initializing GuidManager...");
             GuidManager.Initialize();
 


### PR DESCRIPTION
Hey all, I was talking about something I've built with @LtRipley36706 the other day and he thought other devs would be interested in seeing a PR so here it is:

It would be really interesting if ACE servers could communicate with external services. There's been a ton of discussion about _how_ to do this, going back to https://github.com/ACEmulator/ACE/issues/718. Providing an HTTP API is a really powerful idea but presents a ton of problems such as rate limiting, running read-only replicas of the database, and so on.

A lighter weight and simpler approach is to have ACE servers _send_ any information to external services periodically. The biggest downside here is that the feature only works if the external service stays available.

What I've done here is created a new `*Manager` class called `HeartbeatManager` that based on code that already existed in ACE that sends a JSON payload to a configurable HTTP endpoint at a configurable interval. Think [webhook](https://en.wikipedia.org/wiki/Webhook).

The immediate thing ACE servers could do with this is broadcast whether the server is up and how many players are online to services such as https://treestats.net. People are very interested in how many players are on each server but the TreeStats way of tracking [server populations](https://treestats.net/player_counts/) requires players on each server to run my Decal plugin. And even then, the temporal resolution of the population data depends on how many players are running the plugin. With my system here, ACE servers could send their `OnlineCount` to TreeStats at intervals and we'd all have much better data to look at.

Some notes:

1. This PR isn't done, I'm having some issues figuring out default values in the config
2. The payload is hardcoded to send `WorldName` and `OnlineCount` but I think we could find some easy way to let users configure the Manager to send more info such as any config properties (xp rate, pk/npk, etc) or even information obtained from database queries such as total characters.
3. This type of approach could even be used to send webhooks to Discord servers, Google Sheets, etc
3. I'm open to another name. Maybe even `WebhookManager`

What do you all think? I'm open to both thoughts on the concept as well as specific comments on the PR.