### PR TITLE
Add automatic timeout to Confirmations

### DIFF
--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -124,7 +124,12 @@ namespace ACE.Server.Entity
                     AddConfirmedMember(inviter, newMember, true);
                 }
                 else
-                    newMember.ConfirmationManager.EnqueueSend(new Confirmation_Fellowship(inviter.Guid, newMember.Guid), inviter.Name);
+                {
+                    if (!newMember.ConfirmationManager.EnqueueSend(new Confirmation_Fellowship(inviter.Guid, newMember.Guid), inviter.Name))
+                    {
+                        inviter.Session.Network.EnqueueSend(new GameMessageSystemChat($"{newMember.Name} is busy.", ChatMessageType.Broadcast));
+                    }
+                }
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -817,7 +817,10 @@ namespace ACE.Server.WorldObjects.Managers
 
                     if (player != null)
                     {
-                        player.ConfirmationManager.EnqueueSend(new Confirmation_YesNo(WorldObject.Guid, player.Guid, emote.Message), emote.TestString);
+                        if (!player.ConfirmationManager.EnqueueSend(new Confirmation_YesNo(WorldObject.Guid, player.Guid, emote.Message), emote.TestString))
+                        {
+                            ExecuteEmoteSet(EmoteCategory.TestFailure, emote.Message, player);
+                        }
                     }
                     break;
 

--- a/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Allegiance.cs
@@ -87,7 +87,10 @@ namespace ACE.Server.WorldObjects
 
             if (!confirmed)
             {
-                patron.ConfirmationManager.EnqueueSend(new Confirmation_SwearAllegiance(patron.Guid, Guid), Name);
+                if (!patron.ConfirmationManager.EnqueueSend(new Confirmation_SwearAllegiance(patron.Guid, Guid), Name))
+                {
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"{patron.Name} is busy.", ChatMessageType.Broadcast));
+                }
                 return;
             }
 


### PR DESCRIPTION
Confirmations had 30 second timeouts in retail.

Retail also seemingly could queue multiple confirmations up at the same time, however the client would only display the first one received. The others it would appear timed out. Since ACE doesn't really need to emulate stacking, instead we'll send feedback to initiator if confirmation would have been stacked. Self contained confirmations (Using an Gem, or similar from player inventory) likely do not need feedback on stacking, so continuing to ignore those duplicates for now.

Example would be two different characters (Player A and Player B) attempting to recruit a third character (Player C) into a fellowship. Player A's confirmation request is sent. Player B would get a Player C is busy message.

This also resolves issues with InqYesNo emotes, ensuring a response branch is always triggered, either TestSuccess if player accepts, or TestFailure if they decline, timeout, or somehow trigger stacking.