### PR TITLE
Wire up support for HighRes DAT handling

### DIFF
--- a/Source/ACE.DatLoader/DatDatabaseType.cs
+++ b/Source/ACE.DatLoader/DatDatabaseType.cs
@@ -6,6 +6,7 @@ namespace ACE.DatLoader
         Cell    = 2, // client_cell_1.dat
 
         // This is not explicity defined in the client, but we may want to use these
-        Language = 3 // client_local_English.dat
+        Language = 3, // client_local_English.dat
+        HighRes = 4 // client_highres.dat
     }
 }

--- a/Source/ACE.DatLoader/DatFile.cs
+++ b/Source/ACE.DatLoader/DatFile.cs
@@ -199,6 +199,15 @@ namespace ACE.DatLoader
                 }
             }
 
+            if (datDatabaseType == DatDatabaseType.HighRes)
+            {
+                switch (ObjectId >> 24)
+                {
+                    case 0x06:
+                        return DatFileType.Texture;
+                }
+            }
+
             Console.WriteLine($"Unknown file type: {ObjectId:X8}");
             return null;
         }

--- a/Source/ACE.Server/Managers/DDDManager.cs
+++ b/Source/ACE.Server/Managers/DDDManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,6 +30,11 @@ namespace ACE.Server.Managers
         public static Dictionary<DatDatabaseType, ConcurrentDictionary<uint, byte[]>> CompressedDatFilesCache;
 
         /// <summary>
+        /// The int representation of a byte array from the string, HiFi, which represents the DatFileType of the HighRes DAT file
+        /// </summary>
+        public static readonly int HiFi_String_As_Int = BitConverter.ToInt32(Encoding.UTF8.GetBytes("HiFi"), 0);
+
+        /// <summary>
         /// The rate at which DDDManager.Tick() executes
         /// </summary>
         //private static readonly RateLimiter dddDataQueueRateLimiter = new RateLimiter(1000, TimeSpan.FromMinutes(1));
@@ -49,6 +55,8 @@ namespace ACE.Server.Managers
             InitIterations(DatDatabaseType.Portal, DatManager.PortalDat);
             InitIterations(DatDatabaseType.Cell, DatManager.CellDat);
             InitIterations(DatDatabaseType.Language, DatManager.LanguageDat);
+            if (DatManager.HighResDat != null)
+                InitIterations(DatDatabaseType.HighRes, DatManager.HighResDat);
 
             log.DebugFormat("DDDManager Initialized.");
         }
@@ -149,6 +157,11 @@ namespace ACE.Server.Managers
 
                     datDatabase = DatManager.LanguageDat;
                     break;
+
+                case DatDatabaseType.HighRes:
+
+                    datDatabase = DatManager.HighResDat;
+                    break;
             }
 
             var datFileFound = datDatabase.AllFiles.TryGetValue(datFileId, out datFile);
@@ -179,7 +192,7 @@ namespace ACE.Server.Managers
             }
         }
 
-        public static uint GetMissingIterations(CMostlyConsecutiveIntSet clientPortalDatIntSet, CMostlyConsecutiveIntSet clientCellDatIntSet, CMostlyConsecutiveIntSet clientLanguageDatIntSet, out uint totalFileSize, out Dictionary<DatDatabaseType, Dictionary<uint, List<uint>>> iterations)
+        public static uint GetMissingIterations(CMostlyConsecutiveIntSet clientPortalDatIntSet, CMostlyConsecutiveIntSet clientCellDatIntSet, CMostlyConsecutiveIntSet clientLanguageDatIntSet, CMostlyConsecutiveIntSet clientHighResDatIntSet, out uint totalFileSize, out Dictionary<DatDatabaseType, Dictionary<uint, List<uint>>> iterations)
         {
             uint totalMissingIterations = 0;
             totalFileSize = 0;
@@ -188,6 +201,7 @@ namespace ACE.Server.Managers
             GetMissingIterations(DatDatabaseType.Portal, clientPortalDatIntSet, ref totalFileSize, iterations, ref totalMissingIterations);
             GetMissingIterations(DatDatabaseType.Cell, clientCellDatIntSet, ref totalFileSize, iterations, ref totalMissingIterations);
             GetMissingIterations(DatDatabaseType.Language, clientLanguageDatIntSet, ref totalFileSize, iterations, ref totalMissingIterations);
+            GetMissingIterations(DatDatabaseType.HighRes, clientHighResDatIntSet, ref totalFileSize, iterations, ref totalMissingIterations);
 
             return totalMissingIterations;
         }
