### PR TITLE
Wire up vloc2loc command

### DIFF
--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -254,26 +254,40 @@ namespace ACE.Entity
             RotationZ = payload.ReadSingle();
         }
 
-        public Position(float northSouth, float eastWest)
+        public Position(float northSouth, float eastWest, bool vCoordCorrection = false)
         {
-            northSouth = (northSouth - 0.5f) * 10.0f;
-            eastWest = (eastWest - 0.5f) * 10.0f;
+            var mapCoords = new Vector2(eastWest, northSouth);
 
-            var baseX = (uint)(eastWest + 0x400);
-            var baseY = (uint)(northSouth + 0x400);
+            // convert from (-102, 102) to (0, 204)
+            mapCoords += Vector2.One * 102;
 
-            if (baseX >= 0x7F8 || baseY >= 0x7F8)
-                throw new Exception("Bad coordinates");  // TODO: Instead of throwing exception should we set to a default location?
+            // 204 = map clicks across dereth
+            // 2040 = number of cells across dereth
+            // 24 = meters per cell
+            //var globalPos = mapCoords / 204 * 2040 * 24;
+            var globalPos = mapCoords * 240;   // simplified
 
-            float xOffset = ((baseX & 7) * 24.0f) + 12;
-            float yOffset = ((baseY & 7) * 24.0f) + 12;
-            // float zOffset = GetZFromCellXY(LandblockId.Raw, xOffset, yOffset);
-            const float zOffset = 0.0f;
+            if (vCoordCorrection)
+                globalPos -= Vector2.One * 12.0f; // ?????
 
-            LandblockId = new LandblockId(GetCellFromBase(baseX, baseY));
-            PositionX = xOffset;
-            PositionY = yOffset;
-            PositionZ = zOffset;
+            // inlining, this logic is in PositionExtensions.FromGlobal()
+            var blockX = (int)globalPos.X / BlockLength;
+            var blockY = (int)globalPos.Y / BlockLength;
+
+            var originX = globalPos.X % BlockLength;
+            var originY = globalPos.Y % BlockLength;
+
+            var cellX = (int)originX / CellLength;
+            var cellY = (int)originY / CellLength;
+
+            var cell = cellX * CellSide + cellY + 1;
+
+            var objCellID = (uint)(blockX << 24 | blockY << 16 | cell);
+
+            LandblockId = new LandblockId(objCellID);
+
+            Pos = new Vector3(originX, originY, 0);     // must use PositionExtensions.AdjustMapCoords() to get Z
+
             Rotation = Quaternion.Identity;
         }
 

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -35,7 +35,6 @@ using ACE.Server.WorldObjects.Entity;
 
 using Position = ACE.Entity.Position;
 using Spell = ACE.Server.Entity.Spell;
-using System.IO;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -3336,69 +3335,6 @@ namespace ACE.Server.Command.Handlers
 
                 PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} changed their Faction state to {session.Player.Society.ToSentence()}{(session.Player.Society != FactionBits.None ? $" with a rank of {rankStr}" : "")}.");
             }
