### PR TITLE
Fix StackOverflow on consecutive syncrhonous OnDataReceive calls

### DIFF
--- a/Source/ACE.Server/Network/ConnectionListener.cs
+++ b/Source/ACE.Server/Network/ConnectionListener.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading.Tasks;
 
 using log4net;
 
@@ -9,6 +10,7 @@ using ACE.Server.Network.Managers;
 
 namespace ACE.Server.Network
 {
+    // Reference: https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.beginreceivefrom?view=net-7.0
     public class ConnectionListener
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -125,7 +127,10 @@ namespace ACE.Server.Network
                 }
             }
 
-            Listen();
+            if (result.CompletedSynchronously)
+                Task.Run(() => Listen());
+            else
+                Listen();
         }
     }
 }


### PR DESCRIPTION
There is no guarantee that OnDataReceive will be called asynchronously.

Every time it is called asynchronously, the stack is reset as it's called via a new task.

If it's called synchronously enough times consecutively, the stack will overflow. Ensuring that it's called on a new task in these scenarios will prevent stack overflows.