### PR TITLE
No burden before level 10 (configurable)

### DIFF
--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -565,6 +565,8 @@ namespace ACE.Server.Entity
         /// <param name="player">The fellowship member who originated the luminance</param>
         public void SplitLuminance(ulong amount, XpType xpType, ShareType shareType, Player player)
         {
+            return; //Hard disable luminance
+
             // https://asheron.fandom.com/wiki/Announcements_-_2002/02_-_Fever_Dreams#Letter_to_the_Players_1
 
             shareType &= ~ShareType.Fellowship;

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -619,6 +619,7 @@ namespace ACE.Server.Managers
                 ("corpse_spam_limit", new Property<long>(15, "the number of corpses a player is allowed to leave on a landblock at one time")),
                 ("default_subscription_level", new Property<long>(1, "retail defaults to 1, 1 = standard subscription (same as 2 and 3), 4 grants ToD pre-order bonus item Asheron's Benediction")),
                 ("fellowship_even_share_level", new Property<long>(50, "level when fellowship XP sharing is no longer restricted")),
+                ("ignore_burden_below_character_level", new Property<long>(10, "The minimum character level at which burden will start to apply. Retail defaults to 0.")),
                 ("mansion_min_rank", new Property<long>(6, "overrides the default allegiance rank required to own a mansion")),
                 ("max_chars_per_account", new Property<long>(11, "retail defaults to 11, client supports up to 20")),
                 ("pk_timer", new Property<long>(20, "the number of seconds where a player cannot perform certain actions (ie. teleporting) after becoming involved in a PK battle")),

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -65,6 +65,11 @@ namespace ACE.Server.WorldObjects
         public ACE.Entity.Position LastGroundPos;
         public ACE.Entity.Position SnapPos;
 
+        public bool IsBurdenIgnored
+        {
+            get { return this.Level < PropertyManager.GetLong("ignore_burden_below_character_level").Item; }
+        }
+
         public ConfirmationManager ConfirmationManager;
 
         public SquelchManager SquelchManager;

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -44,6 +44,18 @@ namespace ACE.Server.WorldObjects
             }
 
             var slumlord = (SlumLord)CurrentLandblock.GetObject(slumlord_id);
+
+            // Housing Disabled (apartments only).
+            if (slumlord.House.HouseType == HouseType.Apartment
+                || slumlord.House.HouseType == HouseType.Cottage
+                || slumlord.House.HouseType == HouseType.Villa
+                //|| slumlord.House.HouseType == HouseType.Mansion
+                )
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat("Only Mansions are available for purchase at this time...", ChatMessageType.Broadcast));
+                return;
+            }
+
             if (slumlord == null)
             {
                 log.Error($"[HOUSE] {Name}.HandleActionBuyHouse: Couldn't find slumlord 0x{slumlord_id:X8}!");

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -45,6 +45,8 @@ namespace ACE.Server.WorldObjects
 
         public int GetEncumbranceCapacity()
         {
+            if (this.IsBurdenIgnored)
+                return 10000000;
             var strength = Attributes[PropertyAttribute.Strength].Current;
 
             return (int)((150 * strength) + (AugmentationIncreasedCarryingCapacity * 30 * strength));

--- a/Source/ACE.Server/WorldObjects/Player_Luminance.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Luminance.cs
@@ -14,6 +14,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void EarnLuminance(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            return; //Hard disable luminance
+
             if (IsOlthoiPlayer)
                 return;
 
@@ -34,6 +36,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void GrantLuminance(long amount, XpType xpType, ShareType shareType = ShareType.All)
         {
+            return; //Luminance is hard disabled
+
             if (IsOlthoiPlayer)
                 return;
 
@@ -49,6 +53,8 @@ namespace ACE.Server.WorldObjects
 
         private void AddLuminance(long amount, XpType xpType)
         {
+            return; //Luminance is hard disabled
+
             var available = AvailableLuminance ?? 0;
             var maximum = MaximumLuminance ?? 0;
 
@@ -74,6 +80,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool SpendLuminance(long amount)
         {
+            return false; //Hard disable luminance
+
             var available = AvailableLuminance ?? 0;
 
             if (amount > available)
@@ -91,6 +99,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         private void UpdateLuminance()
         {
+            return; //Luminance is hard disabled
+
             Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt64(this, PropertyInt64.AvailableLuminance, AvailableLuminance ?? 0));
         }
     }

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -334,6 +334,10 @@ namespace ACE.Server.WorldObjects
 
                 Session.Network.EnqueueSend(levelUp);
 
+                var ignore_burden_below_character_level = PropertyManager.GetLong("ignore_burden_below_character_level").Item;
+                if (startingLevel < ignore_burden_below_character_level && Level >= ignore_burden_below_character_level)
+                    Session.Network.EnqueueSend(new GameMessageSystemChat($"WARNING: Your level has reached {Level.Value} you now suffer from the effects of burden! (This effect may not be applied until the next time you log in.)", ChatMessageType.Broadcast));
+
                 SetMaxVitals();
 
                 // play level up effect

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1874,7 +1874,18 @@ namespace ACE.Server.WorldObjects
         public int? EncumbranceVal
         {
             get => GetProperty(PropertyInt.EncumbranceVal);
-            set { if (!value.HasValue) RemoveProperty(PropertyInt.EncumbranceVal); else SetProperty(PropertyInt.EncumbranceVal, value.Value); }
+            set {
+                if (!value.HasValue)
+                    RemoveProperty(PropertyInt.EncumbranceVal);
+                else
+                {
+                    //Player will need to relog once they are past the level limit for burden.
+                    //Couldn't find any way around this as the packet for EncumbranceCapacity seems to be ignored by the client. 
+                    if (this is Player && this.Level < PropertyManager.GetLong("ignore_burden_below_character_level").Item)
+                        value = 0;
+                    SetProperty(PropertyInt.EncumbranceVal, value.Value);
+                }
+            }
         }
 
         public double? BulkMod


### PR DESCRIPTION
added no burden for players up to a configurable level (default set to 10) as to keep metas from benefiting. but still able to be helpful for mules or key pullers.