### PR TITLE
Cache ServerVersion.AutoDetect

### DIFF
--- a/Source/ACE.Database/DatabaseManager.cs
+++ b/Source/ACE.Database/DatabaseManager.cs
@@ -77,13 +77,13 @@ namespace ACE.Database
 
         public static ServerVersion CachedServerVersionAutoDetect(string database, string connectionString)
         {
-            if (cachedServerVersions.TryGetValue(database, out ServerVersion serverVersion)) { return serverVersion; }
-
-            serverVersion = ServerVersion.AutoDetect(connectionString);
-
-            cachedServerVersions[database] = serverVersion;
-
+            if (!cachedServerVersions.TryGetValue(database, out ServerVersion serverVersion))
+            {
+                serverVersion = ServerVersion.AutoDetect(connectionString);
+                cachedServerVersions[database] = serverVersion;
+            }
             return serverVersion;
+
         }
     }
 }

--- a/Source/ACE.Database/DatabaseManager.cs
+++ b/Source/ACE.Database/DatabaseManager.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Microsoft.EntityFrameworkCore;
+
 using log4net;
 
 namespace ACE.Database
@@ -68,6 +70,44 @@ namespace ACE.Database
         {
             if (serializedShardDb != null)
                 serializedShardDb.Stop();
+        }
+
+        private static ServerVersion authServerVersion;
+        private static ServerVersion shardServerVersion;
+        private static ServerVersion worldServerVersion;
+        public static ServerVersion CachedServerVersionAutoDetect(int database, string connectionString)
+        {
+            var serverVersion = database switch
+            {
+                1 => authServerVersion,
+                2 => shardServerVersion,
+                _ => worldServerVersion,
+            };
+
+            if (serverVersion != null)
+                return serverVersion;
+
+            serverVersion = ServerVersion.AutoDetect(connectionString);
+
+            //using var connection = new MySqlConnection(
+            //    new MySqlConnectionStringBuilder(connectionString)
+            //    {
+            //        Database = string.Empty,
+            //        AutoEnlist = false,
+            //        //Pooling = false, 
+            //    }.ConnectionString);
+            //connection.Open();
+
+            //serverVersion = ServerVersion.Parse(connection.ServerVersion);
+
+            if (database == 1)
+                authServerVersion = serverVersion;
+            else if (database == 2)
+                shardServerVersion = serverVersion;
+            else
+                worldServerVersion = serverVersion;
+
+            return serverVersion;
         }
     }
 }

--- a/Source/ACE.Database/DatabaseManager.cs
+++ b/Source/ACE.Database/DatabaseManager.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -73,7 +73,7 @@ namespace ACE.Database
                 serializedShardDb.Stop();
         }
 
-        private static readonly Dictionary<string, ServerVersion> cachedServerVersions = new();
+        private static readonly ConcurrentDictionary<string, ServerVersion> cachedServerVersions = new();
 
         public static ServerVersion CachedServerVersionAutoDetect(string database, string connectionString)
         {

--- a/Source/ACE.Database/DatabaseManager.cs
+++ b/Source/ACE.Database/DatabaseManager.cs
@@ -83,7 +83,6 @@ namespace ACE.Database
                 cachedServerVersions[database] = serverVersion;
             }
             return serverVersion;
-
         }
     }
 }

--- a/Source/ACE.Database/Models/Auth/AuthDbContext.cs
+++ b/Source/ACE.Database/Models/Auth/AuthDbContext.cs
@@ -28,7 +28,7 @@ public partial class AuthDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(1, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });

--- a/Source/ACE.Database/Models/Auth/AuthDbContext.cs
+++ b/Source/ACE.Database/Models/Auth/AuthDbContext.cs
@@ -28,7 +28,7 @@ public partial class AuthDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(1, connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(config.Database, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -104,7 +104,7 @@ public partial class ShardDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(2, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });

--- a/Source/ACE.Database/Models/Shard/ShardDbContext.cs
+++ b/Source/ACE.Database/Models/Shard/ShardDbContext.cs
@@ -104,7 +104,7 @@ public partial class ShardDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(2, connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(config.Database, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });

--- a/Source/ACE.Database/Models/World/WorldDbContext.cs
+++ b/Source/ACE.Database/Models/World/WorldDbContext.cs
@@ -132,7 +132,7 @@ public partial class WorldDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(3, connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(config.Database, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });

--- a/Source/ACE.Database/Models/World/WorldDbContext.cs
+++ b/Source/ACE.Database/Models/World/WorldDbContext.cs
@@ -132,7 +132,7 @@ public partial class WorldDbContext : DbContext
 
             var connectionString = $"server={config.Host};port={config.Port};user={config.Username};password={config.Password};database={config.Database};{config.ConnectionOptions}";
 
-            optionsBuilder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), builder =>
+            optionsBuilder.UseMySql(connectionString, DatabaseManager.CachedServerVersionAutoDetect(3, connectionString), builder =>
             {
                 builder.EnableRetryOnFailure(10);
             });


### PR DESCRIPTION
Adjusted database connections so that they cache ServerVersion.AutoDetect result on first hit and reuse.

This resolves a current bug that exhausts or times out connections to database.