### PR TITLE
fix semi-translucent items after tailoring until relog

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -87,7 +87,6 @@ namespace ACE.Entity.Enum.Properties
         ResistStaminaBoost             = 73,
         ResistManaDrain                = 74,
         ResistManaBoost                = 75,
-        [Ephemeral]
         Translucency                   = 76,
         PhysicsScriptIntensity         = 77,
         Friction                       = 78,

--- a/Source/ACE.Server/Entity/Tailoring.cs
+++ b/Source/ACE.Server/Entity/Tailoring.cs
@@ -226,6 +226,9 @@ namespace ACE.Server.Entity
             target.PaletteBaseId = source.PaletteBaseId;
             target.ClothingBase = source.ClothingBase;
 
+            target.PhysicsTableId = source.PhysicsTableId;
+            target.SoundTableId = source.SoundTableId;
+
             target.Name = source.Name;
             target.LongDesc = LootGenerationFactory.GetLongDesc(target);
 


### PR DESCRIPTION
note that only the [Ephemeral] fix is required for the issue.

the physics/sound table are just added for consistency.

it should still be investigated why EphemeralProperty=null retains the original value at runtime, when the EphemeralProperty originates from the base weenie

it should also be evaluated whether or not the tailoring intermediate items should have Translucency=0.5 on them