### PR TITLE
Improve UpdateDatabaseBiota()

### DIFF
--- a/Source/ACE.Database/Adapter/BiotaUpdater.cs
+++ b/Source/ACE.Database/Adapter/BiotaUpdater.cs
@@ -127,11 +127,12 @@ namespace ACE.Database.Adapter
 
             if (sourceBiota.PropertiesSpellBook != null)
             {
+                // Optimization to help characters with very large spell books and avoid full iterations inside the foreach
+                var existingValues = targetBiota.BiotaPropertiesSpellBook.ToDictionary(r => r.Spell, r => r);
+
                 foreach (var kvp in sourceBiota.PropertiesSpellBook)
                 {
-                    BiotaPropertiesSpellBook existingValue = targetBiota.BiotaPropertiesSpellBook.FirstOrDefault(r => r.Spell == (ushort)kvp.Key);
-
-                    if (existingValue == null)
+                    if (!existingValues.TryGetValue(kvp.Key, out var existingValue))
                     {
                         existingValue = new BiotaPropertiesSpellBook { ObjectId = sourceBiota.Id };
 


### PR DESCRIPTION
In previous master, the full targetBiota spellbook was being iterated for each sourceBiota spell.

This was very time consuming with players with large spell books (100+ ms)

Now, a dictionary is made and that is used to perform the nested lookup.

New result is 0 ms.