### PR TITLE
Use existing Character Ref OnLogin, if exists

### DIFF
--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -589,17 +589,28 @@ namespace ACE.Database
 
             var results = query.ToList();
 
-            query.Include(r => r.CharacterPropertiesContractRegistry).Load();
-            query.Include(r => r.CharacterPropertiesFillCompBook).Load();
-            query.Include(r => r.CharacterPropertiesFriendList).Load();
-            query.Include(r => r.CharacterPropertiesQuestRegistry).Load();
-            query.Include(r => r.CharacterPropertiesShortcutBar).Load();
-            query.Include(r => r.CharacterPropertiesSpellBar).Load();
-            query.Include(r => r.CharacterPropertiesSquelch).Load();
-            query.Include(r => r.CharacterPropertiesTitleBook).Load();
+            for (int i = 0; i < results.Count; i++)
+            {
+                // Do we have a reference to this Character already?
+                var existingChar = CharacterContexts.FirstOrDefault(r => r.Key.Id == results[i].Id);
 
-            foreach (var result in results)
-                CharacterContexts.Add(result, context);
+                if (existingChar.Key != null)
+                    results[i] = existingChar.Key;
+                else
+                {
+                    // No reference, pull all the properties and add it to the cache
+                    query.Include(r => r.CharacterPropertiesContractRegistry).Load();
+                    query.Include(r => r.CharacterPropertiesFillCompBook).Load();
+                    query.Include(r => r.CharacterPropertiesFriendList).Load();
+                    query.Include(r => r.CharacterPropertiesQuestRegistry).Load();
+                    query.Include(r => r.CharacterPropertiesShortcutBar).Load();
+                    query.Include(r => r.CharacterPropertiesSpellBar).Load();
+                    query.Include(r => r.CharacterPropertiesSquelch).Load();
+                    query.Include(r => r.CharacterPropertiesTitleBook).Load();
+
+                    CharacterContexts.Add(results[i], context);
+                }
+            }
 
             return results;
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Database.cs
@@ -68,7 +68,7 @@ namespace ACE.Server.WorldObjects
                         if (this is Player player)
                         {
                             //todo: remove this later?
-                            //player.Session.Network.EnqueueSend(new GameMessageSystemChat("WARNING: A database save for this character has failed. As a result of this failure, it is possible for future saves to also fail. In order to avoid a potentially significant character rollback, please find a safe place, log out of the game and then reconnect & re-login. This error has also been logged to be further reviewed by ACEmulator team.", ChatMessageType.WorldBroadcast));
+                            //player.Session.Network.EnqueueSend(new GameMessageSystemChat("WARNING: A database save for this player has failed. As a result of this failure, it is possible for future saves to also fail. In order to avoid a potentially significant character rollback, please find a safe place, log out of the game and then reconnect & re-login. This error has also been logged to be further reviewed by ACEmulator team.", ChatMessageType.WorldBroadcast));
 
                             // This will trigger a boot on next player tick
                             player.BiotaSaveFailed = true;


### PR DESCRIPTION
This resolves the race condition described as follows:

Session 0 logins in, enters world.
Session 0 closes client with X.
Person reconnects asap.
Session 1 pulls a new, full character list from the DB. Session 0, Character does final logoff (Y logoff animation completes) and does final save Character in database is updated
Session 1 Character record is now not up to date with what exists in the DB.

This PR re-uses Character references when they exist, and thus, solving the race condition, because the character that gets updated during the Y logoff animation is the same reference that the relogged client is also holding onto (at the character selection screen).

The Character cannot be relogged (already existing) until the prev instance is fully out of world, thus, there is no worry of concurrency with two sessions holding ref to the same character object.