### PR TITLE
Improve performance with CharacterOptionExtensions

### DIFF
--- a/Source/ACE.Entity/Enum/CharacterOption.cs
+++ b/Source/ACE.Entity/Enum/CharacterOption.cs
@@ -180,14 +180,24 @@ namespace ACE.Entity.Enum
 
     public static class CharacterOptionExtensions
     {
+        private static Dictionary<CharacterOption, CharacterOptions1Attribute> CharacterOptions1Attributes { get; }
+        private static Dictionary<CharacterOption, CharacterOptions2Attribute> CharacterOptions2Attributes { get; }
+
+        static CharacterOptionExtensions()
+        {
+            var vals = System.Enum.GetValues(typeof(CharacterOption)).Cast<CharacterOption>();
+            CharacterOptions1Attributes = vals.ToDictionary(o => o, o => o.GetAttributeOfType<CharacterOptions1Attribute>());
+            CharacterOptions2Attributes = vals.ToDictionary(o => o, o => o.GetAttributeOfType<CharacterOptions2Attribute>());
+        }
+
         public static CharacterOptions1Attribute GetCharacterOptions1Attribute(this CharacterOption val)
         {
-            return val.GetAttributeOfType<CharacterOptions1Attribute>();
+            return CharacterOptions1Attributes[val];
         }
 
         public static CharacterOptions2Attribute GetCharacterOptions2Attribute(this CharacterOption val)
         {
-            return val.GetAttributeOfType<CharacterOptions2Attribute>();
+            return CharacterOptions2Attributes[val];
         }
 
         public static uint GetCharacterOptions1Flag(this ReadOnlyDictionary<CharacterOption, bool> options)


### PR DESCRIPTION
Improves performance with CharacterOptionExtensions. There is some overhead with calling GetAttributeOfType, so we are pre-caching these results.

Moves CharacterOptionExtensions from ACE.Entity to ACE.Server, as ACE.Entity's .NET Standard doesn't support FrozenDictionary or Enum.GetValues<T>.

I could rewrite this in a way that is compatible with .NET Standard, but it seemed more appropriate for the class to be in ACE.Server anyway so I moved it for now.