### PR TITLE
Adjust verify-skill-credits

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
@@ -349,7 +349,7 @@ namespace ACE.Server.Command.Handlers
             using (var ctx = new ShardDbContext())
             {
                 // 4 possible skill credits from quests
-                // - ChasingOswaldDone
+                // - OswaldManualCompleted
                 // - ArantahKill1 (no 'turned in' stamp, only if given figurine?)
                 // - LumAugSkillQuest (stamped either 1 or 2 times)
 
@@ -364,16 +364,38 @@ namespace ACE.Server.Command.Handlers
                 if (player.Account == null || player.Account.AccessLevel == (uint)AccessLevel.Admin)
                     continue;
 
-                // player starts with 52 skill credits
-                var startCredits = 52;
+                if (!player.Heritage.HasValue)
+                {
+                    Console.WriteLine($"{player.Name} (0x{player.Guid}) does not have a Heritage, skipping!");
+                    continue;
+                }
 
-                // skills that cannot be untrained: arcane lore, jump, loyalty, magic defense, run, salvaging
-                // all of these have '0' cost to train, except for arcane lore, which has 4 (seems to be an outlier?)
-                startCredits += 4;
+                var heritage = (uint)player.Heritage.Value;
+                var heritageGroup = DatManager.PortalDat.CharGen.HeritageGroups[heritage];
+                var adjustedSkillCosts = heritageGroup.Skills.ToDictionary(s => (Skill)s.SkillNum, s => s);
+
+                var startCredits = (int)heritageGroup.SkillCredits;
 
                 var levelCredits = GetAdditionalCredits(player.Level ?? 1);
 
-                var totalCredits = startCredits + levelCredits;
+                var questCredits = 0;
+
+                // 2 possible skill credits from quests
+                // - OswaldManualCompleted
+                if (oswaldSkillCredit.Contains(player.Guid.Full))
+                    questCredits++;
+
+                // - ArantahKill1 (no 'turned in' stamp, only if given figurine?)
+                if (ralireaSkillCredit.Contains(player.Guid.Full))
+                    questCredits++;
+
+                // - LumAugSkillQuest (stamped either 1 or 2 times)
+                if (lumAugSkillCredits.TryGetValue(player.Guid.Full, out var lumSkillCredits))
+                    questCredits += lumSkillCredits;
+
+                var totalCredits = startCredits + levelCredits + questCredits;
+
+                //Console.WriteLine($"{player.Name} (0x{player.Guid}) Heritage: {heritage}, Level: {player.Level}, Base Credits: {startCredits}, Additional Level Credits: {levelCredits}, Quest Credits: {questCredits}, Total Skill Credits: {totalCredits}");
 
                 var used = 0;
 
@@ -387,13 +409,18 @@ namespace ACE.Server.Command.Handlers
 
                     if (!DatManager.PortalDat.SkillTable.SkillBaseHash.TryGetValue((uint)skill.Key, out var skillInfo))
                     {
-                        Console.WriteLine($"{player.Name}.HandleVerifySkillCredits({skill.Key}): unknown skill");
+                        Console.WriteLine($"{player.Name}:0x{player.Guid}.HandleVerifySkillCredits({skill.Key}): unknown skill");
                         continue;
                     }
 
-                    //Console.WriteLine($"{(Skill)skill.Type} trained cost: {skillInfo.TrainedCost}, spec cost: {skillInfo.SpecializedCost}");
+                    adjustedSkillCosts.TryGetValue(skill.Key, out var adjustedCost);
 
-                    used += skillInfo.TrainedCost;
+                    var trainedCost = adjustedCost?.NormalCost ?? skillInfo.TrainedCost;
+                    var specializedCost = adjustedCost?.PrimaryCost ?? skillInfo.SpecializedCost;
+
+                    //Console.WriteLine($"{(Skill)skill.Type} trained cost: {skillInfo.TrainedCost}, spec cost: {skillInfo.SpecializedCost}, adjusted trained cost: {trainedCost}, adjusted spec cost: {specializedCost}");
+
+                    used += trainedCost;
 
                     if (sac == SkillAdvancementClass.Specialized)
                     {
@@ -408,30 +435,14 @@ namespace ACE.Server.Command.Handlers
                                 continue;
                         }
 
-                        used += skillInfo.UpgradeCostFromTrainedToSpecialized;
+                        used += specializedCost - trainedCost;
 
-                        specCreditsSpent += skillInfo.SpecializedCost;
-
-                        if (skill.Key == Skill.ArcaneLore) // exclude Arcane Lore TrainedCost
-                            specCreditsSpent -= skillInfo.TrainedCost;
+                        specCreditsSpent += specializedCost;
                     }
                 }
 
-                // 2 possible skill credits from quests
-                // - ChasingOswaldDone
-                if (oswaldSkillCredit.Contains(player.Guid.Full))
-                    totalCredits++;
-
-                // - ArantahKill1 (no 'turned in' stamp, only if given figurine?)
-                if (ralireaSkillCredit.Contains(player.Guid.Full))
-                    totalCredits++;
-
-                // - LumAugSkillQuest (stamped either 1 or 2 times)
-                if (lumAugSkillCredits.TryGetValue(player.Guid.Full, out var lumSkillCredits))
-                    totalCredits += lumSkillCredits;
-
                 var targetCredits = totalCredits - used;
