### PR TITLE
Attempt Z position adjustments on failed spawns

### DIFF
--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -810,7 +810,7 @@ namespace ACE.Server.Entity
 
         private bool AddWorldObjectInternal(WorldObject wo)
         {
-            for (var i = 0; i < 6; i++)
+            for (var i = 0; i <= 5; i++)
             {
                 wo.CurrentLandblock = this;
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -810,7 +810,6 @@ namespace ACE.Server.Entity
 
         private bool AddWorldObjectInternal(WorldObject wo)
         {
-            retry:
             wo.CurrentLandblock = this;
 
             if (wo.PhysicsObj == null)
@@ -847,7 +846,7 @@ namespace ACE.Server.Entity
 
                         addWorldObjectInternalRetries[wo.Guid.Full] = retries + 1;
 
-                        goto retry;
+                        return AddWorldObjectInternal(wo);
                     }
                     addWorldObjectInternalRetries.Remove(wo.Guid.Full);
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -850,7 +850,7 @@ namespace ACE.Server.Entity
                 }
             }
           
-            for (var i = 0; i <= 5; i++)
+            for (var i = 0; i < 5; i++)
             {
                 wo.CurrentLandblock = this;
 
@@ -876,9 +876,9 @@ namespace ACE.Server.Entity
                         //else if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
                         //    log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()}");
 
-                        if (i < 5)
+                        if (i < 4)
                         {
-                            log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
+                            //log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
 
                             wo.Location.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
 
@@ -887,7 +887,7 @@ namespace ACE.Server.Entity
                         else
                         {
                             if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
-                                log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}], including {i} retries, at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
+                                log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}], including {i + 1} retries, at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
 
                             if (wo.Generator != null)
                                 wo.NotifyOfEvent(RegenerationType.PickUp); // Notify generator the generated object is effectively destroyed, use Pickup to catch both cases.
@@ -897,8 +897,8 @@ namespace ACE.Server.Entity
                     }
                     else
                     {
-                        if (i > 0)
-                            log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {i} retries at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
+                        //if (i > 0)
+                        //    log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {i} retries at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
                         break;
                     }
                 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -838,7 +838,7 @@ namespace ACE.Server.Entity
 
                         if (i < 5)
                         {
-                            log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}");
+                            log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
 
                             var retryLOC = new Position(wo.Location);
                             retryLOC.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
@@ -848,11 +848,11 @@ namespace ACE.Server.Entity
                         }
                         else
                         {
+                            if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
+                                log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}], including {i} retries, at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
+
                             if (wo.Generator != null)
                                 wo.NotifyOfEvent(RegenerationType.PickUp); // Notify generator the generated object is effectively destroyed, use Pickup to catch both cases.
-
-                            if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
-                                log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}], including {i} retries, at {wo.Location.ToLOCString()}");
 
                             return false;
                         }
@@ -860,7 +860,7 @@ namespace ACE.Server.Entity
                     else
                     {
                         if (i > 0)
-                            log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {i} retries at {wo.Location.ToLOCString()}");
+                            log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {i} retries at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
                         break;
                     }
                 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -810,53 +810,59 @@ namespace ACE.Server.Entity
 
         private bool AddWorldObjectInternal(WorldObject wo)
         {
-            wo.CurrentLandblock = this;
-
-            if (wo.PhysicsObj == null)
-                wo.InitPhysicsObj();
-            else
-                wo.PhysicsObj.set_object_guid(wo.Guid);  // re-add to ServerObjectManager
-
-            if (wo.PhysicsObj.CurCell == null)
+            for (var i = 0; i < 6; i++)
             {
-                var success = wo.AddPhysicsObj();
-                if (!success)
+                wo.CurrentLandblock = this;
+
+                if (wo.PhysicsObj == null)
+                    wo.InitPhysicsObj();
+                else
+                    wo.PhysicsObj.set_object_guid(wo.Guid);  // re-add to ServerObjectManager
+
+                if (wo.PhysicsObj.CurCell == null)
                 {
-                    wo.CurrentLandblock = null;
-
-                    var retried = addWorldObjectInternalRetries.TryGetValue(wo.Guid.Full, out var retries);
-
-                    if (wo.Generator != null)
+                    var success = wo.AddPhysicsObj();
+                    if (!success)
                     {
-                        log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()} from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}");
-                        wo.NotifyOfEvent(RegenerationType.PickUp); // Notify generator the generated object is effectively destroyed, use Pickup to catch both cases.
-                    }
-                    else if (wo.IsGenerator) // Some generators will fail random spawns if they're circumference spans over water or cliff edges
-                        log.Debug($"AddWorldObjectInternal: couldn't spawn generator 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()}");
-                    else if (wo.ProjectileTarget == null && !(wo is SpellProjectile) && (retried && retries == 5))
-                        log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(retried ? $", including {retries} retries," : "")} at {wo.Location.ToLOCString()}");
+                        wo.CurrentLandblock = null;
 
