### PR TITLE
Update AwardSkillXP

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -155,7 +155,10 @@ namespace ACE.Server.WorldObjects.Managers
                 case EmoteType.AwardSkillXP:
 
                     if (player != null)
+                    {
+                        if (delay == 0) delay += 1; // because of how AwardSkillXP grants and then raises the skill, ensure delay is at least 1 to allow for processing correctly
                         player.AwardSkillXP((Skill)emote.Stat, (uint)emote.Amount, true);
+                    }
                     break;
 
                 case EmoteType.AwardTrainingCredits:

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -156,7 +156,7 @@ namespace ACE.Server.WorldObjects.Managers
 
                     if (player != null)
                     {
-                        if (delay == 0) delay += 1; // because of how AwardSkillXP grants and then raises the skill, ensure delay is at least 1 to allow for processing correctly
+                        if (delay < 1) delay += 1; // because of how AwardSkillXP grants and then raises the skill, ensure delay is at least 1 to allow for processing correctly
                         player.AwardSkillXP((Skill)emote.Stat, (uint)emote.Amount, true);
                     }
                     break;

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -340,7 +340,13 @@ namespace ACE.Server.WorldObjects
             amount = Math.Min(amount, playerSkill.ExperienceLeft);
 
             GrantXP(amount, XpType.Emote, ShareType.None);
-            HandleActionRaiseSkill(skill, amount);
+            var raiseChain = new ActionChain();
+            raiseChain.AddDelayForOneTick();
+            raiseChain.AddAction(this, () =>
+            {
+                HandleActionRaiseSkill(skill, amount);
+            });
+            raiseChain.EnqueueChain();
 
             if (alertPlayer)
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"You've earned {amount:N0} experience in your {playerSkill.Skill.ToSentence()} skill.", ChatMessageType.Broadcast));


### PR DESCRIPTION
Fix issue with how AwardSkillXP is processed leading to incorrect xp results from test npc.

Create a new character, enter world and do nothing else (do not earn any xp)
/ci drudgecharm
(because of "bug" in ACE, test npc will attack you, ignore the attacks but let it do its thing...)
/neversaydie
/create emotetestnpc

give drudge charm to WEventCoordinator npc

Expected results:

```
You give WEventCoordinator Drudge Charm.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 1,000 XP (AwardLevelProportionalXP 1.0 0 0)"
You are now level 2!
You have 1,000 experience points and 1 skill credits available to raise skills and attributes.
You've earned 1,000 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 500 XP (AwardLevelProportionalXP 1.0 0 500)"
You've earned 500 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 5,000 XP (AwardLevelProportionalXP 1.0 5000 0)"
You are now level 4!
You have 6,500 experience points and 3 skill credits available to raise skills and attributes.
You've earned 5,000 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 10,000 XP (AwardLevelProportionalXP 1.0 10000 100001)"
You are now level 5!
You have 16,500 experience points and 4 skill credits available to raise skills and attributes.
You've earned 10,000 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 10 XP (AwardLevelProportionalXP 1.0 5 10)"
You've earned 10 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 6,783 XP (AwardLevelProportionalXP 1.0 0 0)"
You are now level 6!
You have 23,293 experience points and 5 skill credits available to raise skills and attributes.
You've earned 6,783 experience.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 178 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 1.0 0 0)"
You've earned 178 experience in your Loyalty skill.
Your base Loyalty skill is now 6!
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 200 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 0.01 200 0)"
You've earned 200 experience in your Loyalty skill.
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 4 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 1.0 0 4)"
You've earned 4 experience in your Loyalty skill.
Your base Loyalty skill is now 7!
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 230 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 1.0 100 300)"
You've earned 230 experience in your Loyalty skill.
Your base Loyalty skill is now 8!
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You should recieve 771 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 3.0 10 1000)"
You've earned 771 experience in your Loyalty skill.
Your base Loyalty skill is now 10!
WEventCoordinator tells you, "-------------------------------"
WEventCoordinator tells you, "You will receive a large chunk of XP into your loyalty skill so that I can check that the hard-coded cap has been removed from code."
You've earned 1,000,000,000 experience in your Loyalty skill.
You are now level 92!
You have 1,000,023,293 experience points and 30 skill credits available to raise skills and attributes.
Your base Loyalty skill is now 189!
WEventCoordinator tells you, "You should recieve 78,410,305 XP into your Loyalty skill (AwardLevelProportionalSkillXP LOYALTY 1.0 0 0)"
You've earned 78,410,305 experience in your Loyalty skill.
You are now level 94!
You have 78,433,598 experience points and 30 skill credits available to raise skills and attributes.
You will earn another skill credit at level 95.
Your base Loyalty skill is now 190!
```