### PR TITLE
Update BaseDamage for player Olthoi Soldiers

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -364,7 +364,7 @@ namespace ACE.Server.WorldObjects
 
                 // no weapon, no hand or foot armor
                 if (damageSource?.Damage == null)
-                    return IsOlthoiPlayer ? new BaseDamageMod(new BaseDamage(130, 0.75f)) : new BaseDamageMod(new BaseDamage(2, 0.75f));
+                    return HeritageGroup == HeritageGroup.Olthoi ? new BaseDamageMod(new BaseDamage(130, 0.75f)) : new BaseDamageMod(new BaseDamage(2, 0.75f));
                 else
                     return damageSource.GetDamageMod(this, damageSource);
             }


### PR DESCRIPTION
- Update the BaseDamage value for the player Olthoi Soldiers to better fit their level from the default of 2, with a 0.75 variance, for normal players