### PR TITLE
fixes for previous checkins

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperContentCommands.cs
@@ -953,6 +953,7 @@ namespace ACE.Server.Command.Handlers.Processors
 
             // clear this spell out of the cache (and everything else)
             DatabaseManager.World.ClearSpellCache();
+            WorldObject.ClearSpellCache();
 
             // load spell from db
             var spell = DatabaseManager.World.GetCachedSpell(spellId);

--- a/Source/ACE.Server/Entity/CastSpellParams.cs
+++ b/Source/ACE.Server/Entity/CastSpellParams.cs
@@ -7,19 +7,19 @@ namespace ACE.Server.Entity
     {
         public Spell Spell { get; set; }
         //public bool IsWeaponSpell { get; set; }
-        public WorldObject Caster { get; set; }
+        public WorldObject CasterItem { get; set; }
         public uint MagicSkill { get; set; }
         public uint ManaUsed { get; set; }
         public WorldObject Target { get; set; }
         public Player.CastingPreCheckStatus Status { get; set; }
 
-        public bool HasWindupGestures => !Spell.Flags.HasFlag(SpellFlags.FastCast) && Caster == null && Spell.Formula.HasWindupGestures;
+        public bool HasWindupGestures => !Spell.Flags.HasFlag(SpellFlags.FastCast) && CasterItem == null && Spell.Formula.HasWindupGestures;
 
-        public CastSpellParams(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
+        public CastSpellParams(Spell spell, WorldObject casterItem, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
         {
             Spell = spell;
             //IsWeaponSpell = isWeaponSpell;
-            Caster = caster;
+            CasterItem = casterItem;
             MagicSkill = magicSkill;
             ManaUsed = manaUsed;
             Target = target;
@@ -30,7 +30,7 @@ namespace ACE.Server.Entity
         {
             var targetName = Target != null ? Target.Name : "null";
 
-            return $"{Spell.Name}, {Caster?.Name}, {MagicSkill}, {ManaUsed}, {targetName}, {Status}";
+            return $"{Spell.Name}, {CasterItem?.Name}, {MagicSkill}, {ManaUsed}, {targetName}, {Status}";
         }
     }
 }

--- a/Source/ACE.Server/Entity/CastSpellParams.cs
+++ b/Source/ACE.Server/Entity/CastSpellParams.cs
@@ -9,20 +9,18 @@ namespace ACE.Server.Entity
         //public bool IsWeaponSpell { get; set; }
         public WorldObject Caster { get; set; }
         public uint MagicSkill { get; set; }
-        public uint BaseMagicSkill { get; set; }
         public uint ManaUsed { get; set; }
         public WorldObject Target { get; set; }
         public Player.CastingPreCheckStatus Status { get; set; }
 
         public bool HasWindupGestures => !Spell.Flags.HasFlag(SpellFlags.FastCast) && Caster == null && Spell.Formula.HasWindupGestures;
 
-        public CastSpellParams(Spell spell, WorldObject caster, uint magicSkill, uint baseMagicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
+        public CastSpellParams(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
         {
             Spell = spell;
             //IsWeaponSpell = isWeaponSpell;
             Caster = caster;
             MagicSkill = magicSkill;
-            BaseMagicSkill = baseMagicSkill;
             ManaUsed = manaUsed;
             Target = target;
             Status = status;
@@ -32,7 +30,7 @@ namespace ACE.Server.Entity
         {
             var targetName = Target != null ? Target.Name : "null";
 
-            return $"{Spell.Name}, {Caster?.Name}, {MagicSkill}, {BaseMagicSkill}, {ManaUsed}, {targetName}, {Status}";
+            return $"{Spell.Name}, {Caster?.Name}, {MagicSkill}, {ManaUsed}, {targetName}, {Status}";
         }
     }
 }

--- a/Source/ACE.Server/Entity/MagicState.cs
+++ b/Source/ACE.Server/Entity/MagicState.cs
@@ -184,9 +184,9 @@ namespace ACE.Server.Entity
             WindupParams = null;
         }
 
-        public void SetCastParams(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
+        public void SetCastParams(Spell spell, WorldObject casterItem, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
         {
-            CastSpellParams = new CastSpellParams(spell, caster, magicSkill, manaUsed, target, status);
+            CastSpellParams = new CastSpellParams(spell, casterItem, magicSkill, manaUsed, target, status);
 
             if (Player.RecordCast.Enabled && CastSpellParams.Target != null)
                 Player.RecordCast.Log($"Target Location: {CastSpellParams.Target.Location.ToLOCString()}");

--- a/Source/ACE.Server/Entity/MagicState.cs
+++ b/Source/ACE.Server/Entity/MagicState.cs
@@ -184,9 +184,9 @@ namespace ACE.Server.Entity
             WindupParams = null;
         }
 
-        public void SetCastParams(Spell spell, WorldObject caster, uint magicSkill, uint baseMagicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
+        public void SetCastParams(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, Player.CastingPreCheckStatus status)
         {
-            CastSpellParams = new CastSpellParams(spell, caster, magicSkill, baseMagicSkill, manaUsed, target, status);
+            CastSpellParams = new CastSpellParams(spell, caster, magicSkill, manaUsed, target, status);
 
             if (Player.RecordCast.Enabled && CastSpellParams.Target != null)
                 Player.RecordCast.Log($"Target Location: {CastSpellParams.Target.Location.ToLOCString()}");

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -478,7 +478,7 @@ namespace ACE.Server.WorldObjects
             return false;
         }
 
-        public bool VerifySpellRange(WorldObject target, TargetCategory targetCategory, Spell spell, uint magicSkill)
+        public bool VerifySpellRange(WorldObject target, TargetCategory targetCategory, Spell spell, WorldObject casterItem, uint magicSkill)
         {
             if (targetCategory != TargetCategory.WorldObject && targetCategory != TargetCategory.Wielded || target.Guid == Guid)
                 return true;
@@ -488,6 +488,14 @@ namespace ACE.Server.WorldObjects
                 targetLoc = CurrentLandblock?.GetObject(targetLoc.WielderId.Value);
 
             float distanceTo = Location.Distance2D(targetLoc.Location);
+
+            if (casterItem == null)
+            {
+                // use init + ranks, same as acclient DetermineSpellRange -> InqSkillLevel
+                // this is slightly different from base, and omits things like base augs and enlightenment
+                var playerSkill = GetCreatureSkill(spell.School);
+                magicSkill = playerSkill.InitLevel + playerSkill.Ranks;
+            }
 
             var maxRange = Math.Min(spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod, MaxRadarRange_Outdoors);
 
@@ -699,7 +707,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            DoCastSpell(state.Spell, state.Caster, state.MagicSkill, state.ManaUsed, state.Target, state.Status, checkAngle);
+            DoCastSpell(state.Spell, state.CasterItem, state.MagicSkill, state.ManaUsed, state.Target, state.Status, checkAngle);
         }
 
         public bool IsWithinAngle(WorldObject target)
@@ -731,7 +739,7 @@ namespace ACE.Server.WorldObjects
             return angle <= maxAngle;
         }
 
-        public void DoCastSpell(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, CastingPreCheckStatus castingPreCheckStatus, bool checkAngle = true)
+        public void DoCastSpell(Spell spell, WorldObject casterItem, uint magicSkill, uint manaUsed, WorldObject target, CastingPreCheckStatus castingPreCheckStatus, bool checkAngle = true)
         {
             if (target != null)
             {
@@ -755,7 +763,7 @@ namespace ACE.Server.WorldObjects
 
                         var actionChain = new ActionChain();
                         actionChain.AddDelaySeconds(rotateTime);
-                        actionChain.AddAction(this, () => DoCastSpell(spell, caster, magicSkill, manaUsed, target, castingPreCheckStatus, false));
+                        actionChain.AddAction(this, () => DoCastSpell(spell, casterItem, magicSkill, manaUsed, target, castingPreCheckStatus, false));
                         actionChain.EnqueueChain();
                     }
                     else
@@ -770,7 +778,7 @@ namespace ACE.Server.WorldObjects
                 }
 
                 // verify spell range
-                if (!VerifySpellRange(target, targetCategory, spell, magicSkill))
+                if (!VerifySpellRange(target, targetCategory, spell, casterItem, magicSkill))
                 {
                     FinishCast();
                     return;
@@ -783,7 +791,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            DoCastSpell_Inner(spell, caster, manaUsed, target, castingPreCheckStatus);
+            DoCastSpell_Inner(spell, casterItem, manaUsed, target, castingPreCheckStatus);
         }
 
         public WorldObject TurnTarget;
@@ -1007,7 +1015,7 @@ namespace ACE.Server.WorldObjects
                 magicSkill = (uint)caster.ItemSpellcraft;
 
             // verify spell range
-            if (!VerifySpellRange(target, targetCategory, spell, magicSkill))
+            if (!VerifySpellRange(target, targetCategory, spell, casterItem, magicSkill))
                 return false;
 
             // get casting pre-check status
@@ -1302,7 +1310,7 @@ namespace ACE.Server.WorldObjects
 
             if (parms != null && tryFizzle)
             {
-                DoCastSpell_Inner(parms.Spell, parms.Caster, parms.ManaUsed, parms.Target, CastingPreCheckStatus.CastFailed, false);
+                DoCastSpell_Inner(parms.Spell, parms.CasterItem, parms.ManaUsed, parms.Target, CastingPreCheckStatus.CastFailed, false);
 
                 werror = WeenieError.YourSpellFizzled;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -492,7 +492,7 @@ namespace ACE.Server.WorldObjects
             if (casterItem == null)
             {
                 // use init + ranks, same as acclient DetermineSpellRange -> InqSkillLevel
-                // this is slightly different from base, and omits things like base augs and enlightenment
+                // this is much lower than base, and omits things like attribute formula + base augs + enlightenment
                 var playerSkill = GetCreatureSkill(spell.School);
                 magicSkill = playerSkill.InitLevel + playerSkill.Ranks;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -699,7 +699,7 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            DoCastSpell(state.Spell, state.Caster, state.MagicSkill, state.BaseMagicSkill, state.ManaUsed, state.Target, state.Status, checkAngle);
+            DoCastSpell(state.Spell, state.Caster, state.MagicSkill, state.ManaUsed, state.Target, state.Status, checkAngle);
         }
 
         public bool IsWithinAngle(WorldObject target)
@@ -731,7 +731,7 @@ namespace ACE.Server.WorldObjects
             return angle <= maxAngle;
         }
 
-        public void DoCastSpell(Spell spell, WorldObject caster, uint magicSkill, uint baseMagicSkill, uint manaUsed, WorldObject target, CastingPreCheckStatus castingPreCheckStatus, bool checkAngle = true)
+        public void DoCastSpell(Spell spell, WorldObject caster, uint magicSkill, uint manaUsed, WorldObject target, CastingPreCheckStatus castingPreCheckStatus, bool checkAngle = true)
         {
             if (target != null)
             {
@@ -755,7 +755,7 @@ namespace ACE.Server.WorldObjects
 
                         var actionChain = new ActionChain();
                         actionChain.AddDelaySeconds(rotateTime);
-                        actionChain.AddAction(this, () => DoCastSpell(spell, caster, magicSkill, baseMagicSkill, manaUsed, target, castingPreCheckStatus, false));
+                        actionChain.AddAction(this, () => DoCastSpell(spell, caster, magicSkill, manaUsed, target, castingPreCheckStatus, false));
                         actionChain.EnqueueChain();
                     }
                     else
@@ -770,7 +770,7 @@ namespace ACE.Server.WorldObjects
                 }
 
                 // verify spell range
-                if (!VerifySpellRange(target, targetCategory, spell, baseMagicSkill))
+                if (!VerifySpellRange(target, targetCategory, spell, magicSkill))
                 {
                     FinishCast();
                     return;
@@ -1001,15 +1001,13 @@ namespace ACE.Server.WorldObjects
             var caster = casterItem ?? GetEquippedWand();
             var isWeaponSpell = casterItem != null && IsWeaponSpell(spell.Id, casterItem);
 
-            // Grab player's skill level in the spell's Magic School, current and base
-            var playerSkill = GetCreatureSkill(spell.School);
-            var baseMagicSkill = playerSkill.InitLevel + playerSkill.Ranks; // (matches CACQualities::InqSkillLevel)
-            var magicSkill = playerSkill.Current;
+            // Grab player's skill level in the spell's Magic School
+            var magicSkill = GetCreatureSkill(spell.School).Current;
             if (isWeaponSpell && caster.ItemSpellcraft != null)
                 magicSkill = (uint)caster.ItemSpellcraft;
 
             // verify spell range
-            if (!VerifySpellRange(target, targetCategory, spell, baseMagicSkill))
+            if (!VerifySpellRange(target, targetCategory, spell, magicSkill))
                 return false;
 
             // get casting pre-check status
@@ -1031,7 +1029,7 @@ namespace ACE.Server.WorldObjects
             // cast spell
             DoCastGesture(spell, casterItem, spellChain);
 
-            MagicState.SetCastParams(spell, casterItem, magicSkill, baseMagicSkill, manaUsed, target, castingPreCheckStatus);
+            MagicState.SetCastParams(spell, casterItem, magicSkill, manaUsed, target, castingPreCheckStatus);
 
             if (!FastTick)
                 spellChain.AddAction(this, () => DoCastSpell(MagicState));
@@ -1135,10 +1133,8 @@ namespace ACE.Server.WorldObjects
             if (spell == null)
                 return false;
 
-            // get player's current and base magic skill
-            var playerSkill = GetCreatureSkill(spell.School);
-            var baseMagicSkill = playerSkill.InitLevel + playerSkill.Ranks; // (matches CACQualities::InqSkillLevel)
-            var magicSkill = playerSkill.Current;
+            // get player's current magic skill
+            var magicSkill = GetCreatureSkill(spell.School).Current;
 
             var castingPreCheckStatus = GetCastingPreCheckStatus(spell, magicSkill, false);
 
@@ -1160,7 +1156,7 @@ namespace ACE.Server.WorldObjects
             DoCastGesture(spell, null, spellChain);
 
             // cast untargeted spell
-            MagicState.SetCastParams(spell, null, magicSkill, baseMagicSkill, manaUsed, null, castingPreCheckStatus);
+            MagicState.SetCastParams(spell, null, magicSkill, manaUsed, null, castingPreCheckStatus);
 
             if (!FastTick)
                 spellChain.AddAction(this, () => DoCastSpell(MagicState));

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1357,7 +1357,7 @@ namespace ACE.Server.WorldObjects
 
             var distanceToTarget = creature.GetDistance(targetPlayer);
             var skill = creature.GetCreatureSkill(spell.School);
-            var magicSkill = skill.InitLevel + skill.Ranks;     // ?? - this probably isn't right, should be either base or current
+            var magicSkill = skill.InitLevel + skill.Ranks;     // synced with acclient DetermineSpellRange -> InqSkillLevel
 
             var maxRange = spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod;
             if (maxRange == 0.0f)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1357,7 +1357,7 @@ namespace ACE.Server.WorldObjects
 
             var distanceToTarget = creature.GetDistance(targetPlayer);
             var skill = creature.GetCreatureSkill(spell.School);
-            var magicSkill = skill.InitLevel + skill.Ranks;     // matches CACQualities::InqSkillLevel
+            var magicSkill = skill.InitLevel + skill.Ranks;     // ?? - this probably isn't right, should be either base or current
 
             var maxRange = spell.BaseRangeConstant + magicSkill * spell.BaseRangeMod;
             if (maxRange == 0.0f)


### PR DESCRIPTION
- https://github.com/ACEmulator/ACE/pull/3924 introduced a bug where built-in spells are now using the init + ranks of the caster, instead of the ItemSpellcraft
- cleaned up 3924 to not introduce baseMagicSkill additional parameter
- added missing call to WorldObject.ClearSpellCache() for https://github.com/ACEmulator/ACE/pull/3925
- renamed parameter 'caster' to 'casterItem' for https://github.com/ACEmulator/ACE/pull/3835 to maintain existing consistency. although not the best names, the codebase had previously established these 2 names to mean different things. Specifically, 'casterItem' is always associated with casting the built-in spell in the first slot