### PR TITLE
Change LevelProportionalXP to share with Allegiance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -125,12 +125,11 @@ namespace ACE.Server.WorldObjects.Managers
 
                 case EmoteType.AwardLevelProportionalXP:
 
-                    bool shareXP = emote.Display ?? false;
                     min = emote.Min64 ?? emote.Min ?? 0;
                     max = emote.Max64 ?? emote.Max ?? 0;
 
                     if (player != null)
-                        player.GrantLevelProportionalXp(emote.Percent ?? 0, min, max, shareXP);
+                        player.GrantLevelProportionalXp(emote.Percent ?? 0, min, max);
                     break;
 
                 case EmoteType.AwardLuminance:

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -435,7 +435,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Raise the available XP by a percentage of the current level XP or a maximum
         /// </summary>
-        public void GrantLevelProportionalXp(double percent, long min, long max, bool shareable = false)
+        public void GrantLevelProportionalXp(double percent, long min, long max)
         {
             var nextLevelXP = GetXPBetweenLevels(Level.Value, Level.Value + 1);
 
@@ -447,10 +447,8 @@ namespace ACE.Server.WorldObjects
             if (min > 0)
                 scaledXP = Math.Max(scaledXP, min);
 
-            var shareType = shareable ? ShareType.All : ShareType.None;
-
             // apply xp modifiers?
-            EarnXP(scaledXP, XpType.Quest, shareType);
+            EarnXP(scaledXP, XpType.Quest, ShareType.Allegiance);
         }
 
         /// <summary>


### PR DESCRIPTION
Changes GrantLevelProportionalXp to share with allegiance instead of none. Following a discussion (acemu_bugs, 2021-10-27-22:30-EST), Display is considered garbage code and was just removed, making the shareable parameter extraneous. 

PCAP reasoning for change: 
I'm thinking GrantLevelProportionalXp should be defaulting to ShareType.Allegiance instead of ShareType.None. PCAP miscpcaps3\pkt_2017-1-31_1485843405_log.pcap shows Experience Certificate turn-ins being passed up (patron POV with vassals in sight) starting around packet number 174800 and Diemos tokens being passed up starting around packet 180000 (a few were also turned in off-screen immediately following the certificates). It also shows XP not being shared in fellow (patron and vassals are in a fellow with each other), most clearly when the patron gets full XP from his turn-in at the end. Additionally PCAP Mavness-02-01-2017-pcap\pcap\pkt_2017-1-23_1485229231_log.pcap shows tusker tusk xp being passed up on the allegiance tab, so it appears that it's not a unique situation with those items.

