### PR TITLE
Add monster navigation improvements and stuck detection

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -59,6 +59,14 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.CachedVelocity = Vector3.Zero;
 
             ClearRetaliateTargets();
+            
+            // Heal to full health when returning home
+            if (Health.Current < Health.MaxValue)
+            {
+                Health.Current = Health.MaxValue;
+                if (DebugMove)
+                    Console.WriteLine($"{Name} ({Guid}).Sleep() - Healed to full health");
+            }
         }
 
         public Tolerance Tolerance


### PR DESCRIPTION
Monsters being stuck on buildings etc never returned home, which IMO was a huge performance issue as Physics + Collide would be doing these checks non stop.

Monsters now will return home between 10-15 seconds of being stuck, and return to full HP as they did in retail