### PR TITLE
Add physical damage handling for Life Magic Projectile spells

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -922,9 +922,14 @@ namespace ACE.Server.WorldObjects
                     //if (player != null && player.Fellowship != null)
                     //player.Fellowship.OnVitalUpdate(player);
                 }
+                else if(spell.DamageType != DamageType.Undef)
+                {
+                    // Handle rare case where some of these "Life Magic" spells do physical damage e.g. Hunter's Lash 2970 and Thorn Valley 6159
+                    damageType = spell.DamageType;
+                }
                 else
                 {
-                    log.Warn($"Unknown DamageType for LifeProjectile {spell.Name} - {spell.Id}");
+                    log.Warn($"Unknown DamageType ({spell.DamageType}) for LifeProjectile {spell.Name} - {spell.Id}");
                     return;
                 }
             }


### PR DESCRIPTION
This fixes issues with spells such as Hunter's Lash (built in spell on Weeping Wand and others) not firing.

Thanks to quakerowntmeal for the bug report.