### PR TITLE
Update Containers/Chests to clear/destroy unmanaged inventory on reset

### DIFF
--- a/Source/ACE.Server/WorldObjects/Chest.cs
+++ b/Source/ACE.Server/WorldObjects/Chest.cs
@@ -251,6 +251,8 @@ namespace ACE.Server.WorldObjects
                 EnqueueBroadcast(new GameMessagePublicUpdatePropertyBool(this, PropertyBool.Locked, IsLocked));
             }
 
+            ClearUnmanagedInventory();
+
             if (IsGenerator)
             {
                 ResetGenerator();


### PR DESCRIPTION
Reset now destroys all "unmanaged" inventory in addition to its managed inventory