### PR TITLE
Fix IsCreatureNameInWorldDatabase

### DIFF
--- a/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
+++ b/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
@@ -265,7 +265,7 @@ namespace ACE.Database
         {
             var query = from weenieRecord in context.Weenie
                         join stringProperty in context.WeeniePropertiesString on weenieRecord.ClassId equals stringProperty.ObjectId
-                        where weenieRecord.Type == (int)WeenieType.Creature && stringProperty.Type == (ushort)PropertyString.Name && stringProperty.Value.Equals(name, StringComparison.InvariantCultureIgnoreCase)
+                        where weenieRecord.Type == (int)WeenieType.Creature && stringProperty.Type == (ushort)PropertyString.Name && stringProperty.Value == name
                         select weenieRecord;
 
             var weenie = query


### PR DESCRIPTION
We use a case incensitive collation, utf8_general_ci, so we do not need to specify StringComparison when querying the database.

Previously, this LINQ expression was done client side in the older EF versions.