### PR TITLE
LaunchProjectile destroy failed launches

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -111,16 +111,17 @@ namespace ACE.Server.WorldObjects
                 {
                     if (player != null)
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat("Your missile attack hit the environment.", ChatMessageType.Broadcast));
-
-                    proj.Destroy();
                 }
 
+                proj.Destroy();
                 return null;
             }
 
             if (!IsProjectileVisible(proj))
             {
                 proj.OnCollideEnvironment();
+
+                proj.Destroy();
                 return null;
             }
 


### PR DESCRIPTION
It appears .OnCollideEnvironment doesn't explicitly destroy the object (at least I couldn't easily find a Destroy() in the call path)

There might be other cases that can use a destroy too.

WorldObject_Magic.cs line 1815