### PR TITLE
add missing olthoi koujia sollerets to loot tables

### DIFF
--- a/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
@@ -309,8 +309,8 @@ namespace ACE.Server.Factories.Tables.Wcids
             ( WeenieClassName.ace37198_olthoikoujiakabuton,     0.17f ),
             ( WeenieClassName.ace37203_olthoikoujialeggings,    0.17f ),
             ( WeenieClassName.ace37206_olthoikoujiasleeves,     0.17f ),
-            ( WeenieClassName.ace37215_olthoikoujiabreastplate, 0.17f ),
             ( WeenieClassName.ace37210_olthoikoujiasollerets,   0.16f ),
+            ( WeenieClassName.ace37215_olthoikoujiabreastplate, 0.17f ),
         };
 
         private static ChanceTable<WeenieClassName> OlthoiAlduressaWcids = new ChanceTable<WeenieClassName>()

--- a/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/ArmorWcids.cs
@@ -305,11 +305,12 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         private static ChanceTable<WeenieClassName> OlthoiKoujiaWcids = new ChanceTable<WeenieClassName>()
         {
-            ( WeenieClassName.ace37190_olthoikoujiagauntlets,   0.20f ),
-            ( WeenieClassName.ace37198_olthoikoujiakabuton,     0.20f ),
-            ( WeenieClassName.ace37203_olthoikoujialeggings,    0.20f ),
-            ( WeenieClassName.ace37206_olthoikoujiasleeves,     0.20f ),
-            ( WeenieClassName.ace37215_olthoikoujiabreastplate, 0.20f ),
+            ( WeenieClassName.ace37190_olthoikoujiagauntlets,   0.16f ),
+            ( WeenieClassName.ace37198_olthoikoujiakabuton,     0.17f ),
+            ( WeenieClassName.ace37203_olthoikoujialeggings,    0.17f ),
+            ( WeenieClassName.ace37206_olthoikoujiasleeves,     0.17f ),
+            ( WeenieClassName.ace37215_olthoikoujiabreastplate, 0.17f ),
+            ( WeenieClassName.ace37210_olthoikoujiasollerets,   0.16f ),
         };
 
         private static ChanceTable<WeenieClassName> OlthoiAlduressaWcids = new ChanceTable<WeenieClassName>()


### PR DESCRIPTION
not sure how this was missed, as i could have sworn i had programs that listed every wcid found in the magloot corpse logs, and cross-referenced that with the ace loot tables...

searching the discord history, it looks like this was known as far back as 2020. a content update needed to be made first to fix the 37210 wcid. after the content was updated, i forgot to update the code.

matched the %s up to other tables such as SedgemailLeatherWcids. ideally a format would be added to these tables to express an even chance for sets that are not evenly divisible.

thanks to Aristogeiton and Evanesque for reporting this issue!