### PR TITLE
(Performance) Change static readonly fields to const fields

### DIFF
--- a/Source/ACE.Common/DerethDateTime.cs
+++ b/Source/ACE.Common/DerethDateTime.cs
@@ -8,29 +8,29 @@ namespace ACE.Common
     public class DerethDateTime
     {
         // Changing the four variables below will result in the Date and Time reported in ACClient no longer matching
-        private static int hoursInADay      = 16;   // A Derethian day has 16 hours
-        private static int daysInAMonth     = 30;   // A Derethian month has 30 days and does not vary like Earth months.
-        private static int monthsInAYear    = 12;   // A Derethian year has 12 months
-        private static double dayTicks      = 7620; // A Derethain day has 7620 ticks per day
+        private const int hoursInADay      = 16;   // A Derethian day has 16 hours
+        private const int daysInAMonth     = 30;   // A Derethian month has 30 days and does not vary like Earth months.
+        private const int monthsInAYear    = 12;   // A Derethian year has 12 months
+        private const double dayTicks      = 7620; // A Derethain day has 7620 ticks per day
 
-        private static double hourTicks     = dayTicks / hoursInADay;
-        private static double minuteTicks   = hourTicks / 60;
-        private static double secondTicks   = minuteTicks / 60;
+        private const double hourTicks     = dayTicks / hoursInADay;
+        private const double minuteTicks   = hourTicks / 60;
+        private const double secondTicks   = minuteTicks / 60;
 
-        private static double monthTicks    = dayTicks * daysInAMonth;
-        private static double yearTicks     = monthTicks * monthsInAYear;
+        private const double monthTicks    = dayTicks * daysInAMonth;
+        private const double yearTicks     = monthTicks * monthsInAYear;
 
-        private static double dayZeroTicks  = 0; // Morningthaw 1, 10 P.Y. - Morntide-and-Half
-        private static double hourOneTicks  = 210; // Morningthaw 1, 10 P.Y. - Midsong
-        private static double dayOneTicks   = dayZeroTicks + hourOneTicks + (hourTicks * 8); // Morningthaw 2, 10 P.Y. - Darktide
-        private static double yearOneTicks  = dayOneTicks + (dayTicks * 359); // Morningthaw 1, 11 P.Y. - Darktide
-        private static double yearZeroTicks = dayOneTicks + (dayTicks * 269); // Snowreap 1, 10 P.Y. - Darktide
+        private const double dayZeroTicks  = 0; // Morningthaw 1, 10 P.Y. - Morntide-and-Half
+        private const double hourOneTicks  = 210; // Morningthaw 1, 10 P.Y. - Midsong
+        private const double dayOneTicks   = dayZeroTicks + hourOneTicks + (hourTicks * 8); // Morningthaw 2, 10 P.Y. - Darktide
+        private const double yearOneTicks  = dayOneTicks + (dayTicks * 359); // Morningthaw 1, 11 P.Y. - Darktide
+        private const double yearZeroTicks = dayOneTicks + (dayTicks * 269); // Snowreap 1, 10 P.Y. - Darktide
 
-        private static DateTime dayZero_RealWorld       = new DateTime(1999, 4, 1, 10, 30, 00);
-        private static DateTime dayOne_RealWorld        = new DateTime(1999, 4, 2, 00, 00, 00);
+        private static readonly DateTime dayZero_RealWorld       = new DateTime(1999, 4, 1, 10, 30, 00);
+        private static readonly DateTime dayOne_RealWorld        = new DateTime(1999, 4, 2, 00, 00, 00);
 
-        private static DateTime retailDayOne_RealWorld  = new DateTime(1999, 11, 2, 00, 00, 00);
-        private static DateTime retailDayLast_RealWorld = new DateTime(2017, 1, 31, 12, 00, 00); // Eastern Standard Time
+        private static readonly DateTime retailDayOne_RealWorld  = new DateTime(1999, 11, 2, 00, 00, 00);
+        private static readonly DateTime retailDayLast_RealWorld = new DateTime(2017, 1, 31, 12, 00, 00); // Eastern Standard Time
 
         /// <summary>
         /// <para>A <see cref="DerethDateTime"/> instance set to the Derethian Date, Portal Year and Time when the worlds first opened.</para>
@@ -55,13 +55,13 @@ namespace ACE.Common
         /// <summary>
         /// <para>Date: Morningthaw 1, 10 P.Y. | Time: Morntide-and-Half (0)</para>
         /// </summary>
-        public static readonly double MinValue = 0; // Morningthaw 1, 10 P.Y. - Morntide-and-Half
+        public const double MinValue = 0; // Morningthaw 1, 10 P.Y. - Morntide-and-Half
 
         /// <summary>
         /// <para>Any value higher than this results in acclient crashing upon connection to server.</para>
         /// <para>Date: Thistledown 2, 401 P.Y. | Time: Morntide-and-Half (1073741828)</para>
         /// </summary>
-        public static readonly double MaxValue = (yearTicks * 391) + (monthTicks * 5) + (dayTicks * 1) + 4; // Thistledown 2, 401 P.Y. - Morntide-and-Half (1073741828)
+        public const double MaxValue = (yearTicks * 391) + (monthTicks * 5) + (dayTicks * 1) + 4; // Thistledown 2, 401 P.Y. - Morntide-and-Half (1073741828)
 
         /// <summary>
         /// Months of the Portal Year

--- a/Source/ACE.Common/ThreadSafeRandom.cs
+++ b/Source/ACE.Common/ThreadSafeRandom.cs
@@ -38,7 +38,7 @@ namespace ACE.Common
         /// <summary>
         /// The maximum possible double < 1.0
         /// </summary>
-        private static readonly double maxExclusive = 0.9999999999999999;
+        private const double maxExclusive = 0.9999999999999999;
 
         public static double NextIntervalMax(float qualityMod)
         {

--- a/Source/ACE.DatLoader/DatDatabase.cs
+++ b/Source/ACE.DatLoader/DatDatabase.cs
@@ -13,7 +13,7 @@ namespace ACE.DatLoader
     {
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly uint DAT_HEADER_OFFSET = 0x140;
+        private const uint DAT_HEADER_OFFSET = 0x140;
 
         public string FilePath { get; }
 

--- a/Source/ACE.DatLoader/DatDirectoryHeader.cs
+++ b/Source/ACE.DatLoader/DatDirectoryHeader.cs
@@ -4,7 +4,7 @@ namespace ACE.DatLoader
 {
     public class DatDirectoryHeader : IUnpackable
     {
-        internal static readonly uint ObjectSize = ((sizeof(uint) * 0x3E) + sizeof(uint) + (DatFile.ObjectSize * 0x3D));
+        internal const uint ObjectSize = ((sizeof(uint) * 0x3E) + sizeof(uint) + (DatFile.ObjectSize * 0x3D));
 
         public uint[] Branches { get; } = new uint[0x3E];
         public uint EntryCount { get; private set; }

--- a/Source/ACE.DatLoader/DatFile.cs
+++ b/Source/ACE.DatLoader/DatFile.cs
@@ -7,7 +7,7 @@ namespace ACE.DatLoader
 {
     public class DatFile : IUnpackable
     {
-        internal static readonly uint ObjectSize = (sizeof(uint) * 6);
+        internal const uint ObjectSize = (sizeof(uint) * 6);
 
         
         //public uint BitFlags { get; private set; }

--- a/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
+++ b/Source/ACE.Database/WorldDatabaseWithEntityCache.cs
@@ -863,7 +863,7 @@ namespace ACE.Database
             }
         }
 
-        private static readonly float NormalizeEpsilon = 0.00001f;
+        private const float NormalizeEpsilon = 0.00001f;
 
         private void TreasureMaterialBase_Normalize(Dictionary<int, Dictionary<int, List<TreasureMaterialBase>>> materialBase)
         {

--- a/Source/ACE.Entity/Position.cs
+++ b/Source/ACE.Entity/Position.cs
@@ -503,9 +503,9 @@ namespace ACE.Entity
             return $"0x{LandblockId.Raw:X8} [{PositionX:F6} {PositionY:F6} {PositionZ:F6}] {RotationW:F6} {RotationX:F6} {RotationY:F6} {RotationZ:F6}";
         }
 
-        public static readonly int BlockLength = 192;
-        public static readonly int CellSide = 8;
-        public static readonly int CellLength = 24;
+        public const int BlockLength = 192;
+        public const int CellSide = 8;
+        public const int CellLength = 24;
 
         public bool Equals(Position p)
         {

--- a/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperFixCommands.cs
@@ -1333,10 +1333,10 @@ namespace ACE.Server.Command.Handlers
         }
 
         // head / hands / feet
-        public static readonly int MaxArmorLevel_Extremity = 345;
+        public const int MaxArmorLevel_Extremity = 345;
 
         // everything else
-        public static readonly int MaxArmorLevel_NonExtremity = 315;
+        public const int MaxArmorLevel_NonExtremity = 315;
 
         public static int GetArmorLevel(int armorLevel, EquipMask equipMask, TinkerLog tinkerLog, int numTinkers, int imbuedEffect)
         {

--- a/Source/ACE.Server/Entity/Chess/ChessMatch.cs
+++ b/Source/ACE.Server/Entity/Chess/ChessMatch.cs
@@ -711,7 +711,7 @@ namespace ACE.Server.Entity.Chess
         /// <summary>
         /// How quickly the rankings will raise / lower
         /// </summary>
-        public static readonly int RankFactor = 50;
+        public const int RankFactor = 50;
 
         /// <summary>
         /// Adjusts the chess ranks for 2 players after a match

--- a/Source/ACE.Server/Entity/Cloak.cs
+++ b/Source/ACE.Server/Entity/Cloak.cs
@@ -77,7 +77,7 @@ namespace ACE.Server.Entity
             }
         }
 
-        private static readonly float TwoThirds = 2.0f / 3.0f;
+        private const float TwoThirds = 2.0f / 3.0f;
 
         /// <summary>
         /// Rolls for a chance at procing a cloak spell
@@ -197,7 +197,7 @@ namespace ACE.Server.Entity
         /// <summary>
         /// The amount of damage reduced by a cloak proced with PropertyInt.CloakWeaveProc=2
         /// </summary>
-        public static readonly int DamageReductionAmount = 200;
+        public const int DamageReductionAmount = 200;
 
         public static int GetDamageReductionAmount(WorldObject source)
         {

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -630,7 +630,7 @@ namespace ACE.Server.Entity
             return 1.0;
         }
 
-        public static readonly int MaxDistance = 600;
+        public const int MaxDistance = 600;
 
         /// <summary>
         /// Returns the amount to scale the XP for a fellow

--- a/Source/ACE.Server/Entity/LandblockMesh.cs
+++ b/Source/ACE.Server/Entity/LandblockMesh.cs
@@ -22,22 +22,22 @@ namespace ACE.Server.Entity
         /// <summary>
         /// A landblock has this many cells squared
         /// </summary>
-        public static readonly int CellDim = 8;
+        public const int CellDim = 8;
 
         /// <summary>
         /// A landblock is this unit size squared
         /// </summary>
-        public static readonly int LandblockSize = 192;
+        public const int LandblockSize = 192;
 
         /// <summary>
         /// A landblock cell is this unit size squared
         /// </summary>
-        public static readonly int CellSize = LandblockSize / CellDim;
+        public const int CellSize = LandblockSize / CellDim;
 
         /// <summary>
         /// A landblock has this many vertices squared
         /// </summary>
-        public static readonly int VertexDim = CellDim + 1;
+        public const int VertexDim = CellDim + 1;
 
         /// <summary>
         /// LandHeightTable mapping non-linear heights

--- a/Source/ACE.Server/Entity/Mutations/MutationCache.cs
+++ b/Source/ACE.Server/Entity/Mutations/MutationCache.cs
@@ -512,7 +512,7 @@ namespace ACE.Server.Entity.Mutations
             return null;
         }
 
-        private static readonly string prefix = "ACE.Server.Entity.Mutations.";
+        private const string prefix = "ACE.Server.Entity.Mutations.";
 
         private static List<string> ReadScript(string filename)
         {

--- a/Source/ACE.Server/Factories/Entity/ChanceTable.cs
+++ b/Source/ACE.Server/Factories/Entity/ChanceTable.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.Factories.Entity
     public class ChanceTable<T> : List<(T result, float chance)>
     {
         private bool verified;
-        private static readonly decimal threshold = 0.0000001M;
+        private const decimal threshold = 0.0000001M;
 
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -736,8 +736,8 @@ namespace ACE.Server.Factories
             return gemResult.MaterialType;
         }
 
-        public static readonly float WeaponBulk = 0.50f;
-        public static readonly float ArmorBulk = 0.25f;
+        public const float WeaponBulk = 0.50f;
+        public const float ArmorBulk = 0.25f;
 
         private static bool MutateBurden(WorldObject wo, TreasureDeath treasureDeath, bool isWeapon)
         {
@@ -839,9 +839,9 @@ namespace ACE.Server.Factories
         }
 
         // increase for a wider variance in item value ranges
-        private static readonly float valueFactor = 1.0f / 3.0f;
+        private const float valueFactor = 1.0f / 3.0f;
 
-        private static readonly float valueNonFactor = 1.0f - valueFactor;
+        private const float valueNonFactor = 1.0f - valueFactor;
 
         private static void MutateValue_Generic(WorldObject wo, int tier)
         {

--- a/Source/ACE.Server/Factories/Tables/Cantrips/ArmorCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/ArmorCantrips.cs
@@ -95,7 +95,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.CANTRIPPIERCINGBANE1,
         };
 
-        private static readonly int NumLevels = 4;
+        private const int NumLevels = 4;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Cantrips/JewelryCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/JewelryCantrips.cs
@@ -73,7 +73,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.CANTRIPPIERCINGWARD1,
         };
 
-        private static readonly int NumLevels = 4;
+        private const int NumLevels = 4;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Cantrips/MeleeCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/MeleeCantrips.cs
@@ -29,7 +29,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.CantripSneakAttackProwess1,
         };
 
-        private static readonly int NumLevels = 4;
+        private const int NumLevels = 4;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Cantrips/MissileCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/MissileCantrips.cs
@@ -28,7 +28,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.CantripSneakAttackProwess1,
         };
 
-        private static readonly int NumLevels = 4;
+        private const int NumLevels = 4;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Cantrips/WandCantrips.cs
+++ b/Source/ACE.Server/Factories/Tables/Cantrips/WandCantrips.cs
@@ -32,7 +32,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.CantripSpiritThirst1,
         };
 
