### PR TITLE
update /lootgen command for latest loot system

### DIFF
--- a/Source/ACE.Server/Factories/Tables/GemMaterialChance.cs
+++ b/Source/ACE.Server/Factories/Tables/GemMaterialChance.cs
@@ -113,6 +113,8 @@ namespace ACE.Server.Factories.Tables
 
         private static readonly Dictionary<MaterialType, int> gemMaterialValue = new Dictionary<MaterialType, int>();
 
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
         static GemMaterialChance()
         {
             // build gemMaterialValue
@@ -120,6 +122,13 @@ namespace ACE.Server.Factories.Tables
             {
                 foreach (var material in gemMaterialChances[i].Select(i => i.result))
                     gemMaterialValue.Add(material.MaterialType, gemClassValue[i]);
+            }
+
+            // build wcid hashset for lootgen command
+            foreach (var gemMaterialChance in gemMaterialChances)
+            {
+                foreach (var entry in gemMaterialChance)
+                    _combined.Add(entry.result.ClassName);
             }
         }
 
@@ -132,6 +141,11 @@ namespace ACE.Server.Factories.Tables
                 return gemValue;
             else
                 return 0;   // default?
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/AetheriaWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/AetheriaWcids.cs
@@ -35,5 +35,18 @@ namespace ACE.Server.Factories.Tables
             }
             return WeenieClassName.undef;
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static AetheriaWcids()
+        {
+            foreach (var aetheriaWcid in aetheriaColors)
+                _combined.Add(aetheriaWcid);
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
@@ -1,7 +1,7 @@
+using System.Collections.Generic;
+
 using ACE.Common;
 using ACE.Database.Models.World;
-
-using ACE.Entity.Enum;
 using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Enum;
 
@@ -585,6 +585,52 @@ namespace ACE.Server.Factories.Tables.Wcids
                 return OverRobe_T3_T5_Wcids.Roll();
             else
                 return OverRobe_T6_T8_Wcids.Roll();
+        }
+
+        private static readonly Dictionary<WeenieClassName, TreasureArmorType> _combined = new Dictionary<WeenieClassName, TreasureArmorType>();
+
+        static ArmorWcids()
+        {
+            BuildCombined(LeatherWcids, TreasureArmorType.Leather);
+            BuildCombined(StuddedLeatherWcids, TreasureArmorType.StuddedLeather);
+            BuildCombined(ChainmailWcids, TreasureArmorType.Chainmail);
+            BuildCombined(PlatemailWcids, TreasureArmorType.Platemail);
+            BuildCombined(ScalemailWcids, TreasureArmorType.Scalemail);
+            BuildCombined(YoroiWcids, TreasureArmorType.Yoroi);
+            BuildCombined(CeldonWcids, TreasureArmorType.Celdon);
+            BuildCombined(AmuliWcids, TreasureArmorType.Amuli);
+            BuildCombined(KoujiaWcids, TreasureArmorType.Koujia);
+            BuildCombined(CovenantWcids, TreasureArmorType.Covenant);
+            BuildCombined(LoricaWcids, TreasureArmorType.Lorica);
+            BuildCombined(NariyidWcids, TreasureArmorType.Nariyid);
+            BuildCombined(ChiranWcids, TreasureArmorType.Chiran);
+            BuildCombined(DiforsaWcids, TreasureArmorType.Diforsa);
+            BuildCombined(TenassaWcids, TreasureArmorType.Tenassa);
+            BuildCombined(AlduressaWcids, TreasureArmorType.Alduressa);
+            BuildCombined(OlthoiWcids, TreasureArmorType.Olthoi);
+            BuildCombined(OlthoiCeldonWcids, TreasureArmorType.OlthoiCeldon);
+            BuildCombined(OlthoiAmuliWcids, TreasureArmorType.OlthoiAmuli);
+            BuildCombined(OlthoiKoujiaWcids, TreasureArmorType.OlthoiKoujia);
+            BuildCombined(OlthoiAlduressaWcids, TreasureArmorType.OlthoiAlduressa);
+            BuildCombined(CelestialHandWcids, TreasureArmorType.CelestialHand);
+            BuildCombined(EldrytchWebWcids, TreasureArmorType.EldrytchWeb);
+            BuildCombined(RadiantBloodWcids, TreasureArmorType.RadiantBlood);
+            BuildCombined(HaebreanWcids, TreasureArmorType.Haebrean);
+            BuildCombined(KnorrAcademyWcids, TreasureArmorType.KnorrAcademy);
+            BuildCombined(SedgemailLeatherWcids, TreasureArmorType.Sedgemail);
+            BuildCombined(OverRobe_T3_T5_Wcids, TreasureArmorType.Overrobe);
+            BuildCombined(OverRobe_T6_T8_Wcids, TreasureArmorType.Overrobe);
+        }
+
+        private static void BuildCombined(ChanceTable<WeenieClassName> wcids, TreasureArmorType armorType)
+        {
+            foreach (var entry in wcids)
+                _combined.TryAdd(entry.result, armorType);
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureArmorType armorType)
+        {
+            return _combined.TryGetValue(wcid, out armorType);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
@@ -612,9 +612,9 @@ namespace ACE.Server.Factories.Tables.Wcids
             BuildCombined(OlthoiAmuliWcids, TreasureArmorType.OlthoiAmuli);
             BuildCombined(OlthoiKoujiaWcids, TreasureArmorType.OlthoiKoujia);
             BuildCombined(OlthoiAlduressaWcids, TreasureArmorType.OlthoiAlduressa);
-            BuildCombined(CelestialHandWcids, TreasureArmorType.CelestialHand);
-            BuildCombined(EldrytchWebWcids, TreasureArmorType.EldrytchWeb);
-            BuildCombined(RadiantBloodWcids, TreasureArmorType.RadiantBlood);
+            //BuildCombined(CelestialHandWcids, TreasureArmorType.CelestialHand);   // handled in SocietyArmor
+            //BuildCombined(EldrytchWebWcids, TreasureArmorType.EldrytchWeb);
+            //BuildCombined(RadiantBloodWcids, TreasureArmorType.RadiantBlood);
             BuildCombined(HaebreanWcids, TreasureArmorType.Haebrean);
             BuildCombined(KnorrAcademyWcids, TreasureArmorType.KnorrAcademy);
             BuildCombined(SedgemailLeatherWcids, TreasureArmorType.Sedgemail);

--- a/Source/ACE.Server/Factories/Tables/Wcids/CloakWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/CloakWcids.cs
@@ -29,5 +29,18 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return cloakWcids[rng];
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static CloakWcids()
+        {
+            foreach (var cloakWcid in cloakWcids)
+                _combined.Add(cloakWcid);
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ClothingWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ClothingWcids.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using ACE.Database.Models.World;
 using ACE.Server.Factories.Entity;
 using ACE.Server.Factories.Enum;
@@ -120,6 +122,27 @@ namespace ACE.Server.Factories.Tables.Wcids
                     return ClothingWcids_Viamontian.Roll();
             }
             return WeenieClassName.undef;
+        }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static ClothingWcids()
+        {
+            BuildCombined(ClothingWcids_Aluvian);
+            BuildCombined(ClothingWcids_Gharundim);
+            BuildCombined(ClothingWcids_Sho);
+            BuildCombined(ClothingWcids_Viamontian);
+        }
+
+        private static void BuildCombined(ChanceTable<WeenieClassName> wcids)
+        {
+            foreach (var entry in wcids)
+                _combined.Add(entry.result);
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
         }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/GenericWcids.cs
