### PR TITLE
Add monster navigation improvements and stuck detection

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -206,9 +206,17 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public float GetStanceMod(CreatureVital vital)
         {
-            // only applies to players
-            if ((this as Player) == null) return 1.0f;
+            // Apply monster fast vital regen if idle (typically after returning home)
+            if (!(this is Player))
+            {
+                // Only boost Health/Stamina, not Mana (consistent with player logic)
+                if (vital.Vital != PropertyAttribute2nd.MaxMana && MonsterState == State.Idle)
+                    return 50.0f;   // Large multiplier for fast regen
 
+                return 1.0f; // Default for monsters not idle
+            }
+
+            // Player-specific logic below
             // does not apply for mana?
             if (vital.Vital == PropertyAttribute2nd.MaxMana) return 1.0f;
 

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -211,7 +211,7 @@ namespace ACE.Server.WorldObjects
             {
                 // Only boost Health/Stamina, not Mana (consistent with player logic)
                 if (vital.Vital != PropertyAttribute2nd.MaxMana && MonsterState == State.Idle)
-                    return 50.0f;   // Large multiplier for fast regen
+                    return 250.0f;   // Large multiplier for fast regen
 
                 return 1.0f; // Default for monsters not idle
             }

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -59,6 +59,14 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.CachedVelocity = Vector3.Zero;
 
             ClearRetaliateTargets();
+            
+            // Heal to full health when returning home
+            if (Health.Current < Health.MaxValue)
+            {
+                Health.Current = Health.MaxValue;
+                if (DebugMove)
+                    Console.WriteLine($"{Name} ({Guid}).Sleep() - Healed to full health");
+            }
         }
 
         public Tolerance Tolerance

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -23,9 +23,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public bool IsAwake = false;
 
-        private float? _originalHealthRate = null; // Store original health rate before fast heal
-        private bool _isFastHealingActive = false; // Flag to control the fast healing action chain
-
         /// <summary>
         /// Transitions a monster from idle to awake state
         /// </summary>
@@ -62,90 +59,9 @@ namespace ACE.Server.WorldObjects
             PhysicsObj.CachedVelocity = Vector3.Zero;
 
             ClearRetaliateTargets();
-            
-            // Start fast health regeneration when monster returns home
-            if (Health.Current < Health.MaxValue)
-            {
-                // Store the original rate before potentially modifying it
-                _originalHealthRate = (float?)GetProperty(PropertyFloat.HealthRate);
-                _isFastHealingActive = true; // Activate fast healing
 
-                // Set a high regeneration rate (much higher than normal)
-                var originalHealthRateValue = _originalHealthRate ?? 0; // Use 0 if null
-                
-                // Ensure a minimum regen rate regardless of original value
-                // Using an extremely high value to ensure quick healing
-                var fastHealthRate = Math.Max(10.0f, originalHealthRateValue * 50.0f);
-                
-                SetProperty(PropertyFloat.HealthRate, fastHealthRate);
-                
-                // Create a heartbeat action to monitor health and reset regen rate and damage history when fully healed
-                var actionChain = new ActionChain();
-                actionChain.AddDelaySeconds(0.5f);  // Check more frequently
-                
-                actionChain.AddAction(this, ProcessFastHealingTick);
-                
-                actionChain.EnqueueChain();
-                
-                if (DebugMove)
-                    Console.WriteLine($"{Name} ({Guid}).Sleep() - Started fast health regeneration");
-            }
-        }
-
-        /// <summary>
-        /// Handles a single tick of the fast healing process initiated by Sleep().
-        /// </summary>
-        private void ProcessFastHealingTick()
-        {
-            // Exit if fast healing was cancelled externally (e.g., by taking damage)
-            if (!_isFastHealingActive) return;
-
-            // Direct healing - add 15% of missing health per tick
-            if (Health.Current < Health.MaxValue)
-            {
-                var missingHealth = Health.MaxValue - Health.Current;
-                var healAmount = (uint)(missingHealth * 0.15f);
-                
-                // Ensure we heal at least 10% of max health per tick
-                healAmount = Math.Max(healAmount, (uint)(Health.MaxValue * 0.10f));
-                
-                // Apply direct healing
-                UpdateVitalDelta(Health, (int)healAmount);
-                
-                if (DebugMove)
-                    Console.WriteLine($"{Name} ({Guid}).ProcessFastHealingTick() - Direct healing for {healAmount} points");
-            }
-        
-            // If monster is at full health, stop the process
-            if (Health.Current >= Health.MaxValue)
-            {
-                _isFastHealingActive = false; // Deactivate flag
-
-                // Reset health rate to original value using the stored value
-                if (_originalHealthRate.HasValue)
-                    SetProperty(PropertyFloat.HealthRate, _originalHealthRate.Value);
-                else
-                    RemoveProperty(PropertyFloat.HealthRate);
-
-                _originalHealthRate = null; // Clear the stored value
-
-                // Reset damage history
-                DamageHistory.Reset();
-                
-                if (DebugMove)
-                    Console.WriteLine($"{Name} ({Guid}).ProcessFastHealingTick() - Fully healed, stopping fast heal.");
-            }
-            else
-            {
-                // Still healing, schedule the next tick if still active
-                if (_isFastHealingActive)
-                {
-                     var nextTickChain = new ActionChain();
-                     nextTickChain.AddDelaySeconds(0.5f);  // Check more frequently
-                     nextTickChain.AddAction(this, ProcessFastHealingTick); // Schedule this function again
-                     nextTickChain.EnqueueChain();
-                }
-            }
+            // Reset damage history when going to sleep/idle
+            DamageHistory.Reset();
         }
 
         public Tolerance Tolerance

