### PR TITLE
Restore TimeZoneConverter

### DIFF
--- a/Source/ACE.Common/ACE.Common.csproj
+++ b/Source/ACE.Common/ACE.Common.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
     <PackageReference Include="DouglasCrockford.JsMin" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="TimeZoneConverter" Version="5.0.0" />
   </ItemGroup>
 
     <ItemGroup>

--- a/Source/ACE.Common/DerethDateTime.cs
+++ b/Source/ACE.Common/DerethDateTime.cs
@@ -1,5 +1,7 @@
 using System;
 
+using TimeZoneConverter;
+
 namespace ACE.Common
 {
     /// <summary>
@@ -1059,6 +1061,6 @@ namespace ACE.Common
         /// <summary>
         /// Converts the <see cref="DateTime.UtcNow"/> object to a new <see cref="DerethDateTime"/> object set to EMU Standard Sync Time.
         /// </summary>
-        public static DerethDateTime UtcNowToEMUTime => new DerethDateTime((DateTime.UtcNow - TimeZoneInfo.ConvertTimeToUtc(retailDayLast_RealWorld, TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time"))).TotalSeconds);
+        public static DerethDateTime UtcNowToEMUTime => new DerethDateTime((DateTime.UtcNow - TimeZoneInfo.ConvertTimeToUtc(retailDayLast_RealWorld, TZConvert.GetTimeZoneInfo("Eastern Standard Time"))).TotalSeconds);
     }
 }


### PR DESCRIPTION
due to cross platform issues with native dotnet6 implementation