### PR TITLE
Added two new server properties "salvage_modifier" and "spell_duration_modifier"

### DIFF
--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -1,10 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 using ACE.Entity.Models;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 using ACE.Server.WorldObjects.Managers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace ACE.Server.Entity
 {

--- a/Source/ACE.Server/Entity/AddEnchantmentResult.cs
+++ b/Source/ACE.Server/Entity/AddEnchantmentResult.cs
@@ -1,10 +1,10 @@
+using ACE.Entity.Models;
+using ACE.Server.Managers;
+using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using ACE.Entity.Models;
-using ACE.Server.WorldObjects;
-using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Entity
 {
@@ -95,8 +95,22 @@ namespace ACE.Server.Entity
                         // handle special case to prevent message: Pumpkin Shield casts Web of Defense on you, refreshing Aura of Defense
                         var spellDuration = equip ? double.PositiveInfinity : spell.Duration;
 
-                        if (!equip && caster is Player player && player.AugmentationIncreasedSpellDuration > 0 && !isWeaponSpell)
-                            spellDuration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+
+
+
+                        if (!equip && caster is Player player && !isWeaponSpell)
+                        {
+
+                            var spellDurationModifier = Math.Max(PropertyManager.GetDouble("spell_duration_modifier").Item, 0);
+                            var moddedSpellDuration = spellDuration * spellDurationModifier;
+
+                            spellDuration = Math.Max(moddedSpellDuration, 1);
+
+
+                            if(player.AugmentationIncreasedSpellDuration > 0)
+                                spellDuration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+
+                        }
 
                         var entryDuration = entry.Duration == -1 ? double.PositiveInfinity : entry.Duration;
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -668,7 +668,9 @@ namespace ACE.Server.Managers
                 ("vitae_penalty", new Property<double>(0.05, "the amount of vitae penalty a player gets per death")),
                 ("vitae_penalty_max", new Property<double>(0.40, "the maximum vitae penalty a player can have")),
                 ("void_pvp_modifier", new Property<double>(0.5, "Scales the amount of damage players take from Void Magic. Defaults to 0.5, as per retail. For earlier content where DRR isn't as readily available, this can be adjusted for balance.")),
-                ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players"))
+                ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players")),
+                ("salvage_modifier", new Property<double>(1.0, "scales the amount of salvage recieved by players when using an Ust. Minimum value is 0, and minimum amount of salvage returned is 1.")),
+                ("spell_duration_modifier", new Property<double>(1.0, "scales the duration of buffs cast by players, affects the same buffs as the Archmage's Endurance augmentation. Minimum value is 0, minimum duration for buffs is 1 second."))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<string>> DefaultStringProperties =

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -182,8 +182,15 @@ namespace ACE.Server.WorldObjects.Managers
                 // should be update the StatModVal here?
 
                 var duration = spell.Duration;
-                if (caster is Player player && player.AugmentationIncreasedSpellDuration > 0 && !isWeaponSpell && spell.DotDuration == 0)
-                    duration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+                if (caster is Player player && !isWeaponSpell && spell.DotDuration == 0)
+                {
+                    var spellDurationModifier = Math.Max(PropertyManager.GetDouble("spell_duration_modifier").Item, 0);
+                    var moddedDuration = duration * spellDurationModifier;
+
+                    duration = Math.Max(moddedDuration, 1);
+                    if(player.AugmentationIncreasedSpellDuration > 0)
+                        duration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+                }
 
                 var timeRemaining = refreshSpell.Duration + refreshSpell.StartTime;
 
@@ -219,8 +226,16 @@ namespace ACE.Server.WorldObjects.Managers
             {
                 entry.Duration = spell.Duration;
 
-                if (caster is Player player && player.AugmentationIncreasedSpellDuration > 0 && !isWeaponSpell && spell.DotDuration == 0)
-                    entry.Duration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+                if (caster is Player player && !isWeaponSpell && spell.DotDuration == 0)
+                {
+                    var spellDurationModifier = Math.Max(PropertyManager.GetDouble("spell_duration_modifier").Item, 0);
+                    var moddedDuration = entry.Duration * spellDurationModifier;
+
+                    entry.Duration = Math.Max(moddedDuration, 1);
+
+                    if(player.AugmentationIncreasedSpellDuration > 0)
+                        entry.Duration *= 1.0f + player.AugmentationIncreasedSpellDuration * 0.2f;
+                }
             }
             else
             {

--- a/Source/ACE.Server/WorldObjects/Player_Crafting.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Crafting.cs
@@ -324,6 +324,11 @@ namespace ACE.Server.WorldObjects
             // choose the best one
             var addStructure = Math.Max(salvageAmount, tinkeringAmount);
 
+            // modify by salvage_modifier
+            var salvageModifier = Math.Max(PropertyManager.GetDouble("salvage_modifier").Item,0);
+            var moddedAddStructure = addStructure * salvageModifier;
+            addStructure = (int)Math.Max(Math.Round(moddedAddStructure),1);
+
             var skill = salvageAmount > tinkeringAmount ? Skill.Salvaging : GetMaxSkill(TinkeringSkills).Skill;
 
             message = salvageResults.GetMessage(salvageItem.MaterialType ?? ACE.Entity.Enum.MaterialType.Unknown, skill);


### PR DESCRIPTION
The salvage property is a multiplicative scaling of salvage output using an UST, with a minimum value of 1 item of salvage possible. The spell duration property is a multiplicative scaling of spell duration for spells cast by the player, affecting the same buffs as the Archmage's Endurance augmentation. Both of these properties multiplicatively scale with the respective augmentations.

Negative or zero values for salvage_modifier will result in a salvage output at minimum of size 1.
Negative or zero values for spell_duration_modifier will result in a buff that is at minimum one second.