### PR TITLE
Olthoi play plus

### DIFF
--- a/Source/ACE.DatLoader/Entity/SexCG.cs
+++ b/Source/ACE.DatLoader/Entity/SexCG.cs
@@ -84,15 +84,26 @@ namespace ACE.DatLoader.Entity
             else
                 return null;
         }
-        public uint GetHairTexture(uint hairStyle)
+        public uint? GetHairTexture(uint hairStyle)
         {
             HairStyleCG hairstyle = HairStyleList[Convert.ToInt32(hairStyle)];
-            return hairstyle.ObjDesc.TextureChanges[0].NewTexture;
+
+            // OlthoiAcid has no TextureChanges
+            if (hairstyle.ObjDesc.TextureChanges.Count > 0)
+                return hairstyle.ObjDesc.TextureChanges[0].NewTexture;
+            else
+                return null;
+
         }
-        public uint GetDefaultHairTexture(uint hairStyle)
+        public uint? GetDefaultHairTexture(uint hairStyle)
         {
             HairStyleCG hairstyle = HairStyleList[Convert.ToInt32(hairStyle)];
-            return hairstyle.ObjDesc.TextureChanges[0].OldTexture;
+
+            // OlthoiAcid has no TextureChanges
+            if (hairstyle.ObjDesc.TextureChanges.Count > 0)
+                return hairstyle.ObjDesc.TextureChanges[0].OldTexture;
+            else
+                return null;
         }
 
         // Headgear

