### PR TITLE
fix EmoteType.CreateTreasure mutation when TreasureItemType.Caster is specified directly

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -985,6 +985,7 @@ namespace ACE.Server.Factories
 
                 case TreasureItemType_Orig.Caster:
 
+                    treasureRoll.WeaponType = TreasureWeaponType.Caster;
                     treasureRoll.Wcid = CasterWcids.Roll(treasureDeath.Tier);
                     break;
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1135,11 +1135,6 @@ namespace ACE.Server.Factories
                             MutateMeleeWeapon(wo, treasureDeath, isMagical, treasureRoll);
                             break;
 
-                        case TreasureWeaponType.Caster:
-
-                            MutateCaster(wo, treasureDeath, isMagical, null, treasureRoll);
-                            break;
-
                         case TreasureWeaponType.Bow:
                         case TreasureWeaponType.Crossbow:
                         case TreasureWeaponType.Atlatl:
@@ -1151,6 +1146,11 @@ namespace ACE.Server.Factories
                             log.Error($"CreateAndMutateWcid({treasureDeath.TreasureType}, {(int)treasureRoll.Wcid} - {treasureRoll.Wcid}, {treasureRoll.GetItemType()}, {isMagical}) - unknown weapon type");
                             break;
                     }
+                    break;
+
+                case TreasureItemType_Orig.Caster:
+
+                    MutateCaster(wo, treasureDeath, isMagical, null, treasureRoll);
                     break;
 
                 case TreasureItemType_Orig.Armor:

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -985,6 +985,7 @@ namespace ACE.Server.Factories
 
                 case TreasureItemType_Orig.Caster:
 
+                    // only called if TreasureItemType.Caster was specified directly
                     treasureRoll.WeaponType = TreasureWeaponType.Caster;
                     treasureRoll.Wcid = CasterWcids.Roll(treasureDeath.Tier);
                     break;
@@ -1136,6 +1137,11 @@ namespace ACE.Server.Factories
                             MutateMeleeWeapon(wo, treasureDeath, isMagical, treasureRoll);
                             break;
 
+                        case TreasureWeaponType.Caster:
+
+                            MutateCaster(wo, treasureDeath, isMagical, null, treasureRoll);
+                            break;
+
                         case TreasureWeaponType.Bow:
                         case TreasureWeaponType.Crossbow:
                         case TreasureWeaponType.Atlatl:
@@ -1151,6 +1157,7 @@ namespace ACE.Server.Factories
 
                 case TreasureItemType_Orig.Caster:
 
+                    // alternate path -- only called if TreasureItemType.Caster was specified directly
                     MutateCaster(wo, treasureDeath, isMagical, null, treasureRoll);
                     break;
 


### PR DESCRIPTION
repro steps:

- in "ciloot" developer command, add ``, TreasureItemType_Orig.Caster`` param to CreateRandomLootObjects_New call for testing
- /ciloot 8 3

expected:

3 casters are generated, same as loot system

actual:

3 unmutated casters are generated

cause:

when TreasureItemType.Caster is specified directly (which only EmoteType.CreateTreasure can do), a slightly different path is taken from regular lootgen. In regular lootgen, only TreasureItemType.Weapon can be rolled for initially, which then rolls for a WeaponType, which can end up as caster

if TreasureItemType.Caster is specified directly, that branch needs to manually specify TreasureWeaponType.Caster, and a missing branch for it needed to be added in mutation

Thanks to Ftuoil Xelrash for reporting this issue!

Also thanks to Ripley for pointing out that regular lootgen uses a slight variation of this path, and both branches are required