### PR TITLE
restrict GetNonComponentTargetTypes to items that are selectable in 3d world

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -2272,7 +2272,7 @@ namespace ACE.Server.WorldObjects
                 case ItemType.WeaponOrCaster:           // lure blade, defender cantrip, hermetic link cantrip, mukkir sense
                 case ItemType.Item:                     // essence lull
 
-                    return target.EquippedObjects.Values.Where(i => (i.ItemType & spell.NonComponentTargetType) != 0 && (i.ValidLocations & EquipMask.Selectable) != 0).ToList();
+                    return target.EquippedObjects.Values.Where(i => (i.ItemType & spell.NonComponentTargetType) != 0 && (i.ValidLocations & EquipMask.Selectable) != 0 && i.IsEnchantable).ToList();
             }
             return null;
         }


### PR DESCRIPTION
mukkir strength should not be casting on arrows in ammo slot