-        }
-
-        [CommandHandler("telev", AccessLevel.Developer, CommandHandlerFlag.None, "")]
-        public static void HandleTeleToVCoord(Session session, params string[] parameters)
-        {
-            // Name,ObjectClass,LandCell,X,Y
-            // Master MacTavish,37,-114359889,97.14075000286103,-63.93749958674113
-
-            var vlocs = File.ReadLines(@"c:\ace\vloc.txt").ToArray();
-
-            for (var i = 1; i < vlocs.Count(); i++)
-            {
-                //var split = string.Join(" ", parameters).Split(",");
-
-                var split = vlocs[i].Split(",");
-
-                var name = split[0].Trim();
-                var objectClass = split[1].Trim();
-                var strLandCell = split[2].Trim();
-                var strX = split[3].Trim();
-                var strY = split[4].Trim();
-
-                int.TryParse(strLandCell, out var landCell);
-                var objCellId = (uint)landCell;
-                float.TryParse(strX, out var x);
-                float.TryParse(strY, out var y);
-
-                //if ((objCellId >> 16) != 0x9EE5 && (objCellId >> 16) != 0xF92F) continue;
-
-                //if ((objCellId >> 16) != 0xF81E) continue;
-
-                //if ((objCellId >> 16) != 0x00AB && (objCellId >> 16) != 0x00AC) continue;
-
-                if ((objCellId >> 16) != 0x005F) continue;
-
-                try
-                {
-                    var pos = new Position(y, x, true);
-                    pos.AdjustMapCoords();
-                    pos.Translate(objCellId);
-                    pos.FindZ();
-
-                    using (StreamWriter sw = File.AppendText(@"c:\ace\vlocs.txt"))
-                    {
-                        //sw.WriteLine("This");
-                        //sw.WriteLine("is Extra");
-                        //sw.WriteLine("Text");
-                        sw.WriteLine($"{name} - @teleloc {pos.ToLOCString()}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    using (StreamWriter sw = File.AppendText(@"c:\ace\vlocs.txt"))
-                    {
-                        //sw.WriteLine("This");
-                        //sw.WriteLine("is Extra");
-                        //sw.WriteLine("Text");
-                        sw.WriteLine($"Unable to parse {name} - 0x{objCellId:X8} {strX}, {strY}");
-                    }
-                }
-            }
-
-            //session.Player.Teleport(pos);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -35,6 +35,7 @@ using ACE.Server.WorldObjects.Entity;
 
 using Position = ACE.Entity.Position;
 using Spell = ACE.Server.Entity.Spell;
+using System.IO;
 
 namespace ACE.Server.Command.Handlers
 {
@@ -3335,6 +3336,69 @@ namespace ACE.Server.Command.Handlers
 
                 PlayerManager.BroadcastToAuditChannel(session.Player, $"{session.Player.Name} changed their Faction state to {session.Player.Society.ToSentence()}{(session.Player.Society != FactionBits.None ? $" with a rank of {rankStr}" : "")}.");
             }
+        }
+
+        [CommandHandler("telev", AccessLevel.Developer, CommandHandlerFlag.None, "")]
+        public static void HandleTeleToVCoord(Session session, params string[] parameters)
+        {
+            // Name,ObjectClass,LandCell,X,Y
+            // Master MacTavish,37,-114359889,97.14075000286103,-63.93749958674113
+
+            var vlocs = File.ReadLines(@"c:\ace\vloc.txt").ToArray();
+
+            for (var i = 1; i < vlocs.Count(); i++)
+            {
+                //var split = string.Join(" ", parameters).Split(",");
+
+                var split = vlocs[i].Split(",");
+
+                var name = split[0].Trim();
+                var objectClass = split[1].Trim();
+                var strLandCell = split[2].Trim();
+                var strX = split[3].Trim();
+                var strY = split[4].Trim();
+
+                int.TryParse(strLandCell, out var landCell);
+                var objCellId = (uint)landCell;
+                float.TryParse(strX, out var x);
+                float.TryParse(strY, out var y);
+
+                //if ((objCellId >> 16) != 0x9EE5 && (objCellId >> 16) != 0xF92F) continue;
+
+                //if ((objCellId >> 16) != 0xF81E) continue;
+
+                //if ((objCellId >> 16) != 0x00AB && (objCellId >> 16) != 0x00AC) continue;
+
+                if ((objCellId >> 16) != 0x005F) continue;
+
+                try
+                {
+                    var pos = new Position(y, x, true);
+                    pos.AdjustMapCoords();
+                    pos.Translate(objCellId);
+                    pos.FindZ();
+
+                    using (StreamWriter sw = File.AppendText(@"c:\ace\vlocs.txt"))
+                    {
+                        //sw.WriteLine("This");
+                        //sw.WriteLine("is Extra");
+                        //sw.WriteLine("Text");
+                        sw.WriteLine($"{name} - @teleloc {pos.ToLOCString()}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    using (StreamWriter sw = File.AppendText(@"c:\ace\vlocs.txt"))
+                    {
+                        //sw.WriteLine("This");
+                        //sw.WriteLine("is Extra");
+                        //sw.WriteLine("Text");
+                        sw.WriteLine($"Unable to parse {name} - 0x{objCellId:X8} {strX}, {strY}");
+                    }
+                }
+            }
+
+            //session.Player.Teleport(pos);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2787,6 +2787,7 @@ namespace ACE.Server.Command.Handlers.Processors
                     }
                 }
 
+                vi = new FileInfo(vlocFile);
                 if (vi.Exists)
                     CommandHandlerHelper.WriteOutputInfo(session, $"Successfully wrote VLOCs for 0x{lbid:X4} to {vlocFile}");
                 else

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -2689,5 +2689,113 @@ namespace ACE.Server.Command.Handlers.Processors
 
             CommandHandlerHelper.WriteOutputInfo(session, $"Wrote {path}");
         }
+
+        [CommandHandler("vloc2loc", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Output a set of LOCs for a given landblock found in the VLOCS dataset", "<LandblockID>\nExample: @vloc2loc 0x0007\n         @vloc2loc 0xCE95")]
+        public static void HandleVLOCtoLOC(Session session, params string[] parameters)
+        {
+            var hex = parameters[0];
+
+            if (hex.StartsWith("0x", StringComparison.CurrentCultureIgnoreCase)
+             || hex.StartsWith("&H", StringComparison.CurrentCultureIgnoreCase))
+            {
+                hex = hex[2..];
+            }
+
+            if (uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out var lbid))
+            {
+                DirectoryInfo di = VerifyContentFolder(session);
+                if (!di.Exists) return;
+
+                var sep = Path.DirectorySeparatorChar;
+
+                var vloc_folder = $"{di.FullName}{sep}vlocs{sep}";
+
+                di = new DirectoryInfo(vloc_folder);
+
+                var vlocDB = vloc_folder + "vlocDB.txt";
+
+                var vlocs = di.Exists ? new FileInfo(vlocDB).Exists ? File.ReadLines(vlocDB).ToArray() : null : null;
+
+                if (vlocs == null)
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Unable to read VLOC database file located here: {vlocDB}");
+                    return;
+                }
+
+                // Name,ObjectClass,LandCell,X,Y
+                // Master MacTavish,37,-114359889,97.14075000286103,-63.93749958674113
+
+                if (vlocs.Length == 0 || !vlocs[0].Equals("Name,ObjectClass,LandCell,X,Y"))
+                {
+                    CommandHandlerHelper.WriteOutputInfo(session, $"{vlocDB} does not appear to be a valid VLOC database file.");
+                    return;
+                }
+
+                var vlocFile = vloc_folder + $"{lbid:X4}.txt";
+
+                var vi = new FileInfo(vlocFile);
+                if (vi.Exists)
+                    vi.Delete();
+
+                for (var i = 1; i < vlocs.Length; i++)
+                {
+                    var split = vlocs[i].Split(",");
+
+                    var name = split[0].Trim();
+                    var objectClass = split[1].Trim();
+                    var strLandCell = split[2].Trim();
+                    var strX = split[3].Trim();
+                    var strY = split[4].Trim();
+
+                    if (!int.TryParse(strLandCell, out var landCell))
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Unable to parse LandCell ({strLandCell}) value from line {i} in vlocDB: {vlocs[i]}");
+                        continue;
+                    }
+                    var objCellId = (uint)landCell;
+                    if (!float.TryParse(strX, out var x))
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Unable to parse X ({strX}) value from line {i} in vlocDB: {vlocs[i]}");
+                        continue;
+                    }    
+                    if (!float.TryParse(strY, out var y))
+                    {
+                        CommandHandlerHelper.WriteOutputInfo(session, $"Unable to parse Y ({strY}) value from line {i} in vlocDB: {vlocs[i]}");
+                        continue;
+                    }    
+
+                    if ((objCellId >> 16) != lbid) continue;
+
+                    try
+                    {
+                        var pos = new Position(new Vector2(x, y));
+                        pos.AdjustMapCoords();
+                        pos.Translate(objCellId);
+                        pos.FindZ();
+
+                        using (StreamWriter sw = File.AppendText(vlocFile))
+                        {
+                            sw.WriteLine($"{name} - @teleloc {pos.ToLOCString()}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        using (StreamWriter sw = File.AppendText(vlocFile))
+                        {
+                            sw.WriteLine($"Unable to parse {name} - 0x{objCellId:X8} {strX}, {strY}");
+                        }
+                    }
+                }
+
+                if (vi.Exists)
+                    CommandHandlerHelper.WriteOutputInfo(session, $"Successfully wrote VLOCs for 0x{lbid:X4} to {vlocFile}");
+                else
+                    CommandHandlerHelper.WriteOutputInfo(session, $"No VLOCs able to be written for 0x{lbid:X4}");
+            }
+            else
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Invalid Landblock ID: {parameters[0]}\nLandblock ID should be in the hex format such as this: @vloc2loc 0xAB94");
+            }
+        }
     }
 }

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -11,6 +11,7 @@ using ACE.Server.Physics.Util;
 using ACE.Server.WorldObjects;
 
 using Position = ACE.Entity.Position;
