### PR TITLE
Wire up GameEventMagicPurgeBadEnchantments

### DIFF
--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -95,6 +95,9 @@ namespace ACE.Server.Network.Structure
             {
                 StatModType = spell.StatModType;
                 StatModKey = spell.StatModKey;
+
+                if (spell.IsBeneficial) // should "server" data be fixed or is this the better way to do this?
+                    StatModType |= EnchantmentTypeFlags.Beneficial;
             }
         }
 

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -362,6 +362,19 @@ namespace ACE.Server.WorldObjects.Managers
         }
 
         /// <summary>
+        /// Removes all enchantments except for beneficial enchantments, vitae and item spells
+        /// Called on player death
+        /// </summary>
+        public virtual void RemoveAllBadEnchantments()
+        {
+            // exclude beneficial enchantments, cooldowns and enchantments from items
+            var spellsToExclude = WorldObject.Biota.PropertiesEnchantmentRegistry.Clone(WorldObject.BiotaDatabaseLock).Where(i => i.StatModType.HasFlag(EnchantmentTypeFlags.Beneficial) || i.Duration == -1 || i.SpellId > short.MaxValue).Select(i => i.SpellId);
+
+            WorldObject.Biota.PropertiesEnchantmentRegistry.RemoveAllEnchantments(spellsToExclude, WorldObject.BiotaDatabaseLock);
+            WorldObject.ChangesDetected = true;
+        }
+
+        /// <summary>
         /// Returns the vitae enchantment
         /// </summary>
         public PropertiesEnchantmentRegistry GetVitae()

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -247,6 +247,9 @@ namespace ACE.Server.WorldObjects.Managers
             entry.StatModKey = spell.StatModKey;
             entry.StatModValue = spell.StatModVal;
 
+            if (spell.IsBeneficial) // should "server" data be fixed or is this the better way to do this?
+                entry.StatModType |= EnchantmentTypeFlags.Beneficial;
+
             if (spell.IsDamageOverTime)
             {
                 var heartbeatInterval = WorldObject.HeartbeatInterval ?? 5.0f;

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManagerWithCaching.cs
@@ -80,12 +80,23 @@ namespace ACE.Server.WorldObjects.Managers
         }
 
         /// <summary>
-        /// Removes all enchantments except for vitae
+        /// Removes all enchantments except for vitae and enchantments from items
         /// Called on player death
         /// </summary>
         public override void RemoveAllEnchantments()
         {
             base.RemoveAllEnchantments();
+
+            ClearCache();
+        }
+
+        /// <summary>
+        /// Removes all enchantments except for beneficial enchantments, vitae and enchantments from items
+        /// Called on player death
+        /// </summary>
+        public override void RemoveAllBadEnchantments()
+        {
+            base.RemoveAllBadEnchantments();
 
             ClearCache();
         }

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -215,7 +215,11 @@ namespace ACE.Server.WorldObjects
                 Session.Network.EnqueueSend(msgPurgeEnchantments);
             }
             else
-                Session.Network.EnqueueSend(new GameMessageSystemChat("Your augmentation prevents the tides of death from ripping away your current enchantments!", ChatMessageType.Broadcast));
+            {
+                var msgPurgeBadEnchantments = new GameEventMagicPurgeBadEnchantments(Session);
+                EnchantmentManager.RemoveAllBadEnchantments();
+                Session.Network.EnqueueSend(msgPurgeBadEnchantments, new GameMessageSystemChat("Your augmentation prevents the tides of death from ripping away your current enchantments!", ChatMessageType.Broadcast));
+            }
 
             // wait for the death animation to finish
             var dieChain = new ActionChain();


### PR DESCRIPTION
According to PCAPs GameEventMagicPurgeBadEnchantments was sent to clients for players with Enduring Enchantment augmentation.

Client has slightly different check in CEnchantmentRegistry::PurgeBadEnchantmentList versus CEnchantmentRegistry::PurgeEnchantmentList
```cpp
    if ( v4->data._smod.type & 0x2000000 || v4->data._duration == -1.0 )
```
vs
```cpp
    if ( v4->data._duration == -1.0 )
```