### PR TITLE
partial revert of 3589, full pipeline for proc spell handling

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1058,57 +1058,6 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        /// <summary>
-        /// Called when a player or creature starts an attack
-        /// </summary>
-        public void OnAttack(Creature target)
-        {
-            // self-procs happen on attack, regardless if the attack is successfully landed
-            TryProcEquippedItems(this, true);
-        }
-
-        /// <summary>
-        /// Called when a targeted attack hits successfully
-        /// </summary>
-        public void OnHitTarget(Creature target)
-        {
-            // target-procs happen when the target is successfully hit.
-
-            // this should only be called when targeted attacks are landed.
-
-            // untargeted attacks, such as multi-projectile spells,
-            // should not call this method.
-
-            TryProcEquippedItems(target, false);
-        }
-
-        /// <summary>
-        /// Iterates through all of the equipped objects that have proc spells
-        /// matching the 'selfTarget' bool, and tries procing them w/ rng chance
-        /// </summary>
-        public void TryProcEquippedItems(Creature target, bool selfTarget, WorldObject restrictMelee = null)
-        {
-            // monsters -- try to proc directly on mob
-            if (HasProc && ProcSpellSelfTargeted == selfTarget)
-            {
-                // ignore weapon?
-                TryProcItem(this, target);
-            }
-
-            var tryProcItems = EquippedObjects.Values.Where(i => i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
-
-            foreach (var tryProcItem in tryProcItems)
-            {
-                if (restrictMelee != null)
-                {
-                    // for melee attacks, we want to restrict this to the weapon that dealt the damage
-                    if (tryProcItem != restrictMelee && tryProcItem is MeleeWeapon)
-                        continue;
-                }
-                tryProcItem.TryProcItem(this, target);
-            }
-        }
-
         public static Skill GetDefenseSkill(CombatType combatType)
         {
             switch (combatType)

--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -187,7 +187,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    LifeMagic(spell, out uint damage, out enchantmentStatus, this, item, item, true);
+                    LifeMagic(spell, out uint damage, out enchantmentStatus, this, item, item, equip: true);
                     if (enchantmentStatus.Message != null)
                         EnqueueBroadcast(new GameMessageScript(Guid, spell.TargetEffect, spell.Formula.Scale));
 

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -271,9 +271,11 @@ namespace ACE.Server.WorldObjects
             else if (targetSelf)
                 target = this;
 
+            var caster = GetEquippedWand();
+
             // handle self procs
             if (spell.IsHarmful && target != this)
-                TryProcEquippedItems(this, true);
+                TryProcEquippedItems(this, this, true, caster);
 
             // If the target is too far away, don't cast. This checks to see of this monster and the target are on separate landblock groups, and potentially separate threads.
             // This also fixes cross-threading issues
@@ -286,8 +288,6 @@ namespace ACE.Server.WorldObjects
                 TryHandleFactionMob(target);
                 return;
             }
-
-            var caster = GetEquippedWand();
 
             var targetCreature = target as Creature;
 
@@ -304,7 +304,7 @@ namespace ACE.Server.WorldObjects
                     {
                         // handle target procs
                         if (targetCreature != null && targetCreature != this)
-                            TryProcEquippedItems(targetCreature, false);
+                            TryProcEquippedItems(this, targetCreature, false, caster);
                     }
                     break;
 
@@ -315,7 +315,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.LifeMagic:
 
-                    var targetDeath = LifeMagic(spell, out uint damage, out var msg, target);
+                    var targetDeath = LifeMagic(spell, out uint damage, out var msg, target, null, caster);
 
                     if (spell.MetaSpellType != SpellType.LifeProjectile)
                     {
@@ -328,7 +328,7 @@ namespace ACE.Server.WorldObjects
                         {
                             // handle target procs
                             if (targetCreature != null && targetCreature != this)
-                                TryProcEquippedItems(targetCreature, false);
+                                TryProcEquippedItems(this, targetCreature, false, caster);
                         }
                     }
                     if (targetDeath && targetCreature != null)
@@ -340,7 +340,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.VoidMagic:
 
-                    VoidMagic(target, spell, caster, false);
+                    VoidMagic(target, spell, caster);
 
                     if (spell.NumProjectiles == 0 && target != null)
                         EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
@@ -349,7 +349,7 @@ namespace ACE.Server.WorldObjects
 
                 case MagicSchool.WarMagic:
 
-                    WarMagic(target, spell, caster, false);
+                    WarMagic(target, spell, caster);
                     break;
             }
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -272,8 +272,8 @@ namespace ACE.Server.WorldObjects
                 target = this;
 
             // handle self procs