+using ACE.DatLoader;
 
 namespace ACE.Server.Entity
 {
@@ -230,6 +231,10 @@ namespace ACE.Server.Entity
             // adjust Z to terrain height
             pos.PositionZ = pos.GetTerrainZ();
 
+            //pos.PositionZ = 118.805008f;
+            //pos.PositionZ = 94.805008f;
+            //pos.PositionZ = 76.805008f;
+
             // adjust to building height, if applicable
             var sortCell = LScape.get_landcell(pos.Cell) as SortCell;
             if (sortCell != null && sortCell.has_building())
@@ -243,6 +248,33 @@ namespace ACE.Server.Entity
 
                 pos.LandblockId = new LandblockId(pos.GetCell());
             }
+        }
+
+        public static void Translate(this Position pos, uint blockCell)
+        {
+            var newBlockX = blockCell >> 24;
+            var newBlockY = (blockCell >> 16) & 0xFF;
+
+            var xDiff = (int)newBlockX - pos.LandblockX;
+            var yDiff = (int)newBlockY - pos.LandblockY;
+
+            //pos.Origin.X -= xDiff * 192;
+            pos.PositionX -= xDiff * 192;
+            //pos.Origin.Y -= yDiff * 192;
+            pos.PositionY -= yDiff * 192;
+
+            //pos.ObjCellID = blockCell;
+            pos.LandblockId = new LandblockId(blockCell);
+        }
+
+        public static void FindZ(this Position pos)
+        {
+            //Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            //DatManager.Initialize(@"j:\ac");
+            //var envCell = DatManager.CellDat.ReadFromDat<EnvCell>(pos.ObjCellID);
+            var envCell = DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.EnvCell>(pos.Cell);
+            //pos.Origin.Z = envCell.Position.Origin.Z;
+            pos.PositionZ = envCell.Position.Origin.Z;
         }
 
         public static float GetTerrainZ(this Position p)

