### PR TITLE
retroactively fix weenieType on rynthid tentacle bow

### DIFF
--- a/Database/Updates/Shard/2021-06-17-00-Fix-Rynthid-Tentacle-Bow-WeenieType.sql
+++ b/Database/Updates/Shard/2021-06-17-00-Fix-Rynthid-Tentacle-Bow-WeenieType.sql
@@ -1,0 +1,1 @@
+UPDATE biota SET weenie_Type=3 /* MissileLauncher */ WHERE weenie_Class_Id=51988 /* Rynthid Tentacle Bow */;


### PR DESCRIPTION
this updates weenieType from generic to missile launcher for rynthid tentacle bows generated in the first month before march 25th