### PR TITLE
Alternative determination of patch directory path and patch apply record file path.

### DIFF
--- a/Source/ACE.Server/Program_DbUpdates.cs
+++ b/Source/ACE.Server/Program_DbUpdates.cs
@@ -240,6 +240,29 @@ namespace ACE.Server
         {
             var updatesPath = $"DatabaseSetupScripts{Path.DirectorySeparatorChar}Updates{Path.DirectorySeparatorChar}{dbType}";
             var updatesFile = $"{updatesPath}{Path.DirectorySeparatorChar}applied_updates.txt";
+
+            if (!Directory.Exists(updatesPath))
+            {
+                // File not found in Environment.CurrentDirectory
+                // Lets try the ExecutingAssembly Location
+                var executingAssemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
+
+                var directoryName = Path.GetFullPath(Path.GetDirectoryName(executingAssemblyLocation));
+
+                updatesPath = Path.Combine(directoryName, $"DatabaseSetupScripts{Path.DirectorySeparatorChar}Updates{Path.DirectorySeparatorChar}{dbType}");
+
+                if (!Directory.Exists(updatesPath))
+                {
+                    Console.WriteLine($" error!");
+                    Console.WriteLine($" Unable to locate updates directory");
+                }
+                else
+                {
+                    updatesFile = $"{updatesPath}{Path.DirectorySeparatorChar}applied_updates.txt";
+                }
+
+            }
+
             var appliedUpdates = Array.Empty<string>();
 
             var containerUpdatesFile = $"/ace/Config/{dbType}_applied_updates.txt";


### PR DESCRIPTION
Adds fallback using path of executing assembly to help determine the updates directory path and patch apply record file path when the current directory is set to an unexpected directory path.  This alleviates issue #3885