### PR TITLE
Aura of the Craftsman applies to all RecipeManager interactions that have difficulty

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -84,6 +84,9 @@ namespace ACE.Server.Managers
 
             var showDialog = HasDifficulty(recipe) && player.GetCharacterOption(CharacterOption.UseCraftingChanceOfSuccessDialog);
 
+            if (!confirmed && player.LumAugSkilledCraft > 0)
+                player.SendMessage($"Your Aura of the Craftman augmentation increased your skill by {player.LumAugSkilledCraft}!");
+
             if (showDialog && !confirmed)
             {
                 ShowDialog(player, source, target, recipe, percentSuccess.Value);
@@ -165,7 +168,9 @@ namespace ACE.Server.Managers
 
             //Console.WriteLine("Skill difficulty: " + recipe.Recipe.Difficulty);
 
-            var successChance = SkillCheck.GetSkillChance(playerSkill.Current, recipe.Difficulty);
+            var playerCurrentPlusLumAugSkilledCraft = playerSkill.Current + (uint)player.LumAugSkilledCraft;
+
+            var successChance = SkillCheck.GetSkillChance(playerCurrentPlusLumAugSkilledCraft, recipe.Difficulty);
 
             return successChance;
         }
@@ -202,7 +207,9 @@ namespace ACE.Server.Managers
 
             var difficulty = (int)Math.Floor(((salvageMod * 5.0f) + (itemWorkmanship * salvageMod * 2.0f) - (toolWorkmanship * workmanshipMod * salvageMod / 5.0f)) * attemptMod);
 
-            var successChance = SkillCheck.GetSkillChance((int)skill.Current, difficulty);
+            var playerCurrentPlusLumAugSkilledCraft = skill.Current + (uint)player.LumAugSkilledCraft;
+
+            var successChance = SkillCheck.GetSkillChance((int)playerCurrentPlusLumAugSkilledCraft, difficulty);
 
             // imbue: divide success by 3
             if (recipe.IsImbuing())

--- a/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureSkill.cs
@@ -198,18 +198,18 @@ namespace ACE.Server.WorldObjects.Entity
             else if (player.AugmentationSkilledMagic > 0 && Player.MagicSkills.Contains(Skill))
                 total += (uint)(player.AugmentationSkilledMagic * 10);
 
-            switch (Skill)
-            {
-                case Skill.ArmorTinkering:
-                case Skill.ItemTinkering:
-                case Skill.MagicItemTinkering:
-                case Skill.WeaponTinkering:
-                case Skill.Salvaging:
+            //switch (Skill)
+            //{
+            //    case Skill.ArmorTinkering:
+            //    case Skill.ItemTinkering:
+            //    case Skill.MagicItemTinkering:
+            //    case Skill.WeaponTinkering:
+            //    case Skill.Salvaging:
 
-                    if (player.LumAugSkilledCraft != 0)
-                        total += (uint)player.LumAugSkilledCraft;
-                    break;
-            }
+            //        if (player.LumAugSkilledCraft != 0)
+            //            total += (uint)player.LumAugSkilledCraft;
+            //        break;
+            //}
 
             if (AdvancementClass >= SkillAdvancementClass.Trained && player.Enlightenment != 0)
                 total += (uint)player.Enlightenment;


### PR DESCRIPTION
Aura of the Craftsman does not get applied in Base or Current skill universally, but instead appears to be applied only when in RecipeManager, or in other words, only at the time the player is using one object on another, and that recipe has a difficulty.