### PR TITLE
Add and switch to EMU time for Game World

### DIFF
--- a/Source/ACE.Common/DerethDateTime.cs
+++ b/Source/ACE.Common/DerethDateTime.cs
@@ -1050,5 +1050,15 @@ namespace ACE.Common
         /// Converts the <see cref="DateTime.UtcNow"/> object to a new <see cref="DerethDateTime"/> object set to Lore Time.
         /// </summary>
         public static DerethDateTime UtcNowToLoreTime => ConvertRealWorldToLoreDateTime(DateTime.UtcNow);
+
+        /// <summary>
+        /// Converts the <see cref="DateTime.UtcNow"/> object to a new <see cref="DerethDateTime"/> object set to GDLE Time.
+        /// </summary>
+        public static DerethDateTime UtcNowToGDLETime => new DerethDateTime((DateTime.UtcNow - new DateTime(1999, 9, 1)).TotalSeconds);
+
+        /// <summary>
+        /// Converts the <see cref="DateTime.UtcNow"/> object to a new <see cref="DerethDateTime"/> object set to EMU Standard Sync Time.
+        /// </summary>
+        public static DerethDateTime UtcNowToEMUTime => new DerethDateTime((DateTime.UtcNow - TimeZoneInfo.ConvertTimeToUtc(retailDayLast_RealWorld, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"))).TotalSeconds);
     }
 }

--- a/Source/ACE.Server/Entity/Timers.cs
+++ b/Source/ACE.Server/Entity/Timers.cs
@@ -24,7 +24,7 @@ namespace ACE.Server.Entity
 
 
         /// <summary>
-        /// DerethDateTime.UtcNowToLoreTime at the time the server started.
+        /// DerethDateTime.UtcNowToEMUTime at the time the server started.
         /// </summary>
         public static DerethDateTime WorldStartLoreTime { get; } = DerethDateTime.UtcNowToEMUTime;
 

--- a/Source/ACE.Server/Entity/Timers.cs
+++ b/Source/ACE.Server/Entity/Timers.cs
@@ -31,7 +31,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Returns DerethDateTime.UtcNowToLoreTime
         /// </summary>
-        public static DerethDateTime CurrentLoreTime => DerethDateTime.UtcNowToEMUTime;
+        public static DerethDateTime CurrentLoreTime => DerethDateTime.UtcNowToLoreTime;
 
         /// <summary>
         /// Returns current in game time, as seen on Map Panel, calculated from PortalYearTicks

--- a/Source/ACE.Server/Entity/Timers.cs
+++ b/Source/ACE.Server/Entity/Timers.cs
@@ -26,12 +26,12 @@ namespace ACE.Server.Entity
         /// <summary>
         /// DerethDateTime.UtcNowToLoreTime at the time the server started.
         /// </summary>
-        public static DerethDateTime WorldStartLoreTime { get; } = DerethDateTime.UtcNowToLoreTime;
+        public static DerethDateTime WorldStartLoreTime { get; } = DerethDateTime.UtcNowToEMUTime;
 
         /// <summary>
         /// Returns DerethDateTime.UtcNowToLoreTime
         /// </summary>
-        public static DerethDateTime CurrentLoreTime => DerethDateTime.UtcNowToLoreTime;
+        public static DerethDateTime CurrentLoreTime => DerethDateTime.UtcNowToEMUTime;
 
         /// <summary>
         /// Returns current in game time, as seen on Map Panel, calculated from PortalYearTicks


### PR DESCRIPTION
This change switches PortalYearTicks from UtcNowToLoreTime to a new time called UtcNowToEMUTime.

This switch results in time always rolling forward, as well as syncing all emulated servers up to the same source. The in-game calendar, day-night cycles and weather patterns would be identical across all worlds going forward. Previously there was varied results depending on when the server started up as the "seed" changed at that time. 

As a side benefit to this change, the Journal section of the client (Quill, Journal pages with timers) will now track correctly should anyone wish to use that feature, which previously was unreliable since server time would roll backwards upon restart.