### PR TITLE
Fix: Change IsRunningInContainer to nonInteractiveSetup to keep the c…

### DIFF
--- a/Source/ACE.Server/Program_Setup.cs
+++ b/Source/ACE.Server/Program_Setup.cs
@@ -218,7 +218,7 @@ namespace ACE.Server
                 Console.WriteLine();
 
                 Console.Write($"Enter the Host address for your shard database (default: \"{config.MySql.Shard.Host}\"): ");
-                if (!IsRunningInContainer)
+                if (!nonInteractiveSetup)
                     variable = Console.ReadLine();
                 else
                 {


### PR DESCRIPTION
Looking at the code previous questions use !nonInteractiveSetup. This makes the checks consistent when !IsRunningContainer is failing and ACE_NONINTERACTIVE_SETUP=true.