-                var targetMsg = $"{player.Name} should have {targetCredits} available skill credits";
+                var targetMsg = $"{player.Name} (0x{player.Guid}) should have {targetCredits} available skill credits";
 
                 if (targetCredits < 0)
                 {
@@ -452,7 +463,7 @@ namespace ACE.Server.Command.Handlers
                     // if the player has already spent more skill credits than they should have,
                     // unfortunately this situation requires a partial reset..
 
-                    Console.WriteLine($"{player.Name} has spent {specCreditsSpent} skill credits on specalization, {specCreditsSpent - 70} over the limit of 70. To fix this situation, specialized skill reset will need to be applied{fixStr}");
+                    Console.WriteLine($"{player.Name} (0x{player.Guid}) has spent {specCreditsSpent} skill credits on specalization, {specCreditsSpent - 70} over the limit of 70. To fix this situation, specialized skill reset will need to be applied{fixStr}");
                     foundIssues = true;
 
                     if (fix)
@@ -471,6 +482,20 @@ namespace ACE.Server.Command.Handlers
                     if (fix)
                     {
                         player.SetProperty(PropertyInt.AvailableSkillCredits, targetCredits);
+                        player.SaveBiotaToDatabase();
+                    }
+                }
+
+                var totalSkillCredits = player.GetProperty(PropertyInt.TotalSkillCredits) ?? 0;
+
+                if (totalSkillCredits != totalCredits)
+                {
+                    Console.WriteLine($"{player.Name} (0x{player.Guid}) should have {totalCredits} total skill credits, but they have {totalSkillCredits}{fixStr}");
+                    foundIssues = true;
+
+                    if (fix)
+                    {
+                        player.SetProperty(PropertyInt.TotalSkillCredits, totalCredits);
                         player.SaveBiotaToDatabase();
                     }
                 }

--- a/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
@@ -464,7 +464,7 @@ namespace ACE.Server.Command.Handlers
                     // if the player has already spent more skill credits than they should have,
                     // unfortunately this situation requires a partial reset..
 
-                    Console.WriteLine($"{player.Name} (0x{player.Guid}) has spent {specCreditsSpent} skill credits on specalization, {specCreditsSpent - 70} over the limit of 70. To fix this situation, specialized skill reset will need to be applied{fixStr}");
+                    Console.WriteLine($"{player.Name} (0x{player.Guid}) has spent {specCreditsSpent} skill credits on specialization, {specCreditsSpent - 70} over the limit of 70. To fix this situation, specialized skill reset will need to be applied{fixStr}");
                     foundIssues = true;
 
                     if (fix)
@@ -609,6 +609,9 @@ namespace ACE.Server.Command.Handlers
             player.SetProperty(PropertyInt.AvailableSkillCredits, targetCredits);
 
             player.SetProperty(PropertyBool.UntrainedSkills, true);
+
+            player.SetProperty(PropertyBool.FreeSkillResetRenewed, true);
+            player.SetProperty(PropertyBool.SkillTemplesTimerReset, true);
 
             player.SaveBiotaToDatabase();
         }

--- a/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
@@ -380,7 +380,8 @@ namespace ACE.Server.Command.Handlers
 
                 var questCredits = 0;
 
-                // 2 possible skill credits from quests
+                // 4 possible skill credits from quests
+
                 // - OswaldManualCompleted
                 if (oswaldSkillCredit.Contains(player.Guid.Full))
                     questCredits++;

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -155,6 +155,7 @@ namespace ACE.Server.Factories
 
             // set initial skill credit amount. 52 for all but "Olthoi", which have 68
             player.SetProperty(PropertyInt.AvailableSkillCredits, (int)heritageGroup.SkillCredits);
+            player.SetProperty(PropertyInt.TotalSkillCredits, (int)heritageGroup.SkillCredits);
 
             if (characterCreateInfo.SkillAdvancementClasses.Count != 55)
                 return CreateResult.ClientServerSkillsMismatch;

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -162,7 +162,7 @@ namespace ACE.Server.WorldObjects.Managers
                 case EmoteType.AwardTrainingCredits:
 
                     if (player != null)
-                        player.AddSkillCredits(emote.Amount ?? 0, false);
+                        player.AddSkillCredits(emote.Amount ?? 0);
                     break;
 
                 case EmoteType.AwardXP:

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -464,19 +464,14 @@ namespace ACE.Server.WorldObjects
             return playerSkill.AdvancementClass >= SkillAdvancementClass.Trained && playerSkill.Current >= minSkill;
         }
 
-        public void AddSkillCredits(int amount, bool showText)
+        public void AddSkillCredits(int amount)
         {
             TotalSkillCredits += amount;
             AvailableSkillCredits += amount;
 
             Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.AvailableSkillCredits, AvailableSkillCredits ?? 0));
 
-            if (showText)
-            {
-                var message = string.Format("You have earned {0} skill credit{1}!", amount, amount == 1 ? "" : "s");
-                Session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.Advancement));
-                Session.Network.EnqueueSend(new GameMessageSound(Guid, Sound.RaiseTrait, 1f));
-            }
+            SendTransientError("You have been awarded an additional skill credit.");
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -471,7 +471,7 @@ namespace ACE.Server.WorldObjects
 
             Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.AvailableSkillCredits, AvailableSkillCredits ?? 0));
 
-            if (amount > 0)
+            if (amount > 1)
                 SendTransientError($"You have been awarded {amount:N0} additional skill credits.");
             else
                 SendTransientError("You have been awarded an additional skill credit.");

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -471,7 +471,10 @@ namespace ACE.Server.WorldObjects
 
             Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.AvailableSkillCredits, AvailableSkillCredits ?? 0));
 
-            SendTransientError("You have been awarded an additional skill credit.");
+            if (amount > 0)
+                SendTransientError($"You have been awarded {amount:N0} additional skill credits.");
+            else
+                SendTransientError("You have been awarded an additional skill credit.");
         }
 
         /// <summary>


### PR DESCRIPTION
Fix some issues with the verify command in addition to accurately using the DAT file and storing total on character as well