-            //if (spell.IsHarmful && target != this)
-                //TryProcEquippedItems(this, true);
+            if (spell.IsHarmful && target != this)
+                TryProcEquippedItems(this, true);
 
             // If the target is too far away, don't cast. This checks to see of this monster and the target are on separate landblock groups, and potentially separate threads.
             // This also fixes cross-threading issues
@@ -300,12 +300,12 @@ namespace ACE.Server.WorldObjects
                     if (target != null)
                         EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
 
-                    /*if (spell.IsHarmful)
+                    if (spell.IsHarmful)
                     {
                         // handle target procs
                         if (targetCreature != null && targetCreature != this)
                             TryProcEquippedItems(targetCreature, false);
-                    }*/
+                    }
                     break;
 
                 case MagicSchool.ItemEnchantment:
@@ -324,12 +324,12 @@ namespace ACE.Server.WorldObjects
                         if (target != null)
                             EnqueueBroadcast(new GameMessageScript(target.Guid, spell.TargetEffect, spell.Formula.Scale));
 
-                        /*if (spell.IsHarmful)
+                        if (spell.IsHarmful)
                         {
                             // handle target procs
                             if (targetCreature != null && targetCreature != this)
                                 TryProcEquippedItems(targetCreature, false);
-                        }*/
+                        }
                     }
                     if (targetDeath && targetCreature != null)
                     {

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -73,7 +73,7 @@ namespace ACE.Server.WorldObjects
             var actionChain = new ActionChain();
 
             // handle self-procs
-            TryProcEquippedItems(this, true, weapon);
+            TryProcEquippedItems(this, this, true, weapon);
 
             var prevTime = 0.0f;
             bool targetProc = false;
@@ -131,7 +131,7 @@ namespace ACE.Server.WorldObjects
                         // handle target procs
                         if (!targetProc)
                         {
-                            TryProcEquippedItems(target, false, weapon);
+                            TryProcEquippedItems(this, target, false, weapon);
                             targetProc = true;
                         }
                     }

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -62,6 +62,8 @@ namespace ACE.Server.WorldObjects
             var ammo = weapon.IsAmmoLauncher ? GetEquippedAmmo() : weapon;
             if (ammo == null) return;
 
