### PR TITLE
Update log4net to 3.0.4

### DIFF
--- a/Source/ACE.DatLoader/ACE.DatLoader.csproj
+++ b/Source/ACE.DatLoader/ACE.DatLoader.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="log4net" Version="3.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.13" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>

--- a/Source/ACE.Database/ACE.Database.csproj
+++ b/Source/ACE.Database/ACE.Database.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="log4net" Version="3.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
   </ItemGroup>

--- a/Source/ACE.Server/ACE.Server.csproj
+++ b/Source/ACE.Server/ACE.Server.csproj
@@ -234,9 +234,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Easy.Logger" Version="4.1.0" />
     <PackageReference Include="Lib.Harmony" Version="2.3.5" />
-    <PackageReference Include="log4net" Version="2.0.17" />
-    <PackageReference Include="Log4Net.Async.Standard" Version="3.1.0" />
+    <PackageReference Include="log4net" Version="3.0.4" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/Source/ACE.Server/log4net.config.docker
+++ b/Source/ACE.Server/log4net.config.docker
@@ -40,7 +40,11 @@
     <level value="INFO" />
   </logger>
 
-  <appender name="asyncForwarder" type="Log4Net.Async.AsyncForwardingAppender,Log4Net.Async">
+  <appender name="asyncForwarder" type="Easy.Logger.AsyncBufferingForwardingAppender, Easy.Logger">
+    <lossy value="false" />
+    <bufferSize value="512" />
+    <idleTime value="1" />
+    <fix value="Message, ThreadName, Exception" />
     <appender-ref ref="Console" />
     <appender-ref ref="RollingFileAppender" />
   </appender>

--- a/Source/ACE.Server/log4net.config.example
+++ b/Source/ACE.Server/log4net.config.example
@@ -38,9 +38,13 @@
 
   <logger name="Packets">
     <level value="INFO" />
-  </logger> 
+  </logger>
 
-  <appender name="asyncForwarder" type="Log4Net.Async.AsyncForwardingAppender,Log4Net.Async">
+  <appender name="asyncForwarder" type="Easy.Logger.AsyncBufferingForwardingAppender, Easy.Logger">
+    <lossy value="false" />
+    <bufferSize value="512" />
+    <idleTime value="1" />
+    <fix value="Message, ThreadName, Exception" />
     <appender-ref ref="Console" />
     <appender-ref ref="RollingFileAppender" />
   </appender>


### PR DESCRIPTION
This requires a switch from Log4Net.Async and Log4Net.Async.AsyncForwardingAppender to Easy.Logger and Easy.Logger.AsyncBufferingForwardingAppender as the former has been depreciated and no longer works with log4net 3.0.0+