--- a/Source/ACE.Server/WorldObjects/Monster_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Combat.cs
@@ -388,21 +388,6 @@ namespace ACE.Server.WorldObjects
                     DamageHistory.OnHeal((uint)-damage);
             }
 
-            // Step 1: Stop fast healing if it's active when damage is taken
-            bool wasFastHealing = _isFastHealingActive;
-            if (_isFastHealingActive)
-            {
-                 if (DebugMove)
-                    Console.WriteLine($"{Name} ({Guid}) - Interrupting fast healing due to taking damage.");
-
-                _isFastHealingActive = false;
-                if (_originalHealthRate.HasValue)
-                {
-                    SetProperty(PropertyFloat.HealthRate, _originalHealthRate.Value);
-                    _originalHealthRate = null;
-                }
-            }
-
             // Step 2: React to the damage source if needed (wake up, target attacker, stop returning)
             if (source is Creature attacker)
             {

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -245,13 +245,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Movement()
         {
-            // Skip stuck checks for intentionally immobile/stuck monsters
-            if ((GetProperty(PropertyBool.Stuck) ?? false) || (GetProperty(PropertyBool.AiImmobile) ?? false))
-            {
-                 // Optionally, ensure they aren't trying to move if immobile
-                 if (IsMoving) CancelMoveTo();
-                 return;
-            }
 
             //if (!IsRanged)
                 UpdatePosition();

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -245,9 +245,7 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Movement()
         {
-
-            //if (!IsRanged)
-                UpdatePosition();
+            UpdatePosition();
 
             if (MonsterState == State.Awake && GetDistanceToTarget() >= MaxChaseRange)
             {
@@ -257,7 +255,7 @@ namespace ACE.Server.WorldObjects
             }
 
             // Standard stuck check from MoveToManager
-            if (PhysicsObj.MovementManager.MoveToManager.FailProgressCount > 0 && Timers.RunningTime > NextCancelTime)
+            if (!AiImmobile && PhysicsObj.MovementManager.MoveToManager.FailProgressCount > 0 && Timers.RunningTime > NextCancelTime)
             {
                 // Instead of just canceling, also increment stuck counter
                 StuckCounter++;
@@ -276,7 +274,7 @@ namespace ACE.Server.WorldObjects
             }
             
             // Additional stuck detection - check if position hasn't changed much over time
-            if (Timers.RunningTime - LastStuckCheckTime >= 5.0) // Check every 5 seconds
+            if (!AiImmobile && Timers.RunningTime - LastStuckCheckTime >= 5.0) // Check every 5 seconds
             {
                 var currentPos = Location.ToGlobal();
                 

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -245,6 +245,14 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public void Movement()
         {
+            // Skip stuck checks for intentionally immobile/stuck monsters
+            if ((GetProperty(PropertyBool.Stuck) ?? false) || (GetProperty(PropertyBool.AiImmobile) ?? false))
+            {
+                 // Optionally, ensure they aren't trying to move if immobile
+                 if (IsMoving) CancelMoveTo();
+                 return;
+            }
+
             //if (!IsRanged)
                 UpdatePosition();
 


### PR DESCRIPTION
Monsters being stuck on buildings etc never returned home, which IMO was a huge performance issue as Physics + Collide would be doing these checks non stop.

Monsters now will return home between 10-15 seconds of being stuck, and return to full HP as they did in retail
