### PR TITLE
Remove MySql.Data package ref

### DIFF
--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -238,7 +238,6 @@
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Log4Net.Async.Standard" Version="3.1.0" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
-    <PackageReference Include="MySql.Data" Version="8.2.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.3" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This is the heaviest ref so it's nice to remove.

We used MySql.Data to execute database update scripts since this pr: https://github.com/ACEmulator/ACE/pull/2736/files

Now we use MysqlConnector