+            var launcher = GetEquippedMissileLauncher();
+
             /*if (!IsDirectVisible(AttackTarget))
             {
                 // ensure direct line of sight
@@ -118,7 +120,7 @@ namespace ACE.Server.WorldObjects
 
                 if (AttackTarget != null)
                 {
-                    var projectile = LaunchProjectile(weapon, ammo, AttackTarget, origin, orientation, velocity);
+                    var projectile = LaunchProjectile(launcher, ammo, AttackTarget, origin, orientation, velocity);
                     UpdateAmmoAfterLaunch(ammo);
                 }
             });

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -109,7 +109,7 @@ namespace ACE.Server.WorldObjects
                 if (IsDead) return;
 
                 // handle self-procs
-                TryProcEquippedItems(this, true);
+                TryProcEquippedItems(this, this, true, weapon);
 
                 var sound = GetLaunchMissileSound(weapon);
                 EnqueueBroadcast(new GameMessageSound(Guid, sound, 1.0f));

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -883,7 +883,7 @@ namespace ACE.Server.WorldObjects
 
                     // handle self procs
                     if (spell.IsHarmful && target != this)
-                        TryProcEquippedItems(this, true);
+                        TryProcEquippedItems(this, this, true, caster);
 
                     break;
 
@@ -1104,7 +1104,7 @@ namespace ACE.Server.WorldObjects
 
                         // handle target procs
                         if (targetCreature != null && targetCreature != this)
-                            TryProcEquippedItems(targetCreature, false);
+                            TryProcEquippedItems(this, targetCreature, false, caster);
 
                         if (targetPlayer != null)
                             UpdatePKTimers(this, targetPlayer);
@@ -1131,7 +1131,7 @@ namespace ACE.Server.WorldObjects
                         }
                     }
 
-                    targetDeath = LifeMagic(spell, out uint damage, out enchantmentStatus, target, caster);
+                    targetDeath = LifeMagic(spell, out uint damage, out enchantmentStatus, target, null, caster, isWeaponSpell);
 
                     if (spell.MetaSpellType != SpellType.LifeProjectile)
                     {
@@ -1145,7 +1145,7 @@ namespace ACE.Server.WorldObjects
 
                             // handle target procs
                             if (targetCreature != null && targetCreature != this)
-                                TryProcEquippedItems(targetCreature, false);
+                                TryProcEquippedItems(this, targetCreature, false, caster);
 
                             if (targetPlayer != null)
                                 UpdatePKTimers(this, targetPlayer);

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -882,8 +882,8 @@ namespace ACE.Server.WorldObjects
                     }
 
                     // handle self procs
-                    //if (spell.IsHarmful && target != this)
-                        //TryProcEquippedItems(this, true);
+                    if (spell.IsHarmful && target != this)
+                        TryProcEquippedItems(this, true);
 
                     break;
 
@@ -1103,8 +1103,8 @@ namespace ACE.Server.WorldObjects
                             Proficiency.OnSuccessUse(this, GetCreatureSkill(Skill.CreatureEnchantment), targetCreature.GetCreatureSkill(Skill.MagicDefense).Current);
 
                         // handle target procs
-                        //if (targetCreature != null && targetCreature != this)
-                            //TryProcEquippedItems(targetCreature, false);
+                        if (targetCreature != null && targetCreature != this)
+                            TryProcEquippedItems(targetCreature, false);
 
                         if (targetPlayer != null)
                             UpdatePKTimers(this, targetPlayer);
@@ -1144,8 +1144,8 @@ namespace ACE.Server.WorldObjects
                                 Proficiency.OnSuccessUse(this, GetCreatureSkill(Skill.LifeMagic), targetCreature.GetCreatureSkill(Skill.MagicDefense).Current);
 
                             // handle target procs
-                            //if (targetCreature != null && targetCreature != this)
-                                //TryProcEquippedItems(targetCreature, false);
+                            if (targetCreature != null && targetCreature != this)
+                                TryProcEquippedItems(targetCreature, false);
 
                             if (targetPlayer != null)
                                 UpdatePKTimers(this, targetPlayer);

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -308,7 +308,7 @@ namespace ACE.Server.WorldObjects
             }
 
             // handle self-procs
-            TryProcEquippedItems(this, true, weapon);
+            TryProcEquippedItems(this, this, true, weapon);
 
             var prevTime = 0.0f;
             bool targetProc = false;
@@ -335,7 +335,7 @@ namespace ACE.Server.WorldObjects
                     // handle target procs
                     if (damageEvent != null && damageEvent.HasDamage && !targetProc)
                     {
-                        TryProcEquippedItems(creature, false, weapon);
+                        TryProcEquippedItems(this, creature, false, weapon);
                         targetProc = true;
                     }
 

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -160,6 +160,8 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            var launcher = GetEquippedMissileLauncher();
+
             var creature = target as Creature;
             if (!IsAlive || IsBusy || MissileTarget == null || creature == null || !creature.IsAlive || suicideInProgress)
             {
@@ -239,7 +241,7 @@ namespace ACE.Server.WorldObjects
                 var staminaCost = GetAttackStamina(GetAccuracyRange());
                 UpdateVitalDelta(Stamina, -staminaCost);
 
-                var projectile = LaunchProjectile(weapon, ammo, target, origin, orientation, velocity);
+                var projectile = LaunchProjectile(launcher, ammo, target, origin, orientation, velocity);
                 UpdateAmmoAfterLaunch(ammo);
             });
 

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -228,7 +228,7 @@ namespace ACE.Server.WorldObjects
             actionChain.AddAction(this, () =>
             {
                 // handle self-procs
-                TryProcEquippedItems(this, true);
+                TryProcEquippedItems(this, this, true, weapon);
 
                 var sound = GetLaunchMissileSound(weapon);
                 EnqueueBroadcast(new GameMessageSound(Guid, sound, 1.0f));

--- a/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
+++ b/Source/ACE.Server/WorldObjects/ProjectileCollisionHelper.cs
@@ -103,13 +103,14 @@ namespace ACE.Server.WorldObjects
                     if (LandblockManager.CurrentlyTickingLandblockGroupsMultiThreaded)
                     {
                         // Ok... if we got here, we're likely in the parallel landblock physics processing.
-                        if (sourceCreature.CurrentLandblock == null || targetCreature.CurrentLandblock == null || sourceCreature.CurrentLandblock.CurrentLandblockGroup != targetCreature.CurrentLandblock.CurrentLandblockGroup)
+                        if (worldObject.CurrentLandblock == null || sourceCreature.CurrentLandblock == null || targetCreature.CurrentLandblock == null || worldObject.CurrentLandblock.CurrentLandblockGroup != sourceCreature.CurrentLandblock.CurrentLandblockGroup || sourceCreature.CurrentLandblock.CurrentLandblockGroup != targetCreature.CurrentLandblock.CurrentLandblockGroup)
                             threadSafe = false;
                     }
 
                     if (threadSafe)
                         // This can result in spell projectiles being added to either sourceCreature or targetCreature landblock.
-                        sourceCreature.TryProcEquippedItems(targetCreature, false);
+                        // worldObject is hitting targetCreature, so they should almost always be in the same landblock
+                        worldObject.TryProcEquippedItems(sourceCreature, targetCreature, false, worldObject.ProjectileLauncher);
                     else
                     {
                         // sourceCreature and creatureTarget are now in different landblock groups.

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -31,6 +31,12 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsWeaponSpell { get; set; }
 
+        /// <summary>
+        /// If a spell projectile is from a proc source,
+        /// make sure there is no attempt to re-proc again when the spell projectile hits
+        /// </summary>
+        public bool FromProc { get; set; }
+
         public int DebugVelocity;
 
         /// <summary>
@@ -332,7 +338,7 @@ namespace ACE.Server.WorldObjects
                 // TODO: instead of ProjectileLauncher is Caster, perhaps a SpellProjectile.CanProc bool that defaults to true,
                 // but is set to false if the source of a spell is from a proc, to prevent multi procs?
 
-                if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
+                if (sourceCreature != null && ProjectileTarget != null && !FromProc)
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -346,7 +352,7 @@ namespace ACE.Server.WorldObjects
 
                     if (threadSafe)
                         // This can result in spell projectiles being added to either sourceCreature or creatureTargets landblock.
-                        sourceCreature.TryProcEquippedItems(creatureTarget, false);
+                        sourceCreature.TryProcEquippedItems(sourceCreature, creatureTarget, false, ProjectileLauncher);
                     else
                     {
                         // sourceCreature and creatureTarget are now in different landblock groups.

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -332,10 +332,7 @@ namespace ACE.Server.WorldObjects
                 // TODO: instead of ProjectileLauncher is Caster, perhaps a SpellProjectile.CanProc bool that defaults to true,
                 // but is set to false if the source of a spell is from a proc, to prevent multi procs?
 
-                // caster procs don't appear to be a thing in current db
-                // commenting out this code for now, as the intention is unneeded for current db, until if / when it's discovered it was a thing in retail
-
-                /*if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
+                if (sourceCreature != null && ProjectileTarget != null && ProjectileLauncher is Caster)
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -358,7 +355,7 @@ namespace ACE.Server.WorldObjects
                         // WorldManager.EnqueueAction(new ActionEventDelegate(() => sourceCreature.TryProcEquippedItems(creatureTarget, false)));
                         // But, to keep it simple, we will just ignore it and not bother with TryProcEquippedItems for this particular impact.
                     }
-                }*/
+                }
             }
 
             // also called on resist

