### PR TITLE
Add missing OnTalk to a few places

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Death.cs
@@ -333,6 +333,8 @@ namespace ACE.Server.WorldObjects
             {
                 EnqueueBroadcast(new GameMessageHearSpeech(SuicideMessages[step], GetNameWithSuffix(), Guid.Full, ChatMessageType.Speech), LocalBroadcastRange);
 
+                OnTalk(SuicideMessages[step]);
+
                 var suicideChain = new ActionChain();
                 suicideChain.AddDelaySeconds(3.0f);
                 suicideChain.AddAction(this, () => HandleSuicide(numDeaths, step + 1));

--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -596,6 +596,8 @@ namespace ACE.Server.WorldObjects
             var spellWords = spell._spellBase.GetSpellWords(DatManager.PortalDat.SpellComponentsTable);
             if (!string.IsNullOrWhiteSpace(spellWords) && !isWeaponSpell)
                 EnqueueBroadcast(new GameMessageHearSpeech(spellWords, GetNameWithSuffix(), Guid.Full, ChatMessageType.Spellcasting), LocalBroadcastRange);
+
+            OnTalk(spellWords);
         }
 
         public static float CastSpeed = 2.0f;       // from retail pcaps, player animation speed for windup / first half of cast gesture


### PR DESCRIPTION
OnTalk was missing from Suicide and DoSpellWords, both of which used GameMessageHearSpeech

OnTalk is currently a player function, it is possible it should be moved up the chain so the two remaining GameMessageHearSpeech and similar messages for Creatures or WorldObjects should be included in making HearChat emotes be triggered by players and npc alike for custom content purposes, but there may be a hidden problem with expanding that scope, so I'm not doing that for now.