### PR TITLE
More aggressively try to split larger landblock groups

### DIFF
--- a/Source/ACE.Server/Entity/LandblockGroup.cs
+++ b/Source/ACE.Server/Entity/LandblockGroup.cs
@@ -29,7 +29,7 @@ namespace ACE.Server.Entity
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        public const int LandblockGroupMinSpacing = 5;
+        public const int LandblockGroupMinSpacing = 4;
 
         private const int landblockGroupSpanRequiredBeforeSplitEligibility = LandblockGroupMinSpacing * 4;
 
@@ -243,7 +243,11 @@ namespace ACE.Server.Entity
                 newLandblockGroup = DoTrySplit();
             }
 
-            NextTrySplitTime = DateTime.UtcNow.Add(TrySplitInterval);
+            // If we have a very large landblock group that didn't split, we'll try to split it every 1 minute to help reduce server load
+            if (results.Count == 0 && landblocks.Count >= 200)
+                NextTrySplitTime = DateTime.UtcNow.AddMinutes(1);
+            else
+                NextTrySplitTime = DateTime.UtcNow.Add(TrySplitInterval);
             uniqueLandblockIdsRemoved.Clear();
 
             return results;


### PR DESCRIPTION
This also reduces the spacing by 1 which should still be plenty safe.