-        private static readonly int NumLevels = 4;
+        private const int NumLevels = 4;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Spells/ArmorSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/ArmorSpells.cs
@@ -103,7 +103,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.LightningBane1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Spells/GemSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/GemSpells.cs
@@ -87,7 +87,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.LightningProtectionSelf1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] GemCreatureSpellMatrix = new SpellId[NumTiers][];

--- a/Source/ACE.Server/Factories/Tables/Spells/JewelrySpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/JewelrySpells.cs
@@ -85,7 +85,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.LightningProtectionSelf1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MeleeSpells.cs
@@ -30,7 +30,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.SneakAttackMasterySelf1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/MissileSpells.cs
@@ -29,7 +29,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.SneakAttackMasterySelf1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Factories/Tables/Spells/ScrollSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/ScrollSpells.cs
@@ -346,9 +346,9 @@ namespace ACE.Server.Factories.Tables
             SpellId.CurseWeakness1,
         };
 
-        private static readonly int NumLevels = 7;
+        private const int NumLevels = 7;
 
-        private static readonly int MaxLevels = 8;
+        private const int MaxLevels = 8;
 
         private static readonly int NumSpells = creatureSpells.Count + lifeSpells.Count + itemSpells.Count + warSpells.Count + voidSpells.Count;
 

