### PR TITLE
Added import-sql-folders command

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -288,7 +288,7 @@ namespace ACE.Server.Command.Handlers.Processors
             }
 
             foreach (var file in files)
-                ImportSQLWeenie(session, file.DirectoryName + "\\", file.Name);
+                ImportSQLWeenie(session, file.DirectoryName + sep, file.Name);
                 
         }
 

--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -211,6 +211,13 @@ namespace ACE.Server.Command.Handlers.Processors
                 ImportJsonQuest(session, json_folder, file.Name);
         }
 
+        [CommandHandler("import-sql-folders", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Imports all weenie sql data from the Content folder and all sub-folders", "<wcid>")]
+        public static void HandleImportSQLFolders(Session session, params string[] parameters)
+        {
+            var param = parameters[0];
+            ImportSQLWeenie(session, param, true);
+        }
+
         [CommandHandler("import-sql", AccessLevel.Developer, CommandHandlerFlag.None, 1, "Imports sql data from the Content folder", "<wcid>")]
         public static void HandleImportSQL(Session session, params string[] parameters)
         {
@@ -254,7 +261,7 @@ namespace ACE.Server.Command.Handlers.Processors
             }
         }
 
-        public static void ImportSQLWeenie(Session session, string wcid)
+        public static void ImportSQLWeenie(Session session, string wcid, bool withFolders = false)
         {
             DirectoryInfo di = VerifyContentFolder(session);
             if (!di.Exists) return;
@@ -270,7 +277,9 @@ namespace ACE.Server.Command.Handlers.Processors
 
             di = new DirectoryInfo(sql_folder);
 
-            var files = di.Exists ? di.GetFiles($"{prefix}*.sql") : null;
+            EnumerationOptions options = new EnumerationOptions();
+            options.RecurseSubdirectories = withFolders;
+            var files = di.Exists ? di.GetFiles($"{prefix}*.sql", options) : null;
 
             if (files == null || files.Length == 0)
             {
@@ -279,7 +288,8 @@ namespace ACE.Server.Command.Handlers.Processors
             }
 
             foreach (var file in files)
-                ImportSQLWeenie(session, sql_folder, file.Name);
+                ImportSQLWeenie(session, file.DirectoryName + "\\", file.Name);
+                
         }
 
         public static void ImportSQLRecipe(Session session, string recipeId)


### PR DESCRIPTION
Allows importing of Weenie SQL within sub-folders in the content folder (this goes with the `export-sql-folders` command which exports to the `weenietype\itemtype` folder)

Syntax: `import-sql-folders <wcid>`, e.g. `import-sql-folders 12345` or `import-sql-folders all`