-                    if (!retried || retries < 5)
+                        //if (wo.Generator != null)
+                        //{
+                        //    log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()} from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}");
+                        //    wo.NotifyOfEvent(RegenerationType.PickUp); // Notify generator the generated object is effectively destroyed, use Pickup to catch both cases.
+                        //}
+                        //else if (wo.IsGenerator) // Some generators will fail random spawns if they're circumference spans over water or cliff edges
+                        //    log.Debug($"AddWorldObjectInternal: couldn't spawn generator 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()}");
+                        //else if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
+                        //    log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] at {wo.Location.ToLOCString()}");
+
+                        if (i < 5)
+                        {
+                            log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}");
+
+                            var retryLOC = new Position(wo.Location);
+                            retryLOC.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
+                            wo.Location = retryLOC;
+
+                            continue;
+                        }
+                        else
+                        {
+                            if (wo.Generator != null)
+                                wo.NotifyOfEvent(RegenerationType.PickUp); // Notify generator the generated object is effectively destroyed, use Pickup to catch both cases.
+
+                            if (wo.ProjectileTarget == null && !(wo is SpellProjectile))
+                                log.Warn($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}], including {i} retries, at {wo.Location.ToLOCString()}");
+
+                            return false;
+                        }
+                    }
+                    else
                     {
-                        log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(retried ? $", including {retries} retries," : "")} at {wo.Location.ToLOCString()}");
-
-                        var retryLOC = new Position(wo.Location);
-                        retryLOC.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
-                        wo.Location = retryLOC;
-
-                        addWorldObjectInternalRetries[wo.Guid.Full] = retries + 1;
-
-                        return AddWorldObjectInternal(wo);
+                        if (i > 0)
+                            log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {i} retries at {wo.Location.ToLOCString()}");
+                        break;
                     }
-                    addWorldObjectInternalRetries.Remove(wo.Guid.Full);
-
-                    return false;
-                }
-                else if (addWorldObjectInternalRetries.TryGetValue(wo.Guid.Full, out var retries))
-                {
-                    log.Debug($"AddWorldObjectInternal: successfully spawned 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}] after {retries} retries at {wo.Location.ToLOCString()}");
-
-                    addWorldObjectInternalRetries.Remove(wo.Guid.Full);
                 }
             }
 
@@ -873,8 +879,6 @@ namespace ACE.Server.Entity
 
             return true;
         }
-
-        private Dictionary<uint, int> addWorldObjectInternalRetries = new Dictionary<uint, int>();
 
         public void RemoveWorldObject(ObjectGuid objectId, bool adjacencyMove = false, bool fromPickup = false, bool showError = true)
         {

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -840,9 +840,7 @@ namespace ACE.Server.Entity
                         {
                             log.Debug($"AddWorldObjectInternal: couldn't spawn 0x{wo.Guid}:{wo.Name} [{wo.WeenieClassId} - {wo.WeenieType}]{(i > 0 ? $", including {i} retries," : "")} at {wo.Location.ToLOCString()}{(wo.Generator != null ? $" from generator {wo.Generator.WeenieClassId} - 0x{wo.Generator.Guid}:{wo.Generator.Name}" : "")}");
 
-                            var retryLOC = new Position(wo.Location);
-                            retryLOC.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
-                            wo.Location = retryLOC;
+                            wo.Location.PositionZ += 0.05f * (wo.ObjScale ?? 1.0f);
 
                             continue;
                         }


### PR DESCRIPTION
Prior to #3447 there were corpses that would place items they contained at their same LOC. This didn't work for all the items, so there are many of these items "stuck" in limbo. This attempts to resolve the limbo for many, if not most, of them