### PR TITLE
fix dat chunking

### DIFF
--- a/Source/ACE.DatLoader/DatReader.cs
+++ b/Source/ACE.DatLoader/DatReader.cs
@@ -35,7 +35,7 @@ namespace ACE.DatLoader
 
             while (size > 0)
             {
-                if (size < blockSize)
+                if (nextAddress == 0)
                 {
                     stream.Read(buffer, bufferOffset, Convert.ToInt32(size));
                     size = 0; // We know we've read the only/last sector, so just set this to zero to proceed.


### PR DESCRIPTION
Thanks to @bDekaru for reporting this issue, @paradoxlost for helping to track it down, and @OptimShi for authoring the fix

This fixes cell id 0x01580123 from being read incorrectly for the final bytes

See the full discussion here: https://discord.com/channels/261242462972936192/417073903094202371/1333891031351038066