### PR TITLE
Fix magic absorption for Tomes/Fetish

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -670,7 +670,7 @@ namespace ACE.Server.WorldObjects
             // using an equivalent formula that produces the correct results for 10% and 25%,
             // and also produces the correct results for any %
 
-            var absorbMagicDamage = GetAbsorbMagicDamage();
+            var absorbMagicDamage = item.GetAbsorbMagicDamage();
 
             if (absorbMagicDamage == null)
                 return 1.0f;


### PR DESCRIPTION
It appears that the `item.` reference was removed, so when the magic absorption calculation for a hit is being determined, it is fetching this property from the inbound projectile that is having the `AbsorbMagic` method invoked.

The code in a previous version of ACE where this was working checked against `item.MagicAbsorbDamage` and that works with the Fetish and Tomes.