--- a/Source/ACE.Entity/CharacterCreateInfo.cs
+++ b/Source/ACE.Entity/CharacterCreateInfo.cs
@@ -8,10 +8,10 @@ namespace ACE.Entity
 {
     public class CharacterCreateInfo
     {
-        public uint Heritage { get; set; }
+        public HeritageGroup Heritage { get; set; }
         public uint Gender { get; set; }
 
-        public Appearance Apperance { get; } = new Appearance();
+        public Appearance Appearance { get; } = new Appearance();
 
         public int TemplateOption { get; private set; }
 
@@ -38,10 +38,10 @@ namespace ACE.Entity
         {
             reader.BaseStream.Position += 4;   /* Unknown constant (1) */
 
-            Heritage    = reader.ReadUInt32();
+            Heritage    = (HeritageGroup)reader.ReadUInt32();
             Gender      = reader.ReadUInt32();
 
-            Apperance.Unpack(reader);
+            Appearance.Unpack(reader);
 
             TemplateOption = reader.ReadInt32();
 

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -393,7 +393,10 @@ namespace ACE.Server.Factories
 
             player.Sanctuary = new Position(player.Location);
 
-            player.SetProperty(PropertyBool.RecallsDisabled, true);
+            if (player.IsOlthoiPlayer)
+                player.SetProperty(PropertyBool.RecallsDisabled, false);
+            else
+                player.SetProperty(PropertyBool.RecallsDisabled, true);
 
             if (PropertyManager.GetBool("pk_server").Item)
                 player.SetProperty(PropertyInt.PlayerKillerStatus, (int)PlayerKillerStatus.PK);

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -32,7 +32,7 @@ namespace ACE.Server.Factories
 
         public static CreateResult Create(CharacterCreateInfo characterCreateInfo, Weenie weenie, ObjectGuid guid, uint accountId, WeenieType weenieType, out Player player)
         {
-            var heritageGroup = DatManager.PortalDat.CharGen.HeritageGroups[characterCreateInfo.Heritage];
+            var heritageGroup = DatManager.PortalDat.CharGen.HeritageGroups[(uint)characterCreateInfo.Heritage];
 
             if (weenieType == WeenieType.Admin)
                 player = new Admin(weenie, guid, accountId);
@@ -59,161 +59,177 @@ namespace ACE.Server.Factories
             player.SetProperty(PropertyDataId.CombatTable, sex.CombatTable);
 
             // Check the character scale
-            if (sex.Scale != 100u)
-                player.SetProperty(PropertyFloat.DefaultScale, (sex.Scale / 100f)); // Scale is stored as a percentage
+            if (sex.Scale != 100)
+                player.SetProperty(PropertyFloat.DefaultScale, sex.Scale / 100.0f); // Scale is stored as a percentage
 
             // Get the hair first, because we need to know if you're bald, and that's the name of that tune!
-            var hairstyle = sex.HairStyleList[Convert.ToInt32(characterCreateInfo.Apperance.HairStyle)];
+            var hairstyle = sex.HairStyleList[(int)characterCreateInfo.Appearance.HairStyle];
 
             // Olthoi and Gear Knights have a "Body Style" instead of a hair style. These styles have multiple model/texture changes, instead of a single head/hairstyle.
             // Storing this value allows us to send the proper appearance ObjDesc
             if (hairstyle.ObjDesc.AnimPartChanges.Count > 1)
-                player.SetProperty(PropertyInt.Hairstyle, (int)characterCreateInfo.Apperance.HairStyle);
+                player.SetProperty(PropertyInt.Hairstyle, (int)characterCreateInfo.Appearance.HairStyle);
 
             // Certain races (Undead, Tumeroks, Others?) have multiple body styles available. This is controlled via the "hair style".
             if (hairstyle.AlternateSetup > 0)
                 player.SetProperty(PropertyDataId.Setup, hairstyle.AlternateSetup);
 
-            player.SetProperty(PropertyDataId.EyesTexture, sex.GetEyeTexture(characterCreateInfo.Apperance.Eyes, hairstyle.Bald));
-            player.SetProperty(PropertyDataId.DefaultEyesTexture, sex.GetDefaultEyeTexture(characterCreateInfo.Apperance.Eyes, hairstyle.Bald));
-            player.SetProperty(PropertyDataId.NoseTexture, sex.GetNoseTexture(characterCreateInfo.Apperance.Nose));
-            player.SetProperty(PropertyDataId.DefaultNoseTexture, sex.GetDefaultNoseTexture(characterCreateInfo.Apperance.Nose));
-            player.SetProperty(PropertyDataId.MouthTexture, sex.GetMouthTexture(characterCreateInfo.Apperance.Mouth));
-            player.SetProperty(PropertyDataId.DefaultMouthTexture, sex.GetDefaultMouthTexture(characterCreateInfo.Apperance.Mouth));
-            player.Character.HairTexture = sex.GetHairTexture(characterCreateInfo.Apperance.HairStyle);
-            player.Character.DefaultHairTexture = sex.GetDefaultHairTexture(characterCreateInfo.Apperance.HairStyle);
+            player.SetProperty(PropertyDataId.EyesTexture, sex.GetEyeTexture(characterCreateInfo.Appearance.Eyes, hairstyle.Bald));
+            player.SetProperty(PropertyDataId.DefaultEyesTexture, sex.GetDefaultEyeTexture(characterCreateInfo.Appearance.Eyes, hairstyle.Bald));
+            player.SetProperty(PropertyDataId.NoseTexture, sex.GetNoseTexture(characterCreateInfo.Appearance.Nose));
+            player.SetProperty(PropertyDataId.DefaultNoseTexture, sex.GetDefaultNoseTexture(characterCreateInfo.Appearance.Nose));
+            player.SetProperty(PropertyDataId.MouthTexture, sex.GetMouthTexture(characterCreateInfo.Appearance.Mouth));
+            player.SetProperty(PropertyDataId.DefaultMouthTexture, sex.GetDefaultMouthTexture(characterCreateInfo.Appearance.Mouth));
+            player.Character.HairTexture = sex.GetHairTexture(characterCreateInfo.Appearance.HairStyle) ?? 0;
+            player.Character.DefaultHairTexture = sex.GetDefaultHairTexture(characterCreateInfo.Appearance.HairStyle) ?? 0;
             // HeadObject can be null if we're dealing with GearKnight or Olthoi
-            var headObject = sex.GetHeadObject(characterCreateInfo.Apperance.HairStyle);
+            var headObject = sex.GetHeadObject(characterCreateInfo.Appearance.HairStyle);
             if (headObject != null)
                 player.SetProperty(PropertyDataId.HeadObject, (uint)headObject);
 
             // Skin is stored as PaletteSet (list of Palettes), so we need to read in the set to get the specific palette
             var skinPalSet = DatManager.PortalDat.ReadFromDat<PaletteSet>(sex.SkinPalSet);
-            player.SetProperty(PropertyDataId.SkinPalette, skinPalSet.GetPaletteID(characterCreateInfo.Apperance.SkinHue));
-            player.SetProperty(PropertyFloat.Shade, characterCreateInfo.Apperance.SkinHue);
+            player.SetProperty(PropertyDataId.SkinPalette, skinPalSet.GetPaletteID(characterCreateInfo.Appearance.SkinHue));
+            player.SetProperty(PropertyFloat.Shade, characterCreateInfo.Appearance.SkinHue);
 
             // Hair is stored as PaletteSet (list of Palettes), so we need to read in the set to get the specific palette
-            var hairPalSet = DatManager.PortalDat.ReadFromDat<PaletteSet>(sex.HairColorList[Convert.ToInt32(characterCreateInfo.Apperance.HairColor)]);
-            player.SetProperty(PropertyDataId.HairPalette, hairPalSet.GetPaletteID(characterCreateInfo.Apperance.HairHue));
+            var hairPalSet = DatManager.PortalDat.ReadFromDat<PaletteSet>(sex.HairColorList[(int)characterCreateInfo.Appearance.HairColor]);
+            player.SetProperty(PropertyDataId.HairPalette, hairPalSet.GetPaletteID(characterCreateInfo.Appearance.HairHue));
 
             // Eye Color
-            player.SetProperty(PropertyDataId.EyesPalette, sex.EyeColorList[Convert.ToInt32(characterCreateInfo.Apperance.EyeColor)]);
+            player.SetProperty(PropertyDataId.EyesPalette, sex.EyeColorList[(int)characterCreateInfo.Appearance.EyeColor]);
 
-            if (characterCreateInfo.Apperance.HeadgearStyle < 0xFFFFFFFF) // No headgear is max UINT
+            // do olthoi get clothing?
+            if (characterCreateInfo.Appearance.HeadgearStyle < uint.MaxValue) // No headgear is max UINT
             {
-                var hat = GetClothingObject(sex.GetHeadgearWeenie(characterCreateInfo.Apperance.HeadgearStyle), characterCreateInfo.Apperance.HeadgearColor, characterCreateInfo.Apperance.HeadgearHue);
+                var hat = GetClothingObject(sex.GetHeadgearWeenie(characterCreateInfo.Appearance.HeadgearStyle), characterCreateInfo.Appearance.HeadgearColor, characterCreateInfo.Appearance.HeadgearHue);
                 if (hat != null)
                     player.TryEquipObject(hat, hat.ValidLocations ?? 0);
                 else
-                    player.TryAddToInventory(CreateIOU(sex.GetHeadgearWeenie(characterCreateInfo.Apperance.HeadgearStyle)));
+                    player.TryAddToInventory(CreateIOU(sex.GetHeadgearWeenie(characterCreateInfo.Appearance.HeadgearStyle)));
             }
 
-            var shirt = GetClothingObject(sex.GetShirtWeenie(characterCreateInfo.Apperance.ShirtStyle), characterCreateInfo.Apperance.ShirtColor, characterCreateInfo.Apperance.ShirtHue);
+            var shirt = GetClothingObject(sex.GetShirtWeenie(characterCreateInfo.Appearance.ShirtStyle), characterCreateInfo.Appearance.ShirtColor, characterCreateInfo.Appearance.ShirtHue);
             if (shirt != null)
                 player.TryEquipObject(shirt, shirt.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(sex.GetShirtWeenie(characterCreateInfo.Apperance.ShirtStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetShirtWeenie(characterCreateInfo.Appearance.ShirtStyle)));
 
-            var pants = GetClothingObject(sex.GetPantsWeenie(characterCreateInfo.Apperance.PantsStyle), characterCreateInfo.Apperance.PantsColor, characterCreateInfo.Apperance.PantsHue);
+            var pants = GetClothingObject(sex.GetPantsWeenie(characterCreateInfo.Appearance.PantsStyle), characterCreateInfo.Appearance.PantsColor, characterCreateInfo.Appearance.PantsHue);
             if (pants != null)
                 player.TryEquipObject(pants, pants.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(sex.GetPantsWeenie(characterCreateInfo.Apperance.PantsStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetPantsWeenie(characterCreateInfo.Appearance.PantsStyle)));
 
-            var shoes = GetClothingObject(sex.GetFootwearWeenie(characterCreateInfo.Apperance.FootwearStyle), characterCreateInfo.Apperance.FootwearColor, characterCreateInfo.Apperance.FootwearHue);
+            var shoes = GetClothingObject(sex.GetFootwearWeenie(characterCreateInfo.Appearance.FootwearStyle), characterCreateInfo.Appearance.FootwearColor, characterCreateInfo.Appearance.FootwearHue);
             if (shoes != null)
                 player.TryEquipObject(shoes, shoes.ValidLocations ?? 0);
             else
-                player.TryAddToInventory(CreateIOU(sex.GetFootwearWeenie(characterCreateInfo.Apperance.FootwearStyle)));
+                player.TryAddToInventory(CreateIOU(sex.GetFootwearWeenie(characterCreateInfo.Appearance.FootwearStyle)));
 
             string templateName = heritageGroup.Templates[characterCreateInfo.TemplateOption].Name;
-            //player.SetProperty(PropertyString.Title, templateName);
             player.SetProperty(PropertyString.Template, templateName);
-            player.AddTitle(heritageGroup.Templates[characterCreateInfo.TemplateOption].Title, true);
 
-            // attributes
-            var result = ValidateAttributeCredits(characterCreateInfo, heritageGroup.AttributeCredits);
-
-            if (result != CreateResult.Success)
-                return result;
-
-            player.Strength.StartingValue = characterCreateInfo.StrengthAbility;
-            player.Endurance.StartingValue = characterCreateInfo.EnduranceAbility;
-            player.Coordination.StartingValue = characterCreateInfo.CoordinationAbility;
-            player.Quickness.StartingValue = characterCreateInfo.QuicknessAbility;
-            player.Focus.StartingValue = characterCreateInfo.FocusAbility;
-            player.Self.StartingValue = characterCreateInfo.SelfAbility;
-
-            // data we don't care about
-            //characterCreateInfo.CharacterSlot;
-            //characterCreateInfo.ClassId;
-
-            // characters start with max vitals
-            player.Health.Current = player.Health.Base;
-            player.Stamina.Current = player.Stamina.Base;
-            player.Mana.Current = player.Mana.Base;
-
-            // set initial skill credit amount. 52 for all but "Olthoi", which have 68
-            player.SetProperty(PropertyInt.AvailableSkillCredits, (int)heritageGroup.SkillCredits);
-            player.SetProperty(PropertyInt.TotalSkillCredits, (int)heritageGroup.SkillCredits);
-
-            if (characterCreateInfo.SkillAdvancementClasses.Count != 55)
-                return CreateResult.ClientServerSkillsMismatch;
-
-            for (int i = 0; i < characterCreateInfo.SkillAdvancementClasses.Count; i++)
+            if (!player.IsOlthoiPlayer)
             {
-                var sac = characterCreateInfo.SkillAdvancementClasses[i];
-
-                if (sac == SkillAdvancementClass.Inactive)
-                    continue;
-
-                if (!DatManager.PortalDat.SkillTable.SkillBaseHash.ContainsKey((uint)i))
-                {
-                    log.ErrorFormat("Character {0} tried to create with skill {1} that was not found in Portal dat.", characterCreateInfo.Name, i);
-                    return CreateResult.InvalidSkillRequested;
-                }
-
-                var skill = DatManager.PortalDat.SkillTable.SkillBaseHash[(uint)i];
-
-                var trainedCost = skill.TrainedCost;
-                var specializedCost = skill.UpgradeCostFromTrainedToSpecialized;
-
-                foreach (var skillGroup in heritageGroup.Skills)
-                {
-                    if (skillGroup.SkillNum == i)
-                    {
-                        trainedCost = skillGroup.NormalCost;
-                        specializedCost = skillGroup.PrimaryCost;
-                        break;
-                    }
-                }
-
-                if (sac == SkillAdvancementClass.Specialized)
-                {
-                    if (!player.TrainSkill((Skill)i, trainedCost))
-                        return CreateResult.FailedToTrainSkill;
-                    if (!player.SpecializeSkill((Skill)i, specializedCost))
-                        return CreateResult.FailedToSpecializeSkill;
-                }
-                else if (sac == SkillAdvancementClass.Trained)
-                {
-                    if (!player.TrainSkill((Skill)i, trainedCost, true))
-                        return CreateResult.FailedToTrainSkill;
-                }
-                else if (sac == SkillAdvancementClass.Untrained)
-                    player.UntrainSkill((Skill)i, 0);
+                player.AddTitle(heritageGroup.Templates[characterCreateInfo.TemplateOption].Title, true);
+            }
+            else
+            {
+                // olthoi templates don't contain the correct titles for some reason
+                if (player.HeritageGroup == HeritageGroup.Olthoi)
+                    player.AddTitle(CharacterTitle.Ripper, true);
+                else if (player.HeritageGroup == HeritageGroup.OlthoiAcid)
+                    player.AddTitle(CharacterTitle.AcidSpitter, true);
             }
 
-            var isDualWieldTrainedOrSpecialized = player.Skills[Skill.DualWield].AdvancementClass > SkillAdvancementClass.Untrained;
+            // skip over this for olthoi, use the weenie defaults
+            if (!player.IsOlthoiPlayer)
+            {
+                // attributes
+                var result = ValidateAttributeCredits(characterCreateInfo, heritageGroup.AttributeCredits);
 
-            // Set Heritage based Melee and Ranged Masteries
-            GetMasteries(player.HeritageGroup, out WeaponType meleeMastery, out WeaponType rangedMastery);
+                if (result != CreateResult.Success)
+                    return result;
 
-            player.SetProperty(PropertyInt.MeleeMastery, (int)meleeMastery);
-            player.SetProperty(PropertyInt.RangedMastery, (int)rangedMastery);
+                player.Strength.StartingValue = characterCreateInfo.StrengthAbility;
+                player.Endurance.StartingValue = characterCreateInfo.EnduranceAbility;
+                player.Coordination.StartingValue = characterCreateInfo.CoordinationAbility;
+                player.Quickness.StartingValue = characterCreateInfo.QuicknessAbility;
+                player.Focus.StartingValue = characterCreateInfo.FocusAbility;
+                player.Self.StartingValue = characterCreateInfo.SelfAbility;
 
-            // Set innate augs
-            SetInnateAugmentations(player);
+                // data we don't care about
+                //characterCreateInfo.CharacterSlot;
+                //characterCreateInfo.ClassId;
+
+                // characters start with max vitals
+                player.Health.Current = player.Health.Base;
+                player.Stamina.Current = player.Stamina.Base;
+                player.Mana.Current = player.Mana.Base;
+
+                // set initial skill credit amount. 52 for all but "Olthoi", which have 68
+                player.SetProperty(PropertyInt.AvailableSkillCredits, (int)heritageGroup.SkillCredits);
+                player.SetProperty(PropertyInt.TotalSkillCredits, (int)heritageGroup.SkillCredits);
+
+                if (characterCreateInfo.SkillAdvancementClasses.Count != 55)
+                    return CreateResult.ClientServerSkillsMismatch;
+
+                for (int i = 0; i < characterCreateInfo.SkillAdvancementClasses.Count; i++)
+                {
+                    var sac = characterCreateInfo.SkillAdvancementClasses[i];
+
+                    if (sac == SkillAdvancementClass.Inactive)
+                        continue;
+
+                    if (!DatManager.PortalDat.SkillTable.SkillBaseHash.ContainsKey((uint)i))
+                    {
+                        log.ErrorFormat("Character {0} tried to create with skill {1} that was not found in Portal dat.", characterCreateInfo.Name, i);
+                        return CreateResult.InvalidSkillRequested;
+                    }
+
+                    var skill = DatManager.PortalDat.SkillTable.SkillBaseHash[(uint)i];
+
+                    var trainedCost = skill.TrainedCost;
+                    var specializedCost = skill.UpgradeCostFromTrainedToSpecialized;
+
+                    foreach (var skillGroup in heritageGroup.Skills)
+                    {
+                        if (skillGroup.SkillNum == i)
+                        {
+                            trainedCost = skillGroup.NormalCost;
+                            specializedCost = skillGroup.PrimaryCost;
+                            break;
+                        }
+                    }
+
+                    if (sac == SkillAdvancementClass.Specialized)
+                    {
+                        if (!player.TrainSkill((Skill)i, trainedCost))
+                            return CreateResult.FailedToTrainSkill;
+                        if (!player.SpecializeSkill((Skill)i, specializedCost))
+                            return CreateResult.FailedToSpecializeSkill;
+                    }
+                    else if (sac == SkillAdvancementClass.Trained)
+                    {
+                        if (!player.TrainSkill((Skill)i, trainedCost, true))
+                            return CreateResult.FailedToTrainSkill;
+                    }
+                    else if (sac == SkillAdvancementClass.Untrained)
+                        player.UntrainSkill((Skill)i, 0);
+                }
+
+                // Set Heritage based Melee and Ranged Masteries
+                GetMasteries(player.HeritageGroup, out WeaponType meleeMastery, out WeaponType rangedMastery);
+
+                player.SetProperty(PropertyInt.MeleeMastery, (int)meleeMastery);
+                player.SetProperty(PropertyInt.RangedMastery, (int)rangedMastery);
+
+                // Set innate augs
+                SetInnateAugmentations(player);
+            }
+
+            var isDualWieldTrainedOrSpecialized = player.Skills.TryGetValue(Skill.DualWield, out var dualWield) && dualWield.AdvancementClass > SkillAdvancementClass.Untrained;
 
             // grant starter items based on skills
             var starterGearConfig = StarterGearFactory.GetStarterGearConfiguration();
@@ -221,7 +237,10 @@ namespace ACE.Server.Factories
 
             foreach (var skillGear in starterGearConfig.Skills)
             {
-                var charSkill = player.Skills[(Skill)skillGear.SkillId];
+                //var charSkill = player.Skills[(Skill)skillGear.SkillId];
+                if (!player.Skills.TryGetValue((Skill)skillGear.SkillId, out var charSkill))
+                    continue;
+
                 if (charSkill.AdvancementClass == SkillAdvancementClass.Trained || charSkill.AdvancementClass == SkillAdvancementClass.Specialized)
                 {
                     foreach (var item in skillGear.Gear)
@@ -267,7 +286,7 @@ namespace ACE.Server.Factories
                         }
                     }
 
-                    var heritageLoot = skillGear.Heritage.FirstOrDefault(sh => sh.HeritageId == characterCreateInfo.Heritage);
+                    var heritageLoot = skillGear.Heritage.FirstOrDefault(i => i.HeritageId == (ushort)characterCreateInfo.Heritage);
                     if (heritageLoot != null)
                     {
                         foreach (var item in heritageLoot.Gear)
@@ -317,7 +336,7 @@ namespace ACE.Server.Factories
                     foreach (var spell in skillGear.Spells)
                     {
                         // Olthoi Spitter is a special case
-                        if (characterCreateInfo.Heritage == (int)HeritageGroup.OlthoiAcid)
+                        if (characterCreateInfo.Heritage == HeritageGroup.OlthoiAcid)
                         {
                             player.AddKnownSpell(spell.SpellId);
                             // Continue to next spell as Olthoi spells do not have the SpecializedOnly field
@@ -346,7 +365,7 @@ namespace ACE.Server.Factories
                 starterArea.Locations[0].Frame.Orientation.X, starterArea.Locations[0].Frame.Orientation.Y, starterArea.Locations[0].Frame.Orientation.Z, starterArea.Locations[0].Frame.Orientation.W);
 
             var instantiation = new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f); // ultimate fallback.
-            var spellFreeRide = new ACE.Database.Models.World.Spell();
+            var spellFreeRide = new Database.Models.World.Spell();
             switch (starterArea.Name)
             {
                 case "OlthoiLair": //todo: check this when olthoi play is allowed in ace

--- a/Source/ACE.Server/Factories/PlayerFactoryEx.cs
+++ b/Source/ACE.Server/Factories/PlayerFactoryEx.cs
@@ -76,21 +76,21 @@ namespace ACE.Server.Factories
 
         private static void RandomizeHeritage(CharacterCreateInfo characterCreateInfo)
         {
-            var heritage = (uint)rand.Next(1, 12);
-            var heritageGroup = DatManager.PortalDat.CharGen.HeritageGroups[heritage];
+            var heritage = (HeritageGroup)rand.Next(1, 13);
+            var heritageGroup = DatManager.PortalDat.CharGen.HeritageGroups[(uint)heritage];
 
             characterCreateInfo.Heritage = heritage;
             characterCreateInfo.Gender = (uint)heritageGroup.Genders.ElementAt(rand.Next(0, heritageGroup.Genders.Count)).Key;
 
             var sex = heritageGroup.Genders[(int)characterCreateInfo.Gender];
 
-            characterCreateInfo.Apperance.HairColor = (uint)rand.Next(0, sex.HairColorList.Count);
-            characterCreateInfo.Apperance.HairStyle = (uint)rand.Next(0, sex.HairStyleList.Count);
+            characterCreateInfo.Appearance.HairColor = (uint)rand.Next(0, sex.HairColorList.Count);
+            characterCreateInfo.Appearance.HairStyle = (uint)rand.Next(0, sex.HairStyleList.Count);
 
-            characterCreateInfo.Apperance.Eyes = (uint)rand.Next(0, sex.EyeStripList.Count);
-            characterCreateInfo.Apperance.EyeColor = (uint)rand.Next(0, sex.EyeColorList.Count);
-            characterCreateInfo.Apperance.Nose = (uint)rand.Next(0, sex.NoseStripList.Count);
-            characterCreateInfo.Apperance.Mouth = (uint)rand.Next(0, sex.MouthStripList.Count);
+            characterCreateInfo.Appearance.Eyes = (uint)rand.Next(0, sex.EyeStripList.Count);
+            characterCreateInfo.Appearance.EyeColor = (uint)rand.Next(0, sex.EyeColorList.Count);
+            characterCreateInfo.Appearance.Nose = (uint)rand.Next(0, sex.NoseStripList.Count);
+            characterCreateInfo.Appearance.Mouth = (uint)rand.Next(0, sex.MouthStripList.Count);
 
             // todo randomize skin
         }

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -565,6 +565,7 @@ namespace ACE.Server.Managers
                 ("lifestone_broadcast_death", new Property<bool>(true, "if true, player deaths are additionally broadcast to other players standing near the destination lifestone")),
                 ("loot_quality_mod", new Property<bool>(true, "if FALSE then the loot quality modifier of a Death Treasure profile does not affect loot generation")),
                 ("npc_hairstyle_fullrange", new Property<bool>(false, "if TRUE, allows generated creatures to use full range of hairstyles. Retail only allowed first nine (0-8) out of 51")),
+                ("olthoi_play_enabled", new Property<bool>(false, "allows players to create and play as olthoi characters")),
                 ("override_encounter_spawn_rates", new Property<bool>(false, "if enabled, landblock encounter spawns are overidden by double properties below.")),
                 ("permit_corpse_all", new Property<bool>(false, "If TRUE, /permit grants permittees access to all corpses of the permitter. Defaults to FALSE as per retail, where /permit only grants access to 1 locked corpse")),
                 ("persist_movement", new Property<bool>(false, "If TRUE, persists autonomous movements such as turns and sidesteps through non-autonomous server actions. Retail didn't appear to do this, but some players may prefer this.")),
@@ -666,6 +667,7 @@ namespace ACE.Server.Managers
                 ("dat_warning_msg", new Property<string>("Your DAT files are incomplete.\nACEmulator does not support dynamic DAT updating at this time.\nPlease visit https://emulator.ac/how-to-play to download the complete DAT files.", "Warning message displayed (if show_dat_warning is true) to player if client attempts DAT download from server")),
                 ("popup_header", new Property<string>("Welcome to Asheron's Call!", "Welcome message displayed when you log in")),
                 ("popup_welcome", new Property<string>("To begin your training, speak to the Society Greeter. Walk up to the Society Greeter using the 'W' key, then double-click on her to initiate a conversation.", "Welcome message popup in training halls")),
+                ("popup_welcome_olthoi", new Property<string>("Welcome to the Olthoi hive! Be sure to talk to the Olthoi Queen to receive the Olthoi protections granted by the energies of the hive.", "Welcome message displayed on the first login for an Olthoi Player")),
                 ("popup_motd", new Property<string>("", "Popup message of the day")),
                 ("server_motd", new Property<string>("", "Server message of the day"))
                 );

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -213,6 +213,9 @@ namespace ACE.Server.Managers
                     session.Player.Location = new Position(0xA9B40019, 84, 7.1f, 94, 0, 0, -0.0784591f, 0.996917f);  // ultimate fallback
             }
 
+            if (session.Player.IsOlthoiPlayer)
+                session.Player.Location = session.Player.Sanctuary;
+
             session.Player.PlayerEnterWorld();
 
             var success = LandblockManager.AddObject(session.Player, true);

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -10,6 +10,7 @@ using ACE.Common.Performance;
 using ACE.Database;
 using ACE.Database.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
@@ -161,7 +162,7 @@ namespace ACE.Server.Managers
             {
                 player.CloakStatus = CloakStatus.Undef;
                 player.Attackable = true;
-                player.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.DamagedByCollisions, true);
+                player.SetProperty(PropertyBool.DamagedByCollisions, true);
                 player.AdvocateLevel = null;
                 player.ChannelsActive = null;
                 player.ChannelsAllowed = null;
@@ -190,10 +191,10 @@ namespace ACE.Server.Managers
                 {
                     player.CloakStatus = CloakStatus.Off;
                     player.Attackable = weenie.Attackable;
-                    player.SetProperty(ACE.Entity.Enum.Properties.PropertyBool.DamagedByCollisions, false);
-                    player.AdvocateLevel = weenie.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.AdvocateLevel);
-                    player.ChannelsActive = (Channel?)weenie.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.ChannelsActive);
-                    player.ChannelsAllowed = (Channel?)weenie.GetProperty(ACE.Entity.Enum.Properties.PropertyInt.ChannelsAllowed);
+                    player.SetProperty(PropertyBool.DamagedByCollisions, false);
+                    player.AdvocateLevel = weenie.GetProperty(PropertyInt.AdvocateLevel);
+                    player.ChannelsActive = (Channel?)weenie.GetProperty(PropertyInt.ChannelsActive);
+                    player.ChannelsAllowed = (Channel?)weenie.GetProperty(PropertyInt.ChannelsAllowed);
                     player.Invincible = false;
                     player.Cloaked = false;
 
@@ -245,11 +246,14 @@ namespace ACE.Server.Managers
 
             var popup_header = PropertyManager.GetString("popup_header").Item;
             var popup_motd = PropertyManager.GetString("popup_motd").Item;
-            var popup_welcome = PropertyManager.GetString("popup_welcome").Item;
+            var popup_welcome = player.IsOlthoiPlayer ? PropertyManager.GetString("popup_welcome_olthoi").Item : PropertyManager.GetString("popup_welcome").Item;
 
             if (character.TotalLogins <= 1)
             {
-                session.Network.EnqueueSend(new GameEventPopupString(session, AppendLines(popup_header, popup_motd, popup_welcome)));
+                if (player.IsOlthoiPlayer)
+                    session.Network.EnqueueSend(new GameEventPopupString(session, AppendLines(popup_welcome, popup_motd)));
+                else
+                    session.Network.EnqueueSend(new GameEventPopupString(session, AppendLines(popup_header, popup_motd, popup_welcome)));
             }
             else if (!string.IsNullOrEmpty(popup_motd))
             {

--- a/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/CharacterHandler.cs
@@ -71,7 +71,7 @@ namespace ACE.Server.Network.Handlers
 
             // Disable OlthoiPlay characters for now. They're not implemented yet.
             // FIXME: Restore OlthoiPlay characters when properly handled.
-            if (characterCreateInfo.Heritage == (int)HeritageGroup.Olthoi || characterCreateInfo.Heritage == (int)HeritageGroup.OlthoiAcid)
+            if ((characterCreateInfo.Heritage == HeritageGroup.Olthoi || characterCreateInfo.Heritage == HeritageGroup.OlthoiAcid) && !PropertyManager.GetBool("olthoi_play_enabled").Item)
             {
                 SendCharacterCreateResponse(session, CharacterGenerationVerificationResponse.Pending);
                 return;
@@ -87,19 +87,19 @@ namespace ACE.Server.Network.Handlers
                 else
                     weenie = DatabaseManager.World.GetCachedWeenie("human");
 
-                if (characterCreateInfo.Heritage == (int)HeritageGroup.Olthoi && weenie.WeenieType == WeenieType.Admin)
+                if (characterCreateInfo.Heritage == HeritageGroup.Olthoi && weenie.WeenieType == WeenieType.Admin)
                     weenie = DatabaseManager.World.GetCachedWeenie("olthoiadmin");
 
-                if (characterCreateInfo.Heritage == (int)HeritageGroup.OlthoiAcid && weenie.WeenieType == WeenieType.Admin)
+                if (characterCreateInfo.Heritage == HeritageGroup.OlthoiAcid && weenie.WeenieType == WeenieType.Admin)
                     weenie = DatabaseManager.World.GetCachedWeenie("olthoiacidadmin");
             }
             else
                 weenie = DatabaseManager.World.GetCachedWeenie("human");
 
-            if (characterCreateInfo.Heritage == (int)HeritageGroup.Olthoi && weenie.WeenieType == WeenieType.Creature)
+            if (characterCreateInfo.Heritage == HeritageGroup.Olthoi && weenie.WeenieType == WeenieType.Creature)
                 weenie = DatabaseManager.World.GetCachedWeenie("olthoiplayer");
 
-            if (characterCreateInfo.Heritage == (int)HeritageGroup.OlthoiAcid && weenie.WeenieType == WeenieType.Creature)
+            if (characterCreateInfo.Heritage == HeritageGroup.OlthoiAcid && weenie.WeenieType == WeenieType.Creature)
                 weenie = DatabaseManager.World.GetCachedWeenie("olthoiacidplayer");
 
             if (characterCreateInfo.IsSentinel && session.AccessLevel >= AccessLevel.Sentinel)

--- a/Source/ACE.Server/WorldObjects/Bindstone.cs
+++ b/Source/ACE.Server/WorldObjects/Bindstone.cs
@@ -48,6 +48,12 @@ namespace ACE.Server.WorldObjects
             if (!(worldObject is Player player))
                 return;
 
+            if (player.IsOlthoiPlayer)
+            {
+                player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.OlthoiCannotInteractWithThat));
+                return;
+            }
+
             // check if player is in an allegiance
             if (player.Allegiance == null)
             {

--- a/Source/ACE.Server/WorldObjects/Lifestone.cs
+++ b/Source/ACE.Server/WorldObjects/Lifestone.cs
@@ -46,6 +46,12 @@ namespace ACE.Server.WorldObjects
             if (!(worldObject is Player player))
                 return;
 
+            if (player.IsOlthoiPlayer)
+            {
+                player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.OlthoiCannotUseLifestones));
+                return;
+            }
+
             var actionChain = new ActionChain();
             if (player.CombatMode != CombatMode.NonCombat)
             {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -141,7 +141,7 @@ namespace ACE.Server.WorldObjects
             // radius for object updates
             ListeningRadius = 5f;
 
-            if (Session != null && Common.ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions)
+            if (Session != null && ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions)
             {
                 if (Session.AccessLevel == AccessLevel.Admin)
                     IsAdmin = true;
@@ -157,6 +157,8 @@ namespace ACE.Server.WorldObjects
                 if (Session.AccessLevel == AccessLevel.Advocate)
                     IsAdvocate = true;
             }
+
+            IsOlthoiPlayer = HeritageGroup == HeritageGroup.Olthoi || HeritageGroup == HeritageGroup.OlthoiAcid;
 
             ContainerCapacity = (byte)(7 + AugmentationExtraPackSlot);
 

--- a/Source/ACE.Server/WorldObjects/Player_Luminance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Luminance.cs
@@ -14,6 +14,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void EarnLuminance(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            if (IsOlthoiPlayer)
+                return;
+
             // following the same model as Player_Xp
 
             var modifier = PropertyManager.GetDouble("luminance_modifier").Item;
@@ -31,6 +34,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void GrantLuminance(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            if (IsOlthoiPlayer)
+                return;
+
             if (Fellowship != null && Fellowship.ShareXP && shareType.HasFlag(ShareType.Fellowship))
             {
                 // this will divy up the luminance, and re-call this function

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -61,6 +61,9 @@ namespace ACE.Server.WorldObjects
             get => (Character != null && Character.IsPlussed) || (Session != null && ConfigManager.Config.Server.Accounts.OverrideCharacterPermissions && Session.AccessLevel > AccessLevel.Advocate);
         }
 
+        public bool IsOlthoiPlayer { get; set; }
+
+
         public string GodState
         {
             get => GetProperty(PropertyString.GodState);
@@ -271,7 +274,7 @@ namespace ACE.Server.WorldObjects
             set { if (!value) RemoveProperty(PropertyBool.SafeSpellComponents); else SetProperty(PropertyBool.SafeSpellComponents, value); }
         }
 
-        public bool IsOlthoiPlayer()
+        /*public bool IsOlthoiPlayer()
         {
             switch (WeenieClassId)
             {
@@ -282,7 +285,7 @@ namespace ACE.Server.WorldObjects
                     return true;
             }
             return false;
-        }
+        }*/
 
         /// <summary>
         /// The timestamp when the player last generated a rare
@@ -1274,6 +1277,12 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyFloat.LastPortalTeleportTimestamp);
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.LastPortalTeleportTimestamp); else SetProperty(PropertyFloat.LastPortalTeleportTimestamp, value.Value); }
+        }
+
+        public bool OlthoiPk
+        {
+            get => GetProperty(PropertyBool.OlthoiPk) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.OlthoiPk); else SetProperty(PropertyBool.OlthoiPk, value); }
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -21,6 +21,9 @@ namespace ACE.Server.WorldObjects
         /// <param name="shareable">True if this XP can be shared with Fellowship</param>
         public void EarnXP(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            if (IsOlthoiPlayer)
+                return;
+
             //Console.WriteLine($"{Name}.EarnXP({amount}, {sharable}, {fixedAmount})");
 
             // apply xp modifier
@@ -49,6 +52,9 @@ namespace ACE.Server.WorldObjects
         /// <param name="shareable">If TRUE, this XP can be shared with fellowship members</param>
         public void GrantXP(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            if (IsOlthoiPlayer)
+                return;
+
             if (Fellowship != null && Fellowship.ShareXP && shareType.HasFlag(ShareType.Fellowship))
             {
                 // this will divy up the XP, and re-call this function

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -204,13 +204,13 @@ namespace ACE.Server.WorldObjects
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.NonPKsMayNotUsePortal));
                 }
 
-                if (PortalRestrictions.HasFlag(PortalBitmask.OnlyOlthoiPCs) && !player.IsOlthoiPlayer())
+                if (PortalRestrictions.HasFlag(PortalBitmask.OnlyOlthoiPCs) && !player.IsOlthoiPlayer)
                 {
                     // Only Olthoi may pass through this portal!
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.OnlyOlthoiMayUsePortal));
                 }
 
