### PR TITLE
fix monster homesick radius when they start indoors and end up transitioning to outdoor chase

### DIFF
--- a/Source/ACE.Server/Entity/PositionExtensions.cs
+++ b/Source/ACE.Server/Entity/PositionExtensions.cs
@@ -19,7 +19,7 @@ namespace ACE.Server.Entity
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public static Vector3 ToGlobal(this Position p, bool skipIndoors = true)
+        public static Vector3 ToGlobal(this Position p, bool skipIndoors = false)
         {
             // TODO: Is this necessary? It seemed to be loading rogue physics landblocks. Commented out 2019-04 Mag-nus
             //var landblock = LScape.get_landblock(p.LandblockId.Raw);

--- a/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Navigation.cs
@@ -163,10 +163,12 @@ namespace ACE.Server.WorldObjects
                 if (target == null || target.Location == null)
                     return;
 
-                var matchIndoors = Location.Indoors == target.Location.Indoors;
+                //var matchIndoors = Location.Indoors == target.Location.Indoors;
 
-                var globalLoc = matchIndoors ? Location.ToGlobal() : Location.Pos;
-                var targetLoc = matchIndoors ? target.Location.ToGlobal() : target.Location.Pos;
+                //var globalLoc = matchIndoors ? Location.ToGlobal() : Location.Pos;
+                //var targetLoc = matchIndoors ? target.Location.ToGlobal() : target.Location.Pos;
+                var globalLoc = Location.ToGlobal();
+                var targetLoc = target.Location.ToGlobal();
 
                 var targetDir = GetDirection(globalLoc, targetLoc);
 

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -451,10 +451,12 @@ namespace ACE.Server.WorldObjects
                 return;
 
             var homePosition = GetPosition(PositionType.Home);
-            var matchIndoors = Location.Indoors == homePosition.Indoors;
+            //var matchIndoors = Location.Indoors == homePosition.Indoors;
 
-            var globalPos = matchIndoors ? Location.ToGlobal() : Location.Pos;
-            var globalHomePos = matchIndoors ? homePosition.ToGlobal() : homePosition.Pos;
+            //var globalPos = matchIndoors ? Location.ToGlobal() : Location.Pos;
+            //var globalHomePos = matchIndoors ? homePosition.ToGlobal() : homePosition.Pos;
+            var globalPos = Location.ToGlobal();
+            var globalHomePos = homePosition.ToGlobal();
 
             var homeDistSq = Vector3.DistanceSquared(globalHomePos, globalPos);
 


### PR DESCRIPTION
reviewed all current calls to Position.ToGlobal(), and it looks like the skipIndoors = true default parameter is outdated for current usage. the bugs that parameter was originally intended to fix are no longer applicable to current calls. the 'indoorsMatch' concept when comparing 2 positions also doesn't apply to places they are used, and introduces additional bugs