### PR TITLE
Triggered ActOnUse for ACTIVATION_RESPONSE_INT = 4 (Animate)

### DIFF
--- a/Source/ACE.Server/WorldObjects/Book.cs
+++ b/Source/ACE.Server/WorldObjects/Book.cs
@@ -41,6 +41,9 @@ namespace ACE.Server.WorldObjects
         {
             ObjectDescriptionFlags |= ObjectDescriptionFlag.Book;
 
+            // Ensure a book can always be "read"
+            ActivationResponse |= ActivationResponse.Use;
+
             SetProperty(PropertyInt.AppraisalPages, Biota.PropertiesBookPageData.Count);
 
             SetProperty(PropertyInt.AppraisalMaxPages, Biota.PropertiesBook.MaxNumPages);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -113,7 +113,7 @@ namespace ACE.Server.WorldObjects
                 OnGenerate(activator);
 
             // default use action
-            if (ActivationResponse.HasFlag(ActivationResponse.Use) || ActivationResponse.HasFlag(ActivationResponse.Animate))
+            if (ActivationResponse.HasFlag(ActivationResponse.Use))
             {
                 if (activator is Creature creature)
                 {


### PR DESCRIPTION
The only instance of this value is for the Sentinel and Advocate statues, and this allows them to animate and to trigger the default OnUse of the weenie (they are "books", so it allows the player to "read" them).