### PR TITLE
improve spell projectiles to use weapon that launched the projectile for calculations, instead of current weapon

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2840,26 +2840,26 @@ namespace ACE.Server.Command.Handlers
         public static void HandleFast(Session session, params string[] parameters)
         {
             var spell = new Spell(SpellId.QuicknessSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
 
             spell = new Spell(SpellId.SprintSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
 
             spell = new Spell(SpellId.StrengthSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
         }
 
         [CommandHandler("slow", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]
         public static void HandleSlow(Session session, params string[] parameters)
         {
             var spell = new Spell(SpellId.SlownessSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
 
             spell = new Spell(SpellId.LeadenFeetSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
 
             spell = new Spell(SpellId.WeaknessSelf8);
-            session.Player.CreateEnchantment(session.Player, session.Player, spell);
+            session.Player.CreateEnchantment(session.Player, session.Player, null, spell);
         }
 
         [CommandHandler("rip", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld)]

--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -111,7 +111,7 @@ namespace ACE.Server.Entity
 
             defender.EnqueueBroadcast(msg, WorldObject.LocalBroadcastRange, ChatMessageType.Spellcasting);
 
-            defender.TryCastSpell(spell, target, cloak, false, false);
+            defender.TryCastSpell(spell, target, cloak, cloak, false, false);
 
             return true;
         }

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -219,7 +219,7 @@ namespace ACE.Server.Entity
             // get damage modifiers
             PowerMod = attacker.GetPowerMod(Weapon);
             AttributeMod = attacker.GetAttributeMod(Weapon);
-            SlayerMod = WorldObject.GetWeaponCreatureSlayerModifier(attacker, defender);
+            SlayerMod = WorldObject.GetWeaponCreatureSlayerModifier(Weapon, attacker, defender);
 
             // ratings
             DamageRatingBaseMod = Creature.GetPositiveRatingMod(attacker.GetDamageRating());
@@ -234,7 +234,7 @@ namespace ACE.Server.Entity
 
             // critical hit?
             var attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
-            CriticalChance = WorldObject.GetWeaponCriticalChance(attacker, attackSkill, defender);
+            CriticalChance = WorldObject.GetWeaponCriticalChance(Weapon, attacker, attackSkill, defender);
 
             // https://asheron.fandom.com/wiki/Announcements_-_2002/08_-_Atonement
             // It should be noted that any time a character is logging off, PK or not, all physical attacks against them become automatically critical.
@@ -260,7 +260,7 @@ namespace ACE.Server.Entity
 
                     // verify: CriticalMultiplier only applied to the additional crit damage,
                     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                    CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(attacker, attackSkill, defender);
+                    CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender);
 
                     CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
 
@@ -313,7 +313,7 @@ namespace ACE.Server.Entity
                 ArmorMod = 1.0f;
 
             // get resistance modifiers
-            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(attacker, attackSkill, DamageType);
+            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, attackSkill, DamageType);
 
             if (playerDefender != null)
             {
@@ -403,7 +403,7 @@ namespace ACE.Server.Entity
                 BaseDamageMod.DamageBonus += Weapon.Damage ?? 0;
 
             if (DamageSource.ItemType == ItemType.MissileWeapon)
-                BaseDamageMod.ElementalBonus = WorldObject.GetMissileElementalDamageBonus(attacker, DamageType);
+                BaseDamageMod.ElementalBonus = WorldObject.GetMissileElementalDamageBonus(Weapon, attacker, DamageType);
 
             BaseDamage = (float)ThreadSafeRandom.Next(BaseDamageMod.MinDamage, BaseDamageMod.MaxDamage);
         }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -829,13 +829,9 @@ namespace ACE.Server.Entity
                     {
                         if (wo.ProjectileSource != null)
                             log.Error($"wo.ProjectileSource: 0x{wo.ProjectileSource?.Guid}:{wo.ProjectileSource?.Name}, position: {wo.ProjectileSource?.Location}");
-                        if (wo is SpellProjectile spellProjectile)
-                        {
-                            if (spellProjectile.Caster != null)
-                                log.Error($"wo.Caster: 0x{spellProjectile.Caster?.Guid}:{spellProjectile.Caster?.Name}, position: {spellProjectile.Caster?.Location}");
-                            if (spellProjectile.ProjectileTarget != null)
-                                log.Error($"wo.ProjectileTarget: 0x{spellProjectile.ProjectileTarget?.Guid}:{spellProjectile.ProjectileTarget?.Name}, position: {spellProjectile.ProjectileTarget?.Location}");
-                        }
+
+                        if (wo.ProjectileTarget != null)
+                            log.Error($"wo.ProjectileTarget: 0x{wo.ProjectileTarget?.Guid}:{wo.ProjectileTarget?.Name}, position: {wo.ProjectileTarget?.Location}");
                     }
 
                     log.Error(System.Environment.StackTrace);

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -825,7 +825,7 @@ namespace ACE.Server.WorldObjects
             return sneakAttackMod;
         }
 
-        public void FightDirty(WorldObject target)
+        public void FightDirty(WorldObject target, WorldObject weapon)
         {
             // Skill description:
             // Your melee and missile attacks have a chance to weaken your opponent.
@@ -882,13 +882,13 @@ namespace ACE.Server.WorldObjects
             switch (AttackHeight)
             {
                 case ACE.Entity.Enum.AttackHeight.Low:
-                    FightDirty_ApplyLowAttack(creatureTarget);
+                    FightDirty_ApplyLowAttack(creatureTarget, weapon);
                     break;
                 case ACE.Entity.Enum.AttackHeight.Medium:
-                    FightDirty_ApplyMediumAttack(creatureTarget);
+                    FightDirty_ApplyMediumAttack(creatureTarget, weapon);
                     break;
                 case ACE.Entity.Enum.AttackHeight.High:
-                    FightDirty_ApplyHighAttack(creatureTarget);
+                    FightDirty_ApplyHighAttack(creatureTarget, weapon);
                     break;
             }
         }
@@ -897,7 +897,7 @@ namespace ACE.Server.WorldObjects
         /// Reduces the defense skills of the opponent by
         /// -10 if trained, or -20 if specialized
         /// </summary>
-        public void FightDirty_ApplyLowAttack(Creature target)
+        public void FightDirty_ApplyLowAttack(Creature target, WorldObject weapon)
         {
             var spellID = GetCreatureSkill(Skill.DirtyFighting).AdvancementClass == SkillAdvancementClass.Specialized ?
                 SpellId.DF_Specialized_DefenseDebuff : SpellId.DF_Trained_DefenseDebuff;
@@ -905,7 +905,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            target.EnchantmentManager.Add(spell, this);
+            target.EnchantmentManager.Add(spell, this, weapon);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, PlayScript.DirtyFightingDefenseDebuff));
 
             FightDirty_SendMessage(target, spell);
@@ -916,7 +916,7 @@ namespace ACE.Server.WorldObjects
         /// 120 damage per 20 seconds if specialized
         /// </summary>
         /// <returns></returns>
-        public void FightDirty_ApplyMediumAttack(Creature target)
+        public void FightDirty_ApplyMediumAttack(Creature target, WorldObject weapon)
         {
             var spellID = GetCreatureSkill(Skill.DirtyFighting).AdvancementClass == SkillAdvancementClass.Specialized ?
                 SpellId.DF_Specialized_Bleed : SpellId.DF_Trained_Bleed;
@@ -924,7 +924,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            target.EnchantmentManager.Add(spell, this);
+            target.EnchantmentManager.Add(spell, this, weapon);
 
             // only send if not already applied?
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, PlayScript.DirtyFightingDamageOverTime));
@@ -936,7 +936,7 @@ namespace ACE.Server.WorldObjects
         /// Reduces the attack skills and healing rating for opponent
         /// by -10 if trained, or -20 if specialized
         /// </summary>
