### PR TITLE
Improve ConnectionListener.Listen() to avoid stack overflow

### DIFF
--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -42,7 +42,8 @@ namespace ACE.Server.Network
                 Socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
                 Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 Socket.Bind(ListenerEndpoint);
-                Listen();
+
+                while (Listen());
             }
             catch (Exception exception)
             {
@@ -58,7 +59,10 @@ namespace ACE.Server.Network
                 Socket.Close();
         }
 
-        private void Listen()
+        /// <summary>
+        /// Will return true if the function is to be refired
+        /// </summary>
+        private bool Listen()
         {
             try
             {
@@ -68,12 +72,15 @@ namespace ACE.Server.Network
             catch (SocketException socketException)
             {
                 log.DebugFormat("ConnectionListener.Listen() has thrown {0}: {1}", socketException.SocketErrorCode, socketException.Message);
-                Listen();
+
+                return true;
             }
             catch (Exception exception)
             {
                 log.FatalFormat("ConnectionListener.Listen() has thrown: {0}", exception.Message);
             }
+
+            return false;
         }
 
         private void OnDataReceive(IAsyncResult result)
@@ -125,7 +132,7 @@ namespace ACE.Server.Network
                 }
             }
 
-            Listen();
+            while (Listen());
         }
     }
 }


### PR DESCRIPTION
In rare cases, when Listen() continues to throw a SocketException and call back on itself, and throw and call itself and throw... eventual result is stack overflow.

This change simply returns a bool to indicate of the function should be called again, or the Listen() process should be abandoned.

Note, that even currently, the stack is completely reset on a successful Listen()/OnDataReceive(), as each OnDataReceive() is called as a callback, and thus, not tacked onto the calling stack.

NOTE: This should be tested thoroughly as it touches a core piece of code.