### PR TITLE
extend summoning killtask multicredit bug to fellowships, capped with new server option

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -615,6 +615,7 @@ namespace ACE.Server.Managers
                 ("player_save_interval", new Property<long>(300, "the number of seconds between automatic player saves")),
                 ("rares_max_days_between", new Property<long>(45, "for rares_real_time_v2: the maximum number of days a player can go before a rare is generated on rare eligible creature kills")),
                 ("rares_max_seconds_between", new Property<long>(5256000, "for rares_real_time: the maximum number of seconds a player can go before a second chance at a rare is allowed on rare eligible creature kills that did not generate a rare")),
+                ("summoning_killtask_multicredit_cap", new Property<long>(2, "if allow_summoning_killtask_multicredit is enabled, the maximum # of killtask credits a player can receive from 1 kill")),
                 ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects"))
                 );
 


### PR DESCRIPTION
This PR extends the existing allow_summoning_killtask_multicredit bug (which defaults to true, as per retail) to fellowships, which is also per retail

What this PR does not do is allow fellowships to exploit this bug to any extreme, by default. It is theorized that in retail, it would have been possible for each person in a fellowship to possibly get *46 kill credits* from a single mob, if they knew how to exploit this issue to its maximum theoretical potential.

This PR adds a new server option, summoning_killtask_multicredit_cap, which defaults to 2. This new server option technically makes the old allow_summoning_killtask_multicredit server option obsolete, however the old server option is still supported for compatibility with existing servers who may have already decided to fix this issue.

This means that someone exploiting this issue to any extremity will still only be able to get a maximum of 2 kill credits from 1 kill. Retail was theoretically uncapped here, as evidenced by some people doing solo testing with 1 summoner not involved in a fellowship being able to get 6 kill credits from 1 kill (1 personal, plus an additional 5 summons that they were able to fit into the 3-minute damage history window)

So while this technically reins in the existing solo bug from theoretically 6 max -> 2, it also extends the potential additional credit to each person in the fellowship with at least 1 summoner.

See the writeup for the original PR for additional info:

https://github.com/ACEmulator/ACE/pull/3122

As with the original PR, this new version was extensively tested using a standalone program to simulate all of the different possible combinations and server config settings. The latest version went through a few different iterations to ensure each scenario resulted in the expected output, also similar to the original version.