-                if (PortalRestrictions.HasFlag(PortalBitmask.NoOlthoiPCs) && player.IsOlthoiPlayer())
+                if (PortalRestrictions.HasFlag(PortalBitmask.NoOlthoiPCs) && player.IsOlthoiPlayer)
                 {
                     // Olthoi may not pass through this portal!
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.OlthoiMayNotUsePortal));

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -120,6 +120,12 @@ namespace ACE.Server.WorldObjects
         /// <param name="action">The action performed by the player</param>
         private void ApproachVendor(Player player, VendorType action = VendorType.Undef, uint altCurrencySpent = 0)
         {
+            if (player.IsOlthoiPlayer && CreatureType != ACE.Entity.Enum.CreatureType.Olthoi)
+            {
+                player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.OlthoiVendorLooksInHorror));
+                return;
+            }
+
             var vendorList = AllItemsForSale.Values.ToList();
 
             vendorList = RotUniques(vendorList);


### PR DESCRIPTION
- Built on top of PR #3559
- Add Olthoi player lockouts for XP and Luminance gain, Vendor GUI, excepting for those that are from CreatureType.Olthoi NPCs, Lifestones, and Bindstones
- Disabling the starting PropertyBool.RecallsDisabled for Olthoi players
- Force login locations to always be  session.Player.Sanctuary, which is the spawn spot nearby the Queen
