### PR TITLE
fix issues with disabling house_15day_account for existing chars

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using ACE.Common;
 using ACE.Entity;
@@ -86,7 +85,6 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-
             if (slumlord.House.HouseType != HouseType.Apartment)
             {
                 if (PropertyManager.GetBool("house_15day_account").Item && !Account15Days)
@@ -103,6 +101,9 @@ namespace ACE.Server.WorldObjects
 
                 if (PropertyManager.GetBool("house_30day_cooldown").Item)
                 {
+                    // fix gap
+                    if (!Account15Days) ManageAccount15Days_HousePurchaseTimestamp();
+
                     var lastPurchaseTime = Time.GetDateTimeFromTimestamp(HousePurchaseTimestamp ?? 0);
                     var lastPurchaseTimePlus30 = lastPurchaseTime.AddDays(30);
 
@@ -1826,6 +1827,38 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"{i + 1}. {coords}", ChatMessageType.Broadcast));
             }
             Session.Network.EnqueueSend(new GameMessageSystemChat($"Please choose the house you want to keep with /house-select # , where # is 1-{houses.Count}", ChatMessageType.Broadcast));
+        }
+
+        /// <summary>
+        /// When house_15day_account is true (retail server default),
+        /// new characters logging in on accounts less than 15 days old
+        /// have their HousePurchaseTimestamp set to 15 days before account creation.
+        /// 
+        /// This is for the House panel to show the correct date the character may purchase a house,
+        /// which the client automatically calculates as 30 days after HousePurchaseTimestamp
+        /// </summary>
+        private int FifteenDaysBeforeAccountCreation => (int)Time.GetUnixTime(Account.CreateTime.AddDays(-15));
+
+        /// <summary>
+        /// Munges the HousePurchaseTimestamp for new accounts for correct display on House panel
+        /// </summary>
+        private void ManageAccount15Days_HousePurchaseTimestamp()
+        {
+            // http://acpedia.org/wiki/Housing_FAQ#Purchase_timer
+
+            if (HouseRentTimestamp != null) return;
+
+            if (PropertyManager.GetBool("house_15day_account").Item && !Account15Days)
+            {
+                // this is set so the next purchase time displays properly on house tab
+                HousePurchaseTimestamp = FifteenDaysBeforeAccountCreation;
+            }
+            else if (HousePurchaseTimestamp == FifteenDaysBeforeAccountCreation)
+            {
+                // account is now 15+ days old and still has not purchased a house, remove unneeded HousePurchaseTimestamp
+                // also if server admin sets house_15day_account to false, this corrects the next purchase time on the House panel 
+                HousePurchaseTimestamp = null;
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -45,22 +45,12 @@ namespace ACE.Server.WorldObjects
 
             if (!Account15Days)
             {
-                var accountTimeSpan = DateTime.UtcNow - Account.CreateTime;
-                if (accountTimeSpan.TotalDays >= 15)
+                var accountAge = DateTime.UtcNow - Account.CreateTime;
+
+                if (accountAge.TotalDays >= 15)
                     Account15Days = true;
 
-                if (PropertyManager.GetBool("house_15day_account").Item && !HouseRentTimestamp.HasValue) // account was created less than 15 days ago and has NOT purchased a house (HouseRentTimestamp is null because no house has been bought)
-                {
-                    if (!Account15Days) // http://acpedia.org/wiki/Housing_FAQ#Purchase_timer
-                    {
-                        var accountCreateTimeMinus15Days = Account.CreateTime.AddDays(-15);
-                        HousePurchaseTimestamp = (int)Time.GetUnixTime(accountCreateTimeMinus15Days);
-                    }
-                    else // account is now 15+ days old and still has not purchased a house, remove unneeded HousePurchaseTimestamp
-                    {
-                        HousePurchaseTimestamp = null;
-                    }
-                }
+                ManageAccount15Days_HousePurchaseTimestamp();
             }
 
             if (PlayerKillerStatus == PlayerKillerStatus.PKLite && !PropertyManager.GetBool("pkl_server").Item)

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -71,6 +71,9 @@ namespace ACE.Server.WorldObjects
         // ========== Account Properties ==========
         // ========================================
 
+        /// <summary>
+        /// Flag indicates if an account is at least 15 days old
+        /// </summary>
         public bool Account15Days
         {
             get => GetProperty(PropertyBool.Account15Days) ?? false;


### PR DESCRIPTION
This fixes various state issues with toggling house_15day_account and HousePurchaseTimestamp.

Although undocumented, house_15day_account was a bit different from other server config options. The state of this server config option was basically persisted to new characters on first login, and changing this server option afterwards basically had no effect for existing characters.

A common scenario for this: a server admin sets up a new server, and then later realizes they wish to disable the "accounts must be older than 15 days to purchase a house" restriction. So they set house_15day_account to false, and they are later surprised that existing characters on the server *still* cannot purchase a new house, only this time they are receiving the 30-day repurchase timer error, instead of the 15-day new account error (even though they've never purchased a house before)

This fixes that scenario, so house_15day_account should be able to be reliably togged on and off dynamically, just like the other server config options.