### PR TITLE
Add some basic pruning for shard database

### DIFF
--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -50,7 +50,7 @@ namespace ACE.Common
         public bool PruneDeletedObjectsFromShortcutBars { get; set; }
 
         /// <summary>
-        /// Prune deleted characters from all squelch lists
+        /// Prune deleted characters from all squelch lists, excluding those used to squelch entire accounts
         /// </summary>
         [System.ComponentModel.DefaultValue(false)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -36,6 +36,27 @@ namespace ACE.Common
         public bool PurgeOrphanedBiotas { get; set; }
 
         /// <summary>
+        /// Prune deleted characters from all friend lists
+        /// </summary>
+        [System.ComponentModel.DefaultValue(true)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool PruneDeletedCharactersFromFriendLists { get; set; }
+
+        /// <summary>
+        /// Prune deleted objects from all shortcut bars
+        /// </summary>
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool PruneDeletedObjectsFromShortcutBars { get; set; }
+
+        /// <summary>
+        /// Prune deleted characters from all squelch lists
+        /// </summary>
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool PruneDeletedCharactersFromSquelchLists { get; set; }
+
+        /// <summary>
         /// Automatically check for and update to latest available world database
         /// </summary>
         [System.ComponentModel.DefaultValue(false)]

--- a/Source/ACE.Database/ShardDatabaseOfflineTools.cs
+++ b/Source/ACE.Database/ShardDatabaseOfflineTools.cs
@@ -1021,44 +1021,21 @@ namespace ACE.Database
 
             using (var context = new ShardDbContext())
             {
-                //var charResults = context.Character
-                //            //.Include(r => r.CharacterPropertiesContractRegistry)
-                //            //.Include(r => r.CharacterPropertiesFillCompBook)
-                //            .Include(r => r.CharacterPropertiesFriendList)
-                //            // .Include(r => r.CharacterPropertiesQuestRegistry)
-                //            .Include(r => r.CharacterPropertiesShortcutBar)
-                //            //.Include(r => r.CharacterPropertiesSpellBar)
-                //            .Include(r => r.CharacterPropertiesSquelch)
-                //            //.Include(r => r.CharacterPropertiesTitleBook)
-                //            .ToList();
-
-                //foreach (var item in charResults)
-                //{
-                //    foreach (var friend in item.CharacterPropertiesFriendList.ToList())
-                //    {
-                //        var character = context.Character
-                //            .AsNoTracking()
-                //            .FirstOrDefault(c => c.Id == friend.FriendId && c.DeleteTime == 0 && !c.IsDeleted);
-
-                //        if (character == null)
-                //        {
-                //            item.CharacterPropertiesFriendList.Remove(friend);
-
-                //            log.Info($"Character for {item.Name} (0x{item.Id:X8}) has been altered. Reason: Friend (0x{friend.FriendId:X8}) was not found in database");
-
-                //            context.SaveChanges();
-                //        }
-                //    }
-                //}
-
                 var validCharacterIds = context.Character
                     .AsNoTracking()
                     .Where(c => !c.IsDeleted && c.DeleteTime == 0)
                     .Select(c => c.Id)
                     .ToList();
 
+                var friendIds = context.CharacterPropertiesFriendList
+                    .AsNoTracking()
+                    .Select(c => c.FriendId)
+                    .ToList();
+
+                var invalidFriendIds = friendIds.Except(validCharacterIds).ToList();
+
                 var invalidFriends = context.CharacterPropertiesFriendList
-                    .Where(c => !validCharacterIds.Contains(c.FriendId));
+                    .Where(c => invalidFriendIds.Contains(c.FriendId));
                 //.ToList();
 
                 foreach (var invalidFriend in invalidFriends)
@@ -1082,36 +1059,6 @@ namespace ACE.Database
 
             using (var context = new ShardDbContext())
             {
-                //var charResults = context.Character
-                //            //.Include(r => r.CharacterPropertiesContractRegistry)
-                //            //.Include(r => r.CharacterPropertiesFillCompBook)
-                //            .Include(r => r.CharacterPropertiesFriendList)
-                //            // .Include(r => r.CharacterPropertiesQuestRegistry)
-                //            .Include(r => r.CharacterPropertiesShortcutBar)
-                //            //.Include(r => r.CharacterPropertiesSpellBar)
-                //            .Include(r => r.CharacterPropertiesSquelch)
-                //            //.Include(r => r.CharacterPropertiesTitleBook)
-                //            .ToList();
-
-                //foreach (var item in charResults)
-                //{
-                //    foreach (var shortcut in item.CharacterPropertiesShortcutBar.ToList())
-                //    {
-                //        var biota = context.Biota
-                //            .AsNoTracking()
-                //            .FirstOrDefault(b => b.Id == shortcut.ShortcutObjectId);
-
-                //        if (biota == null)
-                //        {
-                //            item.CharacterPropertiesShortcutBar.Remove(shortcut);
-
-                //            log.Info($"Character for {item.Name} (0x{item.Id:X8}) has been altered. Reason: Shortcut (0x{shortcut.ShortcutObjectId:X8}) was not found in database");
-
-                //            context.SaveChanges();
-                //        }
-                //    }
-                //}
-
                 var validObjectIds = context.Biota
                     .AsNoTracking()
                     .Select(b => b.Id)

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -186,6 +186,15 @@
     // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
     "PurgeOrphanedBiotas": false,
 
+    // This will prune characters that have been deleted from all friend lists in the database
+    "PruneDeletedCharactersFromFriendLists": true,
+
+    // This will prune shortcuts to objects that have been deleted
+    "PruneDeletedObjectsFromShortcutBars": false,
+
+    // This will prune characters that have been deleted from all squlech lists in the database, excluding those used to squlech ancounts
+    "PruneDeletedCharactersFromSquelchLists": false,
+
     // Automatically apply new updates to databases upon startup if they haven't yet been applied
     "AutoApplyDatabaseUpdates": true,
 

--- a/Source/ACE.Server/Config.js.docker
+++ b/Source/ACE.Server/Config.js.docker
@@ -186,13 +186,13 @@
     // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
     "PurgeOrphanedBiotas": false,
 
-    // This will prune characters that have been deleted from all friend lists in the database
+    // This will prune deleted characters from all friend lists in the database
     "PruneDeletedCharactersFromFriendLists": true,
 
-    // This will prune shortcuts to objects that have been deleted
+    // This will prune shortcuts to objects that no longer exist in the database
     "PruneDeletedObjectsFromShortcutBars": false,
 
-    // This will prune characters that have been deleted from all squlech lists in the database, excluding those used to squlech ancounts
+    // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
     "PruneDeletedCharactersFromSquelchLists": false,
 
     // Automatically apply new updates to databases upon startup if they haven't yet been applied

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -186,6 +186,15 @@
     // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
     "PurgeOrphanedBiotas": false,
 
+    // This will prune characters that have been deleted from all friend lists in the database
+    "PruneDeletedCharactersFromFriendLists": true,
+
+    // This will prune shortcuts to objects that have been deleted
+    "PruneDeletedObjectsFromShortcutBars": false,
+
+    // This will prune characters that have been deleted from all squlech lists in the database, excluding those used to squlech ancounts
+    "PruneDeletedCharactersFromSquelchLists": false,
+
     // Automatically apply new updates to databases upon startup if they haven't yet been applied
     "AutoApplyDatabaseUpdates": true,
 

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -186,13 +186,13 @@
     // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
     "PurgeOrphanedBiotas": false,
 
-    // This will prune characters that have been deleted from all friend lists in the database
+    // This will prune deleted characters from all friend lists in the database
     "PruneDeletedCharactersFromFriendLists": true,
 
-    // This will prune shortcuts to objects that have been deleted
+    // This will prune shortcuts to objects that no longer exist in the database
     "PruneDeletedObjectsFromShortcutBars": false,
 
-    // This will prune characters that have been deleted from all squlech lists in the database, excluding those used to squlech ancounts
+    // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
     "PruneDeletedCharactersFromSquelchLists": false,
 
     // Automatically apply new updates to databases upon startup if they haven't yet been applied

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -171,6 +171,14 @@ namespace ACE.Server
                 log.Info($"Purged {numberOfBiotasPurged:N0} biotas.");
             }
 
+            log.Info($"Pruning invalid friends from all friend lists...");
+            ShardDatabaseOfflineTools.PruneDeletedCharactersFromFriendLists(out var numberOfFriendsPruned);
+            log.Info($"Pruned {numberOfFriendsPruned:N0} invalid friends found on friend lists.");
+
+            log.Info($"Pruning invalid shortcuts from all shortcut bars...");
+            ShardDatabaseOfflineTools.PruneDeletedObjectsFromShortcutBars(out var numberOfShortcutsPruned);
+            log.Info($"Pruned {numberOfShortcutsPruned:N0} deleted objects found on shortcut bars.");
+
             if (ConfigManager.Config.Offline.AutoUpdateWorldDatabase)
             {
                 CheckForWorldDatabaseUpdate();

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -171,17 +171,26 @@ namespace ACE.Server
                 log.Info($"Purged {numberOfBiotasPurged:N0} biotas.");
             }
 
-            log.Info($"Pruning invalid friends from all friend lists...");
-            ShardDatabaseOfflineTools.PruneDeletedCharactersFromFriendLists(out var numberOfFriendsPruned);
-            log.Info($"Pruned {numberOfFriendsPruned:N0} invalid friends found on friend lists.");
+            if (ConfigManager.Config.Offline.PruneDeletedCharactersFromFriendLists)
+            {
+                log.Info($"Pruning invalid friends from all friend lists...");
+                ShardDatabaseOfflineTools.PruneDeletedCharactersFromFriendLists(out var numberOfFriendsPruned);
+                log.Info($"Pruned {numberOfFriendsPruned:N0} invalid friends found on friend lists.");
+            }
 
-            log.Info($"Pruning invalid shortcuts from all shortcut bars...");
-            ShardDatabaseOfflineTools.PruneDeletedObjectsFromShortcutBars(out var numberOfShortcutsPruned);
-            log.Info($"Pruned {numberOfShortcutsPruned:N0} deleted objects found on shortcut bars.");
+            if (ConfigManager.Config.Offline.PruneDeletedObjectsFromShortcutBars)
+            {
+                log.Info($"Pruning invalid shortcuts from all shortcut bars...");
+                ShardDatabaseOfflineTools.PruneDeletedObjectsFromShortcutBars(out var numberOfShortcutsPruned);
+                log.Info($"Pruned {numberOfShortcutsPruned:N0} deleted objects found on shortcut bars.");
+            }
 
-            log.Info($"Pruning invalid squelches from all squelch lists...");
-            ShardDatabaseOfflineTools.PruneDeletedCharactersFromSquelchLists(out var numberOfSquelchesPruned);
-            log.Info($"Pruned {numberOfSquelchesPruned:N0} invalid squelched characters found on squelch lists.");
+            if (ConfigManager.Config.Offline.PruneDeletedCharactersFromSquelchLists)
+            {
+                log.Info($"Pruning invalid squelches from all squelch lists...");
+                ShardDatabaseOfflineTools.PruneDeletedCharactersFromSquelchLists(out var numberOfSquelchesPruned);
+                log.Info($"Pruned {numberOfSquelchesPruned:N0} invalid squelched characters found on squelch lists.");
+            }
 
             if (ConfigManager.Config.Offline.AutoUpdateWorldDatabase)
             {

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -179,6 +179,10 @@ namespace ACE.Server
             ShardDatabaseOfflineTools.PruneDeletedObjectsFromShortcutBars(out var numberOfShortcutsPruned);
             log.Info($"Pruned {numberOfShortcutsPruned:N0} deleted objects found on shortcut bars.");
 
+            log.Info($"Pruning invalid squelches from all squelch lists...");
+            ShardDatabaseOfflineTools.PruneDeletedCharactersFromSquelchLists(out var numberOfSquelchesPruned);
+            log.Info($"Pruned {numberOfSquelchesPruned:N0} invalid squelched characters found on squelch lists.");
+
             if (ConfigManager.Config.Offline.AutoUpdateWorldDatabase)
             {
                 CheckForWorldDatabaseUpdate();


### PR DESCRIPTION
Adding some basic functions to prune some records at server startup.

This would prune friend lists of deleted friends (which are stuck in list, show up blank) and shortcuts to deleted objects which probably does not have any noticeable impact.