### PR TITLE
Foward Player object to Activation Target in Activate Emotes

### DIFF
--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -84,7 +84,7 @@ namespace ACE.Server.WorldObjects.Managers
                     {
                         // ActOnUse delay?
                         var activationTarget = WorldObject.CurrentLandblock?.GetObject(WorldObject.ActivationTarget);
-                        activationTarget?.OnActivate(WorldObject);
+                        activationTarget?.OnActivate(player ?? WorldObject);
                     }
                     else if (WorldObject.GeneratorId.HasValue && WorldObject.GeneratorId > 0) // Fallback to linked generator
                     {


### PR DESCRIPTION
This is required for the functionality of the early part of Assassin's Roost where a player uses an item and an NPC sends the player a tell.