--- a/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 using ACE.Entity.Enum;
 using ACE.Server.Entity;
@@ -16,6 +17,42 @@ namespace ACE.Server.WorldObjects
             // no restrictions here
             // player attacker restrictions handled in override
             return null;
+        }
+
+        /// <summary>
+        /// Iterates through all of the equipped objects that have proc spells
+        /// matching the 'selfTarget' bool, and tries procing them w/ rng chance
+        /// </summary>
+        public void TryProcEquippedItems(WorldObject attacker, Creature target, bool selfTarget, WorldObject weapon)
+        {
+            // handle procs directly on this item -- ie. phials
+            // this could also be monsters with the proc spell directly on the creature
+            if (HasProc && ProcSpellSelfTargeted == selfTarget)
+            {
+                TryProcItem(attacker, target);
+            }
+
+            // handle proc spells for weapon
+            // this could be a melee weapon, or a missile launcher
+            if (weapon != null && weapon.HasProc && weapon.ProcSpellSelfTargeted == selfTarget)
+            {
+                weapon.TryProcItem(attacker, target);
+            }
+
+            if (attacker != this && attacker.HasProc && attacker.ProcSpellSelfTargeted == selfTarget)
+            {
+                // handle special case -- missile projectiles from monsters w/ a proc directly on the mob
+                attacker.TryProcItem(attacker, target);
+            }
+
+            // handle aetheria procs
+            if (attacker is Creature wielder)
+            {
+                var equippedAetheria = wielder.EquippedObjects.Values.Where(i => Aetheria.IsAetheria(i.WeenieClassId) && i.HasProc && i.ProcSpellSelfTargeted == selfTarget);
+
+                foreach (var aetheria in equippedAetheria)
+                    aetheria.TryProcItem(this, target);
+            }
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
@@ -20,8 +20,7 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Iterates through all of the equipped objects that have proc spells
-        /// matching the 'selfTarget' bool, and tries procing them w/ rng chance
+        /// Tries to proc any relevant items for the attack
         /// </summary>
         public void TryProcEquippedItems(WorldObject attacker, Creature target, bool selfTarget, WorldObject weapon)
         {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1692,9 +1692,9 @@ namespace ACE.Server.WorldObjects
                     Proficiency.OnSuccessUse(player, player.GetCreatureSkill(Skill.VoidMagic), (target as Creature).GetCreatureSkill(Skill.MagicDefense).Current);
 
                 // handle target procs
-                //var sourceCreature = this as Creature;
-                //if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature)
-                    //sourceCreature.TryProcEquippedItems(targetCreature, false);
+                var sourceCreature = this as Creature;
+                if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature)
+                    sourceCreature.TryProcEquippedItems(targetCreature, false);
 
                 if (player != null && targetPlayer != null)
                     Player.UpdatePKTimers(player, targetPlayer);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -32,7 +32,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Instantly casts a spell for a WorldObject (ie. spell traps)
         /// </summary>
-        public void TryCastSpell(Spell spell, WorldObject target, WorldObject caster = null, WorldObject weapon = null, bool tryResist = true, bool showMsg = true)
+        public void TryCastSpell(Spell spell, WorldObject target, WorldObject caster = null, WorldObject weapon = null, bool tryResist = true, bool showMsg = true, bool fromProc = false)
         {
             // TODO: look into further normalizing this / caster / weapon
 
@@ -54,13 +54,13 @@ namespace ACE.Server.WorldObjects
                 var fellows = targetPlayer.Fellowship.GetFellowshipMembers();
 
                 foreach (var fellow in fellows.Values)
-                    TryCastSpell_Inner(spell, fellow, caster, weapon, tryResist, showMsg);
+                    TryCastSpell_Inner(spell, fellow, caster, weapon, tryResist, showMsg, fromProc);
             }
             else
-                TryCastSpell_Inner(spell, target, caster, weapon, tryResist, showMsg);
+                TryCastSpell_Inner(spell, target, caster, weapon, tryResist, showMsg, fromProc);
         }
 
