### PR TITLE
fixing power/accuracy bar unintentionally resetting on remote servers

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -195,6 +195,7 @@ namespace ACE.Server.WorldObjects
 
             Session.Network.EnqueueSend(new GameEventAttackDone(Session, WeenieError.ActionCancelled));
 
+            AttackTarget = null;
             MeleeTarget = null;
             MissileTarget = null;
 
@@ -212,7 +213,7 @@ namespace ACE.Server.WorldObjects
 
             if (Attacking)
                 AttackCancelled = true;
-            else
+            else if (AttackTarget != null)
                 OnAttackDone();
 
             PhysicsObj.cancel_moveto();


### PR DESCRIPTION
repro steps:

- this needs to be performed on a remote server with some amount of latency. clumsy can also be used w/ 50ms lag on local server
- start charging up a full power melee attack
- press the 'z' key as soon as the power bar starts charging

expected:

- powerbar continues to charge, player starts sidestepping

actual:

- powerbar resets and stops charging, player starts sidestepping