### PR TITLE
Update forcelogoff command

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -2434,7 +2434,7 @@ namespace ACE.Server.Command.Handlers
                 //else
                 //    player.LogOut();
 
-                var msg = $"Player {player.Name} (0x{player.Guid}) found in PlayerManager.\n";
+                var msg = $"Player {player.Name} (0x{player.Guid}) found in PlayerManager.onlinePlayers.\n";
                 msg += $"------- Session: {(player.Session != null ? $"0x{player.Session.EndPoint}" : "NULL")}\n";
                 msg += $"------- CurrentLandblock: {(player.CurrentLandblock != null ? $"0x{player.CurrentLandblock.Id:X4}" : "NULL")}\n";
                 msg += $"------- Location: {(player.Location != null ? $"0x{player.Location.ToLOCString()}" : "NULL")}\n";
@@ -2444,35 +2444,45 @@ namespace ACE.Server.Command.Handlers
                 if (player.CurrentLandblock != null)
                     foundOnLandblock = LandblockManager.GetLandblock(player.CurrentLandblock.Id, false).GetObject(player.Guid) != null;
                 msg += $"------- FoundOnLandblock: {foundOnLandblock}\n";
-                msg += $"------- ForcedLogOffRequested: {player.ForcedLogOffRequested}\n";
+                var playerForcedLogOffRequested = player.ForcedLogOffRequested;
+                msg += $"------- ForcedLogOffRequested: {playerForcedLogOffRequested}\n";
 
                 msg += "Log off path taken: ";
-                if (player.Session != null)
+                if (playerForcedLogOffRequested)
                 {
+                    player.Session?.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested, new GameMessageBootAccount(" because the character was forced to log off by an admin"));
+                    player.ForceLogoff();
+                    msg += "player.Session?.Terminate() | player.ForceLogoff()";
+                }
+                else if (player.Session != null)
+                {
+                    player.ForcedLogOffRequested = true;
                     player.Session.Terminate(Network.Enum.SessionTerminationReason.ForcedLogOffRequested, new GameMessageBootAccount(" because the character was forced to log off by an admin"));
-                    msg += "player.Session.Terminate()";
+                    msg += "player.ForcedLogOffRequested = true | player.Session.Terminate()";
                 }
                 else if (player.CurrentLandblock != null && foundOnLandblock)
                 {
+                    player.ForcedLogOffRequested = true;
                     player.LogOut();
-                    msg += "player.LogOut()";
+                    msg += "player.ForcedLogOffRequested = true | player.LogOut()";
                 }
                 else if (player.IsInDeathProcess)
                 {
+                    player.ForcedLogOffRequested = true;
                     player.IsInDeathProcess = false;
                     player.LogOut_Inner(true);
-                    msg += "player.IsInDeathProcess = false | player.LogOut_Inner(true)";
-                }
-                else if (player.ForcedLogOffRequested)
-                {
-                    player.ForceLogoff();
-                    msg += " player.ForceLogoff()";
+                    msg += "player.ForcedLogOffRequested = true | player.IsInDeathProcess = false | player.LogOut_Inner(true)";
                 }
                 else
                 {
                     player.ForcedLogOffRequested = true;
-                    msg += "player.ForcedLogOffRequested = true\nUse this command again if this player does not properly log off within the next minute";
+                    msg += "player.ForcedLogOffRequested = true";
                 }
+
+                if (!playerForcedLogOffRequested)
+                    msg += "\nUse this command again if this player does not properly log off within the next minute.";
+                else
+                    msg += "\nPlease send the above report to ACEmulator development team via Discord.";
 
                 CommandHandlerHelper.WriteOutputInfo(session, msg);
 

--- a/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
+++ b/Source/ACE.Server/Network/Enum/SessionTerminationReason.cs
@@ -29,7 +29,8 @@ namespace ACE.Server.Network.Enum
         AccountLoggedIn,
         ServerShuttingDown,
         AccountBanned,
