### PR TITLE
improved RecipeManager.UpdateObj handling

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -342,11 +342,14 @@ namespace ACE.Server.Managers
 
             var modified = CreateDestroyItems(player, recipe, source, target, successChance, success);
 
-            if (modified.Contains(source.Guid.Full))
-                UpdateObj(player, source);
+            if (modified != null)
+            {
+                if (modified.Contains(source.Guid.Full))
+                    UpdateObj(player, source);
 
-            if (modified.Contains(target.Guid.Full))
-                UpdateObj(player, target);
+                if (modified.Contains(target.Guid.Full))
+                    UpdateObj(player, target);
+            }
 
             if (success && recipe.Skill > 0 && recipe.Difficulty > 0)
             {
@@ -994,7 +997,7 @@ namespace ACE.Server.Managers
             {
                 log.Error($"RecipeManager.CreateDestroyItems: Recipe.Id({recipe.Id}) couldn't find {(success ? "Success" : "Fail")}WCID {createItem} in database.");
                 player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.CraftGeneralErrorUiMsg));
-                return new HashSet<uint>();
+                return null;
             }
 
             if (destroyTarget)


### PR DESCRIPTION
This syncs RecipeManager.UpdateObj handling up in a way that I think that makes more logical sense, and possibly closer to retail

This prevents UpdateObj from being sent for some things it probably shouldn't be sent for, and sends it for some situations where it currently isn't being sent

With this change, UpdateObj is sent for any source/target objects that are modified via RecipeMods, including mutations. This retains the existing behavior where tinkering an item would bump that item's position up to the first slot in the current container.

What this prevents is a current scenario where UpdateObj is sent for the target item in an arrowhead+arrowshaft operation, where the target item (1 of the crafting components, not the result item) is getting its position bumped to the first slot in the current container.

This also gets rid of the weird shortcut-based logic. Since UpdateObj is no longer sent for one of the crafting components for making arrows, this is no longer needed.

This also fixes an issue where a tinkering operation with a shortcut target wasn't getting an UpdateObj sent. The intention there was to not make shortcut items disappear from the shortcut bar, however in the case of a tinkering operation, I believe the resulting modified item possibly did disappear from the shortcut bar in retail.