### PR TITLE
Command categories and Harmony bump

### DIFF
--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <Platforms>x64</Platforms>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <Platforms>x64</Platforms>
+    </PropertyGroup>
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
@@ -234,7 +234,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.3.0-prerelease.4" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.2" />
     <PackageReference Include="log4net" Version="2.0.17" />
     <PackageReference Include="Log4Net.Async.Standard" Version="3.1.0" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />

--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -4,10 +4,6 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <Platforms>x64</Platforms>
-        <Configurations>Debug;Release</Configurations>
-        <OutputPath>C:\ACE\Server</OutputPath>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     </PropertyGroup>
 
   <PropertyGroup>

--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -4,6 +4,10 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <Platforms>x64</Platforms>
+        <Configurations>Debug;Release</Configurations>
+        <OutputPath>C:\ACE\Server</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     </PropertyGroup>
 
   <PropertyGroup>

--- a/Source/ACE.Server/Command/CommandManager.cs
+++ b/Source/ACE.Server/Command/CommandManager.cs
@@ -19,7 +19,7 @@ namespace ACE.Server.Command
 
         public static readonly bool NonInteractiveConsole = Convert.ToBoolean(Environment.GetEnvironmentVariable("ACE_NONINTERACTIVE_CONSOLE"));
 
-        private static Dictionary<string, CommandHandlerInfo> commandHandlers;
+        private static Dictionary<string, CommandHandlerInfo> commandHandlers = new Dictionary<string, CommandHandlerInfo>(StringComparer.OrdinalIgnoreCase);
 
         public static IEnumerable<CommandHandlerInfo> GetCommands()
         {
@@ -97,7 +97,6 @@ namespace ACE.Server.Command
 
         public static void Initialize()
         {
-            commandHandlers = new Dictionary<string, CommandHandlerInfo>(StringComparer.OrdinalIgnoreCase);
             foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
             {
                 foreach (var method in type.GetMethods())

--- a/Source/ACE.Server/Mods/CommandCategoryAttribute.cs
+++ b/Source/ACE.Server/Mods/CommandCategoryAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ACE.Server.Mods;
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class CommandCategoryAttribute : Attribute
+{
+    public string Category { get; }
+
+    public CommandCategoryAttribute(string category)
+    {
+        Category = category;
+    }
+}

--- a/Source/ACE.Server/Mods/ModCommands.cs
+++ b/Source/ACE.Server/Mods/ModCommands.cs
@@ -95,6 +95,7 @@ namespace ACE.Server.Command.Handlers
                 //Full reload
                 case ModCommand.Find:
                     ModManager.FindMods(true);
+                    ModManager.ListMods();
                     return;
 
                 //Lazy opening of mod settings

--- a/Source/ACE.Server/Mods/ModCommands.cs
+++ b/Source/ACE.Server/Mods/ModCommands.cs
@@ -94,7 +94,7 @@ namespace ACE.Server.Command.Handlers
 
                 //Full reload
                 case ModCommand.Find:
-                    ModManager.FindMods();
+                    ModManager.FindMods(true);
                     return;
 
                 //Lazy opening of mod settings

--- a/Source/ACE.Server/Mods/ModContainer.cs
+++ b/Source/ACE.Server/Mods/ModContainer.cs
@@ -108,9 +108,6 @@ namespace ACE.Server.Mods
                 Instance?.Initialize();
                 Status = ModStatus.Active;
 
-                if (Meta.RegisterCommands)
-                    this.RegisterCommandHandlers();
-
                 log.Info($"Enabled mod `{Meta.Name} (v{Meta.Version})`.");
             }
             catch (Exception ex)
@@ -118,6 +115,12 @@ namespace ACE.Server.Mods
                 log.Error($"Error enabling {Meta.Name}: {ex}");
                 Status = ModStatus.Inactive;    //Todo: what status?  Something to prevent reload attempts?
             }
+        }
+
+        public void RegisterCommands()
+        {
+            if (Meta.RegisterCommands)
+                this.RegisterUncategorizedCommands();
         }
 
         //Todo: decide about removing the assembly?
@@ -131,7 +134,7 @@ namespace ACE.Server.Mods
 
             log.Info($"{FolderName} shutting down @ {DateTime.Now}");
 
