### PR TITLE
Remove UTF-8 BOMs across repository

### DIFF
--- a/AppVeyor/Config.js
+++ b/AppVeyor/Config.js
@@ -1,4 +1,5 @@
-﻿{
+// UTF-8 BOM removed to ensure consistent encoding
+{
   "Server": {
     "WorldName": "ACEmulator",
     "Welcome": "Welcome to this ACE server!\nFor more information visit https://emulator.ac",

--- a/AppVeyor/Config.js
+++ b/AppVeyor/Config.js
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 {
   "Server": {
     "WorldName": "ACEmulator",

--- a/Source/ACE.Common/Extensions/BinaryReaderExtensions.cs
+++ b/Source/ACE.Common/Extensions/BinaryReaderExtensions.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System.IO;
 
 namespace ACE.Common.Extensions

--- a/Source/ACE.Common/Extensions/BinaryReaderExtensions.cs
+++ b/Source/ACE.Common/Extensions/BinaryReaderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+// UTF-8 BOM removed to ensure consistent encoding
+using System.IO;
 
 namespace ACE.Common.Extensions
 {

--- a/Source/ACE.Common/Extensions/CharacterNameExtensions.cs
+++ b/Source/ACE.Common/Extensions/CharacterNameExtensions.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Common.Extensions
 {
     /// <summary>

--- a/Source/ACE.Common/Extensions/CharacterNameExtensions.cs
+++ b/Source/ACE.Common/Extensions/CharacterNameExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Common.Extensions
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Common.Extensions
 {
     /// <summary>
     /// This is a Helper Extension to service common String functions for Names

--- a/Source/ACE.Database/Models/Auth/Accesslevel.cs
+++ b/Source/ACE.Database/Models/Auth/Accesslevel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Auth;

--- a/Source/ACE.Database/Models/Auth/Accesslevel.cs
+++ b/Source/ACE.Database/Models/Auth/Accesslevel.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Auth/Account.cs
+++ b/Source/ACE.Database/Models/Auth/Account.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Auth;

--- a/Source/ACE.Database/Models/Auth/Account.cs
+++ b/Source/ACE.Database/Models/Auth/Account.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/Biota.cs
+++ b/Source/ACE.Database/Models/Shard/Biota.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/Biota.cs
+++ b/Source/ACE.Database/Models/Shard/Biota.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAllegiance.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAllegiance.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAllegiance.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAllegiance.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAnimPart.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute2nd.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute2nd.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute2nd.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesAttribute2nd.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBodyPart.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBodyPart.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBodyPart.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBodyPart.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBook.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBook.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBookPageData.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBookPageData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBookPageData.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBookPageData.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBool.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesBool.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesBool.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesCreateList.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesCreateList.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesCreateList.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesCreateList.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesDID.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesDID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesDID.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesDID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEmote.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEmote.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEmote.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEmote.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEmoteAction.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEmoteAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEmoteAction.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEmoteAction.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEnchantmentRegistry.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEventFilter.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEventFilter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesEventFilter.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesEventFilter.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesFloat.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesFloat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesFloat.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesFloat.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesGenerator.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesGenerator.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesGenerator.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesIID.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesIID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesIID.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesIID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesInt.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesInt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesInt.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesInt.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesInt64.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesInt64.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesInt64.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesInt64.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesPalette.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesPosition.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesPosition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesPosition.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesPosition.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesSkill.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesSkill.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesSkill.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesSkill.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesSpellBook.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesSpellBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesSpellBook.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesSpellBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesString.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesString.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
+++ b/Source/ACE.Database/Models/Shard/BiotaPropertiesTextureMap.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/Character.cs
+++ b/Source/ACE.Database/Models/Shard/Character.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/Character.cs
+++ b/Source/ACE.Database/Models/Shard/Character.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesContractRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesContractRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesContractRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesContractRegistry.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFillCompBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesFriendList.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesQuestRegistry.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesShortcutBar.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesSpellBar.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesSquelch.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesSquelch.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesSquelch.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesSquelch.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
+++ b/Source/ACE.Database/Models/Shard/CharacterPropertiesTitleBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesBoolean.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesBoolean.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesBoolean.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesBoolean.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesDouble.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesDouble.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesDouble.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesDouble.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesLong.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesLong.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesLong.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesLong.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesString.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/ConfigPropertiesString.cs
+++ b/Source/ACE.Database/Models/Shard/ConfigPropertiesString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/Shard/HousePermission.cs
+++ b/Source/ACE.Database/Models/Shard/HousePermission.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.Shard;

--- a/Source/ACE.Database/Models/Shard/HousePermission.cs
+++ b/Source/ACE.Database/Models/Shard/HousePermission.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/CookBook.cs
+++ b/Source/ACE.Database/Models/World/CookBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/CookBook.cs
+++ b/Source/ACE.Database/Models/World/CookBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Encounter.cs
+++ b/Source/ACE.Database/Models/World/Encounter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Encounter.cs
+++ b/Source/ACE.Database/Models/World/Encounter.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Event.cs
+++ b/Source/ACE.Database/Models/World/Event.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Event.cs
+++ b/Source/ACE.Database/Models/World/Event.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/HousePortal.cs
+++ b/Source/ACE.Database/Models/World/HousePortal.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/HousePortal.cs
+++ b/Source/ACE.Database/Models/World/HousePortal.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/LandblockInstance.cs
+++ b/Source/ACE.Database/Models/World/LandblockInstance.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/LandblockInstance.cs
+++ b/Source/ACE.Database/Models/World/LandblockInstance.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/LandblockInstanceLink.cs
+++ b/Source/ACE.Database/Models/World/LandblockInstanceLink.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/LandblockInstanceLink.cs
+++ b/Source/ACE.Database/Models/World/LandblockInstanceLink.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/PointsOfInterest.cs
+++ b/Source/ACE.Database/Models/World/PointsOfInterest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/PointsOfInterest.cs
+++ b/Source/ACE.Database/Models/World/PointsOfInterest.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Quest.cs
+++ b/Source/ACE.Database/Models/World/Quest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Quest.cs
+++ b/Source/ACE.Database/Models/World/Quest.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Recipe.cs
+++ b/Source/ACE.Database/Models/World/Recipe.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Recipe.cs
+++ b/Source/ACE.Database/Models/World/Recipe.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeMod.cs
+++ b/Source/ACE.Database/Models/World/RecipeMod.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeMod.cs
+++ b/Source/ACE.Database/Models/World/RecipeMod.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsBool.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsBool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsBool.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsBool.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsDID.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsDID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsDID.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsDID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsFloat.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsFloat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsFloat.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsFloat.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsIID.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsIID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsIID.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsIID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsInt.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsInt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsInt.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsInt.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeModsString.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeModsString.cs
+++ b/Source/ACE.Database/Models/World/RecipeModsString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsBool.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsBool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsBool.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsBool.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsDID.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsDID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsDID.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsDID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsFloat.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsFloat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsFloat.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsFloat.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsIID.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsIID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsIID.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsIID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsInt.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsInt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsInt.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsInt.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/RecipeRequirementsString.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/RecipeRequirementsString.cs
+++ b/Source/ACE.Database/Models/World/RecipeRequirementsString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Spell.cs
+++ b/Source/ACE.Database/Models/World/Spell.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Spell.cs
+++ b/Source/ACE.Database/Models/World/Spell.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureDeath.cs
+++ b/Source/ACE.Database/Models/World/TreasureDeath.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureDeath.cs
+++ b/Source/ACE.Database/Models/World/TreasureDeath.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureGemCount.cs
+++ b/Source/ACE.Database/Models/World/TreasureGemCount.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureGemCount.cs
+++ b/Source/ACE.Database/Models/World/TreasureGemCount.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureMaterialBase.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureMaterialBase.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialBase.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureMaterialColor.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialColor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureMaterialColor.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialColor.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureMaterialGroups.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialGroups.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureMaterialGroups.cs
+++ b/Source/ACE.Database/Models/World/TreasureMaterialGroups.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/TreasureWielded.cs
+++ b/Source/ACE.Database/Models/World/TreasureWielded.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/TreasureWielded.cs
+++ b/Source/ACE.Database/Models/World/TreasureWielded.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Version.cs
+++ b/Source/ACE.Database/Models/World/Version.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Version.cs
+++ b/Source/ACE.Database/Models/World/Version.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/Weenie.cs
+++ b/Source/ACE.Database/Models/World/Weenie.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/Weenie.cs
+++ b/Source/ACE.Database/Models/World/Weenie.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAnimPart.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAnimPart.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAnimPart.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAnimPart.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAttribute.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAttribute.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAttribute.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAttribute2nd.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAttribute2nd.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesAttribute2nd.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesAttribute2nd.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBodyPart.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBodyPart.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBodyPart.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBodyPart.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBook.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBook.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBookPageData.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBookPageData.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBookPageData.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBookPageData.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBool.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesBool.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesBool.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesCreateList.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesCreateList.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesCreateList.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesCreateList.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesDID.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesDID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesDID.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesDID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEmote.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEmote.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEmote.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEmote.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEmoteAction.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEmoteAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEmoteAction.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEmoteAction.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEventFilter.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEventFilter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesEventFilter.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesEventFilter.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesFloat.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesFloat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesFloat.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesFloat.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesGenerator.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesGenerator.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesGenerator.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesIID.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesIID.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesIID.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesIID.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesInt.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesInt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesInt.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesInt.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesInt64.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesInt64.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesInt64.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesInt64.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesPalette.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesPalette.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesPalette.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesPalette.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesPosition.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesPosition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesPosition.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesPosition.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesSkill.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesSkill.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesSkill.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesSkill.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesSpellBook.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesSpellBook.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesSpellBook.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesSpellBook.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesString.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesString.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Database/Models/World/WeeniePropertiesTextureMap.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesTextureMap.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 
 namespace ACE.Database.Models.World;

--- a/Source/ACE.Database/Models/World/WeeniePropertiesTextureMap.cs
+++ b/Source/ACE.Database/Models/World/WeeniePropertiesTextureMap.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 

--- a/Source/ACE.Entity/AbilityRegenAttribute.cs
+++ b/Source/ACE.Entity/AbilityRegenAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity
 {

--- a/Source/ACE.Entity/AbilityRegenAttribute.cs
+++ b/Source/ACE.Entity/AbilityRegenAttribute.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity

--- a/Source/ACE.Entity/Enum/AccessLevel.cs
+++ b/Source/ACE.Entity/Enum/AccessLevel.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum AccessLevel
     {

--- a/Source/ACE.Entity/Enum/AccessLevel.cs
+++ b/Source/ACE.Entity/Enum/AccessLevel.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum AccessLevel

--- a/Source/ACE.Entity/Enum/CharacterOptionDataFlag.cs
+++ b/Source/ACE.Entity/Enum/CharacterOptionDataFlag.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 namespace ACE.Entity.Enum
 {
     // Thanks to tfarley (aclogview) for these enums

--- a/Source/ACE.Entity/Enum/CharacterOptionDataFlag.cs
+++ b/Source/ACE.Entity/Enum/CharacterOptionDataFlag.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/ChatDisplayMask.cs
+++ b/Source/ACE.Entity/Enum/ChatDisplayMask.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     /// <summary>
     /// The ChatDisplayMask identifies that types of chat that are displayed in each chat window.<para />

--- a/Source/ACE.Entity/Enum/ChatDisplayMask.cs
+++ b/Source/ACE.Entity/Enum/ChatDisplayMask.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     /// <summary>

--- a/Source/ACE.Entity/Enum/ChatFilterMask.cs
+++ b/Source/ACE.Entity/Enum/ChatFilterMask.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/ChatFilterMask.cs
+++ b/Source/ACE.Entity/Enum/ChatFilterMask.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/CombatUse.cs
+++ b/Source/ACE.Entity/Enum/CombatUse.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum CombatUse : byte
     {

--- a/Source/ACE.Entity/Enum/CombatUse.cs
+++ b/Source/ACE.Entity/Enum/CombatUse.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum CombatUse : byte

--- a/Source/ACE.Entity/Enum/ContainerType.cs
+++ b/Source/ACE.Entity/Enum/ContainerType.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum ContainerType
     {

--- a/Source/ACE.Entity/Enum/ContainerType.cs
+++ b/Source/ACE.Entity/Enum/ContainerType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum ContainerType

--- a/Source/ACE.Entity/Enum/EnchantmentTypeFlags.cs
+++ b/Source/ACE.Entity/Enum/EnchantmentTypeFlags.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/EnchantmentTypeFlags.cs
+++ b/Source/ACE.Entity/Enum/EnchantmentTypeFlags.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/IdLookupType.cs
+++ b/Source/ACE.Entity/Enum/IdLookupType.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     /// <summary>
     /// Account lookup Types

--- a/Source/ACE.Entity/Enum/IdLookupType.cs
+++ b/Source/ACE.Entity/Enum/IdLookupType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     /// <summary>

--- a/Source/ACE.Entity/Enum/IdentifyResponseFlags.cs
+++ b/Source/ACE.Entity/Enum/IdentifyResponseFlags.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/IdentifyResponseFlags.cs
+++ b/Source/ACE.Entity/Enum/IdentifyResponseFlags.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/LifestoneType.cs
+++ b/Source/ACE.Entity/Enum/LifestoneType.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/LifestoneType.cs
+++ b/Source/ACE.Entity/Enum/LifestoneType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/ParticleType.cs
+++ b/Source/ACE.Entity/Enum/ParticleType.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum ParticleType
     {

--- a/Source/ACE.Entity/Enum/ParticleType.cs
+++ b/Source/ACE.Entity/Enum/ParticleType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum ParticleType

--- a/Source/ACE.Entity/Enum/PlayerKillerStatus.cs
+++ b/Source/ACE.Entity/Enum/PlayerKillerStatus.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/PlayerKillerStatus.cs
+++ b/Source/ACE.Entity/Enum/PlayerKillerStatus.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/PortalType.cs
+++ b/Source/ACE.Entity/Enum/PortalType.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/PortalType.cs
+++ b/Source/ACE.Entity/Enum/PortalType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/Enum/RadarBehavior.cs
+++ b/Source/ACE.Entity/Enum/RadarBehavior.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum RadarBehavior : byte
     {

--- a/Source/ACE.Entity/Enum/RadarBehavior.cs
+++ b/Source/ACE.Entity/Enum/RadarBehavior.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum RadarBehavior : byte

--- a/Source/ACE.Entity/Enum/RadarColor.cs
+++ b/Source/ACE.Entity/Enum/RadarColor.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum RadarColor : byte

--- a/Source/ACE.Entity/Enum/RadarColor.cs
+++ b/Source/ACE.Entity/Enum/RadarColor.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum RadarColor : byte
     {

--- a/Source/ACE.Entity/Enum/SecurityLevel.cs
+++ b/Source/ACE.Entity/Enum/SecurityLevel.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum SecurityLevel

--- a/Source/ACE.Entity/Enum/SecurityLevel.cs
+++ b/Source/ACE.Entity/Enum/SecurityLevel.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum SecurityLevel
     {

--- a/Source/ACE.Entity/Enum/Sound.cs
+++ b/Source/ACE.Entity/Enum/Sound.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum Sound : uint

--- a/Source/ACE.Entity/Enum/Sound.cs
+++ b/Source/ACE.Entity/Enum/Sound.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum Sound : uint
     {

--- a/Source/ACE.Entity/Enum/SpellType.cs
+++ b/Source/ACE.Entity/Enum/SpellType.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum SpellType

--- a/Source/ACE.Entity/Enum/SpellType.cs
+++ b/Source/ACE.Entity/Enum/SpellType.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum SpellType
     {

--- a/Source/ACE.Entity/Enum/UpdatePositionFlag.cs
+++ b/Source/ACE.Entity/Enum/UpdatePositionFlag.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     using System.Diagnostics.CodeAnalysis;
     using System;

--- a/Source/ACE.Entity/Enum/UpdatePositionFlag.cs
+++ b/Source/ACE.Entity/Enum/UpdatePositionFlag.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     using System.Diagnostics.CodeAnalysis;

--- a/Source/ACE.Entity/Enum/Vital.cs
+++ b/Source/ACE.Entity/Enum/Vital.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity.Enum
 {
     public enum Vital : uint
     {

--- a/Source/ACE.Entity/Enum/Vital.cs
+++ b/Source/ACE.Entity/Enum/Vital.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity.Enum
 {
     public enum Vital : uint

--- a/Source/ACE.Entity/Enum/WeenieHeaderFlags.cs
+++ b/Source/ACE.Entity/Enum/WeenieHeaderFlags.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Entity.Enum
 {

--- a/Source/ACE.Entity/Enum/WeenieHeaderFlags.cs
+++ b/Source/ACE.Entity/Enum/WeenieHeaderFlags.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Entity.Enum

--- a/Source/ACE.Entity/PageData.cs
+++ b/Source/ACE.Entity/PageData.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Entity
 {
     public class PageData

--- a/Source/ACE.Entity/PageData.cs
+++ b/Source/ACE.Entity/PageData.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Entity
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Entity
 {
     public class PageData
     {

--- a/Source/ACE.Server/Command/CommandHandler.cs
+++ b/Source/ACE.Server/Command/CommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Server.Network;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Server.Network;
 
 namespace ACE.Server.Command
 {

--- a/Source/ACE.Server/Command/CommandHandler.cs
+++ b/Source/ACE.Server/Command/CommandHandler.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Server.Network;
 
 namespace ACE.Server.Command

--- a/Source/ACE.Server/Command/CommandHandlerFlag.cs
+++ b/Source/ACE.Server/Command/CommandHandlerFlag.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Server.Command

--- a/Source/ACE.Server/Command/CommandHandlerFlag.cs
+++ b/Source/ACE.Server/Command/CommandHandlerFlag.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Server.Command
 {

--- a/Source/ACE.Server/Command/CommandHandlerInfo.cs
+++ b/Source/ACE.Server/Command/CommandHandlerInfo.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Server.Command

--- a/Source/ACE.Server/Command/CommandHandlerInfo.cs
+++ b/Source/ACE.Server/Command/CommandHandlerInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Server.Command
 {

--- a/Source/ACE.Server/Command/CommandHandlerResponse.cs
+++ b/Source/ACE.Server/Command/CommandHandlerResponse.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Command
 {
     public enum CommandHandlerResponse

--- a/Source/ACE.Server/Command/CommandHandlerResponse.cs
+++ b/Source/ACE.Server/Command/CommandHandlerResponse.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Command
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Command
 {
     public enum CommandHandlerResponse
     {

--- a/Source/ACE.Server/Entity/Actions/EmptyAction.cs
+++ b/Source/ACE.Server/Entity/Actions/EmptyAction.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Entity.Actions
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Entity.Actions
 {
     public class EmptyAction : ActionEventBase
     {

--- a/Source/ACE.Server/Entity/Actions/EmptyAction.cs
+++ b/Source/ACE.Server/Entity/Actions/EmptyAction.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Entity.Actions
 {
     public class EmptyAction : ActionEventBase

--- a/Source/ACE.Server/Entity/Actions/IAction.cs
+++ b/Source/ACE.Server/Entity/Actions/IAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Server.Entity.Actions
 {

--- a/Source/ACE.Server/Entity/Actions/IAction.cs
+++ b/Source/ACE.Server/Entity/Actions/IAction.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Server.Entity.Actions

--- a/Source/ACE.Server/Entity/Events/ChatMessageArgs.cs
+++ b/Source/ACE.Server/Entity/Events/ChatMessageArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using ACE.Entity.Enum;
 
 namespace ACE.Server.Entity.Events

--- a/Source/ACE.Server/Entity/Events/ChatMessageArgs.cs
+++ b/Source/ACE.Server/Entity/Events/ChatMessageArgs.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using ACE.Entity.Enum;
 

--- a/Source/ACE.Server/Entity/Events/DeathMessageArgs.cs
+++ b/Source/ACE.Server/Entity/Events/DeathMessageArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using ACE.Entity;
 
 namespace ACE.Server.Entity.Events

--- a/Source/ACE.Server/Entity/Events/DeathMessageArgs.cs
+++ b/Source/ACE.Server/Entity/Events/DeathMessageArgs.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using ACE.Entity;
 

--- a/Source/ACE.Server/Entity/Events/SpellCastArgs.cs
+++ b/Source/ACE.Server/Entity/Events/SpellCastArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using ACE.Entity;
 
 namespace ACE.Server.Entity.Events

--- a/Source/ACE.Server/Entity/Events/SpellCastArgs.cs
+++ b/Source/ACE.Server/Entity/Events/SpellCastArgs.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using ACE.Entity;
 

--- a/Source/ACE.Server/Entity/HeldItem.cs
+++ b/Source/ACE.Server/Entity/HeldItem.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Entity.Enum;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Entity
 {

--- a/Source/ACE.Server/Entity/HeldItem.cs
+++ b/Source/ACE.Server/Entity/HeldItem.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Entity.Enum;
 
 namespace ACE.Server.Entity

--- a/Source/ACE.Server/Entity/Landcell.cs
+++ b/Source/ACE.Server/Entity/Landcell.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Entity
 {
     public class Landcell

--- a/Source/ACE.Server/Entity/Landcell.cs
+++ b/Source/ACE.Server/Entity/Landcell.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Entity
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Entity
 {
     public class Landcell
     {

--- a/Source/ACE.Server/Entity/Model.cs
+++ b/Source/ACE.Server/Entity/Model.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Entity
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Entity
 {
     /// <summary>
     /// Used to replace model objects with other model objects.

--- a/Source/ACE.Server/Entity/Model.cs
+++ b/Source/ACE.Server/Entity/Model.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Entity
 {
     /// <summary>

--- a/Source/ACE.Server/Entity/ModelPalette.cs
+++ b/Source/ACE.Server/Entity/ModelPalette.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Entity
 {
     /// <summary>

--- a/Source/ACE.Server/Entity/ModelPalette.cs
+++ b/Source/ACE.Server/Entity/ModelPalette.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Entity
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Entity
 {
     /// <summary>
     /// Used to replace default Palette colors / not required

--- a/Source/ACE.Server/Entity/ModelTexture.cs
+++ b/Source/ACE.Server/Entity/ModelTexture.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Entity
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Entity
 {
     /// <summary>
     /// Used to replace default Textures / not required

--- a/Source/ACE.Server/Entity/ModelTexture.cs
+++ b/Source/ACE.Server/Entity/ModelTexture.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Entity
 {
     /// <summary>

--- a/Source/ACE.Server/Network/ChatPacket.cs
+++ b/Source/ACE.Server/Network/ChatPacket.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Entity.Enum;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Entity.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.Network

--- a/Source/ACE.Server/Network/ChatPacket.cs
+++ b/Source/ACE.Server/Network/ChatPacket.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Entity.Enum;
 using ACE.Server.Network.GameMessages.Messages;
 

--- a/Source/ACE.Server/Network/Enum/AddFriendResult.cs
+++ b/Source/ACE.Server/Network/Enum/AddFriendResult.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Enum
 {
     public enum AddFriendResult

--- a/Source/ACE.Server/Network/Enum/AddFriendResult.cs
+++ b/Source/ACE.Server/Network/Enum/AddFriendResult.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Enum
 {
     public enum AddFriendResult
     {

--- a/Source/ACE.Server/Network/Enum/CharacterGenerationVerificationResponse.cs
+++ b/Source/ACE.Server/Network/Enum/CharacterGenerationVerificationResponse.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Enum
 {
     public enum CharacterGenerationVerificationResponse
     {

--- a/Source/ACE.Server/Network/Enum/CharacterGenerationVerificationResponse.cs
+++ b/Source/ACE.Server/Network/Enum/CharacterGenerationVerificationResponse.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Enum
 {
     public enum CharacterGenerationVerificationResponse

--- a/Source/ACE.Server/Network/Enum/RemoveFriendResult.cs
+++ b/Source/ACE.Server/Network/Enum/RemoveFriendResult.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Enum
 {
     public enum RemoveFriendResult

--- a/Source/ACE.Server/Network/Enum/RemoveFriendResult.cs
+++ b/Source/ACE.Server/Network/Enum/RemoveFriendResult.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Enum
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Enum
 {
     public enum RemoveFriendResult
     {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChannelIndex.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChannelIndex.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.Network.GameAction.Actions

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionChannelIndex.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionChannelIndex.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Server.Network.GameEvent.Events;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.Network.GameAction.Actions
 {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionFinishBarber.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionFinishBarber.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.GameAction.Actions
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.GameAction.Actions
 {
     public static class GameActionFinishBarber
     {

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionFinishBarber.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionFinishBarber.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.GameAction.Actions
 {
     public static class GameActionFinishBarber

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionPingRequest.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionPingRequest.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.Network.GameAction.Actions

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionPingRequest.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionPingRequest.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Server.Network.GameEvent.Events;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Server.Network.GameEvent.Events;
 
 namespace ACE.Server.Network.GameAction.Actions
 {

--- a/Source/ACE.Server/Network/GameAction/GameActionAttribute.cs
+++ b/Source/ACE.Server/Network/GameAction/GameActionAttribute.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 
 namespace ACE.Server.Network.GameAction

--- a/Source/ACE.Server/Network/GameAction/GameActionAttribute.cs
+++ b/Source/ACE.Server/Network/GameAction/GameActionAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 
 namespace ACE.Server.Network.GameAction
 {

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPopupString.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPopupString.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventPopupString : GameEventMessage

--- a/Source/ACE.Server/Network/GameEvent/Events/GameEventPopupString.cs
+++ b/Source/ACE.Server/Network/GameEvent/Events/GameEventPopupString.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.GameEvent.Events
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.GameEvent.Events
 {
     public class GameEventPopupString : GameEventMessage
     {

--- a/Source/ACE.Server/Network/GameMessages/GameMessageAttribute.cs
+++ b/Source/ACE.Server/Network/GameMessages/GameMessageAttribute.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using ACE.Server.Network.Enum;
 

--- a/Source/ACE.Server/Network/GameMessages/GameMessageAttribute.cs
+++ b/Source/ACE.Server/Network/GameMessages/GameMessageAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using ACE.Server.Network.Enum;
 
 namespace ACE.Server.Network.GameMessages

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageEmoteText.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageEmoteText.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.GameMessages.Messages
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.GameMessages.Messages
 {
     public class GameMessageEmoteText : GameMessage
     {

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageEmoteText.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageEmoteText.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.GameMessages.Messages
 {
     public class GameMessageEmoteText : GameMessage

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSystemChat.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSystemChat.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Entity.Enum;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Entity.Enum;
 
 namespace ACE.Server.Network.GameMessages.Messages
 {

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSystemChat.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageSystemChat.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Entity.Enum;
 
 namespace ACE.Server.Network.GameMessages.Messages

--- a/Source/ACE.Server/Network/Handlers/FriendsOldHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/FriendsOldHandler.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.Entity.Enum;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages;

--- a/Source/ACE.Server/Network/Handlers/FriendsOldHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/FriendsOldHandler.cs
@@ -1,4 +1,5 @@
-﻿using ACE.Entity.Enum;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.Entity.Enum;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages;
 

--- a/Source/ACE.Server/Network/PacketDirection.cs
+++ b/Source/ACE.Server/Network/PacketDirection.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network
 {
     public enum PacketDirection

--- a/Source/ACE.Server/Network/PacketDirection.cs
+++ b/Source/ACE.Server/Network/PacketDirection.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network
 {
     public enum PacketDirection
     {

--- a/Source/ACE.Server/Network/Packets/PacketInboundConnectResponse.cs
+++ b/Source/ACE.Server/Network/Packets/PacketInboundConnectResponse.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Packets
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Packets
 {
     public class PacketInboundConnectResponse
     {

--- a/Source/ACE.Server/Network/Packets/PacketInboundConnectResponse.cs
+++ b/Source/ACE.Server/Network/Packets/PacketInboundConnectResponse.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Packets
 {
     public class PacketInboundConnectResponse

--- a/Source/ACE.Server/Network/Packets/PacketInboundWorldLoginRequest.cs
+++ b/Source/ACE.Server/Network/Packets/PacketInboundWorldLoginRequest.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Packets
 {
     public class PacketInboundWorldLoginRequest

--- a/Source/ACE.Server/Network/Packets/PacketInboundWorldLoginRequest.cs
+++ b/Source/ACE.Server/Network/Packets/PacketInboundWorldLoginRequest.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Packets
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Packets
 {
     public class PacketInboundWorldLoginRequest
     {

--- a/Source/ACE.Server/Network/Sequence/ISequence.cs
+++ b/Source/ACE.Server/Network/Sequence/ISequence.cs
@@ -1,4 +1,5 @@
-﻿namespace ACE.Server.Network.Sequence
+// UTF-8 BOM removed to ensure consistent encoding
+namespace ACE.Server.Network.Sequence
 {
     public interface ISequence
     {

--- a/Source/ACE.Server/Network/Sequence/ISequence.cs
+++ b/Source/ACE.Server/Network/Sequence/ISequence.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 namespace ACE.Server.Network.Sequence
 {
     public interface ISequence

--- a/Source/ACE.Server/Physics/Common/PalShift.cs
+++ b/Source/ACE.Server/Physics/Common/PalShift.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// UTF-8 BOM removed to ensure consistent encoding
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/ACE.Server/Physics/Common/PalShift.cs
+++ b/Source/ACE.Server/Physics/Common/PalShift.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Source/ACE.Server/Physics/Common/WeenieDesc.cs
+++ b/Source/ACE.Server/Physics/Common/WeenieDesc.cs
@@ -1,4 +1,5 @@
-﻿using ACE.DatLoader.Entity;
+// UTF-8 BOM removed to ensure consistent encoding
+using ACE.DatLoader.Entity;
 
 namespace ACE.Server.Physics.Common
 {

--- a/Source/ACE.Server/Physics/Common/WeenieDesc.cs
+++ b/Source/ACE.Server/Physics/Common/WeenieDesc.cs
@@ -1,4 +1,3 @@
-// UTF-8 BOM removed to ensure consistent encoding
 using ACE.DatLoader.Entity;
 
 namespace ACE.Server.Physics.Common

--- a/Source/ACE.sln
+++ b/Source/ACE.sln
@@ -1,5 +1,5 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# UTF-8 BOM removed to ensure consistent encoding
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30104.148
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/Source/ACE.sln
+++ b/Source/ACE.sln
@@ -1,5 +1,4 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# UTF-8 BOM removed to ensure consistent encoding
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30104.148
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/Source/test.runsettings
+++ b/Source/test.runsettings
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- UTF-8 BOM removed to ensure consistent encoding -->
 <RunSettings>
   <!-- Configurations that affect the Test Framework -->
   <RunConfiguration>

--- a/Source/test.runsettings
+++ b/Source/test.runsettings
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- UTF-8 BOM removed to ensure consistent encoding -->
 <RunSettings>
   <!-- Configurations that affect the Test Framework -->
   <RunConfiguration>


### PR DESCRIPTION
Remove UTF-8 BOMs across repository.

##Note on UTF-8 BOMs and .NET 8 Compatibility##

Context:
Historically, the UTF-8 BOM (Byte Order Mark – EF BB BF) was used to indicate that a file was encoded in UTF-8, particularly in older Windows environments. Tools like early versions of Notepad and Visual Studio relied on this marker to differentiate UTF-8 from other encodings. 

As of .NET Core and continuing into .NET 8, UTF-8 is now the default encoding in most file operations. The platform natively assumes UTF-8 without requiring a BOM, and modern tools, editors, and libraries are designed to handle UTF-8 correctly even in its BOM-less form. 

Current Relevance:
With the adoption of .NET 8, UTF-8 is the default encoding for most file I/O operations, and BOMs are no longer required or recommended. Modern editors, compilers, and runtime environments handle UTF-8 natively and correctly without the need for a BOM.

Why This Matters:
Including a BOM in source or config files can cause issues such as :
- JSON config files may fail to parse due to unexpected BOM characters.
- Scripted command loaders can silently fail if BOM is read as part of the command.
- Source files may show garbage characters in console output or logs.
- Build scripts or third-party tools may break if they don’t expect a BOM.
- Cross-platform editing becomes inconsistent across Windows, Linux, and macOS.
- Version control sees unnecessary diffs due to invisible BOM characters.
- Code reviews and merges are harder to manage when BOMs introduce formatting noise.
- Some .NET libraries may misinterpret BOMs, causing runtime exceptions.
- Unit tests may fail unexpectedly if test data or mock configs include BOMs.
- Shebang lines (#!/usr/bin/env) in scripts can break when preceded by a BOM.
- Localization files or string tables may break formatting if BOM is present.
- Third-party merge tools may flag false conflicts due to invisible BOM changes.
- Batch processing tools may misread the first token, leading to subtle bugs.
- Automated deployment scripts can behave unpredictably if BOMs are read as input.

Action Taken in This PR:
This PR includes a cleanup to remove UTF-8 BOMs from applicable files across the codebase to ensure consistency and avoid downstream issues.

Recommendation Going Forward:
Save all text-based files as UTF-8 without BOM.

Configure editors (e.g., Visual Studio, VS Code, Notepad++) to not include BOMs by default.

Use pre-commit hooks or CI checks if needed to enforce BOM-free files.

How This Helps the Project:
Improves cross-platform reliability: 
- Ensures consistent file behavior across Windows, Linux, and macOS environments—especially during builds or scripting tasks.

Prevents subtle runtime errors: 
- Eliminates encoding-related bugs in file parsing, configuration loading, or data processing that might otherwise be difficult to trace.

Reduces merge conflicts and noise: 
- Keeps version control clean by avoiding invisible characters that trigger unnecessary diffs or editor-induced inconsistencies.

Supports modern development standards: 
- Aligns with .NET 8 best practices, where UTF-8 without BOM is the expected and preferred encoding format.

Future-proofs the codebase: 
- Prevents compatibility issues with tooling, automated tests, and external libraries that may misinterpret or mishandle BOMs.

By ensuring all files are UTF-8 without BOM, we improve overall code quality, stability, and maintainability.