### PR TITLE
Improve Offline Player Saving

### DIFF
--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -126,11 +126,11 @@ namespace ACE.Database
         }
 
 
-        public void SaveBiotasInParallel(IEnumerable<(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback)
+        public void SaveBiotasInParallel(IEnumerable<(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)> biotas, Action<bool> callback, bool doNotAddToCache = false)
         {
             _queue.Add(new Task(() =>
             {
-                var result = BaseDatabase.SaveBiotasInParallel(biotas);
+                var result = BaseDatabase.SaveBiotasInParallel(biotas, doNotAddToCache);
                 callback?.Invoke(result);
             }));
         }

--- a/Source/ACE.Database/ShardDatabase.cs
+++ b/Source/ACE.Database/ShardDatabase.cs
@@ -309,11 +309,11 @@ namespace ACE.Database
             }
         }
 
-        public virtual bool SaveBiota(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)
+        public virtual bool SaveBiota(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock, bool doNotAddToCache = false)
         {
             using (var context = new ShardDbContext())
             {
-                var existingBiota = GetBiota(context, biota.Id);
+                var existingBiota = GetBiota(context, biota.Id, doNotAddToCache);
 
                 rwLock.EnterReadLock();
                 try
@@ -338,13 +338,13 @@ namespace ACE.Database
             }
         }
 
-        public bool SaveBiotasInParallel(IEnumerable<(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)> biotas)
+        public bool SaveBiotasInParallel(IEnumerable<(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)> biotas, bool doNotAddToCache = false)
         {
             var result = true;
 
             Parallel.ForEach(biotas, ConfigManager.Config.Server.Threading.DatabaseParallelOptions, biota =>
             {
-                if (!SaveBiota(biota.biota, biota.rwLock))
+                if (!SaveBiota(biota.biota, biota.rwLock, doNotAddToCache))
                     result = false;
             });
 

--- a/Source/ACE.Database/ShardDatabaseWithCaching.cs
+++ b/Source/ACE.Database/ShardDatabaseWithCaching.cs
@@ -134,7 +134,7 @@ namespace ACE.Database
             return base.GetBiota(id, doNotAddToCache);
         }
 
-        public override bool SaveBiota(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock)
+        public override bool SaveBiota(ACE.Entity.Models.Biota biota, ReaderWriterLockSlim rwLock, bool doNotAddToCache = false)
         {
             CacheObject<Biota> cachedBiota;
 
@@ -162,7 +162,7 @@ namespace ACE.Database
 
             var context = new ShardDbContext();
 
-            var existingBiota = base.GetBiota(context, biota.Id);
+            var existingBiota = base.GetBiota(context, biota.Id, doNotAddToCache);
 
             rwLock.EnterReadLock();
             try
@@ -185,7 +185,8 @@ namespace ACE.Database
 
             if (DoSaveBiota(context, existingBiota))
             {
-                TryAddToCache(context, existingBiota);
+                if (!doNotAddToCache)
+                    TryAddToCache(context, existingBiota);
 
                 return true;
             }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -1173,7 +1173,7 @@ namespace ACE.Server.Entity
                     AddWorldObjectToBiotasSaveCollection(wo, biotas);
             }
 
-            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => { });
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, null);
         }
 
         private void AddWorldObjectToBiotasSaveCollection(WorldObject wo, Collection<(Biota biota, ReaderWriterLockSlim rwLock)> biotas)

--- a/Source/ACE.Server/Managers/PlayerManager.cs
+++ b/Source/ACE.Server/Managers/PlayerManager.cs
@@ -138,7 +138,7 @@ namespace ACE.Server.Managers
                 playersLock.ExitReadLock();
             }
 
-            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => { });
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, null, true);
         }
         
 

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -189,7 +189,7 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
-            DatabaseManager.Shard.SaveBiotasInParallel(biotas, result => { });
+            DatabaseManager.Shard.SaveBiotasInParallel(biotas, null);
         }
 
         public enum RemoveFromInventoryAction


### PR DESCRIPTION
PlayerManager saves offline players in bulk, once very hour. This is done in bulk to help avoid desync between offline player updates.

Player caching is typically set to 30 min.

What can happen now is that PlayerManager may save a bunch of offline players, that will then be loaded into the player biota cache (for 30 min)... then after 30 min, they all get unloaded because nothign touches those biotas, then 30 min later again the PlayerManager performs its hourly maint of bulk save, thus, re-caching all those biotas.

Caching is not necessary for these biotas.

Caching is designed for biotas that exist in an online or recently online state.