### PR TITLE
fix weapon parameter for HandleCastSpell -> CreateEnchantment

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -281,9 +281,9 @@ namespace ACE.Server.WorldObjects
 
                     // TODO: replace with some kind of 'rootOwner unless equip' concept?
                     if (itemCaster != null && (equip || itemCaster is Gem || itemCaster is Food))
-                        CreateEnchantment(targetCreature ?? target, itemCaster, itemCaster, spell, equip);
+                        CreateEnchantment(targetCreature ?? target, itemCaster, weapon, spell, equip);
                     else
-                        CreateEnchantment(targetCreature ?? target, this, this, spell, equip, isWeaponSpell: isWeaponSpell);
+                        CreateEnchantment(targetCreature ?? target, this, weapon, spell, equip, isWeaponSpell: isWeaponSpell);
 
                     break;
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -281,7 +281,7 @@ namespace ACE.Server.WorldObjects
 
                     // TODO: replace with some kind of 'rootOwner unless equip' concept?
                     if (itemCaster != null && (equip || itemCaster is Gem || itemCaster is Food))
-                        CreateEnchantment(targetCreature ?? target, itemCaster, weapon, spell, equip);
+                        CreateEnchantment(targetCreature ?? target, itemCaster, itemCaster, spell, equip);
                     else
                         CreateEnchantment(targetCreature ?? target, this, weapon, spell, equip, isWeaponSpell: isWeaponSpell);
 


### PR DESCRIPTION
repro steps:

- place a debug breakpoint on CalculateDotEnchantment_StatModValue -> GetCasterElementalDamageModifier()
- cast corruption or corrosion with a void wand, and observe that weapon is correctly passed in, and elementalDamageMod is correctly populated
- cast destructive curse

expected:

- elementalDamageMod is correctly populated for a void wand casting destructive curse

actual:

- elementalDamageMod remains at 1.0 for a void wand, because the weapon parameter was not being passed properly down the chain

Thanks for Xenocide for finding and reporting this issue!