-        ClientOutOfDate
+        ClientOutOfDate,
+        ForcedLogOffRequested
     }
     public static class SessionTerminationReasonHelper
     {
@@ -56,7 +57,8 @@ namespace ACE.Server.Network.Enum
             "Account was logged in, booting currently connected account in favor of new connection",
             "Server is shutting down",
             "Account is banned",
-            "Client is not up to date"
+            "Client is not up to date",
+            "Forced log off requested by Admin"
         };
         public static string GetDescription(this SessionTerminationReason reason)
         {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -602,6 +602,8 @@ namespace ACE.Server.WorldObjects
             if (!ForcedLogOffRequested) return;
 
             FinalizeLogout();
+
+            ForcedLogOffRequested = false;
         }
 
         private void FinalizeLogout()

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -597,6 +597,10 @@ namespace ACE.Server.WorldObjects
 
         public bool ForcedLogOffRequested;
 
+        /// <summary>
+        /// Force Log off a player requested to log out by an admin command forcelogoff/forcelogout or the ServerManager.<para />
+        /// THIS FUNCTION FOR SYSTEM USE ONLY; If you want to force a player to logout, use Session.LogOffPlayer().
+        /// </summary>
         public void ForceLogoff()
         {
             if (!ForcedLogOffRequested) return;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -540,7 +540,7 @@ namespace ACE.Server.WorldObjects
                 CurrentActivePet.Destroy();
 
             // If we're in the dying animation process, we cannot logout until that animation completes..
-            if (isInDeathProcess)
+            if (IsInDeathProcess)
                 return;
 
             LogOut_Final();
@@ -552,10 +552,7 @@ namespace ACE.Server.WorldObjects
             {
                 if (skipAnimations)
                 {
-                    CurrentLandblock?.RemoveWorldObject(Guid, false);
-                    SetPropertiesAtLogOut();
-                    SavePlayerToDatabase();
-                    PlayerManager.SwitchPlayerFromOnlineToOffline(this);
+                    FinalizeLogout();
                 }
                 else
                 {
@@ -574,13 +571,10 @@ namespace ACE.Server.WorldObjects
                     logoutChain.AddAction(WorldManager.ActionQueue, () =>
                     {
                         // If we're in the dying animation process, we cannot RemoveWorldObject and logout until that animation completes..
-                        if (isInDeathProcess)
+                        if (IsInDeathProcess)
                             return;
 
-                        CurrentLandblock?.RemoveWorldObject(Guid, false);
-                        SetPropertiesAtLogOut();
-                        SavePlayerToDatabase();
-                        PlayerManager.SwitchPlayerFromOnlineToOffline(this);
+                        FinalizeLogout();
                     });
 
                     // close any open landblock containers (chests / corpses)
@@ -597,10 +591,25 @@ namespace ACE.Server.WorldObjects
             }
             else
             {
-                SetPropertiesAtLogOut();
-                SavePlayerToDatabase();
-                PlayerManager.SwitchPlayerFromOnlineToOffline(this);
+                FinalizeLogout();
             }
+        }
+
+        public bool ForcedLogOffRequested;
+
+        public void ForceLogoff()
+        {
+            if (!ForcedLogOffRequested) return;
+
+            FinalizeLogout();
+        }
+
+        private void FinalizeLogout()
+        {
+            CurrentLandblock?.RemoveWorldObject(Guid, false);
+            SetPropertiesAtLogOut();
+            SavePlayerToDatabase();
+            PlayerManager.SwitchPlayerFromOnlineToOffline(this);
         }
 
         public void HandleMRT()

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -141,7 +141,7 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        private bool isInDeathProcess;
+        public bool IsInDeathProcess;
 
         /// <summary>
         /// Broadcasts the player death animation, updates vitae, and sends network messages for player death
@@ -149,7 +149,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         protected override void Die(DamageHistoryInfo lastDamager, DamageHistoryInfo topDamager)
         {
-            isInDeathProcess = true;
+            IsInDeathProcess = true;
 
             if (topDamager?.Guid == Guid && IsPKType)
             {
@@ -269,7 +269,7 @@ namespace ACE.Server.WorldObjects
 
                     OnHealthUpdate();
 
-                    isInDeathProcess = false;
+                    IsInDeathProcess = false;
 
                     if (IsLoggingOut)
                         LogOut_Final(true);


### PR DESCRIPTION
Update forcelogoff command to work with any state the character may be in if requested. Previously the command was working for characters that were operating correctly, but does not help to un-limbo a character.

This should also resolve stuck in limbo for shutting down, while also not directly resolving the root cause for limbo at this time.