### PR TITLE
Revert "Allow Scatter generators to use their Z instead of ground Z"

### DIFF
--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -1428,7 +1428,7 @@ namespace ACE.Server.Physics
                     // compare: rabbits occasionally spawning in buildings in yaraq,
                     // vs. lich tower @ 3D31FFFF
 
-                    /*var sortCell = LScape.get_landcell(newPos.ObjCellID) as SortCell;
+                    var sortCell = LScape.get_landcell(newPos.ObjCellID) as SortCell;
                     if (sortCell == null || !sortCell.has_building())
                     {
                         // set to ground pos
@@ -1440,7 +1440,7 @@ namespace ACE.Server.Physics
                         else
                             newPos.Frame.Origin.Z = groundZ;
 
-                    }*/
+                    }
                     //else
                         //indoors = true;
 


### PR DESCRIPTION
Reverts ACEmulator/ACE#3797

This needs more investigation. In concept, things with gravity should fall to ground if spawned above it, and this works for some setups, but not all, such as [Black Coral](https://github.com/ACEmulator/ACE-World-16PY-Patches/blob/master/Database/Patches/9%20WeenieDefaults/Stackable/Misc/38613%20Black%20Coral.sql)

I'm sure what to key on specifically here vs something like say [Apple](https://github.com/ACEmulator/ACE-World-16PY/blob/master/Database/3-Core/9%20WeenieDefaults/SQL/Food/Food/00258%20Apple.sql)

however, the end goal would be to allow both objects to spawn any Z height, as specified by generator/instance data, and if above ground level, fall to ground so that the object would not remain floating in the air, and can be interacted with.