### PR TITLE
Address issue with some ImbueStackingBits recipe results

### DIFF
--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -119,9 +119,9 @@ namespace ACE.Server.Network.Structure
             // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
             // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
             // The issue is that the recipe system likely added 0.005 to 0 instead of 1, which is what *should* have happened.
-            if (wo.WeaponMagicDefense.HasValue && wo.WeaponMagicDefense.Value > 0 && wo.WeaponMagicDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+            if (wo.WeaponMagicDefense.HasValue && wo.WeaponMagicDefense.Value > 0 && wo.WeaponMagicDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) != 0)
                 PropertiesFloat[PropertyFloat.WeaponMagicDefense] += 1;
-            if (wo.WeaponMissileDefense.HasValue && wo.WeaponMissileDefense.Value > 0 && wo.WeaponMissileDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+            if (wo.WeaponMissileDefense.HasValue && wo.WeaponMissileDefense.Value > 0 && wo.WeaponMissileDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) != 0)
                 PropertiesFloat[PropertyFloat.WeaponMissileDefense] += 1;
 
             if (wo is Door || wo is Chest)

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -115,6 +115,15 @@ namespace ACE.Server.Network.Structure
             if (wo.Damage != null && !(wo is Clothing) || wo is MeleeWeapon || wo is Missile || wo is MissileLauncher || wo is Ammunition || wo is Caster)
                 BuildWeapon(wo);
 
+            // TODO: Resolve this issue a better way?
+            // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
+            // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
+            // The issue is that the recipe system likely added 0.005 to 0 instead of 1, which is what *should* have happened.
+            if (wo.WeaponMagicDefense.HasValue && wo.WeaponMagicDefense.Value > 0 && wo.WeaponMagicDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+                PropertiesFloat[PropertyFloat.WeaponMagicDefense] += 1;
+            if (wo.WeaponMissileDefense.HasValue && wo.WeaponMissileDefense.Value > 0 && wo.WeaponMissileDefense.Value < 1 && ((wo.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+                PropertiesFloat[PropertyFloat.WeaponMissileDefense] += 1;
+
             if (wo is Door || wo is Chest)
             {
                 // If wo is not locked, do not send ResistLockpick value. If ResistLockpick is sent for unlocked objects, id panel shows bonus to Lockpick skill

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -130,6 +130,14 @@ namespace ACE.Server.Network.Structure
             if (weapon is Ammunition) return 1.0f;
 
             var baseDefense = weapon.GetProperty(PropertyFloat.WeaponDefense) ?? 1.0f;
+
+            // TODO: Resolve this issue a better way?
+            // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
+            // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
+            // The issue is that the recipe system likely added 0.01 to 0 instead of 1, which is what *should* have happened.
+            if (weapon.WeaponDefense.HasValue && weapon.WeaponDefense.Value > 0 && weapon.WeaponDefense.Value < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) == 1)
+                baseDefense += 1;
+
             var defenseMod = weapon.EnchantmentManager.GetDefenseMod();
             var auraDefenseMod = weapon.Wielder != null ? weapon.Wielder.EnchantmentManager.GetDefenseMod() : 0.0f;
             Enchantment_WeaponDefense = weapon.IsEnchantable ? defenseMod + auraDefenseMod : defenseMod;

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -135,7 +135,7 @@ namespace ACE.Server.Network.Structure
             // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
             // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
             // The issue is that the recipe system likely added 0.01 to 0 instead of 1, which is what *should* have happened.
-            if (weapon.WeaponDefense.HasValue && weapon.WeaponDefense.Value > 0 && weapon.WeaponDefense.Value < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) == 1)
+            if (weapon.WeaponDefense.HasValue && weapon.WeaponDefense.Value > 0 && weapon.WeaponDefense.Value < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) != 0)
                 baseDefense += 1;
 
             var defenseMod = weapon.EnchantmentManager.GetDefenseMod();

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -117,7 +117,7 @@ namespace ACE.Server.WorldObjects
             // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
             // The issue is that the recipe system likely added 0.01 to 0 instead of 1, which is what *should* have happened.
             var baseWepDef = (float)(weapon.WeaponDefense ?? defaultModifier);
-            if (weapon.WeaponDefense > 0 && weapon.WeaponDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) == 1)
+            if (weapon.WeaponDefense > 0 && weapon.WeaponDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) != 0)
                 baseWepDef += 1;
 
             var defenseMod = baseWepDef + weapon.EnchantmentManager.GetDefenseMod();

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -110,7 +110,17 @@ namespace ACE.Server.WorldObjects
             if (weapon == null)
                 return defaultModifier;
 
