### PR TITLE
Updated Test Scripts and start_server.bat

### DIFF
--- a/Source/ACE.Server.Tests/StarterGearTests.cs
+++ b/Source/ACE.Server.Tests/StarterGearTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 
 using Newtonsoft.Json;
@@ -14,7 +15,9 @@ namespace ACE.Server.Tests
         [TestMethod]
         public void CanParseStarterGearJson()
         {
-            string contents = File.ReadAllText("../../../../../ACE.Server/starterGear.json");
+            var testDir = AppContext.BaseDirectory;
+            var starterGearPath = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "ACE.Server", "starterGear.json"));
+            string contents = File.ReadAllText(starterGearPath);
 
             StarterGearConfiguration config = JsonConvert.DeserializeObject<StarterGearConfiguration>(contents);
         }

--- a/Source/ACE.Server.Tests/StartupTests.cs
+++ b/Source/ACE.Server.Tests/StartupTests.cs
@@ -16,7 +16,14 @@ namespace ACE.Server.Tests
         public static void TestSetup(TestContext context)
         {
             // copy config.js and initialize configuration
-            File.Copy(Path.Combine(Environment.CurrentDirectory, "..\\..\\..\\..\\..\\ACE.Server\\Config.js"), ".\\Config.js", true);
+            var testDir = AppContext.BaseDirectory;
+            var serverDir = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", "ACE.Server"));
+            var configSource = Path.Combine(serverDir, "Config.js");
+
+            if (!File.Exists(configSource))
+                configSource = Path.Combine(serverDir, "Config.js.example");
+
+            File.Copy(configSource, Path.Combine(testDir, "Config.js"), true);
             ConfigManager.Initialize();
         }
 

--- a/Source/ACE.Server/start_server.bat
+++ b/Source/ACE.Server/start_server.bat
@@ -1,4 +1,7 @@
 @cd %~dp0
-@if not exist "ACE.Server.dll" (echo please run the copy of this file residing in the output folder: .\bin\x64\XXXXX\netcoreapp2.2\
-pause)
+@if not exist "ACE.Server.dll" (
+    echo please run the copy of this file residing in the build output directory, e.g. .\bin\x64\<Configuration>\net8.0\
+    pause
+    exit /b
+)
 dotnet ACE.Server.dll

--- a/Source/test.runsettings
+++ b/Source/test.runsettings
@@ -11,7 +11,7 @@
     <TargetPlatform>x64</TargetPlatform>
 
     <!-- Framework35 | [Framework40] | Framework45 -->
-    <TargetFrameworkVersion>Framework45</TargetFrameworkVersion>
+    <TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
 
   </RunConfiguration>
   


### PR DESCRIPTION
## Summary
- Adjusted the starter gear test so it resolves the JSON file using the test assembly’s base directory, ensuring reliable file access during testing.
- Updated StartupTests.TestSetup to look for an existing Config.js under the ACE.Server project and fall back to Config.js.example only if necessary
- Fix the hint in start_server.bat so it references the net8 build folder
- Add early exit if the batch file isn't run from the build output
- Updated the test configuration so that tests run using the .NET 8.0 target framework instead of the outdated Framework45 setting

##Testing
- Tests passed in test server instance.