@@ -73,5 +73,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return tierChances[tier - 1].Roll();
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static GenericWcids()
+        {
+            foreach (var tierChance in tierChances)
+            {
+                foreach (var entry in tierChance)
+                    _combined.Add(entry.result);
+            }
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/JewelryWcids.cs
@@ -102,5 +102,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return tierChances[tier - 1].Roll();
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static JewelryWcids()
+        {
+            foreach (var tierChance in tierChances)
+            {
+                foreach (var entry in tierChance)
+                    _combined.Add(entry.result);
+            }
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/PetDeviceWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/PetDeviceWcids.cs
@@ -504,5 +504,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return table[petLevelIdx];
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static PetDeviceWcids()
+        {
+            foreach (var petDevice in petDevices)
+            {
+                foreach (var wcid in petDevice)
+                    _combined.Add(wcid);
+            }
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/ScrollWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ScrollWcids.cs
@@ -1409,5 +1409,18 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return scrollWcids[rng];
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static ScrollWcids()
+        {
+            foreach (var scrollWcid in scrollWcids)
+                _combined.Add(scrollWcid);
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/SocietyArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/SocietyArmorWcids.cs
@@ -86,5 +86,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return heritage.ToSociety();
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static SocietyArmorWcids()
+        {
+            foreach (var table in societyArmorTables)
+            {
+                foreach (var wcid in table)
+                    _combined.Add(wcid);
+            }
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
@@ -68,5 +68,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return atlatlTiers[tier - 1].Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static AtlatlWcids()
+        {
+            foreach (var atlatlTier in atlatlTiers)
+            {
+                foreach (var entry in atlatlTier)
+                    _combined.TryAdd(entry.result, TreasureWeaponType.Atlatl);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Aluvian.cs
@@ -70,5 +70,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return bowTiers[tier - 1].Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static BowWcids_Aluvian()
+        {
+            foreach (var bowTier in bowTiers)
+            {
+                foreach (var entry in bowTier)
+                    _combined.TryAdd(entry.result, TreasureWeaponType.Bow);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Gharundim.cs
@@ -70,5 +70,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return bowTiers[tier - 1].Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static BowWcids_Gharundim()
+        {
+            foreach (var bowTier in bowTiers)
+            {
+                foreach (var entry in bowTier)
+                    _combined.TryAdd(entry.result, TreasureWeaponType.Bow);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/BowWcids_Sho.cs
@@ -70,5 +70,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return bowTiers[tier - 1].Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static BowWcids_Sho()
+        {
+            foreach (var bowTier in bowTiers)
+            {
+                foreach (var entry in bowTier)
+                    _combined.TryAdd(entry.result, TreasureWeaponType.Bow);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -168,5 +168,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return casterTiers[tier - 1].Roll();
         }
+
+        private static readonly HashSet<WeenieClassName> _combined = new HashSet<WeenieClassName>();
+
+        static CasterWcids()
+        {
+            foreach (var casterTier in casterTiers)
+            {
+                foreach (var entry in casterTier)
+                    _combined.Add(entry.result);
+            }
+        }
+
+        public static bool Contains(WeenieClassName wcid)
+        {
+            return _combined.Contains(wcid);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CrossbowWcids.cs
@@ -70,5 +70,21 @@ namespace ACE.Server.Factories.Tables.Wcids
         {
             return crossbowTiers[tier - 1].Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static CrossbowWcids()
+        {
+            foreach (var crossbowTier in crossbowTiers)
+            {
+                foreach (var entry in crossbowTier)
+                    _combined.TryAdd(entry.result, TreasureWeaponType.Crossbow);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/FinesseWeaponWcids.cs
@@ -265,5 +265,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return weaponTable.table.Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static FinesseWeaponWcids()
+        {
+            foreach (var finesseWeaponsTable in finesseWeaponsTables)
+            {
+                foreach (var wcid in finesseWeaponsTable.table)
+                    _combined.TryAdd(wcid.result, finesseWeaponsTable.weaponType);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/HeavyWeaponWcids.cs
@@ -285,5 +285,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return weaponTable.table.Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static HeavyWeaponWcids()
+        {
+            foreach (var heavyWeaponsTable in heavyWeaponsTables)
+            {
+                foreach (var wcid in heavyWeaponsTable.table)
+                    _combined.TryAdd(wcid.result, heavyWeaponsTable.weaponType);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/LightWeaponWcids.cs
@@ -232,5 +232,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return weaponTable.table.Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static LightWeaponWcids()
+        {
+            foreach (var lightWeaponsTable in lightWeaponsTables)
+            {
+                foreach (var wcid in lightWeaponsTable.table)
+                    _combined.TryAdd(wcid.result, lightWeaponsTable.weaponType);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/TwoHandedWeaponWcids.cs
@@ -153,5 +153,21 @@ namespace ACE.Server.Factories.Tables.Wcids
 
             return weaponTable.table.Roll();
         }
+
+        private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined = new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+        static TwoHandedWeaponWcids()
+        {
+            foreach (var twoHandedWeaponsTable in twoHandedWeaponTables)
+            {
+                foreach (var wcid in twoHandedWeaponsTable.table)
+                    _combined.TryAdd(wcid.result, twoHandedWeaponsTable.weaponType);
+            }
+        }
+
+        public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+        {
+            return _combined.TryGetValue(wcid, out weaponType);
+        }
     }
 }


### PR DESCRIPTION
This update only affects the /lootgen admin/developer command, and nothing else

This updates the /lootgen command to fully use the updated loot system. The TreasureRoll structure that is normally populated during the wcid roll is now derived and passed to mutation. TreasureRoll not being null enables all of the latest lootgen logic (mutation scripts, rolling for spells/cantrips, and some other missing pieces)