### PR TITLE
sync dirty fighting attack/defense skills to client

### DIFF
--- a/Source/ACE.Entity/Enum/Skill.cs
+++ b/Source/ACE.Entity/Enum/Skill.cs
@@ -167,16 +167,17 @@ namespace ACE.Entity.Enum
             Skill.LifeMagic,
             Skill.VoidMagic,
             Skill.DualWield,
-            Skill.Recklessness,
-            Skill.DirtyFighting,
-            Skill.SneakAttack
+            //Skill.Recklessness,   // confirmed not in client
+            //Skill.DirtyFighting,
+            //Skill.SneakAttack
         };
 
         public static HashSet<Skill> DefenseSkills = new HashSet<Skill>()
         {
             Skill.MeleeDefense,
             Skill.MissileDefense,
-            Skill.MagicDefense
+            Skill.MagicDefense,
+            Skill.Shield            // confirmed in client
         };
     }
 }


### PR DESCRIPTION
Repro steps:

- /dispel
- open skill panel
- appraise self
- /castspell 5942
- observe red skills determined by client
- compare values with /showstats
- repeat with 5944

According to the client, Recklessness/DF/sneak are not considered attack skills that get affected by the DF high enchantments

Also according to the client, Shield is considered a defense skill that gets affected by the DF low enchantments

Thanks to Curryfury for reporting this issue!

