### PR TITLE
Keep HousePurchaseTimestamp synced for roommates

### DIFF
--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventHouseStatus.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventHouseStatus.cs
@@ -1,17 +1,18 @@
+using ACE.Entity.Enum;
 using System;
 
 namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventHouseStatus : GameEventMessage
     {
-        public GameEventHouseStatus(Session session)
+        public GameEventHouseStatus(Session session, WeenieError weenieError = WeenieError.BadParam)
             : base(GameEventType.HouseStatus, GameMessageGroup.UIQueue, session)
         {
             //Console.WriteLine("Sending 0x226 - HouseStatus");
 
             var noticeType = 2u;    // type of message to display
 
-            Writer.Write(noticeType);
+            Writer.Write((uint)weenieError);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -541,16 +541,18 @@ namespace ACE.Server.WorldObjects
 
             var houseOwner = GetHouseOwner();
 
-            var purchaseTime = (uint)(houseOwner.HousePurchaseTimestamp ?? 0);
+            // var purchaseTime = (uint)(houseOwner.HousePurchaseTimestamp ?? 0);
 
-            if (HousePurchaseTimestamp != purchaseTime)
+            if (HousePurchaseTimestamp != houseOwner.HousePurchaseTimestamp)
             {
-                HousePurchaseTimestamp = (int)purchaseTime;
-                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.HousePurchaseTimestamp, (int)HousePurchaseTimestamp), new GameMessageSystemChat("Updating housing information...", ChatMessageType.Broadcast), new GameEventHouseStatus(Session, WeenieError.HouseEvicted));
+                HousePurchaseTimestamp = houseOwner.HousePurchaseTimestamp;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.HousePurchaseTimestamp, HousePurchaseTimestamp ?? 0), new GameMessageSystemChat("Updating housing information...", ChatMessageType.Broadcast), new GameEventHouseStatus(Session, WeenieError.HouseEvicted));
             }
 
-            if (HouseRentTimestamp == null)
-                HouseRentTimestamp = (int)House.GetRentDue(purchaseTime);
+            // var rentTime = (uint)(houseOwner.HouseRentTimestamp ?? 0);
+
+            if (HouseRentTimestamp != houseOwner.HouseRentTimestamp)
+                HouseRentTimestamp  = houseOwner.HouseRentTimestamp;
 
             if (!House.SlumLord.InventoryLoaded)
             {

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -539,7 +539,15 @@ namespace ACE.Server.WorldObjects
             if (House == null) LoadHouse(houseInstance);
             if (House == null || House.SlumLord == null) return;
 
-            var purchaseTime = (uint)(HousePurchaseTimestamp ?? 0);
+            var houseOwner = GetHouseOwner();
+
+            var purchaseTime = (uint)(houseOwner.HousePurchaseTimestamp ?? 0);
+
+            if (HousePurchaseTimestamp != purchaseTime)
+            {
+                HousePurchaseTimestamp = (int)purchaseTime;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.HousePurchaseTimestamp, (int)HousePurchaseTimestamp));
+            }
 
             if (HouseRentTimestamp == null)
                 HouseRentTimestamp = (int)House.GetRentDue(purchaseTime);

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -546,7 +546,7 @@ namespace ACE.Server.WorldObjects
             if (HousePurchaseTimestamp != purchaseTime)
             {
                 HousePurchaseTimestamp = (int)purchaseTime;
-                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.HousePurchaseTimestamp, (int)HousePurchaseTimestamp));
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.HousePurchaseTimestamp, (int)HousePurchaseTimestamp), new GameMessageSystemChat("Updating housing information...", ChatMessageType.Broadcast), new GameEventHouseStatus(Session, WeenieError.HouseEvicted));
             }
 
             if (HouseRentTimestamp == null)


### PR DESCRIPTION
If a character/account has a house, the HousePurchaseTimestamp is synced across all characters so that they all have the same timeout restrictions