### PR TITLE
[TEST] Add audit trail to Destroy, TryRemoveFromInventory, TryDequipObject

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PositionType.cs
+++ b/Source/ACE.Entity/Enum/Properties/PositionType.cs
@@ -183,6 +183,9 @@ namespace ACE.Entity.Enum.Properties
         TeleportedCharacter = 27,
 
         [ServerOnly]
-        PCAPRecordedLocation = 8040
+        PCAPRecordedLocation = 8040,
+
+        [ServerOnly]
+        PreDestroyLocation = 9000
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -96,6 +96,16 @@ namespace ACE.Entity.Enum.Properties
         GodState                        = 9006,
         [ServerOnly]
         TinkerLog                       = 9007,
+        [ServerOnly]
+        DestroyStackLog                 = 9008,
+        [ServerOnly]
+        PreviousOwners                  = 9009,
+        [ServerOnly]
+        PreviousWielders                = 9010,
+        [ServerOnly]
+        PreviousOwnerStackLog           = 9011,
+        [ServerOnly]
+        PreviousWielderStackLog         = 9012,
     }
 
     public static class PropertyStringExtensions

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -648,6 +648,33 @@ namespace ACE.Server.WorldObjects
             {
                 int removedItemsPlacementPosition = item.PlacementPosition ?? 0;
 
+                var currentPrevOwners = item.GetProperty(PropertyString.PreviousOwners) ?? "";
+                var currentOwner = item.OwnerId ?? 0;
+                if (!ObjectGuid.IsPlayer(currentOwner))
+                {
+                    if (item.Container is Container && item.Container.Container is Player)
+                        currentOwner = item.Container.Container.Guid.Full;
+                }
+
+                //if (!ObjectGuid.IsPlayer(currentOwner) && !ObjectGuid.IsStatic(currentOwner))
+                if (!ObjectGuid.IsPlayer(currentOwner))
+                    currentOwner = 0;
+
+                if (currentOwner > 0)
+                {
+                    var owners = currentPrevOwners.Split(";", StringSplitOptions.RemoveEmptyEntries);
+                    if (owners.Length > 0)
+                    {
+                        var lastOwner = owners[owners.Length - 1];
+                        if (Convert.ToUInt32(lastOwner[2..10], 16) != currentOwner)
+                            item.SetProperty(PropertyString.PreviousOwners, currentPrevOwners + $"0x{currentOwner:X8}:{Common.Time.GetUnixTime()};");
+                    }
+                    else
+                        item.SetProperty(PropertyString.PreviousOwners, currentPrevOwners + $"0x{currentOwner:X8}:{Common.Time.GetUnixTime()};");
+                }
+
+                item.SetProperty(PropertyString.PreviousOwnerStackLog, Environment.StackTrace);
+
                 item.OwnerId = null;
                 item.ContainerId = null;
                 item.Container = null;

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -379,6 +379,28 @@ namespace ACE.Server.WorldObjects
 
             RemoveItemFromEquippedItemsRatingCache(worldObject);
 
+            var currentPrevOwners = worldObject.GetProperty(PropertyString.PreviousWielders) ?? "";
+            var currentOwner = worldObject.WielderId ?? 0;
+
+            //if (!ObjectGuid.IsPlayer(currentOwner) && !ObjectGuid.IsStatic(currentOwner))
+            if (!ObjectGuid.IsPlayer(currentOwner))
+                currentOwner = 0;
+
+            if (currentOwner > 0)
+            {
+                var owners = currentPrevOwners.Split(";", StringSplitOptions.RemoveEmptyEntries);
+                if (owners.Length > 0)
+                {
+                    var lastOwner = owners[owners.Length - 1];
+                    if (Convert.ToUInt32(lastOwner[2..10], 16) != currentOwner)
+                        worldObject.SetProperty(PropertyString.PreviousWielders, currentPrevOwners + $"0x{currentOwner:X8}:{Time.GetUnixTime()};");
+                }
+                else
+                    worldObject.SetProperty(PropertyString.PreviousWielders, currentPrevOwners + $"0x{currentOwner:X8}:{Time.GetUnixTime()};");
+            }
+
+            worldObject.SetProperty(PropertyString.PreviousWielderStackLog, Environment.StackTrace);
+
             wieldedLocation = worldObject.CurrentWieldedLocation ?? EquipMask.None;
 
             worldObject.RemoveProperty(PropertyInt.CurrentWieldedLocation);

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -883,10 +883,72 @@ namespace ACE.Server.WorldObjects
 
             CurrentLandblock?.RemoveWorldObject(Guid);
 
-            RemoveBiotaFromDatabase();
+            if (Stuck || ValidLocations < EquipMask.HeadWear || (Container?.Guid.IsStatic() ?? false) || (!Wielder?.Guid.IsPlayer() ?? false))
+            {
+                RemoveBiotaFromDatabase();
 
-            if (Guid.IsDynamic())
-                GuidManager.RecycleDynamicGuid(Guid);
+                if (Guid.IsDynamic())
+                    GuidManager.RecycleDynamicGuid(Guid);
+            }
+            else
+            {
+                var logline = "[DESTROY] ";
+                if (StackSize > 1)
+                logline += $"{StackSize:N0}x ";
+                logline += $"{GetNameWithMaterial(StackSize)} ";
+                logline += $"({Name} | {WeenieClassId} | 0x{Guid}) ";
+                logline += "has been destroyed but not deleted. ";
+                logline += $"OwnerId: 0x{OwnerId ?? 0:X8} | WielderId: 0x{WielderId ?? 0:X8} | ContainerId: 0x{ContainerId ?? 0:X8}\n";
+                if (Location != null && Location.LandblockId.Raw > 0)
+                {
+                    logline += $"LOC: {Location.ToLOCString()}\n";
+                    SetPosition(PositionType.PreDestroyLocation, new Position(Location));
+                    Location = null;
+                }
+                else
+                    logline += $"No Previous Location\n";
+                var previousOwners = GetProperty(PropertyString.PreviousOwners) ?? "";
+                var prevOwners = previousOwners.Split(";", StringSplitOptions.RemoveEmptyEntries);
+                if (prevOwners.Length > 0)
+                {
+                    logline += "Previous Owners: ";
+                    foreach (var p in prevOwners)
+                    {
+                        var po = PlayerManager.FindByGuid(new ObjectGuid(Convert.ToUInt32(p[0..10], 16)));
+                        if (po != null)
+                            logline += $"{po.Name} (0x{po.Guid}) ({Time.GetDateTimeFromTimestamp(Convert.ToDouble(p[11..])):G}), ";
+                        else
+                            logline += $"{p[0..10]} ({Time.GetDateTimeFromTimestamp(Convert.ToDouble(p[11..])):G}), ";
+                    }
+                    if (logline.EndsWith(", "))
+                        logline = logline[..^2] + "\n";
+                }
+                else
+                    logline += $"No Previous Owners\n";
+                var previousWielders = GetProperty(PropertyString.PreviousWielders) ?? "";
+                var prevWielders = previousWielders.Split(";", StringSplitOptions.RemoveEmptyEntries);
+                if (prevWielders.Length > 0)
+                {
+                    logline += "Previous Wielders: ";
+                    foreach (var p in prevWielders)
+                    {
+                        var po = PlayerManager.FindByGuid(new ObjectGuid(Convert.ToUInt32(p[0..10], 16)));
+                        if (po != null)
+                            logline += $"{po.Name} (0x{po.Guid}) ({Time.GetDateTimeFromTimestamp(Convert.ToDouble(p[11..])):G}), ";
+                        else
+                            logline += $"{p[0..10]} ({Time.GetDateTimeFromTimestamp(Convert.ToDouble(p[11..])):G}), ";
+                    }
+                    if (logline.EndsWith(", "))
+                        logline = logline[..^2] + "\n";
+                }
+                else
+                    logline += $"No Previous Wielders\n";
+                var loglineStackTrace = System.Environment.StackTrace;
+                //logline += $"StackTrace: {loglineStackTrace}";
+                log.Debug(logline);
+                SetProperty(PropertyString.DestroyStackLog, loglineStackTrace);
+                SaveBiotaToDatabase();
+            }
         }
 
         public void FadeOutAndDestroy(bool raiseNotifyOfDestructionEvent = true)


### PR DESCRIPTION
This disables wieldable item deletion from database except upon startup orphan purge.

PurgeOrphanedBiotas should be disabled to gather test data.

This will consume GUIDs at a significantly higher rate as any item not deleted cannot be recycled