### PR TITLE
improved move to state handling during pk teleport

### DIFF
--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionMoveToState.cs
@@ -25,14 +25,12 @@ namespace ACE.Server.Network.GameAction.Actions
             if (session.Player.IsPlayerMovingTo2)
                 session.Player.StopExistingMoveToChains2();
 
-            if (!session.Player.Teleporting)
-            {
-                session.Player.OnMoveToState(moveToState);
-                session.Player.LastMoveToState = moveToState;
+            // MoveToState - UpdatePosition broadcasts were capped to 1 per second in retail
+            session.Player.OnMoveToState(moveToState);
+            session.Player.LastMoveToState = moveToState;
 
-                // MoveToState - UpdatePosition broadcasts were capped to 1 per second in retail
+            if (!session.Player.Teleporting)
                 session.Player.SetRequestedLocation(moveToState.Position, false);
-            }
 
             //if (!moveToState.StandingLongJump)
                 session.Player.BroadcastMovement(moveToState);


### PR DESCRIPTION
(just pasting chat log for reference)

ok i found another bug
the server is dropping movement commands when you are in portal space
so if you press 'run forward' to run in a portal, and then release 'run forward' while you are in portal space, the server is not processing the 'release run forward' command correctly in portal space
i have a fix for current master for that, seems to prevent the oddities from happening in portal space
so that, coupled with the 'you have teleported too recently!', should fix any bugs and oddities for that from multiple angles
the physics engine also seems to handle different animations differently, like run forward, strafe, and run forward + strafe all display different stop motion properties in the physics engine, its weird
but out of everything i tried, it seems to be best to just throw everything at the physics engine, and let it handle it naturally
like if you have any combination of movement keys pressed down while in portal space, or release/re-press them, the physics engine handles it all naturally when the player is frozen in pink bubble state, and doesn't move their position or animate them until they are out of pink bubble state