### PR TITLE
Filter Emotes when IsDormant

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -857,6 +857,10 @@ namespace ACE.Server.WorldObjects.Managers
                     if (Debug)
                         Console.Write($".{(MotionCommand)emote.Motion}");
 
+                    // If the landblock is dormant, there are no players in range
+                    if (WorldObject.CurrentLandblock?.IsDormant ?? false)
+                        break;
+
                     // are there players within emote range?
                     if (!WorldObject.PlayersInRange(ClientMaxAnimRange))
                         break;
@@ -948,6 +952,10 @@ namespace ACE.Server.WorldObjects.Managers
 
                     if (creature != null)
                     {
+                        // If the landblock is dormant, there are no players in range
+                        if (WorldObject.CurrentLandblock?.IsDormant ?? false)
+                            break;
+
                         var newPos = new Position(creature.Home);
                         newPos.Pos += new Vector3(emote.OriginX ?? 0, emote.OriginY ?? 0, emote.OriginZ ?? 0);      // uses relative position
 


### PR DESCRIPTION
This adds a IsDormant check on top of EmoteType.Motion, which already checked for PlayersInRange(). This should not change the result, but instead simply provide a more efficient way to filter this emote. IsDormant is less CPU then calling PlayersInRange, and there should never be PlayersInRange when IsDormant.

EmoteType.Move adds an IsDormant check.

These changes bring current master + 219 content to equal if not better performance than current master + 216 content.