### PR TITLE
Bump MSTest.TestFramework to 3.10.1

### DIFF
--- a/Source/ACE.DatLoader.Tests/ACE.DatLoader.Tests.csproj
+++ b/Source/ACE.DatLoader.Tests/ACE.DatLoader.Tests.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/ACE.Database.Tests/ACE.Database.Tests.csproj
+++ b/Source/ACE.Database.Tests/ACE.Database.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/ACE.Server.Tests/ACE.Server.Tests.csproj
+++ b/Source/ACE.Server.Tests/ACE.Server.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.10.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.10.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest.TestFramework dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: MSTest.TestFramework dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: MSTest.TestFramework dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch ...