### PR TITLE
Allow certain crafting to occur in combat based on server property

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -502,7 +502,7 @@ namespace ACE.Server.Managers
                 ("advanced_combat_pets", new Property<bool>(false, "(non-retail function) If enabled, Combat Pets can cast spells")),
                 ("advocate_fane_auto_bestow", new Property<bool>(false, "If enabled, Advocate Fane will automatically bestow new advocates to advocate_fane_auto_bestow_level")),
                 ("aetheria_heal_color", new Property<bool>(false, "If enabled, changes the aetheria healing over time messages from the default retail red color to green")),
-                ("allow_combat_mode_craft", new Property<bool>(false, "enables ability to do things like craft arrows when not in peace mode")),
+                ("allow_combat_mode_crafting", new Property<bool>(false, "If enabled, allows players to do crafting (recipes) from all stances. Forces players to NonCombat first, then continues to recipe action.")),
                 ("allow_door_hold", new Property<bool>(true, "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players")),
                 ("allow_fast_chug", new Property<bool>(true, "enables retail behavior where a player can consume food and drink faster than normal by breaking animation")),
                 ("allow_jump_loot", new Property<bool>(true, "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation")),

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -502,6 +502,7 @@ namespace ACE.Server.Managers
                 ("advanced_combat_pets", new Property<bool>(false, "(non-retail function) If enabled, Combat Pets can cast spells")),
                 ("advocate_fane_auto_bestow", new Property<bool>(false, "If enabled, Advocate Fane will automatically bestow new advocates to advocate_fane_auto_bestow_level")),
                 ("aetheria_heal_color", new Property<bool>(false, "If enabled, changes the aetheria healing over time messages from the default retail red color to green")),
+                ("allow_combat_mode_craft", new Property<bool>(false, "enables ability to do things like craft arrows when not in peace mode")),
                 ("allow_door_hold", new Property<bool>(true, "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players")),
                 ("allow_fast_chug", new Property<bool>(true, "enables retail behavior where a player can consume food and drink faster than normal by breaking animation")),
                 ("allow_jump_loot", new Property<bool>(true, "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation")),

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -94,15 +94,8 @@ namespace ACE.Server.Managers
             if (!confirmed && player.LumAugSkilledCraft > 0)
                 player.SendMessage($"Your Aura of the Craftman augmentation increased your skill by {player.LumAugSkilledCraft}!");
 
-            var motionCommand = MotionCommand.ClapHands;
-
-            var motion = new Motion(player, motionCommand);
-            var currentStance = player.CurrentMotionState.Stance;
-            var animLength = !confirmed ? Physics.Animation.MotionTable.GetAnimationLength(player.MotionTableId, currentStance, motionCommand) : 0.0f;
-
+            var animLength = 0.0f;
             var actionChain = new ActionChain();
-
-            player.IsBusy = true;
 
             if (craftInCombat)
             {
@@ -112,6 +105,13 @@ namespace ACE.Server.Managers
                 actionChain.AddDelaySeconds(stanceTime);
                 animLength += stanceTime;
             }
+
+            var motionCommand = MotionCommand.ClapHands;
+            var motion = new Motion(player, motionCommand);
+            var currentStance = player.CurrentMotionState.Stance;
+            animLength+= !confirmed ? Physics.Animation.MotionTable.GetAnimationLength(player.MotionTableId, currentStance, motionCommand) : 0.0f;
+
+            player.IsBusy = true;
 
             if (!confirmed)
             {

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -47,7 +47,8 @@ namespace ACE.Server.Managers
                 return;
             }
 
-            if (!PropertyManager.GetBool("allow_combat_mode_craft").Item && (player.CombatMode != CombatMode.NonCombat))
+            var craftInCombat = (PropertyManager.GetBool("allow_combat_mode_craft").Item && (player.CombatMode != CombatMode.NonCombat)) ? true : false;
+            if (!craftInCombat && (player.CombatMode != CombatMode.NonCombat))
             {
                 player.SendUseDoneEvent(WeenieError.YouMustBeInPeaceModeToTrade);
                 return;
@@ -102,6 +103,15 @@ namespace ACE.Server.Managers
             var actionChain = new ActionChain();
 
             player.IsBusy = true;
+
+            if (craftInCombat)
+            {
+                // Drop out of combat mode.  This depends on the server property "allow_combat_mode_craft" being True.
+                // If not, this action would have aborted due to not being in NonCombat mode.
+                var stanceTime = player.SetCombatMode(CombatMode.NonCombat);
+                actionChain.AddDelaySeconds(stanceTime);
+                animLength += stanceTime;
+            }
 
             if (!confirmed)
             {

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -47,7 +47,7 @@ namespace ACE.Server.Managers
                 return;
             }
 
-            if (player.CombatMode != CombatMode.NonCombat)
+            if (!PropertyManager.GetBool("allow_combat_mode_craft").Item && (player.CombatMode != CombatMode.NonCombat))
             {
                 player.SendUseDoneEvent(WeenieError.YouMustBeInPeaceModeToTrade);
                 return;


### PR DESCRIPTION
A recent change https://github.com/ACEmulator/ACE/pull/3922 made it so players may no longer craft arrows while in combat mode.  Since most players don't seem to like this change, this PR adds a Server Property to control the behavior.  The default is to disallow combat mode crafting.  However, with this setting, server operators may choose to enable in combat mode crafting (generally arrows).
