### PR TITLE
Performance improvements to Physics.Common.WeenieObject

### DIFF
--- a/Source/ACE.Server/Physics/Animation/MotionInterp.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionInterp.cs
@@ -176,7 +176,7 @@ namespace ACE.Server.Physics.Animation
         {
             if (PhysicsObj == null) return;
 
-            if (WeenieObj != null && !WeenieObj.IsCreature()) return;
+            if (WeenieObj != null && !WeenieObj.IsCreature) return;
 
             if (!PhysicsObj.State.HasFlag(PhysicsState.Gravity)) return;
 
@@ -193,7 +193,7 @@ namespace ACE.Server.Physics.Animation
         {
             if (PhysicsObj == null) return;
 
-            if (WeenieObj != null && !WeenieObj.IsCreature()) return;
+            if (WeenieObj != null && !WeenieObj.IsCreature) return;
 
             if (!PhysicsObj.State.HasFlag(PhysicsState.Gravity)) return;
 
@@ -265,7 +265,7 @@ namespace ACE.Server.Physics.Animation
         {
             if (PhysicsObj == null || !Initted) return;
 
-            if (WeenieObj == null || WeenieObj.IsCreature() && PhysicsObj.movement_is_autonomous())
+            if (WeenieObj == null || WeenieObj.IsCreature && PhysicsObj.movement_is_autonomous())
                 apply_raw_movement(false, false);
             else
                 apply_interpreted_movement(false, false);
@@ -393,7 +393,7 @@ namespace ACE.Server.Physics.Animation
 
         public void adjust_motion(ref uint motion, ref float speed, HoldKey holdKey)
         {
-            if (WeenieObj != null && !WeenieObj.IsCreature())
+            if (WeenieObj != null && !WeenieObj.IsCreature)
                 return;
 
             switch (motion)
@@ -431,7 +431,7 @@ namespace ACE.Server.Physics.Animation
         {
             if (PhysicsObj == null || !Initted) return;
 
-            if (WeenieObj != null && !WeenieObj.IsCreature() || !PhysicsObj.movement_is_autonomous())
+            if (WeenieObj != null && !WeenieObj.IsCreature || !PhysicsObj.movement_is_autonomous())
                 apply_interpreted_movement(cancelMoveTo, allowJump);
             else
                 apply_raw_movement(cancelMoveTo, allowJump);
@@ -588,7 +588,7 @@ namespace ACE.Server.Physics.Animation
             if (motion == (uint)MotionCommand.Dead || motion == (uint)MotionCommand.Falling || motion >= (uint)MotionCommand.TurnRight && motion <= (uint)MotionCommand.TurnLeft)
                 return true;
 
-            if (WeenieObj != null && !WeenieObj.IsCreature())
+            if (WeenieObj != null && !WeenieObj.IsCreature)
                 return true;
 
             if (!PhysicsObj.State.HasFlag(PhysicsState.Gravity))
@@ -744,7 +744,7 @@ namespace ACE.Server.Physics.Animation
             if (PhysicsObj == null)
                 return WeenieError.NoPhysicsObject;
 
-            if (WeenieObj == null && !WeenieObj.IsCreature() || !PhysicsObj.State.HasFlag(PhysicsState.Gravity) ||
+            if (WeenieObj == null && !WeenieObj.IsCreature || !PhysicsObj.State.HasFlag(PhysicsState.Gravity) ||
                 PhysicsObj.TransientState.HasFlag(TransientStateFlags.Contact | TransientStateFlags.OnWalkable))
             {
                 if (PhysicsObj.IsFullyConstrained())
@@ -811,7 +811,7 @@ namespace ACE.Server.Physics.Animation
 
                 if (diff)
                 {
-                    if (WeenieObj != null && WeenieObj.IsCreature() || action.Autonomous)
+                    if (WeenieObj != null && WeenieObj.IsCreature || action.Autonomous)
                     {
                         ServerActionStamp = action.Stamp;
                         movementParams.Speed = action.Speed;

--- a/Source/ACE.Server/Physics/ObjectInfo.cs
+++ b/Source/ACE.Server/Physics/ObjectInfo.cs
@@ -52,7 +52,7 @@ namespace ACE.Server.Physics.Animation
             {
                 if (wobj.IsImpenetrable())
                     State |= ObjectInfoState.IsImpenetrable;
-                if (wobj.IsPlayer())
+                if (wobj.IsPlayer)
                     State |= ObjectInfoState.IsPlayer;
                 if (wobj.IsPK())
                     State |= ObjectInfoState.IsPK;
@@ -86,7 +86,7 @@ namespace ACE.Server.Physics.Animation
             {
                 if (collideObj.WeenieObj != null && collideObj.ID != TargetID)
                 {
-                    if (collideObj.State.HasFlag(PhysicsState.Ethereal) || TargetID != 0 && collideObj.WeenieObj.IsCreature())
+                    if (collideObj.State.HasFlag(PhysicsState.Ethereal) || TargetID != 0 && collideObj.WeenieObj.IsCreature)
                         return true;
                 }
             }

--- a/Source/ACE.Server/Physics/PhysicsEngine.cs
+++ b/Source/ACE.Server/Physics/PhysicsEngine.cs
@@ -93,7 +93,7 @@ namespace ACE.Server.Physics
             else
                 return false;
 
-            var isPlayer = obj.WeenieObj != null && !obj.WeenieObj.IsPlayer();
+            var isPlayer = obj.WeenieObj != null && !obj.WeenieObj.IsPlayer;
             if (!isPlayer || !autonomous)
             {
                 obj.LastMoveWasAutonomous = autonomous;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -148,7 +148,7 @@ namespace ACE.Server.Physics
 
             // todo: only allocate these for server objects
             // get rid of 'DatObject', use the existing WeenieObj == null
-            WeenieObj = new WeenieObject();
+            WeenieObj = WeenieObject.DummyObject;
             ObjMaint = new ObjectMaint(this);
 
             if (PhysicsEngine.Instance != null && PhysicsEngine.Instance.Server)
@@ -385,7 +385,7 @@ namespace ACE.Server.Physics
             if (State.HasFlag(PhysicsState.Ethereal) && State.HasFlag(PhysicsState.IgnoreCollisions))
                 return TransitionState.OK;
 
-            if (WeenieObj != null && transition.ObjectInfo.State.HasFlag(ObjectInfoState.IsViewer) && WeenieObj.IsCreature())
+            if (WeenieObj != null && transition.ObjectInfo.State.HasFlag(ObjectInfoState.IsViewer) && WeenieObj.IsCreature)
                 return TransitionState.OK;
 
             if (State.HasFlag(PhysicsState.Ethereal) || !State.HasFlag(PhysicsState.Static) && transition.ObjectInfo.Ethereal)
@@ -400,13 +400,13 @@ namespace ACE.Server.Physics
 
             // TODO: reverse this check to make it more readable
             // TODO: investigate not initting WeenieObj for DatObjects
-            var exemption = !( /*WeenieObj == null*/ DatObject || !WeenieObj.IsPlayer() || !state.HasFlag(ObjectInfoState.IsPlayer) ||
+            var exemption = !( /*WeenieObj == null*/ DatObject || !WeenieObj.IsPlayer || !state.HasFlag(ObjectInfoState.IsPlayer) ||
                 state.HasFlag(ObjectInfoState.IsImpenetrable) || WeenieObj.IsImpenetrable() ||
                 state.HasFlag(ObjectInfoState.IsPK) && WeenieObj.IsPK() || state.HasFlag(ObjectInfoState.IsPKLite) && WeenieObj.IsPKLite());
 
             var missileIgnore = transition.ObjectInfo.MissileIgnore(this);
 
-            var isCreature = State.HasFlag(PhysicsState.Missile) || WeenieObj != null && WeenieObj.IsCreature();
+            var isCreature = State.HasFlag(PhysicsState.Missile) || WeenieObj != null && WeenieObj.IsCreature;
             //isCreature = false; // hack?
 
             if (!State.HasFlag(PhysicsState.HasPhysicsBSP) || missileIgnore || exemption)
@@ -1289,7 +1289,7 @@ namespace ACE.Server.Physics
                 return SetPositionError.OK;
             }
 
-            if (WeenieObj != null && (WeenieObj.IsStorage() || WeenieObj.IsCorpse()))
+            if (WeenieObj != null && (WeenieObj.IsStorage || WeenieObj.IsCorpse))
                 return ForceIntoCell(newCell, pos);
 
             //if (setPos.Flags.HasFlag(SetPositionFlags.DontCreateCells))


### PR DESCRIPTION
Entire set of fields can be marked as readonly, as it never changes outside of the constructor.
Reduces unnecessary reflection operations by pre-fetching them during constructor
Changes WeenieObject to a sealed class to guarantee immutability
Immutability allows a shared DummyObject to be used by PhysicsObjs which do not have a weenie.

The reflection calls are made frequently by `PhysicsObj.FindObjCollisions(Transition)`, which is a very frequently-called method, so this is expected to improve performance. The 'is' operator is fast by reflection standards, but there is still some overhead with it, which should not be ignored considering the high frequency of the method calls.

ID and UpdateTime are commented out because they are never used. 