### PR TITLE
drop item bug fixes and improvements

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1347,6 +1347,10 @@ namespace ACE.Server.WorldObjects
             item.Location = new Position(Location);
             item.Placement = ACE.Entity.Enum.Placement.Resting;  // This is needed to make items lay flat on the ground.
 
+            // increased precision for non-ethereal objects
+            var ethereal = item.Ethereal;
+            item.Ethereal = true;
+
             if (!CurrentLandblock.AddWorldObject(item))
                 return false;
 
@@ -1365,6 +1369,8 @@ namespace ACE.Server.WorldObjects
 
                 item.SendUpdatePosition(true);
             }
+            item.Ethereal = ethereal;
+
             return true;
         }
 


### PR DESCRIPTION
- SplitTo3D was using ancient and bug-prone drop method. Updated to use common drop method
- SplitTo3D was destroying items on error. Updated to gracefully handle error scenarios
- Common drop method now slides items from player location to destination location behind the scenes. This retains the existing behavior in ACE to prevent items from being dropped on the other side of a wall, while also improving the previous scenarios which would have resulted in drop fails (dropping into a wall, dropping into a hillside) and now result in successful drops closer to the player location.