### PR TITLE
adding NonProjectileMagicImmune check to target procs

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Combat.cs
@@ -30,7 +30,7 @@ namespace ACE.Server.WorldObjects
             {
                 // projectile
                 // monster
-                TryProcItem(attacker, target);
+                TryProcItem(attacker, target, selfTarget);
             }
 
             // handle proc spells for weapon
@@ -38,14 +38,14 @@ namespace ACE.Server.WorldObjects
             if (weapon != null && weapon.HasProc && weapon.ProcSpellSelfTargeted == selfTarget)
             {
                 // weapon
-                weapon.TryProcItem(attacker, target);
+                weapon.TryProcItem(attacker, target, selfTarget);
             }
 
             if (attacker != this && attacker.HasProc && attacker.ProcSpellSelfTargeted == selfTarget)
             {
                 // handle special case -- missile projectiles from monsters w/ a proc directly on the mob
                 // monster
-                attacker.TryProcItem(attacker, target);
+                attacker.TryProcItem(attacker, target, selfTarget);
             }
 
             // handle aetheria procs
@@ -55,7 +55,7 @@ namespace ACE.Server.WorldObjects
 
                 // aetheria
                 foreach (var aetheria in equippedAetheria)
-                    aetheria.TryProcItem(attacker, target);
+                    aetheria.TryProcItem(attacker, target, selfTarget);
             }
         }
     }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -954,7 +954,7 @@ namespace ACE.Server.WorldObjects
             return HasProc && ProcSpell == spellID;
         }
 
-        public void TryProcItem(WorldObject attacker, Creature target)
+        public void TryProcItem(WorldObject attacker, Creature target, bool selfTarget)
         {
             // roll for a chance of casting spell
             var chance = ProcSpellRate ?? 0.0f;
@@ -978,6 +978,17 @@ namespace ACE.Server.WorldObjects
                     else
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"{spell.Name} spell not implemented, yet!", ChatMessageType.System));
                 }
+                return;
+            }
+
+            // not sure if this should go before or after the resist check
+            // after would match Player_Magic, but would require changing the signature of TryCastSpell yet again
+            // starting with the simpler check here
+            if (!selfTarget && target != null && target.NonProjectileMagicImmune && !spell.IsProjectile)
+            {
+                if (attacker is Player player)
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You fail to affect {target.Name} with {spell.Name}", ChatMessageType.Magic));
+
                 return;
             }
 


### PR DESCRIPTION
this fixes phials being able to cast imperil/vuln on NonProjectileMagicImmune mobs

thanks to Boskangeroe for reporting this issue