### PR TITLE
Performance improvements with the help of Claude

### DIFF
--- a/Source/ACE.Server/Network/ClientPacket.cs
+++ b/Source/ACE.Server/Network/ClientPacket.cs
@@ -150,11 +150,13 @@ namespace ACE.Server.Network
             {
                 if (headerChecksum + payloadChecksum == Header.Checksum)
                 {
-                    packetLog.DebugFormat("{0}", this);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("{0}", this);
                     return true;
                 }
 
-                packetLog.DebugFormat("{0}, Checksum Failed", this);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("{0}, Checksum Failed", this);
             }
 
             NetworkStatistics.C2S_CRCErrors_Aggregate_Increment();

--- a/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
+++ b/Source/ACE.Server/Network/Handlers/AuthenticationHandler.cs
@@ -100,7 +100,8 @@ namespace ACE.Server.Network.Handlers
 
         private static void AccountSelectCallback(Account account, Session session, PacketInboundLoginRequest loginRequest)
         {
-            packetLog.DebugFormat("ConnectRequest TS: {0}", Timers.PortalYearTicks);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("ConnectRequest TS: {0}", Timers.PortalYearTicks);
 
             if (session.Network.ConnectionData.ServerSeed == null || session.Network.ConnectionData.ClientSeed == null)
             {

--- a/Source/ACE.Server/Network/Managers/NetworkManager.cs
+++ b/Source/ACE.Server/Network/Managers/NetworkManager.cs
@@ -49,7 +49,8 @@ namespace ACE.Server.Network.Managers
                 //ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_1);
                 if (packet.Header.Flags.HasFlag(PacketHeaderFlags.ConnectResponse))
                 {
-                    packetLog.DebugFormat("{0}, {1}", packet, endPoint);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("{0}, {1}", packet, endPoint);
                     PacketInboundConnectResponse connectResponse = new PacketInboundConnectResponse(packet);
 
                     // This should be set on the second packet to the server from the client.
@@ -95,7 +96,8 @@ namespace ACE.Server.Network.Managers
                 //ServerPerformanceMonitor.RestartEvent(ServerPerformanceMonitor.MonitorType.ProcessPacket_0);
                 if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
                 {
-                    packetLog.DebugFormat("{0}, {1}", packet, endPoint);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("{0}, {1}", packet, endPoint);
                     if (GetAuthenticatedSessionCount() >= ConfigManager.Config.Server.Network.MaximumAllowedSessions)
                     {
                         log.InfoFormat("Login Request from {0} rejected. Server full.", endPoint);

--- a/Source/ACE.Server/Network/MessageFragment.cs
+++ b/Source/ACE.Server/Network/MessageFragment.cs
@@ -48,7 +48,8 @@ namespace ACE.Server.Network
             Index = 0;
             if (Count == 1)
                 TailSent = true;
-            packetLog.DebugFormat("Sequence {0}, count {1}, DataRemaining {2}", sequence, Count, DataRemaining);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("Sequence {0}, count {1}, DataRemaining {2}", sequence, Count, DataRemaining);
         }
 
         public ServerPacketFragment GetTailFragment()
@@ -65,7 +66,8 @@ namespace ACE.Server.Network
 
         private ServerPacketFragment CreateServerFragment(ushort index)
         {
-            packetLog.DebugFormat("Creating ServerFragment for index {0}", index);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("Creating ServerFragment for index {0}", index);
             if (index >= Count)
                 throw new ArgumentOutOfRangeException("index", index, "Passed index is greater then computed count");
 
@@ -97,7 +99,8 @@ namespace ACE.Server.Network
             fragment.Header.Queue = (ushort)Message.Group;
 
             DataRemaining -= dataToSend;
-            packetLog.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("Done creating ServerFragment for index {0}. After reading {1} DataRemaining {2}", index, dataToSend, DataRemaining);
             return fragment;
         }
     }

--- a/Source/ACE.Server/Network/NetworkSession.cs
+++ b/Source/ACE.Server/Network/NetworkSession.cs
@@ -127,7 +127,8 @@ namespace ACE.Server.Network
                 {
                     var currentBundle = currentBundles[(int) grp];
                     currentBundle.EncryptedChecksum = true;
-                    packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, message.Opcode);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, message.Opcode);
                     currentBundle.Enqueue(message);
                 }
             }
