### PR TITLE
Fix multi-thread issue when monsters cast against players that left

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -275,6 +275,11 @@ namespace ACE.Server.WorldObjects
             if (spell.IsHarmful && target != this)
                 TryProcEquippedItems(this, true);
 
+            // If the target is too far away, don't cast. This checks to see of this monster and the target are on separate landblock groups, and potentially separate threads.
+            // This also fixes cross-threading issues
+            if (target != null && (CurrentLandblock == null || target.CurrentLandblock == null || CurrentLandblock.CurrentLandblockGroup != target.CurrentLandblock.CurrentLandblockGroup))
+                return;
+
             // try to resist spell, if applicable
             if (TryResistSpell(target, spell))
             {


### PR DESCRIPTION
Scenario:

Monster targets player
Monster begins to cast a spell at player (windup)
Player teleports out
Monster windup completes and casts
TryResit code now accesses two threads at once determining if the spell can be landed on the player that's now gone.