### PR TITLE
fix /lootgen dev command spell selection for head and foot armor

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -359,6 +359,7 @@ namespace ACE.Server.Factories
             var roll = new TreasureRoll();
 
             roll.Wcid = (WeenieClassName)item.WeenieClassId;
+            roll.BaseArmorLevel = item.ArmorLevel ?? 0;
 
             if (roll.Wcid == WeenieClassName.coinstack)
             {


### PR DESCRIPTION
Fixes a small bug with /lootgen dev command only, for specific pieces of armor

todo: look into deprecating GetSpellSelectionCode_Dynamic and using the actual SpellCodes from PropertyInt.TSysMutationData. I believe I verified / updated all of the TSysMutationData spell codes at some point a long time ago, although I haven't tested it recently for newer items

todo: if BaseArmorLevel concept is still needed, look into just getting it from base Weenie when it's needed, instead of caching the value beforehand