### PR TITLE
fix thrown shield stance swapping

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -273,6 +273,16 @@ namespace ACE.Server.WorldObjects
                         HandleActionChangeCombatMode(CombatMode.Magic);
                         break;
 
+                    case EquipMask.Shield:
+
+                        var weapon = GetEquippedWeapon(true);
+
+                        if (weapon != null && weapon.DefaultCombatStyle == CombatStyle.ThrownWeapon)
+                            HandleActionChangeCombatMode(CombatMode.Missile);
+                        else
+                            HandleActionChangeCombatMode(CombatMode.Melee);
+                        break;
+
                     default:
                         HandleActionChangeCombatMode(CombatMode.Melee);
                         break;
@@ -431,6 +441,11 @@ namespace ACE.Server.WorldObjects
 
                     if (CombatMode == CombatMode.Missile && wieldedLocation == EquipMask.MissileAmmo)
                         newCombatMode = CombatMode.NonCombat;
+
+                    var weapon = GetEquippedWeapon(true);
+
+                    if (weapon != null && weapon.DefaultCombatStyle == CombatStyle.ThrownWeapon)
+                        newCombatMode = CombatMode.Missile;
 
                     HandleActionChangeCombatMode(newCombatMode);
                 }


### PR DESCRIPTION
Thanks to kewne for reporting this issue

repro steps:

- equip a thrown weapon
- enter combat stance
- equip a shield

expected:

- thrown shield stance is transitioned into without exiting combat stance

actual:

- shield is equipped and combat stance is exited

similar problems with unequipping shield while in thrown shield combat stance, and swapping between sword+shield and thrown+shield while in combat stance also fixed