### PR TITLE
Add default ActivationResponse to Portals

### DIFF
--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -39,6 +39,8 @@ namespace ACE.Server.WorldObjects
         {
             ObjectDescriptionFlags |= ObjectDescriptionFlag.Portal;
 
+            ActivationResponse |= ActivationResponse.Use;
+
             UpdatePortalDestination(Destination);
         }
 


### PR DESCRIPTION
This appears to have been a default, similar to Doors, Chests.