### PR TITLE
Added optional check for newer server binary.

### DIFF
--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -66,7 +66,7 @@ namespace ACE.Common
         /// <summary>
         /// Automatically check for updated server binaries
         /// </summary>
-        [System.ComponentModel.DefaultValue(false)]
+        [System.ComponentModel.DefaultValue(true)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool AutoServerUpdateCheck { get; set; }
 

--- a/Source/ACE.Common/OfflineConfiguration.cs
+++ b/Source/ACE.Common/OfflineConfiguration.cs
@@ -64,6 +64,13 @@ namespace ACE.Common
         public bool AutoUpdateWorldDatabase { get; set; }
 
         /// <summary>
+        /// Automatically check for updated server binaries
+        /// </summary>
+        [System.ComponentModel.DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool AutoServerUpdateCheck { get; set; }
+
+        /// <summary>
         /// After updating to latest world database, automatically import further customizations
         /// AutoUpdateWorldDatabase must be true for this option to be used
         /// SQL files will be executed given the sort order of the full paths of the files

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -173,48 +173,51 @@
   },
   // This section can trigger events that may happen before the world starts up, or after it shuts down
   // The shard should be in a disconnected state from any running ACE world
-  "Offline": {
-    // Purge characters that have been deleted longer than PruneDeletedCharactersDays
-    // These characters, and their associated biotas, will be deleted permanantly!
-    "PurgeDeletedCharacters": false,
+    "Offline": {
+        // Purge characters that have been deleted longer than PruneDeletedCharactersDays
+        // These characters, and their associated biotas, will be deleted permanantly!
+        "PurgeDeletedCharacters": false,
 
-    // Number of days a character must have been deleted for before eligible for purging
-    "PurgeDeletedCharactersDays": 30,
+        // Number of days a character must have been deleted for before eligible for purging
+        "PurgeDeletedCharactersDays": 30,
 
-    // This will purge biotas that are completely disconnected from the world
-    // These may have been items that were never deleted properly, items that were given to the town crier before delete was implemented, etc...
-    // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
-    "PurgeOrphanedBiotas": false,
+        // This will purge biotas that are completely disconnected from the world
+        // These may have been items that were never deleted properly, items that were given to the town crier before delete was implemented, etc...
+        // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
+        "PurgeOrphanedBiotas": false,
 
-    // This will prune deleted characters from all friend lists in the database
-    "PruneDeletedCharactersFromFriendLists": true,
+        // This will prune deleted characters from all friend lists in the database
+        "PruneDeletedCharactersFromFriendLists": true,
 
-    // This will prune shortcuts to objects that no longer exist in the database
-    "PruneDeletedObjectsFromShortcutBars": false,
+        // This will prune shortcuts to objects that no longer exist in the database
+        "PruneDeletedObjectsFromShortcutBars": false,
 
-    // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
-    "PruneDeletedCharactersFromSquelchLists": false,
+        // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
+        "PruneDeletedCharactersFromSquelchLists": false,
 
-    // Automatically apply new updates to databases upon startup if they haven't yet been applied
-    "AutoApplyDatabaseUpdates": true,
+        // Automatically check for updated server releases. Does not apply updates, just notifies of new version available.
+        "AutoServerUpdateCheck": true,
 
-    // Automatically check for and update to latest available world database
-    "AutoUpdateWorldDatabase": true,
+        // Automatically apply new updates to databases upon startup if they haven't yet been applied
+        "AutoApplyDatabaseUpdates": true,
 
-    // After updating to latest world database, automatically import further customizations
-    // AutoUpdateWorldDatabase must be true for this option to be used
-    // SQL files will be executed given the sort order of the full paths of the files
-    "AutoApplyWorldCustomizations": true,
+        // Automatically check for and update to latest available world database
+        "AutoUpdateWorldDatabase": true,
 
-    // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
-    // all .sql files in the following directories.
-    // This process will still use ./Content by default, or the the config_properties_string
-    // value for 'content_folder' if it exists
-    // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
-    "WorldCustomizationAddedPaths": [],
+        // After updating to latest world database, automatically import further customizations
+        // AutoUpdateWorldDatabase must be true for this option to be used
+        // SQL files will be executed given the sort order of the full paths of the files
+        "AutoApplyWorldCustomizations": true,
 
-     // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
-     // this will cause the file search to retrieve all files recursively from each directory
-     "RecurseWorldCustomizationPaths": true
-  }
+        // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
+        // all .sql files in the following directories.
+        // This process will still use ./Content by default, or the the config_properties_string
+        // value for 'content_folder' if it exists
+        // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
+        "WorldCustomizationAddedPaths": [],
+
+        // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
+        // this will cause the file search to retrieve all files recursively from each directory
+        "RecurseWorldCustomizationPaths": true
+    }
 }

