### PR TITLE
Switch from BCrypt.Net-Core to BCrypt.Net-Next

### DIFF
--- a/Source/ACE.Common/ACE.Common.csproj
+++ b/Source/ACE.Common/ACE.Common.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>

--- a/Source/ACE.Common/Cryptography/BCryptProvider.cs
+++ b/Source/ACE.Common/Cryptography/BCryptProvider.cs
@@ -4,7 +4,12 @@ namespace ACE.Common.Cryptography
     {
         public static string HashPassword(string input, int workFactor = 10)
         {
-            return BCrypt.Net.BCrypt.HashPassword(input, workFactor, BCrypt.Net.SaltRevision.Revision2Y);
+            // Force BCrypt.Net-Next to use 2y instead of the default 2a
+            // The older bcrypt package ACE used (BCrypt.Net-Core) defaultd to 2y
+            // Reference: https://stackoverflow.com/questions/49878948/hashing-password-with-2y-identifier/75114685
+            string salt = BCrypt.Net.BCrypt.GenerateSalt(workFactor, 'y');
+
+            return BCrypt.Net.BCrypt.HashPassword(input, salt);
         }
 
         public static bool Verify(string text, string hash)
@@ -14,7 +19,12 @@ namespace ACE.Common.Cryptography
 
         public static int GetPasswordWorkFactor(string hash)
         {
-            return BCrypt.Net.BCrypt.GetPasswordWorkFactor(hash);
+            var hashInformation = BCrypt.Net.BCrypt.InterrogateHash(hash);
+
+            if (int.TryParse(hashInformation.WorkFactor, out var workFactor))
+                return workFactor;
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
BCrypt.Net-Core was a 3rd party release to port BCrypt.Net to .NET Core in the early days of .NET Core.

BCrypt.Net-Next is the current standard for BCrypt.Net https://github.com/BcryptNet/bcrypt.net

The same hash method is still used.