### PR TITLE
improve performance for looking up players by name or account id

### DIFF
--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -32,6 +32,12 @@ namespace ACE.Server.Managers
         private static readonly Dictionary<uint, Player> onlinePlayers = new Dictionary<uint, Player>();
         private static readonly Dictionary<uint, OfflinePlayer> offlinePlayers = new Dictionary<uint, OfflinePlayer>();
 
+        // indexed by player name
+        private static readonly Dictionary<string, IPlayer> playerNames = new Dictionary<string, IPlayer>(StringComparer.OrdinalIgnoreCase);
+
+        // indexed by account id
+        private static readonly Dictionary<uint, Dictionary<uint, IPlayer>> playerAccounts = new Dictionary<uint, Dictionary<uint, IPlayer>>();
+
         /// <summary>
         /// OfflinePlayers will be saved to the database every 1 hour
         /// </summary>
@@ -52,6 +58,19 @@ namespace ACE.Server.Managers
 
                 lock (offlinePlayers)
                     offlinePlayers[offlinePlayer.Guid.Full] = offlinePlayer;
+
+                lock (playerNames)
+                    playerNames[offlinePlayer.Name] = offlinePlayer;
+
+                lock (playerAccounts)
+                {
+                    if (!playerAccounts.TryGetValue(offlinePlayer.Account.AccountId, out var playerAccountsDict))
+                    {
+                        playerAccountsDict = new Dictionary<uint, IPlayer>();
+                        playerAccounts[offlinePlayer.Account.AccountId] = playerAccountsDict;
+                    }
+                    playerAccountsDict[offlinePlayer.Guid.Full] = offlinePlayer;
+                }
             });
         }
 
@@ -129,6 +148,15 @@ namespace ACE.Server.Managers
             {
                 var offlinePlayer = new OfflinePlayer(player.Biota);
                 offlinePlayers[offlinePlayer.Guid.Full] = offlinePlayer;
+
+                playerNames[offlinePlayer.Name] = offlinePlayer;
+
+                if (!playerAccounts.TryGetValue(offlinePlayer.Account.AccountId, out var playerAccountsDict))
+                {
+                    playerAccountsDict = new Dictionary<uint, IPlayer>();
+                    playerAccounts[offlinePlayer.Account.AccountId] = playerAccountsDict;
+                }
+                playerAccountsDict[offlinePlayer.Guid.Full] = offlinePlayer;
             }
             finally
             {
@@ -197,6 +225,20 @@ namespace ACE.Server.Managers
             allPlayers.AddRange(onlinePlayers);
 
             return allPlayers;
+        }
+
+        public static Dictionary<uint, IPlayer> GetAccountPlayers(uint accountId)
+        {
+            playersLock.EnterReadLock();
+            try
+            {
+                playerAccounts.TryGetValue(accountId, out var accountPlayers);
+                return accountPlayers;
+            }
+            finally
+            {
+                playersLock.ExitReadLock();
+            }
         }
 
         public static int GetOfflineCount()
@@ -333,6 +375,10 @@ namespace ACE.Server.Managers
 
                 if (!onlinePlayers.TryAdd(player.Guid.Full, player))
                     return false;
