### PR TITLE
extend timeout for GetSequenceGaps

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -106,6 +106,8 @@ namespace ACE.Database
 
             using (var context = new ShardDbContext())
             {
+                context.Database.SetCommandTimeout(TimeSpan.FromMinutes(5));
+
                 var connection = context.Database.GetDbConnection();
                 connection.Open();
                 var command = connection.CreateCommand();


### PR DESCRIPTION
This query is described as being "very fast", but it takes over 60 seconds to run on my local computer for CE's database. Not sure if that is expected or not, but this extends the default timeout so the server doesn't crash on startup.