--- a/Source/ACE.Server/Factories/Tables/Spells/WandSpells.cs
+++ b/Source/ACE.Server/Factories/Tables/Spells/WandSpells.cs
@@ -34,7 +34,7 @@ namespace ACE.Server.Factories.Tables
             SpellId.SneakAttackMasterySelf1,
         };
 
-        private static readonly int NumTiers = 8;
+        private const int NumTiers = 8;
 
         // original api
         public static readonly SpellId[][] Table = new SpellId[spells.Count][];

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -1479,7 +1479,7 @@ namespace ACE.Server.Managers
         /// <summary>
         /// flag to use c# logic instead of mutate script logic
         /// </summary>
-        private static readonly bool useMutateNative = false;
+        private const bool useMutateNative = false;
 
         public static bool TryMutate(Player player, WorldObject source, WorldObject target, Recipe recipe, uint dataId, HashSet<uint> modified)
         {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionQueryAge.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionQueryAge.cs
@@ -17,19 +17,19 @@ namespace ACE.Server.Network.GameAction.Actions
             session.Network.EnqueueSend(new GameEventQueryAgeResponse(session, string.Empty, ageMsg));
         }
 
-        private static readonly int SecondsPerMinute = 60;
-        private static readonly int MinutesPerHour = 60;
-        private static readonly int HoursPerDay = 24;
+        private const int SecondsPerMinute = 60;
+        private const int MinutesPerHour = 60;
+        private const int HoursPerDay = 24;
 
-        private static readonly int DaysPerWeek = 7;
-        private static readonly int DaysPerMonth = 30;
-        private static readonly int DaysPerYear = 365;
+        private const int DaysPerWeek = 7;
+        private const int DaysPerMonth = 30;
+        private const int DaysPerYear = 365;
 