+
+                playerNames[offlinePlayer.Name] = player;
+
+                playerAccounts[offlinePlayer.Account.AccountId][offlinePlayer.Guid.Full] = player;
             }
             finally
             {
@@ -365,6 +411,10 @@ namespace ACE.Server.Managers
 
                 if (!offlinePlayers.TryAdd(offlinePlayer.Guid.Full, offlinePlayer))
                     return false;
+
+                playerNames[offlinePlayer.Name] = offlinePlayer;
+
+                playerAccounts[offlinePlayer.Account.AccountId][offlinePlayer.Guid.Full] = offlinePlayer;
             }
             finally
             {
@@ -398,6 +448,10 @@ namespace ACE.Server.Managers
             {
                 if (!offlinePlayers.Remove(guid, out var offlinePlayer))
                     return false; // This should never happen
+
+                playerNames.Remove(offlinePlayer.Name);
+
+                playerAccounts[offlinePlayer.Account.AccountId].Remove(offlinePlayer.Guid.Full);
             }
             finally
             {
@@ -424,27 +478,16 @@ namespace ACE.Server.Managers
             playersLock.EnterReadLock();
             try
             {
-                var onlinePlayer = onlinePlayers.Values.FirstOrDefault(p => p.Name.TrimStart('+').Equals(name.TrimStart('+'), StringComparison.OrdinalIgnoreCase));
+                playerNames.TryGetValue(name.TrimStart('+'), out var player);
 
-                if (onlinePlayer != null)
-                {
-                    isOnline = true;
-                    return onlinePlayer;
-                }
+                isOnline = player != null && player is Player;
 
-                isOnline = false;
-
-                var offlinePlayer = offlinePlayers.Values.FirstOrDefault(p => p.Name.TrimStart('+').Equals(name.TrimStart('+'), StringComparison.OrdinalIgnoreCase) && !p.IsPendingDeletion);
-
-                if (offlinePlayer != null)
-                    return offlinePlayer;
+                return player;
             }
             finally
             {
                 playersLock.ExitReadLock();
             }
-
-            return null;
         }
 
         /// <summary>
@@ -510,6 +553,7 @@ namespace ACE.Server.Managers
             playersLock.EnterReadLock();
             try
             {
+                // this kind of sucks, possibly investigate?
                 var onlinePlayersResult = onlinePlayers.Values.Where(p => p.MonarchId == monarch.Full);
                 var offlinePlayersResult = offlinePlayers.Values.Where(p => p.MonarchId == monarch.Full);
 

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -64,12 +64,17 @@ namespace ACE.Server.Managers
 
                 lock (playerAccounts)
                 {
-                    if (!playerAccounts.TryGetValue(offlinePlayer.Account.AccountId, out var playerAccountsDict))
+                    if (offlinePlayer.Account != null)
                     {
-                        playerAccountsDict = new Dictionary<uint, IPlayer>();
-                        playerAccounts[offlinePlayer.Account.AccountId] = playerAccountsDict;
+                        if (!playerAccounts.TryGetValue(offlinePlayer.Account.AccountId, out var playerAccountsDict))
+                        {
+                            playerAccountsDict = new Dictionary<uint, IPlayer>();
+                            playerAccounts[offlinePlayer.Account.AccountId] = playerAccountsDict;
+                        }
+                        playerAccountsDict[offlinePlayer.Guid.Full] = offlinePlayer;
                     }
-                    playerAccountsDict[offlinePlayer.Guid.Full] = offlinePlayer;
+                    else
+                        log.Error($"PlayerManager.Initialize: couldn't find account for player {offlinePlayer.Name} ({offlinePlayer.Guid})");
                 }
             });
         }

--- a/Source/ACE.Server/Network/Structure/HouseAccess.cs
+++ b/Source/ACE.Server/Network/Structure/HouseAccess.cs
@@ -74,12 +74,12 @@ namespace ACE.Server.Network.Structure
                 return;
             }
 
-            var accountPlayers = Player.GetAccountPlayers(owner.Account.AccountId);
+            var accountPlayers = PlayerManager.GetAccountPlayers(owner.Account.AccountId);
 
             foreach (var accountPlayer in accountPlayers)
             {
-                if (owner.Guid != accountPlayer.Guid)
-                    Roommates.Add(accountPlayer.Guid);
+                if (owner.Guid.Full != accountPlayer.Key)
+                    Roommates.Add(accountPlayer.Value.Guid);
             }
         }
     }

--- a/Source/ACE.Server/Network/Structure/RestrictionDB.cs
+++ b/Source/ACE.Server/Network/Structure/RestrictionDB.cs
@@ -57,14 +57,14 @@ namespace ACE.Server.Network.Structure
                 return;
             }
 
-            var accountPlayers = Player.GetAccountPlayers(owner.Account.AccountId);
+            var accountPlayers = PlayerManager.GetAccountPlayers(owner.Account.AccountId);
 
             foreach (var accountPlayer in accountPlayers)
             {
-                if (accountPlayer.Guid.Full == HouseOwner)
+                if (accountPlayer.Key == HouseOwner)
                     continue;
 
-                Table.TryAdd(accountPlayer.Guid, 1);
+                Table.TryAdd(accountPlayer.Value.Guid, 1);
             }
         }
     }