-        public void FightDirty_ApplyHighAttack(Creature target)
+        public void FightDirty_ApplyHighAttack(Creature target, WorldObject weapon)
         {
             // attack debuff
             var spellID = GetCreatureSkill(Skill.DirtyFighting).AdvancementClass == SkillAdvancementClass.Specialized ?
@@ -945,7 +945,7 @@ namespace ACE.Server.WorldObjects
             var spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            target.EnchantmentManager.Add(spell, this);
+            target.EnchantmentManager.Add(spell, this, weapon);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, PlayScript.DirtyFightingAttackDebuff));
 
             FightDirty_SendMessage(target, spell);
@@ -957,7 +957,7 @@ namespace ACE.Server.WorldObjects
             spell = new Spell(spellID);
             if (spell.NotFound) return;  // TODO: friendly message to install DF patch
 
-            target.EnchantmentManager.Add(spell, this);
+            target.EnchantmentManager.Add(spell, this, weapon);
             target.EnqueueBroadcast(new GameMessageScript(target.Guid, PlayScript.DirtyFightingHealDebuff));
 
             FightDirty_SendMessage(target, spell);

--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -187,7 +187,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    LifeMagic(spell, out uint damage, out enchantmentStatus, this, item, true);
+                    LifeMagic(spell, out uint damage, out enchantmentStatus, this, item, item, true);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(Guid, spell.TargetEffect, spell.Formula.Scale));
 