@@ -195,6 +209,10 @@ namespace ACE.Server.Managers
         private static void GetMissingIterations(DatDatabaseType datDatabaseType, CMostlyConsecutiveIntSet clientDatIterations, ref uint totalFileSize, Dictionary<DatDatabaseType, Dictionary<uint, List<uint>>> iterations, ref uint totalMissingIterations)
         {
             if (!Iterations.ContainsKey(datDatabaseType))
+                return;
+
+            // if either CELL or HIGHRES dat files report 0 for iterations, that's okay. CELL will download on demand and HIGHRES will not be used.
+            if ((datDatabaseType == DatDatabaseType.Cell || datDatabaseType == DatDatabaseType.HighRes) && clientDatIterations.Iterations == 0)
                 return;
 
             // Generate a list of the missing iterations the client may have
@@ -271,6 +289,9 @@ namespace ACE.Server.Managers
                     break;
                 case DatDatabaseType.Language:
                     dbFile = "client_Local_English.dat";
+                    break;
+                case DatDatabaseType.HighRes:
+                    dbFile = "client_highres.dat";
                     break;
             }
             var debugStr = dbFile + Environment.NewLine + "Completed Iterations:" + Environment.NewLine;

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -505,6 +505,7 @@ namespace ACE.Server.Managers
                 ("allow_combat_mode_crafting", new Property<bool>(false, "If enabled, allows players to do crafting (recipes) from all stances. Forces players to NonCombat first, then continues to recipe action.")),
                 ("allow_door_hold", new Property<bool>(true, "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players")),
                 ("allow_fast_chug", new Property<bool>(true, "enables retail behavior where a player can consume food and drink faster than normal by breaking animation")),
+                ("allow_highres_dat", new Property<bool>(false, "enables client to use highres dat for graphics")),
                 ("allow_jump_loot", new Property<bool>(true, "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation")),
                 ("allow_negative_dispel_resist", new Property<bool>(true, "enables retail behavior where #-# negative dispels can be resisted")),
                 ("allow_negative_rating_curve", new Property<bool>(true, "enables retail behavior where negative DRR from void dots didn't switch to the reverse rating formula, resulting in a possibly unintended curve that quickly ramps up as -rating goes down, eventually approaching infinity / divide by 0 for -100 rating. less than -100 rating would produce negative numbers.")),

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -241,7 +241,7 @@ namespace ACE.Server.Managers
             }
 
             // These warnings are set by DDD_InterrogationResponse
-            if ((session.DatWarnCell || session.DatWarnLanguage || session.DatWarnPortal) && PropertyManager.GetBool("show_dat_warning").Item)
+            if ((session.DatWarnCell || session.DatWarnLanguage || session.DatWarnPortal || session.DatWarnHighRes) && PropertyManager.GetBool("show_dat_warning").Item)
             {
                 var msg = PropertyManager.GetString("dat_older_warning_msg").Item;
                 var chatMsg = new GameMessageSystemChat(msg, ChatMessageType.System);

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDBeginDDD.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDBeginDDD.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using ACE.DatLoader;
+using ACE.Server.Managers;
 
 namespace ACE.Server.Network.GameMessages.Messages
 {
@@ -21,6 +22,9 @@ namespace ACE.Server.Network.GameMessages.Messages
 
             if (missingIterations.ContainsKey(DatDatabaseType.Cell))
                 WriteIterations(DatDatabaseType.Cell, missingIterations[DatDatabaseType.Cell]);
+
+            if (missingIterations.ContainsKey(DatDatabaseType.HighRes))
+                WriteIterations(DatDatabaseType.HighRes, missingIterations[DatDatabaseType.HighRes]);
         }
 
         private void WriteIterations(DatDatabaseType datDatabaseType, Dictionary<uint, List<uint>> iterations)
@@ -42,6 +46,11 @@ namespace ACE.Server.Network.GameMessages.Messages
                     case DatDatabaseType.Language:
                         Writer.Write(1);
                         Writer.Write(3);
+                        break;
+
+                    case DatDatabaseType.HighRes:
+                        Writer.Write(DDDManager.HiFi_String_As_Int); // HiFi
+                        Writer.Write(1);
                         break;
                 }
 

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDDataMessage.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDDataMessage.cs
@@ -36,6 +36,13 @@ namespace ACE.Server.Network.GameMessages.Messages
                     datFileID = 3;
 
                     break;
