### PR TITLE
Improve EnqueueSend

### DIFF
--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -117,22 +117,18 @@ namespace ACE.Server.Network
             if (isReleased) // Session has been removed
                 return;
 
-            messages.GroupBy(k => k.Group).ToList().ForEach(k =>
+            foreach (var message in messages)
             {
-                var grp = k.First().Group;
-                var currentBundleLock = currentBundleLocks[(int)grp];
+                var grp = message.Group;
+                var currentBundleLock = currentBundleLocks[(int) grp];
                 lock (currentBundleLock)
                 {
-                    var currentBundle = currentBundles[(int)grp];
-
-                    foreach (var msg in k)
-                    {
-                        currentBundle.EncryptedChecksum = true;
-                        packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, msg.Opcode);
-                        currentBundle.Enqueue(msg);
-                    }
+                    var currentBundle = currentBundles[(int) grp];
+                    currentBundle.EncryptedChecksum = true;
+                    packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, message.Opcode);
+                    currentBundle.Enqueue(message);
                 }
-            });
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Most uses of this function are a single message.

This removes the overhead of GroupBy() and ToList() for every call at the expense of retaking the lock in cases where multiple messages of the same group are sent.