### PR TITLE
improving MoveToManager for pk

### DIFF
--- a/Source/ACE.Server/Entity/MoveToParams.cs
+++ b/Source/ACE.Server/Entity/MoveToParams.cs
@@ -1,0 +1,24 @@
+using System;
+
+using ACE.Server.WorldObjects;
+
+namespace ACE.Server.Entity
+{
+    public class MoveToParams
+    {
+        public Action<bool> Callback;
+
+        public WorldObject Target;
+
+        public float? UseRadius;
+
+        public MoveToParams(Action<bool> callback, WorldObject target, float? useRadius = null)
+        {
+            Callback = callback;
+
+            Target = target;
+
+            UseRadius = useRadius;
+        }
+    }
+}

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -806,7 +806,7 @@ namespace ACE.Server.WorldObjects
                 var stopCompletely = !MagicState.CastMotionDone;
                 //var stopCompletely = true;
 
-                CreateTurnToChain2(target, null, stopCompletely, MagicState.AlwaysTurn);
+                CreateTurnToChain2(target, null, null, stopCompletely, MagicState.AlwaysTurn);
 
                 MagicState.AlwaysTurn = false;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -279,7 +279,12 @@ namespace ACE.Server.WorldObjects
                 }
 
                 if (FastTick && PhysicsObj.IsMovingOrAnimating || PhysicsObj.Velocity != Vector3.Zero)
+                {
                     UpdatePlayerPhysics();
+
+                    if (MoveToParams?.Callback != null && !PhysicsObj.IsMovingOrAnimating)
+                        HandleMoveToCallback();
+                }
 
                 InUpdate = false;
 


### PR DESCRIPTION
In retail, when a player double clicked an object in the world from far away, or when they tried to use an object in their inventory on another object in the world from far away, the server would have the player automatically MoveTo the remote object. If the player then manually pressed their movement keys while this automatic MoveTo was taking place, their client would automatically say 'Action Cancelled!', and their client would cancel the automatic MoveTo on its own.

However, the client wasn't really cancelling the action they were trying to perform at the end of the MoveTo -- they were only cancelling the MoveTo itself.

In this scenario, when the player released the manually pressed movement keys, the retail server would then attempt to perform the action from their current location. In effect, the performing of the action was not tied to the automatic MoveTo completing successfully, but rather it was tied to OnMotionComplete(Ready), ie. it was tied to the player becoming stationary again.

Thanks to @Nalindar for this info