### PR TITLE
Wired up PortalStorm Events for potential future use

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -3892,5 +3892,38 @@ namespace ACE.Server.Command.Handlers
 
             session.Player.HandleActionUseWithTarget(guid, target.Guid.Full);
         }
+
+        [CommandHandler("portalstorm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Tests starting a portal storm on yourself", "storm_level [0=Brewing, 1=Immeinent, 2=Stormed, 3=Subsided]")]
+        public static void HandlePortalStorm(Session session, params string[] parameters)
+        {
+            if (!uint.TryParse(parameters[0], out var storm_level))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Invalid storm level {parameters[0]}");
+                return;
+            }
+            if (storm_level > 3) storm_level = 3;
+
+            switch (storm_level) {
+                case 0:
+                    session.Network.EnqueueSend(new GameEventPortalStormBrewing(session));
+                    break;
+                case 1:
+                    session.Network.EnqueueSend(new GameEventPortalStormImminent(session));
+                    break;
+                case 2:
+                    // Portal Storm Event comes immediatley before the teleport
+                    session.Network.EnqueueSend(new GameEventPortalStorm(session));
+
+                    // We're going to move the player to 0,0
+                    Position newPos = new Position(0x7F7F001C, 84, 84, 80, 0, 0, 0, 1);
+                    session.Player.Teleport(newPos);
+                    break;
+                case 3:
+                    session.Network.EnqueueSend(new GameEventPortalStormSubsided(session));
+                    break;
+            }
+        }
+
+
     }
 }

--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -3893,7 +3893,7 @@ namespace ACE.Server.Command.Handlers
             session.Player.HandleActionUseWithTarget(guid, target.Guid.Full);
         }
 
-        [CommandHandler("portalstorm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Tests starting a portal storm on yourself", "storm_level [0=Brewing, 1=Immeinent, 2=Stormed, 3=Subsided]")]
+        [CommandHandler("portalstorm", AccessLevel.Developer, CommandHandlerFlag.RequiresWorld, 1, "Tests starting a portal storm on yourself", "storm_level [0=Brewing, 1=Imminent, 2=Stormed, 3=Subsided]")]
         public static void HandlePortalStorm(Session session, params string[] parameters)
         {
             if (!uint.TryParse(parameters[0], out var storm_level))

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStorm.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStorm.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Server.Network.GameEvent.Events
+{
+    class GameEventPortalStorm : GameEventMessage
+    {
+        public GameEventPortalStorm(Session session)
+            : base(GameEventType.MiscPortalStorm, GameMessageGroup.UIQueue, session)
+        {
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormBrewing.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormBrewing.cs
@@ -1,0 +1,14 @@
+namespace ACE.Server.Network.GameEvent.Events
+{
+    /// <summary>
+    /// Lets players know that a portal storm is brewing "This area is getting too crowded - a Portal Storm is brewing."
+    /// </summary>
+    public class GameEventPortalStormBrewing : GameEventMessage
+    {
+        public GameEventPortalStormBrewing(Session session, float extent = 0.4f)
+            : base(GameEventType.MiscPortalStormBrewing, GameMessageGroup.UIQueue, session)
+        {
+            Writer.Write(extent);
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormImminent.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormImminent.cs
@@ -1,0 +1,14 @@
+namespace ACE.Server.Network.GameEvent.Events
+{
+    /// <summary>
+    /// Lets players know that a portal storm is brewing "This area is getting too crowded - a Portal Storm is brewing."
+    /// </summary>
+    public class GameEventPortalStormImminent : GameEventMessage
+    {
+        public GameEventPortalStormImminent(Session session, float extent = 0.6f)
+            : base(GameEventType.MiscPortalStormImminent, GameMessageGroup.UIQueue, session)
+        {
+            Writer.Write(extent);
+        }
+    }
+}

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormSubsided.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPortalStormSubsided.cs
@@ -1,0 +1,13 @@
+/// <summary>
+/// Lets players know that a portal storm is brewing "This area is getting too crowded - a Portal Storm is brewing."
+/// </summary>
+namespace ACE.Server.Network.GameEvent.Events
+{
+    class GameEventPortalStormSubsided : GameEventMessage
+    {
+        public GameEventPortalStormSubsided(Session session)
+            : base(GameEventType.MiscPortalstormSubsided, GameMessageGroup.UIQueue, session)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Added a simple Developer Command to test a portal storm on yourself:

`portalstorm (storm_level [0=Brewing, 1=Imminent, 2=Stormed, 3=Subsided])`

`portalstorm 0` would cause the "This area is getting too crowded - a Portal Storm is brewing." message to display
`portalstorm 1` would cause the "A Portal Storm is imminent - leave this crowded area!" message to display
`portalstorm 2` will cause you to be portal stormed. For the purposes of testing, this location is hard-coded to 0N, 0E
`portalstorm 3` would cause the "The Portal Storm has subsided" message to display