### PR TITLE
refactor wielded treasure, fixing some bugs

### DIFF
--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -242,7 +242,8 @@ namespace ACE.Server.Entity
             if (RegenLocationType.HasFlag(RegenLocationType.Treasure))
             {
                 objects = TreasureGenerator();
-                if (objects.Count > 0)
+
+                if (objects != null && objects.Count > 0)
                 {
                     Generator.GeneratedTreasureItem = true;
                     GeneratedTreasureItem = true;
@@ -474,13 +475,13 @@ namespace ACE.Server.Entity
                     //log.Debug($"{_generator.Name}.TreasureGenerator(): found wielded treasure {Biota.WeenieClassId}");
 
                     // roll into the wielded treasure table
-                    var table = new TreasureWieldedTable(wieldedTreasure);
-                    return Generator.GenerateWieldedTreasureSets(table);
+                    //var table = new TreasureWieldedTable(wieldedTreasure);
+                    return WorldObject.GenerateWieldedTreasureSets(wieldedTreasure);
                 }
                 else
                 {
                     log.Debug($"{Generator.Name}.TreasureGenerator(): couldn't find death treasure or wielded treasure for ID {Biota.WeenieClassId}");
-                    return new List<WorldObject>();
+                    return null;
                 }
             }
         }

--- a/Source/ACE.Server/Entity/TreasureWieldedSet.cs
+++ b/Source/ACE.Server/Entity/TreasureWieldedSet.cs
@@ -132,7 +132,7 @@ namespace ACE.Server.Entity
                         if (item.ContinuesPreviousSet)
                         {
                             // ensure subset parsed
-                            if (node.Subset != null)
+                            if (node.Subset != null)    // why is this here? causing bugs with 178..
                             {
                                 node = new TreasureWieldedNode(items, idx);
                                 Items.Add(node);

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -738,9 +738,12 @@ namespace ACE.Server.WorldObjects
         {
             if (WieldedTreasure == null) return;
 
-            var table = new TreasureWieldedTable(WieldedTreasure);
+            //var table = new TreasureWieldedTable(WieldedTreasure);
 
-            var wieldedTreasure = GenerateWieldedTreasureSets(table);
+            var wieldedTreasure = GenerateWieldedTreasureSets(WieldedTreasure);
+
+            if (wieldedTreasure == null)
+                return;
 
             foreach (var item in wieldedTreasure)
             {


### PR DESCRIPTION
Wielded Treasure table 178 (ex. wcid 8105 for Shadow Cyst) should have a ~19.7% chance of not wielding any items

TreasureWieldedSet was previously producing some unexpected results. This class made more sense for the original way ACE was handling > 100% overages, however it makes less sense now. There are some inter-dependencies between the 3 bools (SetStart/HasSubSet/ContinuesPreviousSet) that should be independent.

GenerateWieldedTreasureSets() is now 1 simple function that better aligns with the current requirements of the system. It should be a bit more performant and produce less memory churn as well.