@@ -196,9 +196,9 @@ namespace ACE.Server.WorldObjects
                 case MagicSchool.ItemEnchantment:
 
                     if (spell.HasItemCategory || spell.IsPortalSpell)
-                        enchantmentStatus = ItemMagic(this, spell, item, true);
+                        enchantmentStatus = ItemMagic(this, spell, item, item, true);
                     else
-                        enchantmentStatus = ItemMagic(item, spell, item, true);
+                        enchantmentStatus = ItemMagic(item, spell, item, item, true);
 
                     var playScript = spell.IsPortalSpell && spell.CasterEffect > 0 ? spell.CasterEffect : spell.TargetEffect;
                     EnqueueBroadcast(new GameMessageScript(Guid, playScript, spell.Formula.Scale));

--- a/Source/ACE.Server/WorldObjects/Food.cs
+++ b/Source/ACE.Server/WorldObjects/Food.cs
@@ -142,7 +142,7 @@ namespace ACE.Server.WorldObjects
             // should be 'You cast', instead of 'Item cast'
             // omitting the item caster here, so player is also used for enchantment registry caster,
             // which could prevent some scenarios with spamming enchantments from multiple food sources to protect against dispels
-            player.TryCastSpell(spell, player, this, false);
+            player.TryCastSpell(spell, player, this, this, false);
         }
 
         public Sound GetUseSound()

--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -146,9 +146,9 @@ namespace ACE.Server.WorldObjects
 
                 // TODO: figure this out better
                 if (spell.MetaSpellType == SpellType.PortalSummon)
-                    TryCastSpell(spell, player, this, false);
+                    TryCastSpell(spell, player, this, this, false);
                 else