-        private static readonly int SecondsPerHour = SecondsPerMinute * MinutesPerHour;     // 3600
-        private static readonly int SecondsPerDay = SecondsPerHour * HoursPerDay;           // 86400
-        private static readonly int SecondsPerWeek = SecondsPerDay * DaysPerWeek;           // 604800
-        private static readonly int SecondsPerMonth = SecondsPerDay * DaysPerMonth;         // 2592000
-        private static readonly int SecondsPerYear = SecondsPerDay * DaysPerYear;           // 31536000
+        private const int SecondsPerHour = SecondsPerMinute * MinutesPerHour;     // 3600
+        private const int SecondsPerDay = SecondsPerHour * HoursPerDay;           // 86400
+        private const int SecondsPerWeek = SecondsPerDay * DaysPerWeek;           // 604800
+        private const int SecondsPerMonth = SecondsPerDay * DaysPerMonth;         // 2592000
+        private const int SecondsPerYear = SecondsPerDay * DaysPerYear;           // 31536000
 
         public static string CalculateAgeMessage(int ageSeconds)
         {

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventStartBarber.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventStartBarber.cs
@@ -2,8 +2,8 @@ namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventStartBarber : GameEventMessage
     {
-        public static readonly uint EmpyreanMaleMotionDID   = 0x0900020E;
-        public static readonly uint EmpyreanFemaleMotionDID = 0x0900020D;
+        public const uint EmpyreanMaleMotionDID   = 0x0900020E;
+        public const uint EmpyreanFemaleMotionDID = 0x0900020D;
 
         public GameEventStartBarber(Session session)
             : base(GameEventType.StartBarber, GameMessageGroup.UIQueue, session, 68)

--- a/Source/ACE.Server/Network/Structure/AllegianceHierarchy.cs
+++ b/Source/ACE.Server/Network/Structure/AllegianceHierarchy.cs
@@ -163,8 +163,8 @@ namespace ACE.Server.Network.Structure
 
         // aside from RestrictionDB, this appears to be the only other place in the client that calls PHashTable/IntrusiveHashTable constructor directly
         // 256 is ignored, and 23 is used
-        private static readonly ushort headerNumBuckets = 256;
-        private static readonly ushort actualNumBuckets = 23;
+        private const ushort headerNumBuckets = 256;
+        private const ushort actualNumBuckets = 23;
 
         private static readonly GuidComparer guidComparer = new GuidComparer(actualNumBuckets);
 

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.Network.Structure
     /// </summary>
     public class AppraiseInfo
     {
-        private static readonly uint EnchantmentMask = 0x80000000;
+        private const uint EnchantmentMask = 0x80000000;
 
         public IdentifyResponseFlags Flags;
 

--- a/Source/ACE.Server/Network/Structure/RestrictionDB.cs
+++ b/Source/ACE.Server/Network/Structure/RestrictionDB.cs
@@ -79,11 +79,11 @@ namespace ACE.Server.Network.Structure
             writer.Write(restrictions.Table);
         }
 
-        private static readonly ushort headerNumBuckets = 768;  // this # of buckets was sent over the wire in retail header
+        private const ushort headerNumBuckets = 768;            // this # of buckets was sent over the wire in retail header
                                                                 // however, this value ends up being unused, and the "real" # of buckets originates
                                                                 // from a hardcoded value in g_bucketSizeArray in the client constant data
 
-        private static readonly ushort actualNumBuckets = 89;   // in RestrictionDB constructor in acclient,
+        private const ushort actualNumBuckets = 89;             // in RestrictionDB constructor in acclient,
                                                                 // client uses PHashTable for this (as opposed to the typical PackableHashTable)
 
                                                                 // which inits an IntrusiveHashTable with size 64

--- a/Source/ACE.Server/Physics/Animation/MotionInterp.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionInterp.cs
@@ -23,13 +23,13 @@ namespace ACE.Server.Physics.Animation
         public float MyRunRate;
         public LinkedList<MotionNode> PendingMotions;
 
-        public static readonly float BackwardsFactor = 6.4999998e-1f;
-        public static readonly float MaxSidestepAnimRate = 3.0f;
-        public static readonly float RunAnimSpeed = 4.0f;
-        public static readonly float RunTurnFactor = 1.5f;
-        public static readonly float SidestepAnimSpeed = 1.25f;
-        public static readonly float SidestepFactor = 0.5f;
-        public static readonly float WalkAnimSpeed = 3.1199999f;
+        public const float BackwardsFactor = 6.4999998e-1f;
+        public const float MaxSidestepAnimRate = 3.0f;
+        public const float RunAnimSpeed = 4.0f;
+        public const float RunTurnFactor = 1.5f;
+        public const float SidestepAnimSpeed = 1.25f;
+        public const float SidestepFactor = 0.5f;
+        public const float WalkAnimSpeed = 3.1199999f;
 
         public MotionInterp() { }
 

--- a/Source/ACE.Server/Physics/Animation/MovementParameters.cs
+++ b/Source/ACE.Server/Physics/Animation/MovementParameters.cs
@@ -42,12 +42,12 @@ namespace ACE.Server.Physics.Animation
         public HoldKey HoldKeyToApply;
         public int ActionStamp;
 
-        public static readonly float Default_DistanceToObject = 0.6f;
-        public static readonly float Default_FailDistance = float.MaxValue;
-        public static readonly float Default_MinDistance = 0.0f;
-        public static readonly float Default_Speed = 1.0f;
-        //public static readonly float Default_WalkRunThreshold = 15.0f;
-        public static readonly float Default_WalkRunThreshold = 1.0f;
+        public const float Default_DistanceToObject = 0.6f;
+        public const float Default_FailDistance = float.MaxValue;
+        public const float Default_MinDistance = 0.0f;
+        public const float Default_Speed = 1.0f;
+        //public const float Default_WalkRunThreshold = 15.0f;
+        public const float Default_WalkRunThreshold = 1.0f;
 
         public MovementParameters()
         {

--- a/Source/ACE.Server/Physics/Common/LandDefs.cs
+++ b/Source/ACE.Server/Physics/Common/LandDefs.cs
@@ -83,31 +83,31 @@ namespace ACE.Server.Physics.Common
             RoadType = 0x20
         };
 
-        public static readonly int BlockCellID = 0x0000FFFF;
-        public static readonly int FirstEnvCellID = 0x100;
-        public static readonly int LastEnvCellID = 0xFFFD;
-        public static readonly int FirstLandCellID = 1;
-        public static readonly int LastLandCellID = 64;
+        public const int BlockCellID = 0x0000FFFF;
+        public const int FirstEnvCellID = 0x100;
+        public const int LastEnvCellID = 0xFFFD;
+        public const int FirstLandCellID = 1;
+        public const int LastLandCellID = 64;
 
-        public static readonly uint BlockMask = 0xFFFF0000;
-        public static readonly int BlockX_Mask = 0xFF00;
-        public static readonly int BlockY_Mask = 0x00FF;
-        public static readonly int CellID_Mask = 0x0000FFFF;
-        public static readonly int LandblockMask = 7;
+        public const uint BlockMask = 0xFFFF0000;
+        public const int BlockX_Mask = 0xFF00;
+        public const int BlockY_Mask = 0x00FF;
+        public const int CellID_Mask = 0x0000FFFF;
+        public const int LandblockMask = 7;
 
-        public static readonly int BlockPartShift = 16;
-        public static readonly int LandblockShift = 3;
-        public static readonly int MaxBlockShift = 8;
+        public const int BlockPartShift = 16;
+        public const int LandblockShift = 3;
+        public const int MaxBlockShift = 8;
 
-        public static readonly int BlockLength = 192;
-        public static readonly int CellLength = 24;
-        public static readonly int LandLength = 2040;
-        public static readonly int VertexDim = 9;
+        public const int BlockLength = 192;
+        public const int CellLength = 24;
+        public const int LandLength = 2040;
+        public const int VertexDim = 9;
 
-        public static readonly int BlockSide = 8;
-        public static readonly int VertexPerCell = 1;
-        public static readonly int HalfSquareLength = 12;
-        public static readonly int SquareLength = 24;
+        public const int BlockSide = 8;
+        public const int VertexPerCell = 1;
+        public const int HalfSquareLength = 12;
+        public const int SquareLength = 24;
 
         public static List<float> LandHeightTable;
 

--- a/Source/ACE.Server/Physics/Common/ObjectMaint.cs
+++ b/Source/ACE.Server/Physics/Common/ObjectMaint.cs
@@ -18,7 +18,7 @@ namespace ACE.Server.Physics.Common
         /// <summary>
         /// The client automatically removes known objects if they remain outside visibility for this amount of time
         /// </summary>
-        public static readonly float DestructionTime = 25.0f;
+        public const float DestructionTime = 25.0f;
 
         private static readonly ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 

--- a/Source/ACE.Server/Physics/Common/Position.cs
+++ b/Source/ACE.Server/Physics/Common/Position.cs
@@ -136,8 +136,8 @@ namespace ACE.Server.Physics.Common
             return offset.Length() - (radius + otherRadius);
         }
 
-        public static readonly float ThresholdMed = 1.0f / 3.0f;
-        public static readonly float ThresholdHigh = 2.0f / 3.0f;
+        public const float ThresholdMed = 1.0f / 3.0f;
+        public const float ThresholdHigh = 2.0f / 3.0f;
 
         public Quadrant DetermineQuadrant(float height, Position position)
         {

--- a/Source/ACE.Server/Physics/Managers/InterpolationManager.cs
+++ b/Source/ACE.Server/Physics/Managers/InterpolationManager.cs
@@ -15,8 +15,8 @@ namespace ACE.Server.Physics.Animation
         public int NodeFailCounter;
         public Position BlipToPosition;
 
-        public static readonly float LargeDistance = 999999.0f;
-        public static readonly float MaxInterpolatedVelocity = 7.5f;
+        public const float LargeDistance = 999999.0f;
+        public const float MaxInterpolatedVelocity = 7.5f;
 
         public static bool UseAdjustedSpeed = true;
 

--- a/Source/ACE.Server/Physics/Managers/StickyManager.cs
+++ b/Source/ACE.Server/Physics/Managers/StickyManager.cs
@@ -17,9 +17,9 @@ namespace ACE.Server.Physics.Animation
         public bool Initialized;
         public double StickyTimeoutTime;
 
-        public static readonly float StickyRadius = 0.3f;
+        public const float StickyRadius = 0.3f;
 
-        public static readonly float StickyTime = 1.0f;
+        public const float StickyTime = 1.0f;
 
         public StickyManager()
         {

--- a/Source/ACE.Server/Physics/PhysicsGlobals.cs
+++ b/Source/ACE.Server/Physics/PhysicsGlobals.cs
@@ -6,55 +6,55 @@ namespace ACE.Server.Physics
 {
     public class PhysicsGlobals
     {
-        public static readonly float EPSILON = 0.0002f;
+        public const float EPSILON = 0.0002f;
 
-        public static readonly float EpsilonSq = EPSILON * EPSILON;
+        public const float EpsilonSq = EPSILON * EPSILON;
 
-        public static readonly float Gravity = -9.8f;
+        public const float Gravity = -9.8f;
 
-        public static readonly float DefaultFriction = 0.95f;
+        public const float DefaultFriction = 0.95f;
 
-        public static readonly float DefaultElasticity = 0.05f;
+        public const float DefaultElasticity = 0.05f;
 
-        public static readonly float DefaultTranslucency = 0.0f;
+        public const float DefaultTranslucency = 0.0f;
 
-        public static readonly float DefaultMass = 1.0f;
+        public const float DefaultMass = 1.0f;
 
-        public static readonly float DefaultScale = 1.0f;
+        public const float DefaultScale = 1.0f;
 
         public static readonly PhysicsState DefaultState =
             PhysicsState.EdgeSlide | PhysicsState.LightingOn | PhysicsState.Gravity | PhysicsState.ReportCollisions;
 
-        public static readonly float MaxElasticity = 0.1f;
+        public const float MaxElasticity = 0.1f;
 
-        public static readonly float MaxVelocity = 50.0f;
+        public const float MaxVelocity = 50.0f;
 
-        public static readonly float MaxVelocitySquared = MaxVelocity * MaxVelocity;
+        public const float MaxVelocitySquared = MaxVelocity * MaxVelocity;
 
-        public static readonly float SmallVelocity = 0.25f;
+        public const float SmallVelocity = 0.25f;
 
-        public static readonly float SmallVelocitySquared = SmallVelocity * SmallVelocity;
+        public const float SmallVelocitySquared = SmallVelocity * SmallVelocity;
 
-        public static readonly float MinQuantum = 1.0f / 30.0f;     // 0.0333... 30fps
+        public const float MinQuantum = 1.0f / 30.0f;     // 0.0333... 30fps
 
-        //public static readonly float MaxQuantum = 0.2f;     // 5fps   // this is buggy with MoveToManager turning
-        public static readonly float MaxQuantum = 0.1f;     // 10fps
+        //public const float MaxQuantum = 0.2f;     // 5fps   // this is buggy with MoveToManager turning
+        public const float MaxQuantum = 0.1f;     // 10fps
 
-        public static readonly float HugeQuantum = 2.0f;    // 0.5fps
+        public const float HugeQuantum = 2.0f;    // 0.5fps
 
         /// <summary>
         /// The walkable allowance when landing on the ground
         /// </summary>
-        public static readonly float LandingZ = 0.0871557f;
+        public const float LandingZ = 0.0871557f;
 
-        public static readonly float FloorZ = 0.66417414618662751f;
+        public const float FloorZ = 0.66417414618662751f;
 
-        public static readonly float DummySphereRadius = 0.1f;
+        public const float DummySphereRadius = 0.1f;
 
         public static readonly Sphere DummySphere = new Sphere(new Vector3(0, 0, DummySphereRadius), DummySphereRadius);
 
         public static readonly Sphere DefaultSortingSphere;
 
-        public static readonly float DefaultStepHeight = 0.01f;
+        public const float DefaultStepHeight = 0.01f;
     }
 }

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -114,7 +114,7 @@ namespace ACE.Server.Physics
         public ObjectMaint ObjMaint;
         public bool IsPlayer => ID >= 0x50000001 && ID <= 0x5FFFFFFF;
 
-        public static readonly int UpdateTimeLength = 9;
+        public const int UpdateTimeLength = 9;
 
         public bool IsSticky => PositionManager?.StickyManager != null && PositionManager.StickyManager.TargetID != 0;
 

--- a/Source/ACE.Server/Physics/Sphere.cs
+++ b/Source/ACE.Server/Physics/Sphere.cs
@@ -60,8 +60,8 @@ namespace ACE.Server.Physics
             Radius = sphere.Radius;
         }
 
-        public static readonly float ThresholdMed = 1.0f / 3.0f;
-        public static readonly float ThresholdHigh = 2.0f / 3.0f;
+        public const float ThresholdMed = 1.0f / 3.0f;
+        public const float ThresholdHigh = 2.0f / 3.0f;
 
         public static Quadrant Attack(Position targetPos, float targetRadius, float targetHeight, Position attackPos, Vector2 left, Vector2 right, float attackRadius, float attackHeight)
         {

--- a/Source/ACE.Server/WorldObjects/Corpse.cs
+++ b/Source/ACE.Server/WorldObjects/Corpse.cs
@@ -24,7 +24,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The maximum number of seconds for an empty corpse to stick around
         /// </summary>
-        public static readonly double EmptyDecayTime = 15.0;
+        public const double EmptyDecayTime = 15.0;
 
         /// <summary>
         /// Flag indicates if a corpse is from a monster or a player

--- a/Source/ACE.Server/WorldObjects/Creature_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Melee.cs
@@ -100,11 +100,11 @@ namespace ACE.Server.WorldObjects
             return dist1.CompareTo(dist2);
         }
 
-        public static readonly float CleaveRange = 5.0f;
-        public static readonly float CleaveRangeSq = CleaveRange * CleaveRange;
-        public static readonly float CleaveAngle = 180.0f;
+        public const float CleaveRange = 5.0f;
+        public const float CleaveRangeSq = CleaveRange * CleaveRange;
+        public const float CleaveAngle = 180.0f;
 
-        public static readonly float CleaveCylRange = 2.0f;
+        public const float CleaveCylRange = 2.0f;
 
         /// <summary>
         /// Performs a cleaving attack for two-handed weapons

--- a/Source/ACE.Server/WorldObjects/Creature_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Missile.cs
@@ -142,7 +142,7 @@ namespace ACE.Server.WorldObjects
             return proj;
         }
 
-        public static readonly float ProjSpawnHeight = 0.8454f;
+        public const float ProjSpawnHeight = 0.8454f;
 
         /// <summary>
         /// Returns the origin to spawn the projectile in the attacker local space
@@ -205,7 +205,7 @@ namespace ACE.Server.WorldObjects
         }
 
         // lowest value found in data / for starter bows
