### PR TITLE
Fix issue where Shade was not being properly set on items given from emote

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3330,7 +3330,7 @@ namespace ACE.Server.WorldObjects
 
                     if (palette > 0)
                         item.PaletteTemplate = palette;
-                    if (item.Shade > 0)
+                    if (shade > 0)
                         item.Shade = shade;
 
                     TryCreateForGive(emoter, item);


### PR DESCRIPTION
Emotes were not using the proper value to compare the shade to see if it should set it or not resulting in items being the wrong color.