### PR TITLE
update max chase range to intended value

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Return to home if target distance exceeds this range
         /// </summary>
-        public static readonly float MaxChaseRange = 192.0f;
+        public static readonly float MaxChaseRange = 96.0f;
         public static readonly float MaxChaseRangeSq = MaxChaseRange * MaxChaseRange;
 
         /// <summary>


### PR DESCRIPTION
This updates monster max chase range to the originally intended value.

I can't believe this was set to 192 since inception... I am certain this was originally set to 96 during development, and an incorrect value must have gotten checked in. I don't want to think about all of the wasted CPU cycles from monsters chasing players a full landblock across the landscape from this...

Note that this is different from the default HomeRadius, which is still set to 192 by default, unless overridden by the mob. A mob will travel up to HomeRadius from its home to reach a target, before returning home. It will also return home if the target is more than than MaxChaseDist away.

For reference, approximate maximum distance a ranged player can launch a projectile is about 75 meters away.