### PR TITLE
Wire up ResetInterval logic into some objects

### DIFF
--- a/Source/ACE.Server/WorldObjects/PressurePlate.cs
+++ b/Source/ACE.Server/WorldObjects/PressurePlate.cs
@@ -1,7 +1,9 @@
 using System;
 
+using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Network.GameMessages.Messages;
 
@@ -72,7 +74,23 @@ namespace ACE.Server.WorldObjects
 
             player.EnqueueBroadcast(new GameMessageSound(player.Guid, UseSound));
 
-            base.OnActivate(activator);
+            if (Time.GetUnixTime() < ResetTimestamp)
+            {
+                var activationFailure = GetProperty(PropertyString.ActivationFailure);
+                if (activationFailure != null)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat(activationFailure, ChatMessageType.Broadcast));
+                }
+            }
+            else
+            {
+                base.OnActivate(activator);
+
+                if (ResetInterval > 0)
+                {
+                    ResetTimestamp = Time.GetFutureUnixTime(ResetInterval ?? 0);
+                }
+            }
         }
 
         public override void ActOnUse(WorldObject wo)


### PR DESCRIPTION
For PressurePlates and Switches, when on cooldown send player ActivationFailure text if object has property.

For Vendors, reset to Home position when left "idle" for a default of 300 seconds or whatever ResetInterval is defined to.

As far as I can tell, standard Creatures (NPCs) do not have any ResetInterval type logic seen in videos, while some use MoveHome emotes to effectively do the same thing.