### PR TITLE
Added `spell` to import/export sql functions

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -59,6 +59,8 @@ namespace ACE.Server.Command.Handlers.Processors
                     return FileType.Recipe;
                 else if (fileType.StartsWith("weenie"))
                     return FileType.Weenie;
+                else if (fileType.StartsWith("spell"))
+                    return FileType.Spell;
             }
             return FileType.Undefined;
         }
@@ -250,6 +252,10 @@ namespace ACE.Server.Command.Handlers.Processors
                         ImportSQLRecipe(session, param);
                         break;
 
+                    case FileType.Spell:
+                        ImportSQLSpell(session, param);
+                        break;
+
                     case FileType.Weenie:
                         ImportSQLWeenie(session, param);
                         break;
@@ -374,6 +380,34 @@ namespace ACE.Server.Command.Handlers.Processors
 
             foreach (var file in files)
                 ImportSQLQuest(session, sql_folder, file.Name);
+        }
+
+        public static void ImportSQLSpell(Session session, string spellId)
+        {
+            DirectoryInfo di = VerifyContentFolder(session);
+            if (!di.Exists) return;
+
+            var sep = Path.DirectorySeparatorChar;
+
+            var sql_folder = $"{di.FullName}{sep}sql{sep}spells{sep}";
+
+            var prefix = spellId.PadLeft(5, '0') + " ";
+
+            if (spellId.Equals("all", StringComparison.OrdinalIgnoreCase))
+                prefix = "";
+
+            di = new DirectoryInfo(sql_folder);
+
+            var files = di.Exists ? di.GetFiles($"{prefix}*.sql") : null;
+
+            if (files == null || files.Length == 0)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Couldn't find {sql_folder}{prefix}*.sql");
+                return;
+            }
+
+            foreach (var file in files)
+                ImportSQLSpell(session, sql_folder, file.Name);
         }
 
         /// <summary>
@@ -567,6 +601,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
         public static CookBookSQLWriter CookBookSQLWriter;
         public static RecipeSQLWriter RecipeSQLWriter;
+        public static SpellSQLWriter SpellSQLWriter;
 
         public static string json2sql_recipe(Session session, string folder, string json_filename)
         {
@@ -902,6 +937,25 @@ namespace ACE.Server.Command.Handlers.Processors
 
             // convert to json file
             sql2json_quest(session, quest, sql_folder, sql_file);
+        }
+
+        private static void ImportSQLSpell(Session session, string sql_folder, string sql_file)
+        {
+            if (!uint.TryParse(Regex.Match(sql_file, @"\d+").Value, out var spellId))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Couldn't find spell id from {sql_file}");
+                return;
+            }
+
+            // import sql to db
+            ImportSQL(sql_folder + sql_file);
+            CommandHandlerHelper.WriteOutputInfo(session, $"Imported {sql_file}");
+
+            // clear this spell out of the cache (and everything else)
+            DatabaseManager.World.ClearSpellCache();
+
+            // load spell from db
+            var spell = DatabaseManager.World.GetCachedSpell(spellId);
         }
 
         /// <summary>
@@ -2019,6 +2073,10 @@ namespace ACE.Server.Command.Handlers.Processors
                     ExportSQLRecipe(session, param);
                     break;
 
+                case FileType.Spell:
+                    ExportSQLSpell(session, param);
+                    break;
+
                 case FileType.Weenie:
                     ExportSQLWeenie(session, param);
                     break;
@@ -2272,6 +2330,60 @@ namespace ACE.Server.Command.Handlers.Processors
                 sqlFile.WriteLine();
 
                 QuestSQLWriter.CreateSQLINSERTStatement(quest, sqlFile);
+
+                sqlFile.Close();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                CommandHandlerHelper.WriteOutputInfo(session, $"Failed to export {sql_folder}{sql_filename}");
+                return;
+            }
+
+            CommandHandlerHelper.WriteOutputInfo(session, $"Exported {sql_folder}{sql_filename}");
+        }
+
+
+        public static void ExportSQLSpell(Session session, string param)
+        {
+            DirectoryInfo di = VerifyContentFolder(session, false);
+
+            var sep = Path.DirectorySeparatorChar;
+
+            if (!uint.TryParse(param, out var spellId))
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"{param} not a valid spell id");
+                return;
+            }
+
+            var spell = DatabaseManager.World.GetCachedSpell(spellId);
+
+            if (spell == null)
+            {
+                CommandHandlerHelper.WriteOutputInfo(session, $"Couldn't find spell id {spellId}");
+                return;
+            }
+
+            var sql_folder = $"{di.FullName}{sep}sql{sep}spells{sep}";
+
+            di = new DirectoryInfo(sql_folder);
+
+            if (!di.Exists)
+                di.Create();
+
+            if (SpellSQLWriter == null)
+                SpellSQLWriter = new SpellSQLWriter();
+
+            var sql_filename = SpellSQLWriter.GetDefaultFileName(spell);
+
+            try
+            {
+                var sqlFile = new StreamWriter(sql_folder + sql_filename);
+
+                SpellSQLWriter.CreateSQLDELETEStatement(spell, sqlFile);
+                sqlFile.WriteLine();
+
+                SpellSQLWriter.CreateSQLINSERTStatement(spell, sqlFile);
 
                 sqlFile.Close();
             }


### PR DESCRIPTION
Syntax is:

`export-sql spell <spellId>` or `import-sql spell <spellId>`