-            var defenseMod = (float)(weapon.WeaponDefense ?? defaultModifier) + weapon.EnchantmentManager.GetDefenseMod();
+            //var defenseMod = (float)(weapon.WeaponDefense ?? defaultModifier) + weapon.EnchantmentManager.GetDefenseMod();
+
+            // TODO: Resolve this issue a better way?
+            // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
+            // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
+            // The issue is that the recipe system likely added 0.01 to 0 instead of 1, which is what *should* have happened.
+            var baseWepDef = (float)(weapon.WeaponDefense ?? defaultModifier);
+            if (weapon.WeaponDefense > 0 && weapon.WeaponDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 4) == 1)
+                baseWepDef += 1;
+
+            var defenseMod = baseWepDef + weapon.EnchantmentManager.GetDefenseMod();
 
             if (weapon.IsEnchantable)
                 defenseMod += wielder.EnchantmentManager.GetDefenseMod();
@@ -128,8 +138,19 @@ namespace ACE.Server.WorldObjects
             if (weapon == null || wielder.CombatMode == CombatMode.NonCombat)
                 return defaultModifier;
 
+            //// no enchantments?
+            //return (float)(weapon.WeaponMissileDefense ?? 1.0f);
+
+            var baseWepDef = (float)(weapon.WeaponMissileDefense ?? 1.0f);
+            // TODO: Resolve this issue a better way?
+            // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
+            // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
+            // The issue is that the recipe system likely added 0.005 to 0 instead of 1, which is what *should* have happened.
+            if (weapon.WeaponMissileDefense > 0 && weapon.WeaponMissileDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+                baseWepDef += 1;
+
             // no enchantments?
-            return (float)(weapon.WeaponMissileDefense ?? 1.0f);
+            return baseWepDef;
         }
 
         /// <summary>
@@ -142,8 +163,19 @@ namespace ACE.Server.WorldObjects
             if (weapon == null || wielder.CombatMode == CombatMode.NonCombat)
                 return defaultModifier;
 
+            //// no enchantments?
+            //return (float)(weapon.WeaponMagicDefense ?? 1.0f);
+
+            var baseWepDef = (float)(weapon.WeaponMagicDefense ?? 1.0f);
+            // TODO: Resolve this issue a better way?
+            // Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
+            // we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly
+            // The issue is that the recipe system likely added 0.005 to 0 instead of 1, which is what *should* have happened.
+            if (weapon.WeaponMagicDefense > 0 && weapon.WeaponMagicDefense < 1 && ((weapon.GetProperty(PropertyInt.ImbueStackingBits) ?? 0) & 1) == 1)
+                baseWepDef += 1;
+
             // no enchantments?
-            return (float)(weapon.WeaponMagicDefense ?? 1.0f);
+            return baseWepDef;
         }
 
         /// <summary>


### PR DESCRIPTION
Because of the way ACE handles default base values in recipe system (or rather the lack thereof)
we need to check the following weapon properties to see if they're below expected minimum and adjust accordingly

weapons with ImbueStackingBits 1 or 4

WeaponDefense
WeaponMagicDefense
WeaponMissileDefense

This doesn't resolve the data inconsistency, but runtime fixes the massive debuff a weapon gets when the following recipes modify a weapon that has no set value for the above properties.

[Magic Defense Weapon Augmentation](http://acpedia.org/wiki/Magic_Defense_Weapon_Augmentation)
[Missile Defense Weapon Augmentation](http://acpedia.org/wiki/Missile_Defense_Weapon_Augmentation)
[Gauntlet Defense Amplification](http://acpedia.org/wiki/Gauntlet_Defense_Amplification)

If something better can be done to resolve the problem, this patch can be removed.