--- a/Source/ACE.Server/Config.js.example
+++ b/Source/ACE.Server/Config.js.example
@@ -173,51 +173,51 @@
   },
   // This section can trigger events that may happen before the world starts up, or after it shuts down
   // The shard should be in a disconnected state from any running ACE world
-    "Offline": {
-        // Purge characters that have been deleted longer than PruneDeletedCharactersDays
-        // These characters, and their associated biotas, will be deleted permanantly!
-        "PurgeDeletedCharacters": false,
+  "Offline": {
+    // Purge characters that have been deleted longer than PruneDeletedCharactersDays
+    // These characters, and their associated biotas, will be deleted permanantly!
+    "PurgeDeletedCharacters": false,
 
-        // Number of days a character must have been deleted for before eligible for purging
-        "PurgeDeletedCharactersDays": 30,
+    // Number of days a character must have been deleted for before eligible for purging
+    "PurgeDeletedCharactersDays": 30,
 
-        // This will purge biotas that are completely disconnected from the world
-        // These may have been items that were never deleted properly, items that were given to the town crier before delete was implemented, etc...
-        // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
-        "PurgeOrphanedBiotas": false,
+    // This will purge biotas that are completely disconnected from the world
+    // These may have been items that were never deleted properly, items that were given to the town crier before delete was implemented, etc...
+    // This can be time consuming so it's not something you would have set to true for every server startup. You might run this once every few months
+    "PurgeOrphanedBiotas": false,
 
-        // This will prune deleted characters from all friend lists in the database
-        "PruneDeletedCharactersFromFriendLists": true,
+    // This will prune deleted characters from all friend lists in the database
+    "PruneDeletedCharactersFromFriendLists": true,
 
-        // This will prune shortcuts to objects that no longer exist in the database
-        "PruneDeletedObjectsFromShortcutBars": false,
+    // This will prune shortcuts to objects that no longer exist in the database
+    "PruneDeletedObjectsFromShortcutBars": false,
 
-        // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
-        "PruneDeletedCharactersFromSquelchLists": false,
+    // This will prune deleted characters from all squlech lists in the database, excluding those used to squlech accounts
+    "PruneDeletedCharactersFromSquelchLists": false,
 
-        // Automatically check for updated server releases. Does not apply updates, just notifies of new version available.
-        "AutoServerUpdateCheck": true,
+    // Automatically check for updated server releases. Does not apply updates, just notifies of new version available.
+    "AutoServerUpdateCheck": true,
 
-        // Automatically apply new updates to databases upon startup if they haven't yet been applied
-        "AutoApplyDatabaseUpdates": true,
+    // Automatically apply new updates to databases upon startup if they haven't yet been applied
+    "AutoApplyDatabaseUpdates": true,
 
-        // Automatically check for and update to latest available world database
-        "AutoUpdateWorldDatabase": true,
+    // Automatically check for and update to latest available world database
+    "AutoUpdateWorldDatabase": true,
 
-        // After updating to latest world database, automatically import further customizations
-        // AutoUpdateWorldDatabase must be true for this option to be used
-        // SQL files will be executed given the sort order of the full paths of the files
-        "AutoApplyWorldCustomizations": true,
+    // After updating to latest world database, automatically import further customizations
+    // AutoUpdateWorldDatabase must be true for this option to be used
+    // SQL files will be executed given the sort order of the full paths of the files
+    "AutoApplyWorldCustomizations": true,
 
-        // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
-        // all .sql files in the following directories.
-        // This process will still use ./Content by default, or the the config_properties_string
-        // value for 'content_folder' if it exists
-        // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
-        "WorldCustomizationAddedPaths": [],
+    // When AutoApplyWorldCustomizations is set to true, the auto apply process will search for
+    // all .sql files in the following directories.
+    // This process will still use ./Content by default, or the the config_properties_string
+    // value for 'content_folder' if it exists
+    // Example: [ "C:\\MyContent", "C:\\FTPRoot\\Editor1Content", "C:\\FTPRoot\\Editor2Content" ]
+    "WorldCustomizationAddedPaths": [],
 
-        // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
-        // this will cause the file search to retrieve all files recursively from each directory
-        "RecurseWorldCustomizationPaths": true
-    }
+     // When retrieving a file list of .sql files in the AutoApplyWorldCustomizations process
+     // this will cause the file search to retrieve all files recursively from each directory
+     "RecurseWorldCustomizationPaths": true
+  }
 }

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -192,8 +192,6 @@ namespace ACE.Server
                 log.Info($"Pruned {numberOfSquelchesPruned:N0} invalid squelched characters found on squelch lists.");
             }
 
