### PR TITLE
Wire up InventoryTreasureType support

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
@@ -78,7 +78,7 @@ namespace ACE.Entity.Enum.Properties
         [ServerOnly]
         InventoryTreasureType      = 33,
         [ServerOnly]
-        ShowTreasureType           = 34,
+        ShopTreasureType           = 34,
         [ServerOnly]
         DeathTreasureType          = 35,
         [ServerOnly]

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -127,6 +127,8 @@ namespace ACE.Server.WorldObjects
 
                 EquipInventoryItems();
 
+                GenerateInventoryTreasure();
+
                 // TODO: fix tod data
                 Health.Current = Health.MaxValue;
                 Stamina.Current = Stamina.MaxValue;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -636,28 +636,6 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-            // contain and non-wielded treasure create
-            if (Biota.PropertiesCreateList != null)
-            {
-                var createList = Biota.PropertiesCreateList.Where(i => (i.DestinationType & DestinationType.Contain) != 0 ||
-                                (i.DestinationType & DestinationType.Treasure) != 0 && (i.DestinationType & DestinationType.Wield) == 0).ToList();
-
-                var selected = CreateListSelect(createList);
-
-                foreach (var item in selected)
-                {
-                    var wo = WorldObjectFactory.CreateNewWorldObject(item);
-
-                    if (wo != null)
-                    {
-                        if (corpse != null)
-                            corpse.TryAddToInventory(wo);
-                        else
-                            droppedItems.Add(wo);
-                    }
-                }
-            }
-
             // move wielded treasure over, which also should include Wielded objects not marked for destroy on death.
             // allow server operators to configure this behavior due to errors in createlist post 16py data
             var dropFlags = PropertyManager.GetBool("creatures_drop_createlist_wield").Item ? DestinationType.WieldTreasure : DestinationType.Treasure;
@@ -678,6 +656,28 @@ namespace ACE.Server.WorldObjects
                 }
                 else
                     droppedItems.Add(item);
+            }
+
+            // contain and non-wielded treasure create
+            if (Biota.PropertiesCreateList != null)
+            {
+                var createList = Biota.PropertiesCreateList.Where(i => (i.DestinationType & DestinationType.Contain) != 0 ||
+                                (i.DestinationType & DestinationType.Treasure) != 0 && (i.DestinationType & DestinationType.Wield) == 0).ToList();
+
+                var selected = CreateListSelect(createList);
+
+                foreach (var item in selected)
+                {
+                    var wo = WorldObjectFactory.CreateNewWorldObject(item);
+
+                    if (wo != null)
+                    {
+                        if (corpse != null)
+                            corpse.TryAddToInventory(wo);
+                        else
+                            droppedItems.Add(wo);
+                    }
+                }
             }
 
             return droppedItems;


### PR DESCRIPTION
Based on property name found in older data (thanks to @OptimShi)
This property was only found 5 weenies, entirely contained in Focusing Stone quest.

Assuming that the value might have possibly allowed for either Death or Wielded treasure, but technically it might have only been the former, so for now, coded for checking both types.

Although the property's name seemingly was removed, either it's value was still used in code OR its value was moved into DeathTreasureType/CreateList because PCAPs for these 5 objects do show similar, if not exact, results on corpses.

[Lich Overseer](https://github.com/ACEmulator/ACE-PCAP-Dynamics-Exports/blob/master/Database/3-Core/9%20WeenieDefaults/SQL/Creature/Undead/04124%20Lich%20Overseer.sql)
[Cursed Forman](https://github.com/ACEmulator/ACE-PCAP-Dynamics-Exports/blob/master/Database/3-Core/9%20WeenieDefaults/SQL/Creature/Undead/04127%20Cursed%20Foreman.sql)
[Video of quest on retail](https://youtu.be/St8Y1DQLr1Y?t=580)