### PR TITLE
ServerPerformance allow toggle cumulative

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminStatCommands.cs
@@ -132,20 +132,38 @@ namespace ACE.Server.Command.Handlers
         [CommandHandler("serverperformance", AccessLevel.Advocate, CommandHandlerFlag.None, 0, "Displays a summary of server performance statistics")]
         public static void HandleServerPerformance(Session session, params string[] parameters)
         {
-            if (parameters != null && parameters.Length == 1)
+            if (parameters != null && (parameters.Length == 1 || parameters.Length == 2))
             {
                 if (parameters[0].ToLower() == "start")
                 {
-                    ServerPerformanceMonitor.Start();
-                    CommandHandlerHelper.WriteOutputInfo(session, "Server Performance Monitor started");
-                    return;
+                    if (parameters[1].ToLower() == "cumulative")
+                    {
+                        ServerPerformanceMonitor.StartCumulative();
+                        CommandHandlerHelper.WriteOutputInfo(session, "Cumulative Server Performance Monitor started");
+                        return;
+                    }
+                    else
+                    {
+                        ServerPerformanceMonitor.Start();
+                        CommandHandlerHelper.WriteOutputInfo(session, "Server Performance Monitor started");
+                        return;
+                    }
                 }
 
                 if (parameters[0].ToLower() == "stop")
                 {
-                    ServerPerformanceMonitor.Stop();
-                    CommandHandlerHelper.WriteOutputInfo(session, "Server Performance Monitor stopped");
-                    return;
+                    if (parameters[1].ToLower() == "cumulative")
+                    {
+                        ServerPerformanceMonitor.StopCumulative();
+                        CommandHandlerHelper.WriteOutputInfo(session, "Cumulative Server Performance Monitor stopped");
+                        return;
+                    }
+                    else
+                    {
+                        ServerPerformanceMonitor.Stop();
+                        CommandHandlerHelper.WriteOutputInfo(session, "Server Performance Monitor stopped");
+                        return;
+                    }
                 }
 
                 if (parameters[0].ToLower() == "reset")

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -46,7 +46,7 @@ namespace ACE.Server.Network.Managers
         {
             if (connectionListener.ListenerEndpoint.Port == ConfigManager.Config.Server.Network.Port + 1)
             {
-                ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
+                //ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
                 if (packet.Header.Flags.HasFlag(PacketHeaderFlags.ConnectResponse))
                 {
                     packetLog.Debug($"{packet}, {endPoint}");
@@ -87,11 +87,11 @@ namespace ACE.Server.Network.Managers
                 {
                     log.ErrorFormat("Packet from {0} rejected. Packet sent to listener 1 and is not a ConnectResponse or CICMDCommand", endPoint);
                 }
-                ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
+                //ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
             }
             else // ConfigManager.Config.Server.Network.Port + 0
             {
-                ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
+                //ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
                 if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
                 {
                     packetLog.Debug($"{packet}, {endPoint}");
@@ -162,7 +162,7 @@ namespace ACE.Server.Network.Managers
                 {
                     log.DebugFormat("Unsolicited Packet from {0} with Id {1}", endPoint, packet.Header.Id);
                 }
-                ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
+                //ServerPerformanceMonitor.RegisterEventEnd(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
             }
         }
 


### PR DESCRIPTION
cumulative monitoring can potentially add a bit of server overhead

/serverperformance stop cumulative
/serverperformance start cumulative

ProcessPacket monitoring now also commented out.