### PR TITLE
Prefer shared types in plugin loader

### DIFF
--- a/Source/ACE.Server/Mods/ModContainer.cs
+++ b/Source/ACE.Server/Mods/ModContainer.cs
@@ -16,7 +16,7 @@ namespace ACE.Server.Mods
         public ModMetadata Meta { get; set; }
         public ModStatus Status = ModStatus.Unloaded;
 
-        public Assembly ModAssembly { get; set; }   
+        public Assembly ModAssembly { get; set; }
         public Type ModType { get; set; }
         public IHarmonyMod Instance { get; set; }
 
@@ -36,7 +36,6 @@ namespace ACE.Server.Mods
             ModAssembly.ManifestModule.ScopeName.Replace(".dll", "." + ModMetadata.TYPENAME);
 
         public PluginLoader Loader { get; private set; }
-        //private FileSystemWatcher _dllWatcher;
         private DateTime _lastChange = DateTime.Now;
 
         /// <summary>
@@ -50,31 +49,16 @@ namespace ACE.Server.Mods
                 return;
             }
 
-            //Watching for changes in the dll might be needed if it has unreleased resources?
-            //https://github.com/natemcmaster/DotNetCorePlugins/issues/86
-            //_dllWatcher = new FileSystemWatcher()
-            //{
-            //    Path = FolderPath,
-            //    //Filter = DllPath,
-            //    Filter = $"{FolderName}.dll",
-            //    EnableRaisingEvents = true,
-            //    NotifyFilter = NotifyFilters.LastWrite  //?
-            //};
-            //_dllWatcher.Changed += ModDll_Changed;
-            //_dllWatcher.Created += ModDll_Created;
-            //_dllWatcher.Renamed += ModDll_Renamed;
-            //_dllWatcher.Deleted += ModDll_Changed;
-            //_dllWatcher.NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName;
-
             Loader = PluginLoader.CreateFromAssemblyFile(
                 assemblyFile: DllPath,
                 isUnloadable: true,
-                sharedTypes: new Type[] {  },
+                sharedTypes: new Type[] { },
                 configure: config =>
                 {
                     config.EnableHotReload = Meta.HotReload;
-                    config.IsLazyLoaded = false;     //?
-                }                
+                    config.IsLazyLoaded = false;
+                    config.PreferSharedTypes = true;
+                }
             );
             Loader.Reloaded += Reload;
 


### PR DESCRIPTION
Sets `PreferSharedTypes` in the plugin loader to allow mods to use Nuget/other references with. Cleaned up unused lines.