### PR TITLE
Fix Appraise for equipment with banes

### DIFF
--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -473,8 +473,12 @@ namespace ACE.Server.Network.Structure
                 // Only show Clothing type item enchantments
                 foreach (var enchantment in woEnchantments)
                 {
-                    if ((enchantment.SpellCategory >= SpellCategory.ArmorValueRaising) && (enchantment.SpellCategory <= SpellCategory.AcidicResistanceLowering))
+                    // TODO this still needs to be fixed for rare banes
+                    if ((enchantment.SpellCategory >= SpellCategory.ArmorValueRaising && enchantment.SpellCategory <= SpellCategory.AcidicResistanceLowering) ||
+                        (enchantment.SpellCategory >= SpellCategory.ExtraAcidResistanceRaising && enchantment.SpellCategory <= SpellCategory.ExtraElectricResistanceLowering))
+                    {
                         activeSpells.Add(new AppraisalSpellBook() { SpellId = (ushort)enchantment.SpellId, EnchantmentState = AppraisalSpellBook._EnchantmentState.On });
+                    }
                 }
             }
             else


### PR DESCRIPTION
/ci 45967

current master, the bane spell does not show up in the items enchantments list in the appraise window