--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 
 using log4net;
 
+using ACE.DatLoader;
 using ACE.Entity;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Physics.Common;
@@ -11,7 +12,6 @@ using ACE.Server.Physics.Util;
 using ACE.Server.WorldObjects;
 
 using Position = ACE.Entity.Position;
-using ACE.DatLoader;
 
 namespace ACE.Server.Entity
 {
@@ -231,10 +231,6 @@ namespace ACE.Server.Entity
             // adjust Z to terrain height
             pos.PositionZ = pos.GetTerrainZ();
 
-            //pos.PositionZ = 118.805008f;
-            //pos.PositionZ = 94.805008f;
-            //pos.PositionZ = 76.805008f;
-
             // adjust to building height, if applicable
             var sortCell = LScape.get_landcell(pos.Cell) as SortCell;
             if (sortCell != null && sortCell.has_building())
@@ -269,11 +265,7 @@ namespace ACE.Server.Entity
 
         public static void FindZ(this Position pos)
         {
-            //Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            //DatManager.Initialize(@"j:\ac");
-            //var envCell = DatManager.CellDat.ReadFromDat<EnvCell>(pos.ObjCellID);
             var envCell = DatManager.CellDat.ReadFromDat<DatLoader.FileTypes.EnvCell>(pos.Cell);
-            //pos.Origin.Z = envCell.Position.Origin.Z;
             pos.PositionZ = envCell.Position.Origin.Z;
         }
 

--- a/Source/ACE.Server/Physics/Common/BuildingObj.cs
+++ b/Source/ACE.Server/Physics/Common/BuildingObj.cs
@@ -135,6 +135,8 @@ namespace ACE.Server.Physics.Common
 
             foreach (var buildingCell in BuildingCells.Where(i => i.Environment != null))
             {
+                if (buildingCell.Environment == null) continue;
+
                 foreach (var cellStruct in buildingCell.Environment.Cells.Values)
                 {
                     foreach (var vertex in cellStruct.VertexArray.Vertices.Values)


### PR DESCRIPTION
Allows the conversion of VI Coord database objects to AC/ACE compatible LOCs for content recreation.

Requires [vlocDB.txt](https://github.com/ACEmulator/ACE/files/7574049/vlocDB.txt) to be placed in Content folder under vlocs directory for use.

Examples:
> `/vloc2loc 0xCE95`
> `/vloc2loc 0x0007`
> `/vloc2loc 0x00AF`
> `/vloc2loc 0xF92F`
