### PR TITLE
fix equipping non-selectables in combat mode exiting combat mode

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -256,6 +256,10 @@ namespace ACE.Server.WorldObjects
             // do the appropriate combat stance shuffling, based on the item types
             // todo: instead of switching the weapon immediately, the weapon should be swapped in the middle of the animation chain
 
+            // todo: find better / more appropriate logic for this
+            // should this be based on something else, such as CombatUse?
+            if ((wieldedLocation & EquipMask.Selectable) == 0) return;
+
             if (CombatMode != CombatMode.NonCombat && CombatMode != CombatMode.Undef)
             {
                 switch (wieldedLocation)


### PR DESCRIPTION
repro steps:

- go into combat mode

- dequip an item that isn't selectable in the 3d world (ie. a piece of armor, aetheria, or cloak)

- re-equip it

expected:

item is re-equipped as normal, similar to dequipping it

actual:

character automatically exits combat mode while re-equipping item

Thanks to ╞ô╡ for reporting this issue!