-        public static readonly float DefaultProjectileSpeed = 20.0f;
+        public const float DefaultProjectileSpeed = 20.0f;
 
         public float GetProjectileSpeed()
         {
@@ -399,9 +399,9 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        public static readonly float MetersToYards = 1.094f;    // 1.09361
-        public static readonly float MissileRangeCap = 85.0f / MetersToYards;   // 85 yards = ~77.697 meters w/ ac formula
-        public static readonly float DefaultMaxVelocity = 20.0f;    // ?
+        public const float MetersToYards = 1.094f;    // 1.09361
+        public const float MissileRangeCap = 85.0f / MetersToYards;   // 85 yards = ~77.697 meters w/ ac formula
+        public const float DefaultMaxVelocity = 20.0f;    // ?
 
         public float GetMaxMissileRange()
         {

--- a/Source/ACE.Server/WorldObjects/Healer.cs
+++ b/Source/ACE.Server/WorldObjects/Healer.cs
@@ -116,7 +116,7 @@ namespace ACE.Server.WorldObjects
             DoHealMotion(healer, targetPlayer, true);
         }
 
-        public static readonly float Healing_MaxMove = 5.0f;
+        public const float Healing_MaxMove = 5.0f;
 
         public void DoHealMotion(Player healer, Player target, bool success)
         {

--- a/Source/ACE.Server/WorldObjects/Managers/ConfirmationManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/ConfirmationManager.cs
@@ -17,7 +17,7 @@ namespace ACE.Server.WorldObjects.Managers
 
         private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-        private static readonly double confirmationTimeout = 30;
+        private const double confirmationTimeout = 30;
 
         private UIntSequence contextSequence = new UIntSequence();
 

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -374,12 +374,12 @@ namespace ACE.Server.WorldObjects
         /// The most common value from retail
         /// Some other common values are in the range of 12-25
         /// </summary>
-        public static readonly float VisualAwarenessRange_Default = 18.0f;
+        public const float VisualAwarenessRange_Default = 18.0f;
 
         /// <summary>
         /// The highest value found in the current database
         /// </summary>
-        public static readonly float VisualAwarenessRange_Highest = 75.0f;
+        public const float VisualAwarenessRange_Highest = 75.0f;
 
         public double? VisualAwarenessRange
         {

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -200,9 +200,9 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
-        private static readonly float PreCastSpeed = 2.0f;
-        private static readonly float PostCastSpeed = 1.0f;
-        private static readonly float PostCastSpeed_Ranged = 1.66f;  // ??
+        private const float PreCastSpeed = 2.0f;
+        private const float PostCastSpeed = 1.0f;
+        private const float PostCastSpeed_Ranged = 1.66f;  // ??
 
         /// <summary>
         /// Perform the first part of monster spell casting animation - spreading arms out

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -14,7 +14,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The delay between missile attacks (todo: find actual value)
         /// </summary>
-        public static readonly float MissileDelay = 1.0f;
+        public const float MissileDelay = 1.0f;
 
         /// <summary>
         /// Returns TRUE if monster has physical ranged attacks

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -18,21 +18,21 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Return to home if target distance exceeds this range
         /// </summary>
-        public static readonly float MaxChaseRange = 96.0f;
-        public static readonly float MaxChaseRangeSq = MaxChaseRange * MaxChaseRange;
+        public const float MaxChaseRange = 96.0f;
+        public const float MaxChaseRangeSq = MaxChaseRange * MaxChaseRange;
 
         /// <summary>
         /// Determines if a monster is within melee range of target
         /// </summary>
-        //public static readonly float MaxMeleeRange = 1.5f;
-        public static readonly float MaxMeleeRange = 0.75f;
-        //public static readonly float MaxMeleeRange = 1.5f + 0.6f + 0.1f;    // max melee range + distance from + buffer
+        //public const float MaxMeleeRange = 1.5f;
+        public const float MaxMeleeRange = 0.75f;
+        //public const float MaxMeleeRange = 1.5f + 0.6f + 0.1f;    // max melee range + distance from + buffer
 
         /// <summary>
         /// The maximum range for a monster missile attack
         /// </summary>
-        //public static readonly float MaxMissileRange = 80.0f;
-        //public static readonly float MaxMissileRange = 40.0f;   // for testing
+        //public const float MaxMissileRange = 80.0f;
+        //public const float MaxMissileRange = 40.0f;   // for testing
 
         /// <summary>
         /// The distance per second from running animation

--- a/Source/ACE.Server/WorldObjects/Pet.cs
+++ b/Source/ACE.Server/WorldObjects/Pet.cs
@@ -194,7 +194,7 @@ namespace ACE.Server.WorldObjects
                 SlowTick(currentUnixTime);
         }
 
-        private static readonly double slowTickSeconds = 1.0;
+        private const double slowTickSeconds = 1.0;
         private double nextSlowTickTime;
 
         /// <summary>
@@ -225,8 +225,8 @@ namespace ACE.Server.WorldObjects
         // if the passive pet is between min-max distance to owner,
         // it will turn and start running torwards its owner
 
-        private static readonly float MinDistance = 2.0f;
-        private static readonly float MaxDistance = 192.0f;
+        private const float MinDistance = 2.0f;
+        private const float MaxDistance = 192.0f;
 
         private void StartFollow()
         {

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -69,8 +69,8 @@ namespace ACE.Server.WorldObjects
 
         public SquelchManager SquelchManager;
 
-        public static readonly float MaxRadarRange_Indoors = 25.0f;
-        public static readonly float MaxRadarRange_Outdoors = 75.0f;
+        public const float MaxRadarRange_Indoors = 25.0f;
+        public const float MaxRadarRange_Outdoors = 75.0f;
 
         public DateTime PrevObjSend;
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -729,7 +729,7 @@ namespace ACE.Server.WorldObjects
 
         public CombatMode LastCombatMode;
 
-        public static readonly float UseTimeEpsilon = 0.05f;
+        public const float UseTimeEpsilon = 0.05f;
 
         /// <summary>
         /// This method processes the Game Action (F7B1) Change Combat Mode (0x0053)

--- a/Source/ACE.Server/WorldObjects/Player_Commerce.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Commerce.cs
@@ -47,7 +47,7 @@ namespace ACE.Server.WorldObjects
             SendUseDoneEvent();
         }
 
-        private static readonly uint coinStackWcid = (uint)ACE.Entity.Enum.WeenieClassName.W_COINSTACK_CLASS;
+        private const uint coinStackWcid = (uint)ACE.Entity.Enum.WeenieClassName.W_COINSTACK_CLASS;
 
         /// <summary>
         /// Vendor has validated the transactions and sent a list of items for processing.

--- a/Source/ACE.Server/WorldObjects/Player_Database.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Database.cs
@@ -14,7 +14,7 @@ namespace ACE.Server.WorldObjects
 {
     partial class Player
     {
-        public static readonly long DefaultPlayerSaveIntervalSecs = 300; // default to 5 minutes
+        public const long DefaultPlayerSaveIntervalSecs = 300; // default to 5 minutes
 
         public DateTime CharacterLastRequestedDatabaseSave { get; protected set; }
 

--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -618,7 +618,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// The maximum # of items a player can drop
         /// </summary>
-        public static readonly int MaxItemsDropped = 14;
+        public const int MaxItemsDropped = 14;
 
         /// <summary>
         /// Rolls for the # of items to drop for a player death

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -792,7 +792,7 @@ namespace ACE.Server.WorldObjects
                 CurrentLandblock?.SetActive();
         }
 
-        public static readonly float RunFactor = 1.5f;
+        public const float RunFactor = 1.5f;
 
         /// <summary>
         /// Returns the amount of time for player to rotate by the # of degrees

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -687,7 +687,7 @@ namespace ACE.Server.WorldObjects
         }
 
         // 20 from MoveToManager threshold?
-        public static readonly float MaxAngle = 5;
+        public const float MaxAngle = 5;
 
         public void DoCastSpell(MagicState _state, bool checkAngle = true)
         {

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -163,9 +163,9 @@ namespace ACE.Server.WorldObjects
                 HandleActionTargetedMeleeAttack_Inner(target, attackSequence);
         }
 
-        public static readonly float MeleeDistance  = 0.6f;
-        public static readonly float StickyDistance = 4.0f;
-        public static readonly float RepeatDistance = 16.0f;
+        public const float MeleeDistance  = 0.6f;
+        public const float StickyDistance = 4.0f;
+        public const float RepeatDistance = 16.0f;
 
         public void HandleActionTargetedMeleeAttack_Inner(WorldObject target, int attackSequence)
         {
@@ -429,7 +429,7 @@ namespace ACE.Server.WorldObjects
             return animLength;
         }
 
-        public static readonly float KickThreshold = 0.75f;
+        public const float KickThreshold = 0.75f;
 
         public MotionCommand PrevMotionCommand;
 

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -117,7 +117,7 @@ namespace ACE.Server.WorldObjects
         /// If a player tries to use 2 portals in under this amount of time,
         /// they receive an error message
         /// </summary>
-        private static readonly float minTimeSinceLastPortal = 3.5f;
+        private const float minTimeSinceLastPortal = 3.5f;
 
         public override ActivationResult CheckUseRequirements(WorldObject activator)
         {

--- a/Source/ACE.Server/WorldObjects/SkillFormula.cs
+++ b/Source/ACE.Server/WorldObjects/SkillFormula.cs
@@ -8,12 +8,12 @@ namespace ACE.Server.WorldObjects
     public class SkillFormula
     {
         // everything else: melee weapons (including finesse), thrown weapons, atlatls
-        public static readonly float DefaultMod = 0.011f;
+        public const float DefaultMod = 0.011f;
 
         // bows and crossbows
-        public static readonly float BowMod = 0.008f;
+        public const float BowMod = 0.008f;
 
-        public static readonly float ArmorMod = 200.0f / 3.0f;
+        public const float ArmorMod = 200.0f / 3.0f;
 
         public static float GetAttributeMod(int currentSkill, bool isBow = false)
         {

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -319,7 +319,7 @@ namespace ACE.Server.WorldObjects
             }
         }
 
-        private static readonly float closeInterval = 1.5f;
+        private const float closeInterval = 1.5f;
 
         /// <summary>
         /// After a player approaches a vendor, this is called every closeInterval seconds

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -1015,8 +1015,8 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsLinkSpot => WeenieType == WeenieType.Generic && WeenieClassName.Equals("portaldestination");
 
-        public static readonly float LocalBroadcastRange = 96.0f;
-        public static readonly float LocalBroadcastRangeSq = LocalBroadcastRange * LocalBroadcastRange;
+        public const float LocalBroadcastRange = 96.0f;
+        public const float LocalBroadcastRangeSq = LocalBroadcastRange * LocalBroadcastRange;
 
         public SetPosition ScatterPos { get; set; }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1518,7 +1518,7 @@ namespace ACE.Server.WorldObjects
             return LaunchSpellProjectiles(spell, target, spellType, weapon, isWeaponSpell, fromProc, origins, velocity, lifeProjectileDamage);
         }
 
-        public static readonly float ProjHeight = 2.0f / 3.0f;
+        public const float ProjHeight = 2.0f / 3.0f;
 
         public Vector3 CalculatePreOffset(Spell spell, ProjectileSpellType spellType, WorldObject target)
         {
@@ -1682,7 +1682,7 @@ namespace ACE.Server.WorldObjects
 
         public static readonly Quaternion OneEighty = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)Math.PI);
 
-        public static readonly float ProjHeightArc = 5.0f / 6.0f;
+        public const float ProjHeightArc = 5.0f / 6.0f;
 
         /// <summary>
         /// Calculates the spell projectile velocity in global space
@@ -2195,7 +2195,7 @@ namespace ACE.Server.WorldObjects
             IsAffecting = false;
         }
 
