### PR TITLE
Added Double server property 'rare_drop_rate_percent'

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
@@ -43,7 +43,15 @@ namespace ACE.Server.Factories
 
         public static WorldObject TryCreateRare(int luck = 0)
         {
-            var t1_chance = 2500; // 1 in 2,500 chance
+            //var t1_chance = 2500; // 1 in 2,500 chance // Old rate. Property default is 0.04 (which is 0.04%, or the same 1/2500)
+            double rare_drop_rate_percent = (float)Managers.PropertyManager.GetDouble("rare_drop_rate_percent").Item;
+
+            // Check to make sure there *IS* a chance. Less than/equal to 0 would mean zero chance, so we can stop here
+            if (rare_drop_rate_percent <= 0) {
+                return null;
+            }
+            rare_drop_rate_percent = Math.Max(rare_drop_rate_percent/100, 1); 
+            int t1_chance = (int)Math.Round(1 / rare_drop_rate_percent); // Default PropertyManager value results in a 1 in 2,500 chance
             t1_chance = Math.Max(t1_chance - luck, 1);
 
             int tier = 0;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Factories
             if (rare_drop_rate_percent <= 0) {
                 return null;
             }
-            rare_drop_rate_percent = Math.Max(rare_drop_rate_percent/100, 1); 
+            rare_drop_rate_percent = Math.Min(rare_drop_rate_percent/100, 1); 
             int t1_chance = (int)Math.Round(1 / rare_drop_rate_percent); // Default PropertyManager value results in a 1 in 2,500 chance
             t1_chance = Math.Max(t1_chance - luck, 1);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Rare.cs
@@ -47,9 +47,9 @@ namespace ACE.Server.Factories
             double rare_drop_rate_percent = (float)Managers.PropertyManager.GetDouble("rare_drop_rate_percent").Item;
 
             // Check to make sure there *IS* a chance. Less than/equal to 0 would mean zero chance, so we can stop here
-            if (rare_drop_rate_percent <= 0) {
+            if (rare_drop_rate_percent <= 0)
                 return null;
-            }
+            
             rare_drop_rate_percent = Math.Min(rare_drop_rate_percent/100, 1); 
             int t1_chance = (int)Math.Round(1 / rare_drop_rate_percent); // Default PropertyManager value results in a 1 in 2,500 chance
             t1_chance = Math.Max(t1_chance - luck, 1);

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -644,7 +644,7 @@ namespace ACE.Server.Managers
                 ("pk_new_character_grace_period", new Property<double>(300, "the number of seconds, in addition to pk_respite_timer, that a player killer is set to non-player killer status after first exiting training academy")),
                 ("pk_respite_timer", new Property<double>(300, "the number of seconds that a player killer is set to non-player killer status after dying to another player killer")),
                 ("quest_mindelta_rate", new Property<double>(1.0, "scales all quest min delta time between solves, 1 being normal")),
-                ("rare_drop_rate_percent", new Property<double>(0.04, "Adjust the chance of a rare to sapwn as a percentage. Default is 0.04, or 1 in 2,500. Max is 100, or every eligible drop.")),
+                ("rare_drop_rate_percent", new Property<double>(0.04, "Adjust the chance of a rare to spawn as a percentage. Default is 0.04, or 1 in 2,500. Max is 100, or every eligible drop.")),
                 ("spellcast_max_angle", new Property<double>(5.0, "for advanced player spell casting, the maximum angle to target release a spell projectile. retail seemed to default to a lower 5-20 value here, although some players seem to prefer a higher 45 degree angle")),
                 ("trophy_drop_rate", new Property<double>(1.0, "Modifier for trophies dropped on creature death")),
                 ("unlocker_window", new Property<double>(10.0, "The number of seconds a player unlocking a chest has exclusive access to first opening the chest.")),

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -644,6 +644,7 @@ namespace ACE.Server.Managers
                 ("pk_new_character_grace_period", new Property<double>(300, "the number of seconds, in addition to pk_respite_timer, that a player killer is set to non-player killer status after first exiting training academy")),
                 ("pk_respite_timer", new Property<double>(300, "the number of seconds that a player killer is set to non-player killer status after dying to another player killer")),
                 ("quest_mindelta_rate", new Property<double>(1.0, "scales all quest min delta time between solves, 1 being normal")),
+                ("rare_drop_rate_percent", new Property<double>(0.04, "Adjust the chance of a rare to sapwn as a percentage. Default is 0.04, or 1 in 2,500. Max is 100, or every eligible drop.")),
                 ("spellcast_max_angle", new Property<double>(5.0, "for advanced player spell casting, the maximum angle to target release a spell projectile. retail seemed to default to a lower 5-20 value here, although some players seem to prefer a higher 45 degree angle")),
                 ("trophy_drop_rate", new Property<double>(1.0, "Modifier for trophies dropped on creature death")),
                 ("unlocker_window", new Property<double>(10.0, "The number of seconds a player unlocking a chest has exclusive access to first opening the chest.")),


### PR DESCRIPTION
Adjust the chance of a rare to spawn as a percentage. 
Default is 0.04, or 1 in 2,500. 
Max is 100, or every eligible drop (100%!)