### PR TITLE
Update starterGear.json to include missing weenieIDs of some training weapons

### DIFF
--- a/Source/ACE.Server/starterGear.json
+++ b/Source/ACE.Server/starterGear.json
@@ -666,6 +666,7 @@
                     "name": "Tumerok",
                     "gear": [
                         {
+                            "weenieId": "12745",
                             "name": "Training Trident",
                             "stacksize": "1"
                         }
@@ -737,6 +738,7 @@
                     "name": "Gharu'ndim",
                     "gear": [
                         {
+                            "weenieId":  "45550",
                             "name": "Training Staff",
                             "stacksize": "1"
                         }
@@ -780,6 +782,7 @@
                     "name": "Gear",
                     "gear": [
                         {
+                            "weenieID": "45542",
                             "name": "Training Club",
                             "stacksize": "1"
                         }
@@ -790,6 +793,7 @@
                     "name": "Tumerok",
                     "gear": [
                         {
+                            "weenieID": "45546",
                             "name": "Training Spear",
                             "stacksize": "1"
                         }


### PR DESCRIPTION
Noticed that Gharu light weapon toons started without Training Staff. Looking into it, there were also a few missing Tumerok weapons as well. Added.