--- a/Source/ACE.Server/WorldObjects/Managers/SquelchManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/SquelchManager.cs
@@ -125,9 +125,7 @@ namespace ACE.Server.WorldObjects.Managers
 
         public void SquelchCharacter(IPlayer player, ChatMessageType messageType)
         {
-            var squelches = Player.Character.GetSquelches(Player.CharacterDatabaseLock);
-
-            var existing = squelches.FirstOrDefault(i => i.SquelchCharacterId == player.Guid.Full);
+            Squelches.Characters.TryGetValue(player.Guid.Full, out SquelchInfo existing);
 
             var newMask = messageType.ToMask();
 
@@ -135,7 +133,7 @@ namespace ACE.Server.WorldObjects.Managers
 
             if (existing != null)
             {
-                var existingMask = (SquelchMask)existing.Type;
+                var existingMask = existing.Filters[0];
 
                 newMask = existingMask.Add(newMask);
 
@@ -154,9 +152,7 @@ namespace ACE.Server.WorldObjects.Managers
 
         public void UnsquelchCharacter(IPlayer player, ChatMessageType messageType)
         {
-            var squelches = Player.Character.GetSquelches(Player.CharacterDatabaseLock);
-
-            var existing = squelches.FirstOrDefault(i => i.SquelchCharacterId == player.Guid.Full);
+            Squelches.Characters.TryGetValue(player.Guid.Full, out SquelchInfo existing);
 
             if (existing == null)
             {
@@ -173,7 +169,7 @@ namespace ACE.Server.WorldObjects.Managers
             }
             else
             {
-                var existingMask = (SquelchMask)existing.Type;
+                var existingMask = existing.Filters[0];
                 var removeMask = messageType.ToMask();
 
                 if (!existingMask.HasFlag(removeMask))

--- a/Source/ACE.Server/WorldObjects/Player_House.cs
+++ b/Source/ACE.Server/WorldObjects/Player_House.cs
@@ -979,8 +979,9 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            var accountPlayers = Player.GetAccountPlayers(Account.AccountId).Select(p => p.Guid).ToList();
-            if (Guests.ContainsKey(guest.Guid) || accountPlayers.Contains(guest.Guid))
+            var accountPlayers = PlayerManager.GetAccountPlayers(Account.AccountId);
+
+            if (Guests.ContainsKey(guest.Guid) || accountPlayers.ContainsKey(guest.Guid.Full))
             {
                 Session.Network.EnqueueSend(new GameMessageSystemChat($"{guest.Name} is already on your guest list.", ChatMessageType.Broadcast));
                 return;
@@ -1740,16 +1741,11 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(new GameMessageSystemChat($"You have revoked your monarchy's access to the allegiance housing storage.", ChatMessageType.Broadcast));
         }
 
-        public static List<IPlayer> GetAccountPlayers(uint accountID)
-        {
-            return PlayerManager.GetAllPlayers().Where(i => i.Account != null && i.Account.AccountId == accountID).ToList();
-        }
-
         public IPlayer GetAccountHouseOwner()
         {
-            var accountPlayers = GetAccountPlayers(Account.AccountId);
+            var accountPlayers = PlayerManager.GetAccountPlayers(Account.AccountId);
 
-            var accountHouseOwners = accountPlayers.Where(i => i.HouseInstance != null);
+            var accountHouseOwners = accountPlayers.Values.Where(i => i.HouseInstance != null);
 
             return accountHouseOwners.OrderBy(i => i.HousePurchaseTimestamp).FirstOrDefault();
         }


### PR DESCRIPTION
looking up players by name or account id currently has O(n) performance characteristics, where n is the total # of online+offline characters on the server. for larger servers, this is starting to have scalability issues. this PR brings it down to O(1) by adding and maintaining 2 new dictionaries in PlayerManager -- 1 for player names, and another for account ids.

some areas that call these functions: friends list, house storage/permissions, corpse looting permissions, squelches, gags, allegiance management