### PR TITLE
fix busy state timer for allow_fast_chug=true + pk/pkl + MimeEat/MimeDrink

### DIFF
--- a/Source/ACE.Server/Entity/FoodState.cs
+++ b/Source/ACE.Server/Entity/FoodState.cs
@@ -32,11 +32,6 @@ namespace ACE.Server.Entity
         public Action Callback { get; set; }
 
         /// <summary>
-        /// Passing this along for some weird gem animations
-        /// </summary>
-        public float AnimMod { get; set; }
-
-        /// <summary>
         /// Similar requirements as previous var
         /// </summary>
         public float UseAnimTime { get; set; }
@@ -54,15 +49,13 @@ namespace ACE.Server.Entity
         /// <summary>
         /// Called when a player starts performing the motion to apply a consumable
         /// </summary>
-        public void StartChugging(MotionCommand useMotion, Action callback, float animMod, float useAnimTime, MotionStance prevStance)
+        public void StartChugging(MotionCommand useMotion, Action callback, float useAnimTime, MotionStance prevStance)
         {
             IsChugging = true;
 
             UseMotion = useMotion;
 
             Callback = callback;
-
-            AnimMod = animMod;
 
             UseAnimTime = useAnimTime;
 
@@ -79,8 +72,6 @@ namespace ACE.Server.Entity
             UseMotion = MotionCommand.Invalid;
 
             Callback = null;
-
-            AnimMod = 1.0f;
 
             UseAnimTime = 0.0f;
 

--- a/Source/ACE.Server/WorldObjects/Player_Use.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Use.cs
@@ -237,7 +237,7 @@ namespace ACE.Server.WorldObjects
         {
             if (PropertyManager.GetBool("allow_fast_chug").Item && FastTick)
             {
-                ApplyConsumableWithAnimationCallbacks(useMotion, action, animMod);
+                ApplyConsumableWithAnimationCallbacks(useMotion, action);
                 return;
             }
             IsBusy = true;
@@ -283,7 +283,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public FoodState FoodState { get; set; }
 
-        public void ApplyConsumableWithAnimationCallbacks(MotionCommand useMotion, Action action, float animMod = 1.0f)
+        public void ApplyConsumableWithAnimationCallbacks(MotionCommand useMotion, Action action)
         {
             IsBusy = true;
 
@@ -298,12 +298,12 @@ namespace ACE.Server.WorldObjects
                 animTime = EnqueueMotion_Force(actionChain, MotionStance.NonCombat, MotionCommand.Ready, (MotionCommand)prevStance);
 
             // start the eat/drink motion
-            var useAnimTime = EnqueueMotion_Force(actionChain, MotionStance.NonCombat, useMotion, null, 1.0f, animMod);
+            var useAnimTime = EnqueueMotion_Force(actionChain, MotionStance.NonCombat, useMotion);
 
             animTime += useAnimTime;
 
             // the rest is based on animation callback now
-            FoodState.StartChugging(useMotion, action, animMod, useAnimTime, prevStance);
+            FoodState.StartChugging(useMotion, action, useAnimTime, prevStance);
 
             actionChain.EnqueueChain();
 
@@ -321,7 +321,6 @@ namespace ACE.Server.WorldObjects
                 return;
 
             // restore state vars
-            var animMod = FoodState.AnimMod;
             var animTime = 0.0f;
             var actionChain = new ActionChain();
             var useMotion = FoodState.UseMotion;
@@ -338,13 +337,7 @@ namespace ACE.Server.WorldObjects
 
                 FoodState.UseMotion = MotionCommand.Ready;
 
-                if (animMod == 1.0f)
-                {
-                    // return to ready stance
-                    animTime += EnqueueMotion_Force(actionChain, MotionStance.NonCombat, MotionCommand.Ready, useMotion);
-                }
-                else
-                    actionChain.AddDelaySeconds(useAnimTime * (1.0f - animMod));
+                animTime += EnqueueMotion_Force(actionChain, MotionStance.NonCombat, MotionCommand.Ready, useMotion);
             }
             else
             {


### PR DESCRIPTION
animMod is not viable for fast chugging

I'm starting to wonder if retail had this same issue with MimeEat/MimeDrink as well, where the effect didn't proc until the player had returned to Ready state

This is only an issue with Gems that have a PropertyDataId.UseUserAnimation set to MimeEat/MimeDrink. Oddly enough, most of these gems are food-type items in-game. Actual food weenies don't even appear to use this field, or have an animation defined in the data at all for that matter -- ACE is currently just determining Eat/Drink animation based on the Sound of consuming the food, which is defined in the data.

```
SELECT class_Id, class_Name, HEX(did.value) AS motionCommand FROM weenie
INNER JOIN weenie_properties_d_i_d did ON did.object_Id=weenie.class_Id AND did.`type`=27
WHERE weenie.`type`=18 /* Food */ OR weenie.`type`=38 /* Gem */
ORDER BY weenie.`type`;

class_Id, class_Name, motionCommand
5670, appletempting, MimeEat
5671, milkcold, MimeEat
5672, teaherbal, MimeEat
5802, flamingkimchi, MimeEat
7556, potiondispel1, MimeEat
7557, potiondispel2, MimeEat
7558, potiondispel3, MimeEat
7559, potiondispel4, MimeEat
8997, wateradja, MimeEat
10959, cheesepepperjack-xp, MimeEat
11127, cakecarrotolthoi-xp, MimeEat
11128, cakechocolateolthoi-xp, MimeEat
11129, cakehealingchocolateolthoi-xp, MimeEat
11130, cakeheartycarrotolthoi-xp, MimeEat
11131, cakeheartychocolateolthoi-xp, MimeEat
11132, cakeheartyolthoi-xp, MimeEat
11133, cakemanachocolateolthoi-xp, MimeEat
11134, cakeolthoi-xp, MimeEat
11135, eggolthoifriedvesayen-xp, MimeEat
11136, eggolthoifried-xp, MimeEat
11137, eggolthoihardboiled-xp, MimeEat
11139, eggolthoipickled-xp, MimeEat
11142, piepumpkinolthoi-xp, MimeEat
11143, toastolthoi-xp, MimeEat
25781, snowpie, MimeEat
27258, gemplatinumspirits, MimeEat
27260, gempudding, MimeEat
27261, waterrefreshingicy, MimeEat
28452, alelugian, MimeEat
28453, breadlugian, MimeEat
28454, stewlugian, MimeEat
30798, teablackmarrow, MimeEat
36189, ace36189-harbingerbloodinfusion, MimeEat
48707, ace48707-mugofwarmcider, MimeEat
49563, ace49563-facilityhubportalgem, Sanctuary
```