### PR TITLE
add MoveTo/TurnTo logic if needed to base Player_Use.HandleActionUseWithTarget

### DIFF
--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -104,13 +104,16 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            if (!healer.Equals(targetPlayer))
+            /*if (!healer.Equals(targetPlayer))
             {
                 // perform moveto
                 healer.CreateMoveToChain(target, (success) => DoHealMotion(healer, targetPlayer, success));
             }
             else
-                DoHealMotion(healer, targetPlayer, true);
+                DoHealMotion(healer, targetPlayer, true);*/
+
+            // MoveTo is now handled in base Player_Use
+            DoHealMotion(healer, targetPlayer, true);
         }
 
         public static readonly float Healing_MaxMove = 5.0f;

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -104,7 +104,29 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            sourceItem.HandleActionUseOnTarget(this, target);
+            if (target.CurrentLandblock != null && target != this)
+            {
+                // todo: verify target can be used remotely
+                // move RecipeManager.VerifyUse logic into base Player_Use
+                // this was avoided because i didn't want to deal with the ramifications of random items missing the correct ItemUseable flags,
+                // and because there are still some ItemUseable flags with missing logic we haven't quite figured out yet
+
+                if (IsBusy)
+                {
+                    SendUseDoneEvent(WeenieError.YoureTooBusy);
+                    return;
+                }
+
+                CreateMoveToChain(target, (success) =>
+                {
+                    if (success)
+                        sourceItem.HandleActionUseOnTarget(this, target);
+                    else
+                        SendUseDoneEvent();
+                });
+            }
+            else
+                sourceItem.HandleActionUseOnTarget(this, target);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes using keys in locked doors and chests remotely. The player now correctly performs a MoveTo/TurnTo the remote object, if necessary