### PR TITLE
Adjust Ethereal state on Drop

### DIFF
--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -2854,6 +2854,18 @@ namespace ACE.Server.Command.Handlers
                         }
                         item.Ethereal = ethereal;
 
+                        if (item.Ethereal == null)
+                        {
+                            var defaultPhysicsState = (PhysicsState)(item.GetProperty(PropertyInt.PhysicsState) ?? 0);
+
+                            if (defaultPhysicsState.HasFlag(PhysicsState.Ethereal))
+                                item.Ethereal = true;
+                            else
+                                item.Ethereal = false;
+                        }
+
+                        item.EnqueueBroadcastPhysicsState();
+
                         // drop success
                         player.Session.Network.EnqueueSend(
                             new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, ObjectGuid.Invalid),

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1483,6 +1483,18 @@ namespace ACE.Server.WorldObjects
             }
             item.Ethereal = ethereal;
 
+            if (item.Ethereal == null)
+            {
+                var defaultPhysicsState = (PhysicsState)(item.GetProperty(PropertyInt.PhysicsState) ?? 0);
+
+                if (defaultPhysicsState.HasFlag(PhysicsState.Ethereal))
+                    item.Ethereal = true;
+                else
+                    item.Ethereal = false;
+            }
+
+            item.EnqueueBroadcastPhysicsState();
+
             return true;
         }
 


### PR DESCRIPTION
Re-enforces expected default state of Ethereal after object is dropped by player