@@ -151,7 +152,8 @@ namespace ACE.Server.Network
                 {
                     var currentBundle = currentBundles[(int)grp];
                     currentBundle.EncryptedChecksum = true;
-                    packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, message.Opcode);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Enqueuing Message {1}", session.LoggingIdentifier, message.Opcode);
                     currentBundle.Enqueue(message);
                 }
             }
@@ -202,7 +204,8 @@ namespace ACE.Server.Network
                     {
                         if (sendResync && !currentBundle.TimeSync && DateTime.UtcNow > nextResync)
                         {
-                            packetLog.DebugFormat("[{0}] Setting to send TimeSync packet", session.LoggingIdentifier);
+                            if (packetLog.IsDebugEnabled)
+                                packetLog.DebugFormat("[{0}] Setting to send TimeSync packet", session.LoggingIdentifier);
                             currentBundle.TimeSync = true;
                             currentBundle.EncryptedChecksum = true;
                             nextResync = DateTime.UtcNow.AddMilliseconds(timeBetweenTimeSync);
@@ -210,14 +213,16 @@ namespace ACE.Server.Network
 
                         if (sendAck && !currentBundle.SendAck && DateTime.UtcNow > nextAck)
                         {
-                            packetLog.DebugFormat("[{0}] Setting to send ACK packet", session.LoggingIdentifier);
+                            if (packetLog.IsDebugEnabled)
+                                packetLog.DebugFormat("[{0}] Setting to send ACK packet", session.LoggingIdentifier);
                             currentBundle.SendAck = true;
                             nextAck = DateTime.UtcNow.AddMilliseconds(timeBetweenAck);
                         }
 
                         if (currentBundle.NeedsSending && DateTime.UtcNow >= nextSend)
                         {
-                            packetLog.DebugFormat("[{0}] Swapping bundle", session.LoggingIdentifier);
+                            if (packetLog.IsDebugEnabled)
+                                packetLog.DebugFormat("[{0}] Swapping bundle", session.LoggingIdentifier);
                             // Swap out bundle so we can process it
                             bundleToSend = currentBundle;
                             currentBundles[i] = new NetworkBundle();
@@ -227,7 +232,8 @@ namespace ACE.Server.Network
                     {
                         if (currentBundle.NeedsSending && DateTime.UtcNow >= nextSend)
                         {
-                            packetLog.DebugFormat("[{0}] Swapping bundle", session.LoggingIdentifier);
+                            if (packetLog.IsDebugEnabled)
+                                packetLog.DebugFormat("[{0}] Swapping bundle", session.LoggingIdentifier);
                             // Swap out bundle so we can process it
                             bundleToSend = currentBundle;
                             currentBundles[i] = new NetworkBundle();
@@ -271,7 +277,8 @@ namespace ACE.Server.Network
             if (isReleased) // Session has been removed
                 return;
 
-            packetLog.DebugFormat("[{0}] Processing packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("[{0}] Processing packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
             NetworkStatistics.C2S_Packets_Aggregate_Increment();
 
             if (!packet.VerifyCRC(ConnectionData.CryptoClient))
@@ -351,7 +358,8 @@ namespace ACE.Server.Network
             var desiredSeq = lastReceivedPacketSequence + 1;
             if (packet.Header.Sequence > desiredSeq)
             {
-                packetLog.DebugFormat("[{0}] Packet {1} received out of order", session.LoggingIdentifier, packet.Header.Sequence);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Packet {1} received out of order", session.LoggingIdentifier, packet.Header.Sequence);
 
                 if (!outOfOrderPackets.ContainsKey(packet.Header.Sequence))
                     outOfOrderPackets.TryAdd(packet.Header.Sequence, packet);
@@ -434,7 +442,8 @@ namespace ACE.Server.Network
         /// <param name="packet">ClientPacket to handle</param>
         private void HandleOrderedPacket(ClientPacket packet)
         {
-            packetLog.DebugFormat("[{0}] Handling packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("[{0}] Handling packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
 
             // If we have an EchoRequest flag, we should flag to respond with an echo response on next send.
             if (packet.Header.HasFlag(PacketHeaderFlags.EchoRequest))
@@ -449,7 +458,8 @@ namespace ACE.Server.Network
 
             if (packet.Header.HasFlag(PacketHeaderFlags.TimeSync))
             {
-                packetLog.DebugFormat("[{0}] Incoming TimeSync TS: {1}", session.LoggingIdentifier, packet.HeaderOptional.TimeSynch);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Incoming TimeSync TS: {1}", session.LoggingIdentifier, packet.HeaderOptional.TimeSynch);
                 // Do something with this...
                 // Based on network traces these are not 1:1.  Server seems to send them every 20 seconds per port.
                 // Client seems to send them alternatingly every 2 or 4 seconds per port.
@@ -462,7 +472,8 @@ namespace ACE.Server.Network
             // In our current implimenation we handle all roles in this one server.
             if (packet.Header.HasFlag(PacketHeaderFlags.LoginRequest))
             {
-                packetLog.DebugFormat("[{0}] LoginRequest", session.LoggingIdentifier);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] LoginRequest", session.LoggingIdentifier);
                 AuthenticationHandler.HandleLoginRequest(packet, session);
                 return;
             }
@@ -482,7 +493,8 @@ namespace ACE.Server.Network
         /// <param name="fragment">ClientPacketFragment to process</param>
         private void ProcessFragment(ClientPacketFragment fragment)
         {
-            packetLog.DebugFormat("[{0}] Processing fragment {1}", session.LoggingIdentifier, fragment.Header.Sequence);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("[{0}] Processing fragment {1}", session.LoggingIdentifier, fragment.Header.Sequence);
 
             ClientMessage message = null;
 
@@ -490,17 +502,20 @@ namespace ACE.Server.Network
             if (fragment.Header.Count != 1)
             {
                 // Packet is split
-                packetLog.DebugFormat("[{0}] Fragment {1} is split, this index {2} of {3} fragments", session.LoggingIdentifier, fragment.Header.Sequence, fragment.Header.Index, fragment.Header.Count);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Fragment {1} is split, this index {2} of {3} fragments", session.LoggingIdentifier, fragment.Header.Sequence, fragment.Header.Index, fragment.Header.Count);
 
                 if (partialFragments.TryGetValue(fragment.Header.Sequence, out var buffer))
                 {
                     // Existing buffer, add this to it and check if we are finally complete.
                     buffer.AddFragment(fragment);
-                    packetLog.DebugFormat("[{0}] Added fragment {1} to existing buffer. Buffer at {2} of {3}", session.LoggingIdentifier, fragment.Header.Sequence, buffer.Count, buffer.TotalFragments);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Added fragment {1} to existing buffer. Buffer at {2} of {3}", session.LoggingIdentifier, fragment.Header.Sequence, buffer.Count, buffer.TotalFragments);
                     if (buffer.Complete)
                     {
                         // The buffer is complete, so we can go ahead and handle
-                        packetLog.DebugFormat("[{0}] Buffer {1} is complete", session.LoggingIdentifier, buffer.Sequence);
+                        if (packetLog.IsDebugEnabled)
+                            packetLog.DebugFormat("[{0}] Buffer {1} is complete", session.LoggingIdentifier, buffer.Sequence);
                         message = buffer.TryGetMessage();
                         MessageBuffer removed = null;
                         partialFragments.TryRemove(fragment.Header.Sequence, out removed);
@@ -509,18 +524,21 @@ namespace ACE.Server.Network
                 else
                 {
                     // No existing buffer, so add a new one for this fragment sequence.
-                    packetLog.DebugFormat("[{0}] Creating new buffer {1} for this split fragment", session.LoggingIdentifier, fragment.Header.Sequence);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Creating new buffer {1} for this split fragment", session.LoggingIdentifier, fragment.Header.Sequence);
                     var newBuffer = new MessageBuffer(fragment.Header.Sequence, fragment.Header.Count);
                     newBuffer.AddFragment(fragment);
 
-                    packetLog.DebugFormat("[{0}] Added fragment {1} to the new buffer. Buffer at {2} of {3}", session.LoggingIdentifier, fragment.Header.Sequence, newBuffer.Count, newBuffer.TotalFragments);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Added fragment {1} to the new buffer. Buffer at {2} of {3}", session.LoggingIdentifier, fragment.Header.Sequence, newBuffer.Count, newBuffer.TotalFragments);
                     partialFragments.TryAdd(fragment.Header.Sequence, newBuffer);
                 }
             }
             else
             {
                 // Packet is not split, proceed with handling it.
-                packetLog.DebugFormat("[{0}] Fragment {1} is not split", session.LoggingIdentifier, fragment.Header.Sequence);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Fragment {1} is not split", session.LoggingIdentifier, fragment.Header.Sequence);
 
                 if (fragment.Data.Length >= 4) // ClientMessage must be a minimum of 4 bytes in length
                     message = new ClientMessage(fragment.Data);
@@ -532,12 +550,14 @@ namespace ACE.Server.Network
                 // First check if this message is the next sequence, if it is not, add it to our outOfOrderFragments
                 if (fragment.Header.Sequence == lastReceivedFragmentSequence + 1)
                 {
-                    packetLog.DebugFormat("[{0}] Handling fragment {1}", session.LoggingIdentifier, fragment.Header.Sequence);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Handling fragment {1}", session.LoggingIdentifier, fragment.Header.Sequence);
                     HandleFragment(message);
                 }
                 else
                 {
-                    packetLog.DebugFormat("[{0}] Fragment {1} is early, lastReceivedFragmentSequence = {2}", session.LoggingIdentifier, fragment.Header.Sequence, lastReceivedFragmentSequence);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] Fragment {1} is early, lastReceivedFragmentSequence = {2}", session.LoggingIdentifier, fragment.Header.Sequence, lastReceivedFragmentSequence);
                     outOfOrderFragments.TryAdd(fragment.Header.Sequence, message);
                 }
             }
@@ -560,7 +580,8 @@ namespace ACE.Server.Network
         {
             while (outOfOrderPackets.TryRemove(lastReceivedPacketSequence + 1, out var packet))
             {
-                packetLog.DebugFormat("[{0}] Ready to handle out-of-order packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Ready to handle out-of-order packet {1}", session.LoggingIdentifier, packet.Header.Sequence);
                 HandleOrderedPacket(packet);
             }
         }
@@ -572,7 +593,8 @@ namespace ACE.Server.Network
         {
             while (outOfOrderFragments.TryRemove(lastReceivedFragmentSequence + 1, out var message))
             {
-                packetLog.DebugFormat("[{0}] Ready to handle out of order fragment {1}", session.LoggingIdentifier, lastReceivedFragmentSequence + 1);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Ready to handle out of order fragment {1}", session.LoggingIdentifier, lastReceivedFragmentSequence + 1);
                 HandleFragment(message);
             }
         }
@@ -676,7 +698,8 @@ namespace ACE.Server.Network
         {
             if (cachedPackets.TryGetValue(sequence, out var cachedPacket))
             {
-                packetLog.DebugFormat("[{0}] Retransmit {1}", session.LoggingIdentifier, sequence);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Retransmit {1}", session.LoggingIdentifier, sequence);
 
                 if (!cachedPacket.Header.HasFlag(PacketHeaderFlags.Retransmission))
                     cachedPacket.Header.Flags |= PacketHeaderFlags.Retransmission;
@@ -711,7 +734,8 @@ namespace ACE.Server.Network
         {
             while (packetQueue.TryDequeue(out var packet))
             {
-                packetLog.DebugFormat("[{0}] Flushing packets, count {1}", session.LoggingIdentifier, packetQueue.Count);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Flushing packets, count {1}", session.LoggingIdentifier, packetQueue.Count);
 
                 if (packet.Header.HasFlag(PacketHeaderFlags.EncryptedChecksum) && ConnectionData.PacketSequence.CurrentValue == 0)
                     ConnectionData.PacketSequence = new Sequence.UIntSequence(1);
@@ -763,7 +787,8 @@ namespace ACE.Server.Network
 
                 packet.CreateReadyToSendPacket(buffer, out var size);
 
-                packetLog.DebugFormat("{0}", packet);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("{0}", packet);
 
                 if (packetLog.IsDebugEnabled)
                 {
@@ -795,7 +820,7 @@ namespace ACE.Server.Network
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(buffer, true);
+                ArrayPool<byte>.Shared.Return(buffer);
             }
         }
 
@@ -807,7 +832,8 @@ namespace ACE.Server.Network
         /// <param name="bundle"></param>
         private void SendBundle(NetworkBundle bundle, GameMessageGroup group)
         {
-            packetLog.DebugFormat("[{0}] Sending Bundle", session.LoggingIdentifier);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("[{0}] Sending Bundle", session.LoggingIdentifier);
 
             bool writeOptionalHeaders = true;
 
@@ -822,7 +848,8 @@ namespace ACE.Server.Network
                 fragments.Add(fragment);
             }
 
-            packetLog.DebugFormat("[{0}] Bundle Fragment Count: {1}", session.LoggingIdentifier, fragments.Count);
+            if (packetLog.IsDebugEnabled)
+                packetLog.DebugFormat("[{0}] Bundle Fragment Count: {1}", session.LoggingIdentifier, fragments.Count);
 
             // Loop through while we have fragements
             while (fragments.Count > 0 || writeOptionalHeaders)
@@ -845,7 +872,8 @@ namespace ACE.Server.Network
                     // If a large message send only this one, filling the whole packet
                     if (firstMessage.DataRemaining >= availableSpace)
                     {
-                        packetLog.DebugFormat("[{0}] Sending large fragment", session.LoggingIdentifier);
+                        if (packetLog.IsDebugEnabled)
+                            packetLog.DebugFormat("[{0}] Sending large fragment", session.LoggingIdentifier);
                         ServerPacketFragment spf = firstMessage.GetNextFragment();
                         packet.Fragments.Add(spf);
                         availableSpace -= spf.Length;
@@ -873,7 +901,8 @@ namespace ACE.Server.Network
                             // Is this a large fragment and does it have a tail that needs sending?
                             if (!fragment.TailSent && availableSpace >= fragment.TailSize)
                             {
-                                packetLog.DebugFormat("[{0}] Sending tail fragment", session.LoggingIdentifier);
+                                if (packetLog.IsDebugEnabled)
+                                    packetLog.DebugFormat("[{0}] Sending tail fragment", session.LoggingIdentifier);
                                 ServerPacketFragment spf = fragment.GetTailFragment();
                                 packet.Fragments.Add(spf);
                                 availableSpace -= spf.Length;
@@ -881,7 +910,8 @@ namespace ACE.Server.Network
                             // Otherwise will this message fit in the remaining space?
                             else if (availableSpace >= fragment.NextSize)
                             {
-                                packetLog.DebugFormat("[{0}] Sending small message", session.LoggingIdentifier);
+                                if (packetLog.IsDebugEnabled)
+                                    packetLog.DebugFormat("[{0}] Sending small message", session.LoggingIdentifier);
                                 ServerPacketFragment spf = fragment.GetNextFragment();
                                 packet.Fragments.Add(spf);
                                 availableSpace -= spf.Length;
@@ -905,7 +935,8 @@ namespace ACE.Server.Network
                 // If no messages, write optional headers
                 else
                 {
-                    packetLog.DebugFormat("[{0}] No messages, just sending optional headers", session.LoggingIdentifier);
+                    if (packetLog.IsDebugEnabled)
+                        packetLog.DebugFormat("[{0}] No messages, just sending optional headers", session.LoggingIdentifier);
                     if (writeOptionalHeaders)
                     {
                         writeOptionalHeaders = false;
@@ -925,7 +956,8 @@ namespace ACE.Server.Network
             if (bundle.SendAck) // 0x4000
             {
                 packetHeader.Flags |= PacketHeaderFlags.AckSequence;
-                packetLog.DebugFormat("[{0}] Outgoing AckSeq: {1}", session.LoggingIdentifier, lastReceivedPacketSequence);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Outgoing AckSeq: {1}", session.LoggingIdentifier, lastReceivedPacketSequence);
                 packet.InitializeDataWriter();
                 packet.DataWriter.Write(lastReceivedPacketSequence);
             }
@@ -933,7 +965,8 @@ namespace ACE.Server.Network
             if (bundle.TimeSync) // 0x1000000
             {
                 packetHeader.Flags |= PacketHeaderFlags.TimeSync;
-                packetLog.DebugFormat("[{0}] Outgoing TimeSync TS: {1}", session.LoggingIdentifier, Timers.PortalYearTicks);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Outgoing TimeSync TS: {1}", session.LoggingIdentifier, Timers.PortalYearTicks);
                 packet.InitializeDataWriter();
                 packet.DataWriter.Write(Timers.PortalYearTicks);
             }
@@ -941,7 +974,8 @@ namespace ACE.Server.Network
             if (bundle.ClientTime != -1f) // 0x4000000
             {
                 packetHeader.Flags |= PacketHeaderFlags.EchoResponse;
-                packetLog.DebugFormat("[{0}] Outgoing EchoResponse: {1}", session.LoggingIdentifier, bundle.ClientTime);
+                if (packetLog.IsDebugEnabled)
+                    packetLog.DebugFormat("[{0}] Outgoing EchoResponse: {1}", session.LoggingIdentifier, bundle.ClientTime);
                 packet.InitializeDataWriter();
                 packet.DataWriter.Write(bundle.ClientTime);
                 packet.DataWriter.Write((float)Timers.PortalYearTicks - bundle.ClientTime);

--- a/Source/ACE.Server/Physics/Polygon.cs
+++ b/Source/ACE.Server/Physics/Polygon.cs
@@ -403,11 +403,14 @@ namespace ACE.Server.Physics
             if (dp <= path.WalkableAllowance) return false;
             Vector3 contactPoint = Vector3.Zero;
             var hit = polygon_hits_sphere_precise(sphere, ref contactPoint);
-            if (hit != polygon_hits_sphere(sphere, ref contactPoint))
-            {
-                polygon_hits_sphere_precise(sphere, ref contactPoint);
-                polygon_hits_sphere(sphere, ref contactPoint);
-            }
+            // The client decompile has this branch of code as well.
+            // The purpose was likely for a devleoper to put a break point to debug if these two functions ever return a different result.
+            // Comment this out and put a break point, long, debug, or exception if you want to debug cross-check.
+            //if (hit != polygon_hits_sphere(sphere, ref contactPoint))
+            //{
+            //    polygon_hits_sphere_precise(sphere, ref contactPoint);
+            //    polygon_hits_sphere(sphere, ref contactPoint);
+            //}
             return hit;
         }
 

--- a/Source/ACE.Server/Physics/Transition.cs
+++ b/Source/ACE.Server/Physics/Transition.cs
@@ -689,9 +689,7 @@ namespace ACE.Server.Physics.Animation
         /// <returns></returns>
         public static Transition MakeTransition()
         {
-            var transition = new Transition();
-            transition.Init();
-            return transition;
+            return new Transition();
         }
 
         public TransitionState PlacementInsert()

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -66,7 +66,7 @@ namespace ACE.Server.WorldObjects
         {
             // get base armor/resistance level
             var baseArmor = armor.GetProperty(PropertyInt.ArmorLevel) ?? 0;
-            var armorType = armor.GetProperty(PropertyInt.ArmorType) ?? 0;
+            //var armorType = armor.GetProperty(PropertyInt.ArmorType) ?? 0;
             var resistance = Creature.GetResistance(armor, damageType);
 
             /*Console.WriteLine(armor.Name);

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -492,7 +492,7 @@ namespace ACE.Server.WorldObjects
         {
             // get base armor/resistance level
             var baseArmor = armor.GetProperty(PropertyInt.ArmorLevel) ?? 0;
-            var armorType = armor.GetProperty(PropertyInt.ArmorType) ?? 0;
+            //var armorType = armor.GetProperty(PropertyInt.ArmorType) ?? 0;
             var resistance = GetResistance(armor, damageType);
 
             /*Console.WriteLine(armor.Name);


### PR DESCRIPTION
This has 5 minor performance improvements found with the help of Claude

In networking, check for packetLog.IsDebugEnabled before the calls.
- packetLog is disabled in almost all servers. This removes the boxing cost and GC pressure it adds for var/struct types with structured logging.
- Don't clear the array when its released back to the pool. We're not leaking any secrets here. It's an AC server. We can skip this cost.

Polygon walkable_hits_sphere included some test code that was ported over from the client. This code was likely code added to the client with a break point so that a developer could test if the two functions ever mismatched. Not needed for us.

Transition calls init in its ctor, no need to explicitly call it again. Saves re-creation of a few objects.

Creature_BodyPart and Monster_Melee referenced a few biota properties that were never used. Querying a property incurs a slight cost (lookups, rwLock, etc...)