### PR TITLE
Add shared types config to enable mods using libraries

### DIFF
--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -32,7 +32,11 @@
     <ApplicationIcon>images\ace_retro_icon_2.ico</ApplicationIcon>
   </PropertyGroup>
 
-  <ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
     <None Remove="Entity\Mutations\ArmorLevel\armor_level_extremity.txt" />
     <None Remove="Entity\Mutations\ArmorLevel\armor_level_non_extremity.txt" />
     <None Remove="Entity\Mutations\ArmorLevel\covenant_armor.txt" />

--- a/Source/ACE.Server/Mods/ModContainer.cs
+++ b/Source/ACE.Server/Mods/ModContainer.cs
@@ -36,7 +36,6 @@ namespace ACE.Server.Mods
             ModAssembly.ManifestModule.ScopeName.Replace(".dll", "." + ModMetadata.TYPENAME);
 
         public PluginLoader Loader { get; private set; }
-        //private FileSystemWatcher _dllWatcher;
         private DateTime _lastChange = DateTime.Now;
 
         /// <summary>
@@ -50,22 +49,6 @@ namespace ACE.Server.Mods
                 return;
             }
 
-            //Watching for changes in the dll might be needed if it has unreleased resources?
-            //https://github.com/natemcmaster/DotNetCorePlugins/issues/86
-            //_dllWatcher = new FileSystemWatcher()
-            //{
-            //    Path = FolderPath,
-            //    //Filter = DllPath,
-            //    Filter = $"{FolderName}.dll",
-            //    EnableRaisingEvents = true,
-            //    NotifyFilter = NotifyFilters.LastWrite  //?
-            //};
-            //_dllWatcher.Changed += ModDll_Changed;
-            //_dllWatcher.Created += ModDll_Created;
-            //_dllWatcher.Renamed += ModDll_Renamed;
-            //_dllWatcher.Deleted += ModDll_Changed;
-            //_dllWatcher.NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName;
-
             Loader = PluginLoader.CreateFromAssemblyFile(
                 assemblyFile: DllPath,
                 isUnloadable: true,
@@ -73,7 +56,8 @@ namespace ACE.Server.Mods
                 configure: config =>
                 {
                     config.EnableHotReload = Meta.HotReload;
-                    config.IsLazyLoaded = false;     //?
+                    config.IsLazyLoaded = false;
+                    config.PreferSharedTypes = true;
                 }                
             );
             Loader.Reloaded += Reload;


### PR DESCRIPTION
Sets `PreferSharedTypes` in the plugin loader to allow mods to use Nuget/other references with.  Cleaned up unused lines.

Adds a framework reference to ASP.NET to let mods do web stuff.