+
+                case DatDatabaseType.HighRes:
+
+                    datFileType = DDDManager.HiFi_String_As_Int; // HiFi
+                    datFileID = 1;
+
+                    break;
             }
 
             var datFileContents = DDDManager.TryGetDatFileContentsForTransmission(datFileId, datDatabaseType, out var datFile, out var isCompressed);

--- a/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDInterrogation.cs
+++ b/Source/ACE.Server/Network/GameMessages/Messages/GameMessageDDDInterrogation.cs
@@ -1,3 +1,5 @@
+using ACE.Server.Managers;
+
 namespace ACE.Server.Network.GameMessages.Messages
 {
     public class GameMessageDDDInterrogation : GameMessage
@@ -5,9 +7,13 @@ namespace ACE.Server.Network.GameMessages.Messages
         public GameMessageDDDInterrogation()
             : base(GameMessageOpcode.DDD_Interrogation, GameMessageGroup.DatabaseQueue, 28)
         {
+            uint productID = 0x1;
+            if (PropertyManager.GetBool("allow_highres_dat").Item)
+                productID |= 0x4;
+
             Writer.Write(1u); // m_dwServersRegion
             Writer.Write(1u); // m_NameRuleLanguage
-            Writer.Write(1u); // m_dwProductID
+            Writer.Write(productID); // m_dwProductID
             Writer.Write(2u); // m_SupportedLanguages.Count
                 Writer.Write(0u); // Invalid
                 Writer.Write(1u); // English

--- a/Source/ACE.Server/Network/Handlers/DDDHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/DDDHandler.cs
@@ -45,6 +45,8 @@ namespace ACE.Server.Network.Handlers
                 switch (entry.DatFileId)
                 {
                     case 1: // PORTAL
+                        if (entry.DatFileType != 0 || entry.DatFileType == 1766222152) // HIRES
+                            continue;
                         clientPortalDatIntSet = entry.List;
                         if (entry.List.Iterations < DatManager.PortalDat.Iteration)
                         {

--- a/Source/ACE.Server/Network/Handlers/DDDHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/DDDHandler.cs
@@ -240,6 +240,7 @@ namespace ACE.Server.Network.Handlers
                 session.DatWarnPortal = false;
                 session.DatWarnCell = false;
                 session.DatWarnLanguage = false;
+                session.DatWarnHighRes = false;
 
                 log.Info($"[DDD] client {session.Account} reported it successfully received and patched its DAT files with expected BeginDDD payload");
             }

--- a/Source/ACE.Server/Network/Handlers/DDDHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/DDDHandler.cs
@@ -31,6 +31,7 @@ namespace ACE.Server.Network.Handlers
             var clientPortalDatIntSet = new CMostlyConsecutiveIntSet();
             var clientCellDatIntSet = new CMostlyConsecutiveIntSet();
             var clientLanguageDatIntSet = new CMostlyConsecutiveIntSet();
+            var clientHighResDatIntSet = new CMostlyConsecutiveIntSet();
 
             var showDatWarning = PropertyManager.GetBool("show_dat_warning").Item;
 
@@ -44,29 +45,60 @@ namespace ACE.Server.Network.Handlers
             {
                 switch (entry.DatFileId)
                 {
-                    case 1: // PORTAL
-                        if (entry.DatFileType != 0 || entry.DatFileType == 1766222152) // HIRES
-                            continue;
-                        clientPortalDatIntSet = entry.List;
-                        if (entry.List.Iterations < DatManager.PortalDat.Iteration)
+                    case 1: // PORTAL or HIGHRES
+                        if (entry.DatFileType == 0) // PORTAL
                         {
-                            if (showDatWarning)
-                                session.DatWarnPortal = true;
+                            clientPortalDatIntSet = entry.List;
+                            if (entry.List.Iterations < DatManager.PortalDat.Iteration)
+                            {
+                                if (showDatWarning)
+                                    session.DatWarnPortal = true;
 
-                            clientIsMissingIterations = true;
+                                clientIsMissingIterations = true;
+                            }
+                            else if (entry.List.Iterations > DatManager.PortalDat.Iteration)
+                            {
+                                if (showDatWarning)
+                                    session.DatWarnPortal = true;
+
+                                clientHasExtraIterations = true;
+                            }
                         }
-                        else if (entry.List.Iterations > DatManager.PortalDat.Iteration)
+                        else if (entry.DatFileType == DDDManager.HiFi_String_As_Int) // HIGHRES
                         {
-                            if (showDatWarning)
-                                session.DatWarnPortal = true;
+                            clientHighResDatIntSet = entry.List;
 
-                            clientHasExtraIterations = true;
+                            if (DatManager.HighResDat == null)
+                            {
+                                continue;
+                            }
+
+                            if (entry.List.Iterations < DatManager.HighResDat.Iteration)
+                            {
+                                if (clientHighResDatIntSet.Iterations == 0)
+                                    continue;
+
+                                if (showDatWarning)
+                                    session.DatWarnHighRes = true;
+
+                                clientIsMissingIterations = true;
+                            }
+                            else if (entry.List.Iterations > DatManager.HighResDat.Iteration)
+                            {
+                                if (showDatWarning)
+                                    session.DatWarnHighRes = true;
+
+                                clientHasExtraIterations = true;
+                            }
                         }
                         break;
                     case 2: // CELL
                         clientCellDatIntSet = entry.List;
                         if (entry.List.Iterations < DatManager.CellDat.Iteration)
                         {
+                            if (clientCellDatIntSet.Iterations == 0)
+                                continue;
+
                             if (showDatWarning)
                                 session.DatWarnCell = true;
 
@@ -105,11 +137,14 @@ namespace ACE.Server.Network.Handlers
                 Console.WriteLine($"{session.Account} client_portal.dat:" + Environment.NewLine + clientPortalDatIntSet);
                 Console.WriteLine($"{session.Account} client_cell_1.dat:" + Environment.NewLine + clientCellDatIntSet);
                 Console.WriteLine($"{session.Account} client_Local_English.dat:" + Environment.NewLine + clientLanguageDatIntSet);
+                Console.WriteLine($"{session.Account} client_highres.dat:" + Environment.NewLine + clientHighResDatIntSet);
             }
 
             var enableDATpatching = ConfigManager.Config.DDD.EnableDATPatching;
 
             var logMsg = $"[DDD] client {session.Account} responded to Interrogation:\n client_portal.dat: {clientPortalDatIntSet.Iterations} | client_cell_1.dat: {clientCellDatIntSet.Iterations} | client_Local_English.dat: {clientLanguageDatIntSet.Iterations}";
+            if (PropertyManager.GetBool("allow_highres_dat").Item)
+                logMsg += $"\n client_highres.dat: {clientHighResDatIntSet.Iterations}{(DatManager.HighResDat == null ? " (server allows but does not have client_highres.dat to validate)" : "")}";
             if (clientHasExtraIterations) logMsg += " | client has more iterations than server, cannot update";
             else if (clientIsMissingIterations) logMsg += " | update required";
             else logMsg += " | no update required";
@@ -123,7 +158,7 @@ namespace ACE.Server.Network.Handlers
             }
             else if (clientIsMissingIterations && enableDATpatching)
             {
-                var totalMissingIterations = DDDManager.GetMissingIterations(clientPortalDatIntSet, clientCellDatIntSet, clientLanguageDatIntSet, out var totalFileSize, out var missingIterations);                
+                var totalMissingIterations = DDDManager.GetMissingIterations(clientPortalDatIntSet, clientCellDatIntSet, clientLanguageDatIntSet, clientHighResDatIntSet, out var totalFileSize, out var missingIterations);                
                 var patchStatusMessage = new GameMessageDDDBeginDDD(totalMissingIterations, totalFileSize, missingIterations);
                 session.Network.EnqueueSend(patchStatusMessage);
                 session.BeginDDDSentTime = DateTime.UtcNow;
@@ -133,6 +168,7 @@ namespace ACE.Server.Network.Handlers
 
                 var hasPortalMissingIterations = missingIterations.TryGetValue(DatDatabaseType.Portal, out var portalMissingIterations);
                 var hasLanguageMissingIterations = missingIterations.TryGetValue(DatDatabaseType.Language, out var languageMissingIterations);
+                var hasHighResMissingIterations = missingIterations.TryGetValue(DatDatabaseType.HighRes, out var highresMissingIterations);
 
                 if (hasPortalMissingIterations)
                 {
@@ -160,6 +196,21 @@ namespace ACE.Server.Network.Handlers
                                 DDDManager.AddToQueue(session, fileId, DatDatabaseType.Language);
                             else
                                 log.Warn($"[DDD] DDD_InterrogationResponse: DDDManager.AddToQueue failed: DatManager.LanguageDat.AllFiles does not contain 0x{fileId:X8}");
+                        }
+                    }
+                }
+
+                if (hasHighResMissingIterations)
+                {
+                    foreach (var iteration in highresMissingIterations.Values)
+                    {
+                        foreach (var fileId in iteration.OrderBy(f => f))
+                        {
+                            if (DatManager.HighResDat.AllFiles.TryGetValue(fileId, out _))
+                                //session.Network.EnqueueSend(new GameMessageDDDDataMessage(fileId, DatDatabaseType.HighRes));
+                                DDDManager.AddToQueue(session, fileId, DatDatabaseType.HighRes);
+                            else
+                                log.Warn($"[DDD] DDD_InterrogationResponse: DDDManager.AddToQueue failed: DatManager.HighResDat.AllFiles does not contain 0x{fileId:X8}");
                         }
                     }
                 }

--- a/Source/ACE.Server/Network/Session.cs
+++ b/Source/ACE.Server/Network/Session.cs
@@ -60,6 +60,7 @@ namespace ACE.Server.Network
         public bool DatWarnCell;
         public bool DatWarnPortal;
         public bool DatWarnLanguage;
+        public bool DatWarnHighRes;
 
         /// <summary>
         /// This boolean is set to true if GameMessageDDDBeginDDD is sent to the client. Used to determine when response is needed for DDD_EndDDD


### PR DESCRIPTION
As recently pointed out by @CrimsonMage, the client does not make use of the client_highres.dat file without the server "allowing" it when it initially connects.

Apparently this feature was disabled sometime prior to the last month of retail and PCAPs never appear to show this option being "enabled" when clients connect.

As this reasoning is unknown at this time, I've made the server property `allow_highres_dat` which will instruct clients that connect to look for and make use of the client_highres.dat file, if present on the client and/or/both the server. The default will be **False**, as we do not currently know why this was not allowed at the end of retail, but perhaps others will want to enable this and see some modest improvements in the game world.

Server operators would need to place the client_highres.dat file in the same directory as the other DAT files it uses in order to use in place DDD updating, but that is not required to allow the client to make use of whatever it currently has. This adjustment also does update the server's DDD handling to understand the fourth iteration set, and make use of or discard depending on its DDD patch settings.

End users would need to place, if they haven't already, the client_highres.dat file into the same directory as the acclient.exe and other DAT files, and additionally change their graphics settings to `Very High` for both Landscape Texture Detail and Environment Detail, and click Apply which will then instruct the user to restart their client for it to actually load the higher resolution graphics. 

You can see these options in the Config panel below:
<img width="235" height="56" alt="image" src="https://github.com/user-attachments/assets/cd8d9224-e42c-4382-98dc-53696a8e18cd" />

The server **must** have the `allow_highres_dat` server property set to **True** for the client to actually load and use the higher resolution graphics. 

To Enable on server:
```
/modifybool allow_highres_dat true
```

To Disable on server:
```
/modifybool allow_highres_dat false
```