-                    player.TryCastSpell(spell, player, this, false);
+                    player.TryCastSpell(spell, player, this, this, false);
             }
 
             if (UseCreateContractId > 0)

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -131,7 +131,7 @@ namespace ACE.Server.WorldObjects.Managers
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public virtual AddEnchantmentResult Add(Spell spell, WorldObject caster, bool equip = false)
+        public virtual AddEnchantmentResult Add(Spell spell, WorldObject caster, WorldObject weapon, bool equip = false)
         {
             var result = new AddEnchantmentResult();
 
@@ -141,7 +141,7 @@ namespace ACE.Server.WorldObjects.Managers
             // if none, add new record
             if (entries.Count == 0)
             {
-                var newEntry = BuildEntry(spell, caster, equip);
+                var newEntry = BuildEntry(spell, caster, weapon, equip);
                 newEntry.LayerId = 1;
                 WorldObject.Biota.PropertiesEnchantmentRegistry.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
                 WorldObject.ChangesDetected = true;
@@ -167,7 +167,7 @@ namespace ACE.Server.WorldObjects.Managers
 
             if (refreshSpell == null)
             {
-                var newEntry = BuildEntry(spell, caster, equip);
+                var newEntry = BuildEntry(spell, caster, weapon, equip);
                 newEntry.LayerId = result.NextLayerId;
                 WorldObject.Biota.PropertiesEnchantmentRegistry.AddEnchantment(newEntry, WorldObject.BiotaDatabaseLock);
 
@@ -206,7 +206,7 @@ namespace ACE.Server.WorldObjects.Managers
         /// <summary>
         /// Builds an enchantment registry entry from a spell ID
         /// </summary>
-        private PropertiesEnchantmentRegistry BuildEntry(Spell spell, WorldObject caster = null, bool equip = false)
+        private PropertiesEnchantmentRegistry BuildEntry(Spell spell, WorldObject caster = null, WorldObject weapon = null, bool equip = false)
         {
             var entry = new PropertiesEnchantmentRegistry();
 
@@ -260,7 +260,7 @@ namespace ACE.Server.WorldObjects.Managers
                 // calculate runtime StatModValue for enchantment
                 if (caster != null)
                 {
-                    entry.StatModValue = caster.CalculateDotEnchantment_StatModValue(spell, WorldObject, entry.StatModValue);
+                    entry.StatModValue = caster.CalculateDotEnchantment_StatModValue(spell, WorldObject, weapon, entry.StatModValue);
                 }
                 //Console.WriteLine($"enchantment_statModVal: {entry.StatModValue}");
             }

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -47,9 +47,9 @@ namespace ACE.Server.WorldObjects.Managers
         /// <summary>
         /// Add/update an enchantment in this object's registry
         /// </summary>
-        public override AddEnchantmentResult Add(Spell spell, WorldObject caster, bool equip = false)
+        public override AddEnchantmentResult Add(Spell spell, WorldObject caster, WorldObject weapon, bool equip = false)
         {
-            var result = base.Add(spell, caster, equip);
+            var result = base.Add(spell, caster, weapon, equip);
 
             ClearCache();
 

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -287,6 +287,8 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            var caster = GetEquippedWand();
+
             var targetCreature = target as Creature;
 
             switch (spell.School)
@@ -338,7 +340,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.VoidMagic:
 
-                    VoidMagic(target, spell, this);
+                    VoidMagic(target, spell, caster, false);
 
                     if (spell.NumProjectiles == 0 && target != null)
                         EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
@@ -347,7 +349,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.WarMagic:
 
-                    WarMagic(target, spell, this);
+                    WarMagic(target, spell, caster, false);
                     break;
             }
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -113,18 +113,19 @@ namespace ACE.Server.WorldObjects
 
                             // handle Dirty Fighting
                             if (GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                FightDirty(targetPlayer);
+                                FightDirty(targetPlayer, damageEvent.Weapon);
                         }
                         else if (combatPet != null || targetPet != null || Faction1Bits != null || target.Faction1Bits != null || PotentialFoe(target))
                         {
                             // combat pet inflicting or receiving damage
                             //Console.WriteLine($"{target.Name} taking {Math.Round(damage)} {damageType} damage from {Name}");
                             target.TakeDamage(this, damageEvent.DamageType, damageEvent.Damage);
+
                             EmitSplatter(target, damageEvent.Damage);
 
                             // handle Dirty Fighting
                             if (GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                FightDirty(target);
+                                FightDirty(target, damageEvent.Weapon);
                         }
 
                         // handle target procs

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -872,7 +872,7 @@ namespace ACE.Server.WorldObjects
         public void HandleActionJump(JumpPack jump)
         {
             StartJump = new ACE.Entity.Position(Location);
-            //Console.WriteLine($"JumpPack: Velocity: {jump.Velocity}, Extent: {jump.Extent}");
+            Console.WriteLine($"JumpPack: Velocity: {jump.Velocity}, Extent: {jump.Extent}");
 
             var strength = Strength.Current;
             var capacity = EncumbranceSystem.EncumbranceCapacity((int)strength, AugmentationIncreasedCarryingCapacity);
@@ -913,7 +913,7 @@ namespace ACE.Server.WorldObjects
                     PhysicsObj.UpdateTime = PhysicsTimer.CurrentTime;
 
                 // perform jump in physics engine
-                PhysicsObj.TransientState &= ~(Physics.TransientStateFlags.Contact | Physics.TransientStateFlags.WaterContact);
+                PhysicsObj.TransientState &= ~(TransientStateFlags.Contact | TransientStateFlags.WaterContact);
                 PhysicsObj.calc_acceleration();
                 PhysicsObj.set_on_walkable(false);
                 PhysicsObj.set_local_velocity(jump.Velocity, false);

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -177,7 +177,7 @@ namespace ACE.Server.WorldObjects
 
                 // handle Dirty Fighting
                 if (GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                    FightDirty(target);
+                    FightDirty(target, damageEvent.Weapon);
                 
                 target.EmoteManager.OnDamage(this);
 

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -831,12 +831,12 @@ namespace ACE.Server.WorldObjects
             }
 
             // consume mana
-            WorldObject caster = this;
+            var caster = GetEquippedWand();  // TODO: persist this from the beginning, since this is done with delay
+
             if (!isWeaponSpell)
                 UpdateVitalDelta(Mana, -(int)manaUsed);
             else
             {
-                caster = GetEquippedWand();     // TODO: persist this from the beginning, since this is done with delay
                 if (caster != null)
                     caster.ItemCurMana -= (int)manaUsed;
                 else
@@ -894,13 +894,13 @@ namespace ACE.Server.WorldObjects
                         switch (spell.School)
                         {
                             case MagicSchool.WarMagic:
-                                WarMagic(target, spell, caster);
+                                WarMagic(target, spell, caster, isWeaponSpell);
                                 break;
                             case MagicSchool.VoidMagic:
-                                VoidMagic(target, spell, caster);
+                                VoidMagic(target, spell, caster, isWeaponSpell);
                                 break;
                             case MagicSchool.LifeMagic:
-                                LifeMagic(spell, out uint damage, out var enchantmentStatus, target, caster);
+                                LifeMagic(spell, out uint damage, out var enchantmentStatus, target, caster, caster, isWeaponSpell);
                                 break;
                         }
                     }
@@ -1063,9 +1063,7 @@ namespace ACE.Server.WorldObjects
             LastSuccessCast_School = spell.School;
             LastSuccessCast_Time = Time.GetUnixTime();
 
-            WorldObject caster = this;
-            if (isWeaponSpell)
-                caster = GetEquippedWand();
+            var caster = GetEquippedWand();
 
             // verify after windup, still consumes mana
             if (spell.MetaSpellType == SpellType.Dispel && !VerifyDispelPKStatus(this, target))
@@ -1074,10 +1072,10 @@ namespace ACE.Server.WorldObjects
             switch (spell.School)
             {
                 case MagicSchool.WarMagic:
-                    WarMagic(target, spell, caster);
+                    WarMagic(target, spell, caster, isWeaponSpell);
                     break;
                 case MagicSchool.VoidMagic:
-                    VoidMagic(target, spell, caster);
+                    VoidMagic(target, spell, caster, isWeaponSpell);
                     break;
 
                 case MagicSchool.CreatureEnchantment:

--- a/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
+++ b/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
@@ -68,7 +68,7 @@ namespace ACE.Server.WorldObjects
 
                             // handle Dirty Fighting
                             if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                sourceCreature.FightDirty(targetPlayer);
+                                sourceCreature.FightDirty(targetPlayer, damageEvent.Weapon);
                         }
                         else
                             targetPlayer.OnEvade(sourceCreature, CombatType.Missile);
@@ -84,7 +84,7 @@ namespace ACE.Server.WorldObjects
 
                             // handle Dirty Fighting
                             if (sourceCreature.GetCreatureSkill(Skill.DirtyFighting).AdvancementClass >= SkillAdvancementClass.Trained)
-                                sourceCreature.FightDirty(targetCreature);
+                                sourceCreature.FightDirty(targetCreature, damageEvent.Weapon);
                         }
 
                         if (!(targetCreature is CombatPet))

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -24,13 +24,12 @@ namespace ACE.Server.WorldObjects
         public float DistanceToTarget { get; set; }
         public uint LifeProjectileDamage { get; set; }
 
-        /// <summary>
-        /// If a spell projectile has been cast from a built-in weapon spell,
-        /// this will point to the item instead of the Creature
-        /// </summary>
-        public WorldObject Caster { get; set; }
-
         public SpellProjectileInfo Info { get; set; }
+
+        /// <summary>
+        /// Only set to true when this spell was launched by using the built-in spell on a caster
+        /// </summary>
+        public bool IsWeaponSpell { get; set; }
 
         public int DebugVelocity;
 
@@ -301,7 +300,7 @@ namespace ACE.Server.WorldObjects
             var critDefended = false;
             var overpower = false;
 
-            var damage = CalculateDamage(ProjectileSource, Caster, creatureTarget, ref critical, ref critDefended, ref overpower);
+            var damage = CalculateDamage(ProjectileSource, creatureTarget, ref critical, ref critDefended, ref overpower);
 
             if (damage != null)
             {
@@ -309,7 +308,8 @@ namespace ACE.Server.WorldObjects
                 // instead of instant damage, add DoT to target's enchantment registry
                 if (Spell.School == MagicSchool.VoidMagic && Spell.Duration > 0)
                 {
-                    var dot = ProjectileSource.CreateEnchantment(creatureTarget, ProjectileSource, Spell);
+                    var dot = ProjectileSource.CreateEnchantment(creatureTarget, ProjectileSource, ProjectileLauncher, Spell);
+
                     if (dot.Message != null && player != null)
                         player.Session.Network.EnqueueSend(dot.Message);
 
@@ -328,7 +328,11 @@ namespace ACE.Server.WorldObjects
                 // handle target procs
                 // note that for untargeted multi-projectile spells,
                 // ProjectileTarget will be null here, so procs will not apply
-                if (sourceCreature != null && ProjectileTarget != null)
+
+                // TODO: instead of ProjectileLauncher is Caster, perhaps a SpellProjectile.CanProc bool that defaults to true,
+                // but is set to false if the source of a spell is from a proc, to prevent multi procs?
+
+                if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -370,7 +374,7 @@ namespace ACE.Server.WorldObjects
         /// Calculates the damage for a spell projectile
         /// Used by war magic, void magic, and life magic projectiles
         /// </summary>
-        public float? CalculateDamage(WorldObject source, WorldObject caster, Creature target, ref bool criticalHit, ref bool critDefended, ref bool overpower)
+        public float? CalculateDamage(WorldObject source, Creature target, ref bool criticalHit, ref bool critDefended, ref bool overpower)
         {
             var sourcePlayer = source as Player;
             var targetPlayer = target as Player;
@@ -407,7 +411,11 @@ namespace ACE.Server.WorldObjects
             if (sourceCreature?.Overpower != null)
                 overpower = Creature.GetOverpower(sourceCreature, target);
 
-            var resisted = source.TryResistSpell(target, Spell, caster, true);
+            var weapon = ProjectileLauncher;
+
+            var resistSource = IsWeaponSpell ? weapon : source;
+
+            var resisted = source.TryResistSpell(target, Spell, resistSource, true);
             if (resisted && !overpower)
                 return null;
 
@@ -416,7 +424,7 @@ namespace ACE.Server.WorldObjects
                 attackSkill = sourceCreature.GetCreatureSkill(Spell.School);
 
             // critical hit
-            var criticalChance = GetWeaponMagicCritFrequency(sourceCreature, attackSkill, target);
+            var criticalChance = GetWeaponMagicCritFrequency(weapon, sourceCreature, attackSkill, target);
 
             if (ThreadSafeRandom.Next(0.0f, 1.0f) < criticalChance)
             {
@@ -448,10 +456,10 @@ namespace ACE.Server.WorldObjects
             if (isPVP && Spell.IsHarmful)
                 Player.UpdatePKTimers(sourcePlayer, targetPlayer);
 
-            var elementalDamageMod = GetCasterElementalDamageModifier(sourceCreature, target, Spell.DamageType);
+            var elementalDamageMod = GetCasterElementalDamageModifier(weapon, sourceCreature, target, Spell.DamageType);
 
             // Possible 2x + damage bonus for the slayer property
-            var slayerMod = GetWeaponCreatureSlayerModifier(sourceCreature, target);
+            var slayerMod = GetWeaponCreatureSlayerModifier(weapon, sourceCreature, target);
 
             // life magic projectiles: ie., martyr's hecatomb
             if (Spell.MetaSpellType == ACE.Entity.Enum.SpellType.LifeProjectile)
@@ -464,12 +472,12 @@ namespace ACE.Server.WorldObjects
                 {
                     // verify: CriticalMultiplier only applied to the additional crit damage,
                     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                    weaponCritDamageMod = GetWeaponCritDamageMod(sourceCreature, attackSkill, target);
+                    weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
                     critDamageBonus = lifeMagicDamage * 0.5f * weaponCritDamageMod;
                 }
 
-                weaponResistanceMod = GetWeaponResistanceModifier(sourceCreature, attackSkill, Spell.DamageType);
+                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
 
                 // if attacker/weapon has IgnoreMagicResist directly, do not transfer to spell projectile
                 // only pass if SpellProjectile has it directly, such as 2637 - Invoking Aun Tanua
@@ -506,7 +514,7 @@ namespace ACE.Server.WorldObjects
 
                     // verify: CriticalMultiplier only applied to the additional crit damage,
                     // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                    weaponCritDamageMod = GetWeaponCritDamageMod(sourceCreature, attackSkill, target);
+                    weaponCritDamageMod = GetWeaponCritDamageMod(weapon, sourceCreature, attackSkill, target);
 
                     critDamageBonus *= weaponCritDamageMod;
                 }
@@ -532,7 +540,7 @@ namespace ACE.Server.WorldObjects
                 }
                 baseDamage = ThreadSafeRandom.Next(Spell.MinDamage, Spell.MaxDamage);
 
-                weaponResistanceMod = GetWeaponResistanceModifier(sourceCreature, attackSkill, Spell.DamageType);
+                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
 
                 // if attacker/weapon has IgnoreMagicResist directly, do not transfer to spell projectile
                 // only pass if SpellProjectile has it directly, such as 2637 - Invoking Aun Tanua

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -84,10 +84,11 @@ namespace ACE.Server.WorldObjects
         public EmoteManager EmoteManager;
         public EnchantmentManagerWithCaching EnchantmentManager;
 
-        public WorldObject ProjectileSource;
-        public WorldObject ProjectileTarget;
+        // todo: move these to a base projectile class
+        public WorldObject ProjectileSource { get; set; }
+        public WorldObject ProjectileTarget { get; set; }
 
-        public WorldObject ProjectileLauncher;
+        public WorldObject ProjectileLauncher { get; set; }
 
         public bool HitMsg;     // FIXME: find a better way to do this for projectiles
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Tick.cs
@@ -338,7 +338,7 @@ namespace ACE.Server.WorldObjects
                         spellProjectile.DebugVelocity++;
 
                         if (spellProjectile.DebugVelocity == 30)
-                            log.Error($"Spell projectile w/ zero velocity detected @ {spellProjectile.Location.ToLOCString()}, launched by {spellProjectile.Caster?.Name} ({spellProjectile.Caster?.Guid}), spell ID {spellProjectile.Spell?.Id} - {spellProjectile.Spell?.Name}");
+                            log.Error($"Spell projectile w/ zero velocity detected @ {spellProjectile.Location.ToLOCString()}, launched by {spellProjectile.ProjectileSource?.Name} ({spellProjectile.ProjectileSource?.Guid}), spell ID {spellProjectile.Spell?.Id} - {spellProjectile.Spell?.Name}");
                     }
 
                     if (spellProjectile.SpellType == ProjectileSpellType.Ring)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -246,12 +246,10 @@ namespace ACE.Server.WorldObjects
         private const float defaultPhysicalCritFrequency = 0.1f;    // 10% base chance
 
         /// <summary>
-        /// Returns the critical chance for the current weapon
+        /// Returns the critical chance for the attack weapon
         /// </summary>
-        public static float GetWeaponCriticalChance(Creature wielder, CreatureSkill skill, Creature target)
+        public static float GetWeaponCriticalChance(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
         {
-            WorldObject weapon = GetWeapon(wielder);
-
             var critRate = (float)(weapon?.CriticalFrequency ?? defaultPhysicalCritFrequency);
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
@@ -281,14 +279,11 @@ namespace ACE.Server.WorldObjects
         private const float defaultMagicCritFrequency = 0.05f;
 
         /// <summary>
-        /// Returns the critical chance for the current magic weapon
+        /// Returns the critical chance for the caster weapon
         /// </summary>
-        public static float GetWeaponMagicCritFrequency(Creature wielder, CreatureSkill skill, Creature target)
+        public static float GetWeaponMagicCritFrequency(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
         {
             // TODO : merge with above function
-            // FIXME: do not use GetWeapon for spell projectiles
-
-            WorldObject weapon = GetWeapon(wielder as Player);
 
             if (weapon == null)
                 return defaultMagicCritFrequency;
@@ -316,12 +311,10 @@ namespace ACE.Server.WorldObjects
         private const float defaultCritDamageMultiplier = 1.0f;
 
         /// <summary>
-        /// Returns the critical damage multiplier for the current weapon
+        /// Returns the critical damage multiplier for the attack weapon
         /// </summary>
-        public static float GetWeaponCritDamageMod(Creature wielder, CreatureSkill skill, Creature target)
+        public static float GetWeaponCritDamageMod(WorldObject weapon, Creature wielder, CreatureSkill skill, Creature target)
         {
-            WorldObject weapon = GetWeapon(wielder);
-
             var critDamageMod = (float)(weapon?.GetProperty(PropertyFloat.CriticalMultiplier) ?? defaultCritDamageMultiplier);
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
@@ -341,10 +334,8 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns a multiplicative elemental damage modifier for the magic caster weapon type
         /// </summary>
-        public static float GetCasterElementalDamageModifier(Creature wielder, Creature target, DamageType damageType)
+        public static float GetCasterElementalDamageModifier(WorldObject weapon, Creature wielder, Creature target, DamageType damageType)
         {
-            var weapon = GetWeapon(wielder as Player);
-
             if (wielder == null || !(weapon is Caster) || weapon.W_DamageType != damageType)
                 return 1.0f;
 
@@ -367,10 +358,8 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns an additive elemental damage bonus for the missile launcher weapon type
         /// </summary>
-        public static int GetMissileElementalDamageBonus(Creature wielder, DamageType damageType)
+        public static int GetMissileElementalDamageBonus(WorldObject weapon, Creature wielder, DamageType damageType)
         {
-            WorldObject weapon = GetWeapon(wielder as Player);
-
             if (weapon is MissileLauncher && weapon.ElementalDamageBonus != null)
             {
                 var elementalDamageType = weapon.W_DamageType;
@@ -394,13 +383,11 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Returns the slayer damage multiplier for the current weapon
+        /// Returns the slayer damage multiplier for the attack weapon
         /// against a particular creature type
         /// </summary>
-        public static float GetWeaponCreatureSlayerModifier(Creature wielder, Creature target)
+        public static float GetWeaponCreatureSlayerModifier(WorldObject weapon, Creature wielder, Creature target)
         {
-            WorldObject weapon = GetWeapon(wielder as Player);
-
             if (weapon != null && weapon.SlayerCreatureType != null && weapon.SlayerDamageBonus != null &&
                 target != null && weapon.SlayerCreatureType == target.CreatureType)
             {
@@ -426,11 +413,9 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the resistance modifier or rending modifier
         /// </summary>
-        public static float GetWeaponResistanceModifier(Creature wielder, CreatureSkill skill, DamageType damageType)
+        public static float GetWeaponResistanceModifier(WorldObject weapon, Creature wielder, CreatureSkill skill, DamageType damageType)
         {
             float resistMod = defaultModifier;
-
-            WorldObject weapon = GetWeapon(wielder as Player);
 
             if (wielder == null || weapon == null)
                 return defaultModifier;


### PR DESCRIPTION
This PR starts with WorldObject_Weapon, for the following functions:

```
GetWeaponCriticalChance
* GetWeaponMagicCritFrequency
* GetWeaponCritDamageMod
* GetCasterElementalDamageModifier
GetMissileElementalDamageBonus
* GetWeaponCreatureSlayerModifier
* GetWeaponResistanceModifier
```

Previously, all of these functions were using GetCurrentWeapon(). These functions now accept a WorldObject weapon parameter.

A simple scenario to repro this issue would be to launch a spell projectile at something from far away, with a wand that doesn't have a Slayer property on it. Then switch to a wand that does have the appropriate Slayer property on it, while the spell projectile is in-flight. When the spell projectile that was launched with the non-Slayer wand hits the target, it will incorrectly have gotten the slayer bonus.

This was an issue with bow/crossbow/atlatl projectiles awhile ago, and it was mostly cleaned up for physical projectiles some time ago. However, there were still a few gaps lingering around even for physical missiles.

The implementation for this PR would have been simpler if it didn't need to touch the generic TryCastSpell function. Since that generic entrypoint function also needs to support this, the new weapon parameter started to spread much further. It *almost* looked like the itemCaster and weapon concepts could have been merged, however there were just a few spots where merging them could have possibly caused some issues. itemCaster is used for a lot determinations for who the 'true' caster is that gets added as the EnchantmentManager source caster, and also for spell messages for the caster of the spell.

An example of why this needs to touch the core TryCastSpell function is for proc spells. The issue originally reported that spurred this PR was from a dual-wield melee that cast a proc spell projectile with their main hand weapon, and then got the slayer bonus from their offhand weapon when the spell projectile landed.

Another bug in current master with proc spell projectiles was also found while testing before this PR. This bug becomes very obvious if the proc rate for a weapon is set to 100% for testing. If you have a melee weapon with a 'cast on strike' target proc spell projectile, when that melee weapon procs, and the spell projectile hits the target immediately afterwards, the spell projectile hitting the target will then try to re-proc any target spells again at that point. With 100% proc rates, this causes a rapid-fire chain proc spells, repeating in quick succession until the target is dead.

This additional bug was patched by having target procs from spell projectiles only happen if the spell projectile was launched from a caster weapon. If the spell projectile was launched something like a melee weapon procing, then the spell projectile hitting won't have a chance to re-activate another target proc in that scenario. A comment was left in the code that perhaps a better solution to this might be a 'CanProc' bool on the SpellProjectile that defaults to true. If the source of a spell projectile is from a proc, then CanProc would be set to false for that situation.