### PR TITLE
Reset PetDevices

### DIFF
--- a/Database/Updates/Shard/2021-07-21-00-Fix-Summon-Pets.sql
+++ b/Database/Updates/Shard/2021-07-21-00-Fix-Summon-Pets.sql
@@ -1,0 +1,10 @@
+UPDATE
+    `biota_properties_int` bint
+INNER JOIN `biota` ON bint.`object_Id` = `biota`.`Id`
+INNER JOIN `ace_world`.`weenie_properties_int` wint
+ON
+    wint.`object_Id` = `biota`.`weenie_Class_Id`
+SET
+    `bint`.`value` = wint.`value`
+WHERE
+    biota.`weenie_Type` = 70 /* PetDevice */ AND bint.`type` = 266 /* PetClass */ AND wint.`type` = 266;


### PR DESCRIPTION
Fixes an issue where some older WeenieType.PetDevice (e.g. summoning essences) may be spawning pets of the wrong damage type.