### PR TITLE
Server setting to enable substituting legendary key rewards emotes

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -612,6 +612,7 @@ namespace ACE.Server.Managers
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =
             DictOf(
+                ("award_wcid_for_legendary", new Property<long>(0, "the WCID to award for emote giving instead of legendary keys.  0 = disabled feature")),
                 ("char_delete_time", new Property<long>(3600, "the amount of time in seconds a deleted character can be restored")),
                 ("chat_requires_account_time_seconds", new Property<long>(0, "the amount of time in seconds an account is required to have existed for for global chat privileges")),
                 ("chat_requires_player_age", new Property<long>(0, "the amount of time in seconds a player is required to have played for global chat privileges")),

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -3383,7 +3383,34 @@ namespace ACE.Server.WorldObjects
             Prev_PutItemInContainer[1] = Prev_PutItemInContainer[0];
             Prev_PutItemInContainer[0] = new PutItemInContainerEvent(itemGuid, containerGuid, placement);
         }
-        
+
+        // Map of the various legendary keys that may be given on emote/quest and the number of uses.
+        // Static map for quick comparisons
+        static Dictionary<uint, int> _LegendaryKeyUses = new Dictionary<uint, int>()
+        {
+            {48746, 1 }, // Aged Legendary Key
+            {48747, 1 }, // 24 hour, single use
+            {48748, 2 }, // 24 hour, 2 use
+            {48749, 3 }, // 24 hour, 3 use
+            {48750, 4 }, // 24 hour, 4 use
+            {48914, 1 }, // 24 hour, 1 use, quest legendary chest key
+            {51558, 1 }, // 1 use
+            {51586, 3 }, // 24 hour, 3 use, quest legendary chest key
+            {51648, 3 }, // 24 hour, 3 use, quest legendary chest key
+            {51954, 10 }, // Durable Legendary Key
+            {51963, 25 }, // 25 use
+            {52010, 5 }, // 24 hour, 5 use, quest legendary chest key
+            {72048, 1 }, // 24 hour, 1 use, quest legendary chest key non-pcap
+            {72338, 3 }, // 24 hour, 3 use, quest legendary chest key non-pcap
+            {72474, 2 }, // 24 hour, 2 use, quest legendary chest key non-pcap
+            {72600, 1 }, // 24 hour, 1 use, quest legendary chest key non-pcap
+            {72628, 1 }, // 24 hour, 1 use, quest legendary chest key non-pcap
+            {72635, 3 }, // 24 hour, 3 use, quest legendary chest key non-pcap
+            {72669, 1 }, // 24 hour, 1 use, quest legendary chest key non-pcap
+            {72807, 2 }, // 24 hour, 2 use, quest legendary chest key non-pcap
+            {87168, 4 }  // 24 hour, 4 use, quest legendary chest key non-pcap
+        };
+
         public void GiveFromEmote(WorldObject emoter, uint weenieClassId, int amount = 1, int palette = 0, float shade = 0)
         {
             if (emoter is null || weenieClassId == 0)
@@ -3397,8 +3424,17 @@ namespace ACE.Server.WorldObjects
             }
             var itemsToReceive = new ItemsToReceive(this);
 
-            itemsToReceive.Add(weenieClassId, amount);
+            // If supported by server setting, substitute emote given items across all interactions
+            uint substituteItem = (uint)PropertyManager.GetLong("award_wcid_for_legendary").Item;
+            if ((substituteItem != 0) && _LegendaryKeyUses.ContainsKey(weenieClassId))
+            {
+                // log.Debug($"Substituting {substituteItem} for {weenieClassId} with quantity {amount}");
+                amount *= _LegendaryKeyUses[weenieClassId];
+                weenieClassId = substituteItem;
+                // log.Debug($"Substituted quantity {amount}");
+            }
 
+            itemsToReceive.Add(weenieClassId, amount);
             var itemStacks = itemsToReceive.RequiredSlots;
 
             if (itemsToReceive.PlayerExceedsLimits)


### PR DESCRIPTION
This PR provides a server setting "award_wcid_for_legendary" that allows for substitution of legendary keys with the provided WCID.  For instance, a server offering legendary keys for sale on a vendor for 1 MMD per pull may set this to 20630.  This allows players to not have to deal with large numbers of unstackable legendary keys from Kill Tasks and other quests.  Another option would be Promissory Notes (43901).  The server operator can provide any WCID but generally it would be something stackable.

This change only impacts emote based giving.  It does not change any looting of legendary keys from corpses or chests such as at the casinos.

The default option is "0" which is interpreted as disabled so there is no substitution.

The actual rewards to users depend a bit on how the quest emotes are configured.  If they offer 5 rewards, each of 1 Aged Legendary Key, then the player would get 5 different of the substituted item.  You can see this in the Tou Tou KTs.  For Frozen Valley Gurog, it is a singe reward of multiple keys.  In this case the new items (promissory notes in this case) are stacked.  At Hoshino's the Durable keys become stacks of 10 of the item.

![AgedLegendaries_grp_5](https://user-images.githubusercontent.com/1765994/209414274-24b34a21-ab7f-4838-baeb-87143fe3fbd7.png)
![AgedLegendaries_grp_5_log](https://user-images.githubusercontent.com/1765994/209414281-f149e9c3-ebca-45df-8d93-a9afd0d24e03.png)

![DurableKey_subst_reward](https://user-images.githubusercontent.com/1765994/209414291-5aa9c23e-2d14-4c4f-9d55-b86dba5d88aa.png)
![DurableKey_subst_reward_log](https://user-images.githubusercontent.com/1765994/209414298-ef95ec1e-d45e-4011-89ae-6dad5529f34a.png)