-        public void TryCastSpell_Inner(Spell spell, WorldObject target, WorldObject caster = null, WorldObject weapon = null, bool tryResist = true, bool showMsg = true)
+        public void TryCastSpell_Inner(Spell spell, WorldObject target, WorldObject caster = null, WorldObject weapon = null, bool tryResist = true, bool showMsg = true, bool fromProc = false)
         {
             // verify before resist, still consumes source item
             if (spell.MetaSpellType == SpellType.Dispel && !VerifyDispelPKStatus(caster, target))
@@ -76,11 +76,11 @@ namespace ACE.Server.WorldObjects
             switch (spell.School)
             {
                 case MagicSchool.WarMagic:
-                    WarMagic(target, spell, weapon, false);
+                    WarMagic(target, spell, weapon, false, fromProc);
                     break;
 
                 case MagicSchool.LifeMagic:
-                    var targetDeath = LifeMagic(spell, out uint damage, out status, target, caster);
+                    var targetDeath = LifeMagic(spell, out uint damage, out status, target, caster, fromProc: fromProc);
                     if (targetDeath && target is Creature targetCreature)
                     {
                         targetCreature.OnDeath(new DamageHistoryInfo(this), DamageType.Health, false);
@@ -97,7 +97,7 @@ namespace ACE.Server.WorldObjects
                     break;
 
                 case MagicSchool.VoidMagic:
-                    VoidMagic(target, spell, weapon, false);
+                    VoidMagic(target, spell, weapon, false, fromProc);
                     break;
             }
 
@@ -251,7 +251,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a Life Magic spell
         /// </summary>
-        protected bool LifeMagic(Spell spell, out uint damage, out EnchantmentStatus enchantmentStatus, WorldObject target = null, WorldObject itemCaster = null, WorldObject weapon = null, bool equip = false)
+        protected bool LifeMagic(Spell spell, out uint damage, out EnchantmentStatus enchantmentStatus, WorldObject target = null, WorldObject itemCaster = null, WorldObject weapon = null, bool isWeaponSpell = false, bool equip = false, bool fromProc = false)
         {
             string srcVital, destVital;
             enchantmentStatus = new EnchantmentStatus(spell);
@@ -579,7 +579,7 @@ namespace ACE.Server.WorldObjects
                 case SpellType.Projectile:
 
                     damage = 0;
-                    var projectiles = CreateSpellProjectiles(spell, target, weapon, false);
+                    var projectiles = CreateSpellProjectiles(spell, target, weapon, isWeaponSpell, fromProc);
                     break;
 
                 case SpellType.LifeProjectile:
@@ -610,7 +610,7 @@ namespace ACE.Server.WorldObjects
                             //player.Fellowship.OnVitalUpdate(player);
                     }
 
-                    var lifeProjectiles = CreateSpellProjectiles(spell, target, weapon, false, damage);
+                    var lifeProjectiles = CreateSpellProjectiles(spell, target, weapon, isWeaponSpell, fromProc, damage);
 
                     if (caster.Health.Current <= 0)
                     {
@@ -775,7 +775,7 @@ namespace ACE.Server.WorldObjects
             // redirect item dispels to life magic
             if (spell.MetaSpellType == SpellType.Dispel)
             {
-                LifeMagic(spell, out uint damage, out enchantmentStatus, target, itemCaster, weapon, equip);
+                LifeMagic(spell, out uint damage, out enchantmentStatus, target, itemCaster, weapon, false, equip);
                 return enchantmentStatus;
             }
 
@@ -1203,7 +1203,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Creates and launches the projectiles for a spell
         /// </summary>
-        public List<SpellProjectile> CreateSpellProjectiles(Spell spell, WorldObject target, WorldObject weapon, bool isWeaponSpell, uint lifeProjectileDamage = 0)
+        public List<SpellProjectile> CreateSpellProjectiles(Spell spell, WorldObject target, WorldObject weapon, bool isWeaponSpell = false, bool fromProc = false, uint lifeProjectileDamage = 0)
         {
             if (spell.NumProjectiles == 0)
             {
@@ -1217,7 +1217,7 @@ namespace ACE.Server.WorldObjects
 
             var velocity = CalculateProjectileVelocity(spell, target, spellType, origins[0]);
 
-            return LaunchSpellProjectiles(spell, target, spellType, weapon, isWeaponSpell, origins, velocity, lifeProjectileDamage);
+            return LaunchSpellProjectiles(spell, target, spellType, weapon, isWeaponSpell, fromProc, origins, velocity, lifeProjectileDamage);
         }
 
         public static readonly float ProjHeight = 2.0f / 3.0f;
@@ -1453,7 +1453,7 @@ namespace ACE.Server.WorldObjects
             return dir * speed;
         }
 
-        public List<SpellProjectile> LaunchSpellProjectiles(Spell spell, WorldObject target, ProjectileSpellType spellType, WorldObject weapon, bool isWeaponSpell, List<Vector3> origins, Vector3 velocity, uint lifeProjectileDamage = 0)
+        public List<SpellProjectile> LaunchSpellProjectiles(Spell spell, WorldObject target, ProjectileSpellType spellType, WorldObject weapon, bool isWeaponSpell, bool fromProc, List<Vector3> origins, Vector3 velocity, uint lifeProjectileDamage = 0)
         {
             var useGravity = spellType == ProjectileSpellType.Arc;
 
@@ -1504,6 +1504,7 @@ namespace ACE.Server.WorldObjects
                 sp.Location.Rotation = sp.PhysicsObj.Position.Frame.Orientation;
 
                 sp.ProjectileSource = this;
+                sp.FromProc = fromProc;
 
                 // side projectiles always untargeted?
                 if (i == 0)     
@@ -1633,27 +1634,27 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Launches a targeted War Magic spell projectile
         /// </summary>
-        protected void WarMagic(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell)
+        protected void WarMagic(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell = false, bool fromProc = false)
         {
-            CreateSpellProjectiles(spell, target, weapon, isWeaponSpell);
+            CreateSpellProjectiles(spell, target, weapon, isWeaponSpell, fromProc);
         }
 
         /// <summary>
         /// Launches a Void Magic spell attack
         /// </summary>
-        protected void VoidMagic(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell)
+        protected void VoidMagic(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell = false, bool fromProc = false)
         {
             if (spell.NumProjectiles > 0)
-                CreateSpellProjectiles(spell, target, weapon, isWeaponSpell);
+                CreateSpellProjectiles(spell, target, weapon, isWeaponSpell, fromProc);
             else
                 // curses - apply with code similar to creature/life magic?
-                TryApplyEnchantment(target, spell, weapon, isWeaponSpell);
+                TryApplyEnchantment(target, spell, weapon, isWeaponSpell, fromProc);
         }
 
         /// <summary>
         /// Attempts to apply an enchantment (added for Void Magic)
         /// </summary>
-        protected bool TryApplyEnchantment(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell)
+        protected bool TryApplyEnchantment(WorldObject target, Spell spell, WorldObject weapon, bool isWeaponSpell = false, bool fromProc = false)
         {
             var player = this as Player;
 
@@ -1693,8 +1694,8 @@ namespace ACE.Server.WorldObjects
 
                 // handle target procs
                 var sourceCreature = this as Creature;
-                if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature)
-                    sourceCreature.TryProcEquippedItems(targetCreature, false);
+                if (sourceCreature != null && targetCreature != null && sourceCreature != targetCreature && !fromProc)
+                    sourceCreature.TryProcEquippedItems(sourceCreature, targetCreature, false, weapon);
 
                 if (player != null && targetPlayer != null)
                     Player.UpdatePKTimers(player, targetPlayer);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -909,13 +909,13 @@ namespace ACE.Server.WorldObjects
             return HasProc && ProcSpell == spellID;
         }
 
-        public void TryProcItem(Creature wielder, Creature target)
+        public void TryProcItem(WorldObject attacker, Creature target)
         {
             // roll for a chance of casting spell
             var chance = ProcSpellRate ?? 0.0f;
 
             // special handling for aetheria
-            if (Aetheria.IsAetheria(WeenieClassId))
+            if (Aetheria.IsAetheria(WeenieClassId) && attacker is Creature wielder)
                 chance = Aetheria.CalcProcRate(this, wielder);
 
             var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
@@ -926,7 +926,7 @@ namespace ACE.Server.WorldObjects
 
             if (spell.NotFound)
             {
-                if (wielder is Player player)
+                if (attacker is Player player)
                 {
                     if (spell._spellBase == null)
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"SpellId {ProcSpell.Value} Invalid.", ChatMessageType.System));
@@ -937,9 +937,9 @@ namespace ACE.Server.WorldObjects
             }
 
             if (spell.NonComponentTargetType == ItemType.None)
-                wielder.TryCastSpell(spell, null, this);
+                attacker.TryCastSpell(spell, null, this, fromProc: true);
             else
-                wielder.TryCastSpell(spell, target, this);
+                attacker.TryCastSpell(spell, target, this, fromProc: true);
         }
 
         private bool? isMasterable;


### PR DESCRIPTION
For https://github.com/ACEmulator/ACE/pull/3589, it completely slipped my mind that even though no Caster items contain proc spells directly, procing on magic attacks is still definitely needed for Aetheria.

This re-enables procing for magic casting and spell projectiles, and finishes the complete pipeline in the proper way. When a spell is proced, a new bool 'fromProc' is passed around to the appropriate functions. This ensures when spell procs land, they don't make any attempt to re-proc. This avoids the multi-proc issues and chain proc bugs.

The procing code was also cleaned up a bit for missile projectiles, to further reflect how those should 'truly' work, for both phials, and missile launchers (ie. bows) with procs on them

The LandblockGroup thread safety code was updated to ensure all 3 relevant WorldObjects are in the same landblock group (attacker, defender, projectile)

A 4th WorldObject could also potentially be involved -- the MissileLauncher in the case of things like bows. In almost every case, the MissileLauncher will not be on a landblock, and will be in the attacker's EquippedItems (or possibly their inventory, if they de-equipped it).

It is technically possible for the attacker to launch an arrow, and then drop their bow in the landblock though. If this were to happen, I would imagine it be very difficult for that bow to get to a different landblock group than the other 3 relevant WorldObjects.

It's still a technical possibility, although an extremely unlikely one in-game. If one wanted to be really secure, you could check if ProjectileLauncher?.CurrentLandblock isn't null, make sure it matches up with the other 3 objects.