### PR TITLE
Fix issue with TimeZones on platforms other than Windows

### DIFF
--- a/Source/ACE.Common/ACE.Common.csproj
+++ b/Source/ACE.Common/ACE.Common.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
     <PackageReference Include="DouglasCrockford.JsMin" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/Source/ACE.Common/DerethDateTime.cs
+++ b/Source/ACE.Common/DerethDateTime.cs
@@ -1,5 +1,7 @@
 using System;
 
+using TimeZoneConverter;
+
 namespace ACE.Common
 {
     /// <summary>
@@ -1059,6 +1061,6 @@ namespace ACE.Common
         /// <summary>
         /// Converts the <see cref="DateTime.UtcNow"/> object to a new <see cref="DerethDateTime"/> object set to EMU Standard Sync Time.
         /// </summary>
-        public static DerethDateTime UtcNowToEMUTime => new DerethDateTime((DateTime.UtcNow - TimeZoneInfo.ConvertTimeToUtc(retailDayLast_RealWorld, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"))).TotalSeconds);
+        public static DerethDateTime UtcNowToEMUTime => new DerethDateTime((DateTime.UtcNow - TimeZoneInfo.ConvertTimeToUtc(retailDayLast_RealWorld, TZConvert.GetTimeZoneInfo("Eastern Standard Time"))).TotalSeconds);
     }
 }


### PR DESCRIPTION
See [here](https://devblogs.microsoft.com/dotnet/cross-platform-time-zones-with-net-core/) for issue explanation 

Adding and using [this](https://github.com/mattjohnsonpint/TimeZoneConverter) nuget package to resolve until .NET6

> .NET 6 will have built-in support for IANA and Windows time zones in a cross-platform manner, removing the need for the TimeZoneConverter library. If you are planning to use .NET 6 (or higher), you don't need to use the TimeZoneConverter library!