### PR TITLE
Switch PhysicsTimer

### DIFF
--- a/Source/ACE.Server/Physics/Common/PhysicsTimer.cs
+++ b/Source/ACE.Server/Physics/Common/PhysicsTimer.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 
+using ACE.Server.Entity;
+
 namespace ACE.Server.Physics.Common
 {
     /// <summary>
@@ -10,11 +12,14 @@ namespace ACE.Server.Physics.Common
     {
         private static readonly Stopwatch _timer;
 
+        /*
         /// <summary>
         /// This should only be used by the ACE.Server.Physics namespace and physics related properties<para />
         /// For a equally precise timer outside of this namespace, you can use WorldManager.PortalYearTicks
         /// </summary>
         public static double CurrentTime => _timer.Elapsed.TotalSeconds;
+        */
+        public static double CurrentTime => Timers.PortalYearTicks;
 
         static PhysicsTimer()
         {

--- a/Source/ACE.Server/Physics/Common/PhysicsTimer.cs
+++ b/Source/ACE.Server/Physics/Common/PhysicsTimer.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using System;
 
 using ACE.Server.Entity;
 
@@ -10,20 +10,19 @@ namespace ACE.Server.Physics.Common
     /// </summary>
     public class PhysicsTimer
     {
-        private static readonly Stopwatch _timer;
+        // When using PhysicsTimer outside of a running ACE instance, you must uncomment these lines and use this version of the timer. Otherwise, your CurrentTime will not increment.
+        // You can use this method when running in an ACE instance, it's just less efficient.
+        /*private static readonly System.Diagnostics.Stopwatch _timer;
 
-        /*
-        /// <summary>
-        /// This should only be used by the ACE.Server.Physics namespace and physics related properties<para />
-        /// For a equally precise timer outside of this namespace, you can use WorldManager.PortalYearTicks
-        /// </summary>
         public static double CurrentTime => _timer.Elapsed.TotalSeconds;
-        */
-        public static double CurrentTime => Timers.PortalYearTicks;
 
         static PhysicsTimer()
         {
-            _timer = Stopwatch.StartNew();
-        }
+            _timer = System.Diagnostics.Stopwatch.StartNew();
+        }*/
+
+
+        // When using PhysicsTimer in a running ACE instance, you should use this timer instead. It is more efficient. Timers.PortalYearTicks is incremented by the WorldManager.
+        public static double CurrentTime => Timers.PortalYearTicks;
     }
 }


### PR DESCRIPTION
PhysicsTimer.CurrentTime evalulated the stopwatch every single call.

This simply redirects the timer to use the master Timers.PortalYearTicks timer