-            this.UnregisterCommandHandlers();
+            this.UnregisterAllCommands();
 
             try
             {

--- a/Source/ACE.Server/Mods/ModManager.cs
+++ b/Source/ACE.Server/Mods/ModManager.cs
@@ -217,33 +217,10 @@ namespace ACE.Server.Mods
         #endregion
 
         #region Command Registration
-        /// <summary>
-        /// Mods may start prior to the CommandManager, causing a conflict with logic to register a CommandCategory
-        /// If the CommandManager is unavailable the category will be added to a list maintained by the ModManager to be added the next time commands are registered
-        /// </summary>
-        private static readonly List<(ModContainer Container, string CategoryPattern)> _pendingCommandCategories = new ();
-        private static bool commandManagerAvailable = false;
-        public static void RegisterCommandCategory(ModContainer container, string categoryPattern)
-        {
-            if (commandManagerAvailable)
-                container?.RegisterCommandCategory(categoryPattern);
-            else
-                _pendingCommandCategories.Add((container, categoryPattern));
-        }
-
         public static void RegisterCommands()
         {
-            //The CommandManager is assumed to be available the firs time commands are registered, at the end of startup.
-            //Todo: decide on exposing this in CommandManager
-            commandManagerAvailable = true;
-
             foreach (var mod in Mods.Where(x => x.Status == ModStatus.Active && x.Meta.RegisterCommands))
                 mod?.RegisterUncategorizedCommands();
-
-            foreach(var categoryPair in _pendingCommandCategories)
-                categoryPair.Container?.RegisterCommandCategory(categoryPair.CategoryPattern);
-
-            _pendingCommandCategories.Clear();
         }
         public static void UnregisterCommands()
         {

--- a/Source/ACE.Server/Mods/ModManager.cs
+++ b/Source/ACE.Server/Mods/ModManager.cs
@@ -70,8 +70,6 @@ namespace ACE.Server.Mods
 
             if (registerCommands)
                 RegisterCommands();
-
-            ListMods();
         }
 
         /// <summary>

--- a/Source/ACE.Server/Mods/ModManager.cs
+++ b/Source/ACE.Server/Mods/ModManager.cs
@@ -68,7 +68,7 @@ namespace ACE.Server.Mods
 
             EnableMods(Mods);
 
-            if (registerCommands == true)
+            if (registerCommands)
                 RegisterCommands();
 
             ListMods();

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -153,6 +153,9 @@ namespace ACE.Server
             log.Info("Initializing ConfigManager...");
             ConfigManager.Initialize();
 
+            log.Info("Initializing ModManager...");
+            ModManager.Initialize();
+
             if (ConfigManager.Config.Server.WorldName != "ACEmulator")
             {
                 consoleTitle = $"{ConfigManager.Config.Server.WorldName} | {consoleTitle}";
@@ -241,9 +244,6 @@ namespace ACE.Server
             }
             else
                 log.Info("DAT Patching Disabled...");
-
-            log.Info("Initializing ModManager...");
-            ModManager.Initialize();
 
             log.Info("Initializing DatabaseManager...");
             DatabaseManager.Initialize();

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -334,6 +334,7 @@ namespace ACE.Server
             //Register mod commands
             log.Info("Registering ModManager commands...");
             ModManager.RegisterCommands();
+            ModManager.ListMods();
 
             if (!PropertyManager.GetBool("world_closed", false).Item)
             {

--- a/Source/ACE.Server/Program.cs
+++ b/Source/ACE.Server/Program.cs
@@ -242,6 +242,9 @@ namespace ACE.Server
             else
                 log.Info("DAT Patching Disabled...");
 
+            log.Info("Initializing ModManager...");
+            ModManager.Initialize();
+
             log.Info("Initializing DatabaseManager...");
             DatabaseManager.Initialize();
 
@@ -328,8 +331,9 @@ namespace ACE.Server
             log.Info("Initializing CommandManager...");
             CommandManager.Initialize();
 
-            log.Info("Initializing ModManager...");
-            ModManager.Initialize();
+            //Register mod commands
+            log.Info("Registering ModManager commands...");
+            ModManager.RegisterCommands();
 
             if (!PropertyManager.GetBool("world_closed", false).Item)
             {


### PR DESCRIPTION
* Updates Harmony to 2.3.2 from a prerelease/alpha that is no longer published on Nuget
* Added a `CommandCategory` attribute for selective command loading similar to Harmony's implementation
Separated command registration from startup
* Moved the startup/Harmony part of mods to just after the `ConfigManager` initialization to give an option to patch other major startup code