-            //if (ConfigManager.Config.Offline)
-
             if (ConfigManager.Config.Offline.AutoServerUpdateCheck)
                 CheckForServerUpdate();
             else

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -192,6 +192,13 @@ namespace ACE.Server
                 log.Info($"Pruned {numberOfSquelchesPruned:N0} invalid squelched characters found on squelch lists.");
             }
 
+            //if (ConfigManager.Config.Offline)
+
+            if (ConfigManager.Config.Offline.AutoServerUpdateCheck)
+                CheckForServerUpdate();
+            else
+                log.Info($"AutoServerVersionCheck is disabled...");
+
             if (ConfigManager.Config.Offline.AutoUpdateWorldDatabase)
             {
                 CheckForWorldDatabaseUpdate();

--- a/Source/ACE.Server/Program_BinUpdates.cs
+++ b/Source/ACE.Server/Program_BinUpdates.cs
@@ -1,0 +1,70 @@
+extern alias MySqlConnectorAlias;
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Collections.Generic;
+
+using ACE.Common;
+
+using Newtonsoft.Json;
+
+namespace ACE.Server
+{
+    partial class Program
+    {
+        private static void CheckForServerUpdate()
+        {
+            log.Info($"Automatic Server version check started...");
+            try
+            {
+                var worldDb = new Database.WorldDatabase();
+                var currentVersion = worldDb.GetVersion();
+                log.Info($"Current Server Binary: {ServerBuildInfo.FullVersion}");
+
+                var url = "https://api.github.com/repos/ACEmulator/ACE/releases/latest";
+                var request = (HttpWebRequest)WebRequest.Create(url);
+                request.UserAgent = "ACE.Server";
+
+                var response = request.GetResponse();
+                var reader = new StreamReader(response.GetResponseStream(), System.Text.Encoding.UTF8);
+                var html = reader.ReadToEnd();
+                reader.Close();
+                response.Close();
+
+                dynamic json = JsonConvert.DeserializeObject(html);
+
+                string tag = json.tag_name;
+               
+                //Split the tag from "v{version}.{build}" into discrete components  - "tag_name": "v1.39.4192"
+                Version v = new Version(tag.Remove(0, 1));
+                Version currentServerVersion = ServerBuildInfo.GetServerVersion();
+
+                var versionStatus = v.CompareTo(currentServerVersion);
+                // Status returns > 0 if the GitHub version is newer. (0 if the same, or < 0 if older.)
+                if (versionStatus > 0)
+                {
+                    log.Warn("There is a newer version of ACE available!");
+                    log.Warn($"Please visit {json.html_url} for more information.");
+
+                    // the Console.Title.Get() only works on Windows...
+                    #pragma warning disable CA1416 // Validate platform compatibility
+                    Console.Title += " -- Server Binary Update Available";
+                    #pragma warning restore CA1416 // Validate platform compatibility
+                }
+                else
+                {
+                    log.Info($"Latest Server Version is {tag} -- No Update Required!");
+                }
+                return;
+            }
+            catch (Exception ex)
+            {
+                log.Info($"Unable to continue with Automatic Server Version Check due to the following error: {ex}");
+            }
+        }
+    }
+}

--- a/Source/ACE.Server/Program_DbUpdates.cs
+++ b/Source/ACE.Server/Program_DbUpdates.cs
@@ -25,7 +25,7 @@ namespace ACE.Server
                 var currentVersion = worldDb.GetVersion();
                 log.Info($"Current World Database version: Base - {currentVersion.BaseVersion} | Patch - {currentVersion.PatchVersion}");
 
-                var url = "https://api.github.com/repos/ACEmulator/ACE-World-16PY-Patches/releases";
+                var url = "https://api.github.com/repos/ACEmulator/ACE-World-16PY-Patches/releases/latest";
                 var request = (HttpWebRequest)WebRequest.Create(url);
                 request.UserAgent = "ACE.Server";
 
@@ -36,9 +36,9 @@ namespace ACE.Server
                 response.Close();
 
                 dynamic json = JsonConvert.DeserializeObject(html);
-                string tag = json[0].tag_name;
-                string dbURL = json[0].assets[0].browser_download_url;
-                string dbFileName = json[0].assets[0].name;
+                string tag = json.tag_name;
+                string dbURL = json.assets[0].browser_download_url;
+                string dbFileName = json.assets[0].name;
 
                 if (currentVersion.PatchVersion != tag)
                 {

--- a/Source/ACE.Server/Program_Setup.cs
+++ b/Source/ACE.Server/Program_Setup.cs
@@ -393,7 +393,7 @@ namespace ACE.Server
                 Console.Write("Looking up latest release from ACEmulator/ACE-World-16PY-Patches .... ");
 
                 // webrequest code provided by OptimShi
-                var url = "https://api.github.com/repos/ACEmulator/ACE-World-16PY-Patches/releases";
+                var url = "https://api.github.com/repos/ACEmulator/ACE-World-16PY-Patches/releases/latest";
                 var request = (HttpWebRequest)WebRequest.Create(url);
                 request.UserAgent = "Mozilla//5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko//20100101 Firefox//72.0";
                 request.UserAgent = "ACE.Server";
@@ -405,9 +405,9 @@ namespace ACE.Server
                 response.Close();
 
                 dynamic json = JsonConvert.DeserializeObject(html);
-                string tag = json[0].tag_name;
-                string dbURL = json[0].assets[0].browser_download_url;
-                string dbFileName = json[0].assets[0].name;
+                string tag = json.tag_name;
+                string dbURL = json.assets[0].browser_download_url;
+                string dbFileName = json.assets[0].name;
                 // webrequest code provided by OptimShi
 
                 Console.WriteLine($"Found {tag} !");

--- a/Source/ACE.Server/ServerBuildInfo_Static.cs
+++ b/Source/ACE.Server/ServerBuildInfo_Static.cs
@@ -2,7 +2,6 @@ using ACE.Database;
 
 using System;
 
-
 namespace ACE.Server
 {
     public static partial class ServerBuildInfo
@@ -31,5 +30,11 @@ namespace ACE.Server
                 msg += "Server is running inside a Container\n";
             return msg;
         }
+
+        public static Version GetServerVersion()
+        {
+            return new Version(Version + "." + Build);
+        }
+
     }
 }


### PR DESCRIPTION
New Config option `Offline.AutoServerUpdateCheck` configures if the server is to check at startup for a newer server binary version.
Changed AutoUpdateWorldDatabase functionality to only check the latest release. This was all it was doing anyways, but this just makes it more efficient.