### PR TITLE
adding support for ProcSpell directly on mobs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1088,6 +1088,13 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void TryProcEquippedItems(Creature target, bool selfTarget, WorldObject restrictMelee = null)
         {
+            // monsters -- try to proc directly on mob
+            if (HasProc && ProcSpellSelfTargeted == selfTarget)
+            {
+                // ignore weapon?
+                TryProcItem(this, target);
+            }
+
             var tryProcItems = EquippedObjects.Values.Where(i => i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
 
             foreach (var tryProcItem in tryProcItems)

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -272,8 +272,8 @@ namespace ACE.Server.WorldObjects
                 target = this;
 
             // handle self procs
-            if (spell.IsHarmful && target != this)
-                TryProcEquippedItems(this, true);
+            //if (spell.IsHarmful && target != this)
+                //TryProcEquippedItems(this, true);
 
             // If the target is too far away, don't cast. This checks to see of this monster and the target are on separate landblock groups, and potentially separate threads.
             // This also fixes cross-threading issues
@@ -300,12 +300,12 @@ namespace ACE.Server.WorldObjects
                     if (target != null)
                         EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
 
-                    if (spell.IsHarmful)
+                    /*if (spell.IsHarmful)
                     {
                         // handle target procs
                         if (targetCreature != null && targetCreature != this)
                             TryProcEquippedItems(targetCreature, false);
-                    }
+                    }*/
                     break;
 
                 case MagicSchool.ItemEnchantment:
@@ -324,12 +324,12 @@ namespace ACE.Server.WorldObjects
                         if (target != null)
                             EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
 
-                        if (spell.IsHarmful)
+                        /*if (spell.IsHarmful)
                         {
                             // handle target procs
                             if (targetCreature != null && targetCreature != this)
                                 TryProcEquippedItems(targetCreature, false);
-                        }
+                        }*/
                     }
                     if (targetDeath && targetCreature != null)
                     {

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -882,8 +882,8 @@ namespace ACE.Server.WorldObjects
                     }
 
                     // handle self procs
-                    if (spell.IsHarmful && target != this)
-                        TryProcEquippedItems(this, true);
+                    //if (spell.IsHarmful && target != this)
+                        //TryProcEquippedItems(this, true);
 
                     break;
 
@@ -1103,8 +1103,8 @@ namespace ACE.Server.WorldObjects
                             Proficiency.OnSuccessUse(this, GetCreatureSkill(Skill.CreatureEnchantment), targetCreature.GetCreatureSkill(Skill.MagicDefense).Current);
 
                         // handle target procs
-                        if (targetCreature != null && targetCreature != this)
-                            TryProcEquippedItems(targetCreature, false);
+                        //if (targetCreature != null && targetCreature != this)
+                            //TryProcEquippedItems(targetCreature, false);
 
                         if (targetPlayer != null)
                             UpdatePKTimers(this, targetPlayer);
@@ -1144,8 +1144,8 @@ namespace ACE.Server.WorldObjects
                                 Proficiency.OnSuccessUse(this, GetCreatureSkill(Skill.LifeMagic), targetCreature.GetCreatureSkill(Skill.MagicDefense).Current);
 
                             // handle target procs
-                            if (targetCreature != null && targetCreature != this)
-                                TryProcEquippedItems(targetCreature, false);
+                            //if (targetCreature != null && targetCreature != this)
+                                //TryProcEquippedItems(targetCreature, false);
 
                             if (targetPlayer != null)
                                 UpdatePKTimers(this, targetPlayer);

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -332,7 +332,10 @@ namespace ACE.Server.WorldObjects
                 // TODO: instead of ProjectileLauncher is Caster, perhaps a SpellProjectile.CanProc bool that defaults to true,
                 // but is set to false if the source of a spell is from a proc, to prevent multi procs?
 
-                if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
+                // caster procs don't appear to be a thing in current db
+                // commenting out this code for now, as the intention is unneeded for current db, until if / when it's discovered it was a thing in retail
+
+                /*if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -355,7 +358,7 @@ namespace ACE.Server.WorldObjects
                         // WorldManager.EnqueueAction(new ActionEventDelegate(() => sourceCreature.TryProcEquippedItems(creatureTarget, false)));
                         // But, to keep it simple, we will just ignore it and not bother with TryProcEquippedItems for this particular impact.
                     }
-                }
+                }*/
             }
 
             // also called on resist

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1692,9 +1692,9 @@ namespace ACE.Server.WorldObjects
                     Proficiency.OnSuccessUse(player, player.GetCreatureSkill(Skill.VoidMagic), (target as Creature).GetCreatureSkill(Skill.MagicDefense).Current);
 
                 // handle target procs
-                var sourceCreature = this as Creature;
-                if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature)
-                    sourceCreature.TryProcEquippedItems(targetCreature, false);
+                //var sourceCreature = this as Creature;
+                //if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature)
+                    //sourceCreature.TryProcEquippedItems(targetCreature, false);
 
                 if (player != null && targetPlayer != null)
                     Player.UpdatePKTimers(player, targetPlayer);


### PR DESCRIPTION
The current mobs in the db that have ProcSpells directly on them:

31013,Wicked Skeleton,Blade Vulnerability Other VI
31014,Naughty Skeleton,Blade Vulnerability Other VI
31279,Bone Scourge,Blade Vulnerability Other VI
87173,Naughty Skeleton,Blade Vulnerability Other VI
87175,Wicked Skeleton,Blade Vulnerability Other VI

It was also found that Caster items having ProcSpells is not a thing in the current db, and it's unknown if it was ever a thing in retail.

Even when caster target procs are working 100% in theory, they still display some oddities. Since it's possible this was never even a concept in eor, procs from caster items are being disabled until if/when they are discovered to have been a thing.