-        private static readonly double defaultIgnoreSomeMagicProjectileDamage = 0.25;
+        private const double defaultIgnoreSomeMagicProjectileDamage = 0.25;
 
         public double? GetAbsorbMagicDamage()
         {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -374,7 +374,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// PvP damaged is halved, automatically displayed in the client
         /// </summary>
-        public static readonly float ElementalDamageBonusPvPReduction = 0.5f;
+        public const float ElementalDamageBonusPvPReduction = 0.5f;
 
         /// <summary>
         /// Returns a multiplicative elemental damage modifier for the magic caster weapon type
@@ -1030,7 +1030,7 @@ namespace ACE.Server.WorldObjects
         // - 1/3 - 2/3 sec. Power-up Time = High Backhand
         // -       2/3 sec+ Power-up Time = High Slash
 
-        public static readonly float ThrustThreshold = 0.33f;
+        public const float ThrustThreshold = 0.33f;
 
         /// <summary>
         /// Returns TRUE if this is a thrust/slash weapon,


### PR DESCRIPTION
This will at least somewhat improve performance, as confirmed through microbenchmark testing.

const fields are replaced with literal values in the Assembly's IL code, while static readonly fields may be optimized by the JIT, and is not guaranteed to happen. const fields may also lend themselves to stronger optimizations at runtime.

Method is [LandDefs.AdjustToOutside](https://github.com/ACEmulator/ACE/blob/89e023c9d3dc2600a720a59229d1edeb2b5b0402/Source/ACE.Server/Physics/Common/LandDefs.cs#L125-L147).
Baseline (static readonly):
```
| Method          | Mean     | Error    | StdDev   | Allocated |
|---------------- |---------:|---------:|---------:|----------:|
| AdjustToOutside | 15.90 ns | 0.300 ns | 0.308 ns |         - |
```
With [constants](https://github.com/Flaggs-ACE-Contributions/ACE/commit/7709a5820b385adfa032a64f01bead6b6418c9ca#diff-a1f4bef19969e8833e3f787e6779be4285d57d14a9ea30b1f6b39d92d20b0a41L86-R110):
```
| Method          | Mean     | Error    | StdDev   | Allocated |
|---------------- |---------:|---------:|---------:|----------:|
| AdjustToOutside | 13.36 ns | 0.243 ns | 0.227 ns |         - |
```

This is a 15% improvement for LandDefs.AdjustToOutside. Additionally, I measured through some [custom profiler code](https://github.com/ACRealms/ACRealms.WorldServer/commit/9c58704106b30917d1ab6b680292060f14d51eee) that LandDefs.AdjustToOutside is called [very frequently](https://gist.github.com/FlaggAC/fb862223306e454f81279883c95e0d8b). So I would estimate this to be a solid improvement.
